### PR TITLE
Phase 1 baseline: data plane complete + AI context + alerts engine

### DIFF
--- a/docs/database-audit-2026-05-09.md
+++ b/docs/database-audit-2026-05-09.md
@@ -1,0 +1,198 @@
+# Database audit — what's connected, what isn't, what's unused (2026-05-09)
+
+Goal: for any random event, show what data we have on it, where the
+gaps are, and which tables we collect into but never read from.
+
+## TL;DR — the headline findings
+
+1. **TEvo + ESPN + Wikipedia are wired correctly.** Any TEvo event we
+   care about (popular sports + concert) gets full TEvo listings depth
+   plus an ESPN xref plus performer Wikipedia text. End to end this
+   side just works.
+
+2. **SeatGeek cross-reference is broken.** We pull 7,298 listing
+   snapshots, 400 orders, 200 seller listings — but only ~7%, 0%, and
+   0.5% respectively are linked back to a `tevo_event_id`. The data is
+   in the database. Day-trader views can't see it.
+
+3. **SeatData is essentially silent.** 1 event xref'd, 254 sales rows
+   on that one event. Either the SD pull pipeline isn't iterating
+   events, or we're not feeding it the event list.
+
+4. **Unmatched events bucket: 228 entries** — 208 SG + 20 EVO + 0 SD.
+   The orphan bucket from mig 20260509330000 is doing its job; that
+   number IS the work the day-trader has to clear.
+
+5. **8 tables are collected into but never queried.** Not enormous,
+   but worth pruning or wiring. List + verdict below.
+
+## Per-event audit — Thunder @ Lakers G3 (tevo_event_id 3344959)
+
+Tonight, 5/9 17:30 PT, Crypto.com Arena. Picked because it's a
+high-traffic playoff game so any signal we have on a single event
+should be present.
+
+| Source | Rows / state | Verdict |
+|---|---|---|
+| `events` (TEvo)             | name, venue, performer, type=game, popularity 0 | ✓ basics fine |
+| `listings_snapshots`        | **240,382** rows; 9,339 distinct ticket_groups; 354 capture times; latest 5/9 19:20 UTC; price $20–$13,133; 652 tickets in latest snap | ✓ deep |
+| `event_metrics`             | 354 rows                | ✓ matches captures 1:1 |
+| `section_metrics`           | 28,071 rows             | ✓ |
+| `zone_metrics`              | 382 rows                | ✓ |
+| `evo_orders` / `evo_order_items` | 1 line item        | ✓ (we sold 1 ticket) |
+| `event_xref` → ESPN         | espn_event_id=401871328 | ✓ |
+| `espn_event_snapshots`      | 3 rows                  | ✓ light but present |
+| `performer_wikipedia`       | "The Los Angeles Lakers are an American professional basketball team based in Los…" | ✓ enriched |
+| `performer_home_venues`     | row exists              | ✓ |
+| `event_sentiment`           | 1 row                   | ✓ |
+| `watch_sources`             | tracked                 | ✓ |
+| **`seatgeek_listings_snapshots`** | **0**             | ✗ MISS |
+| **`seatgeek_orders`**             | **0**             | ✗ MISS |
+| **`seatgeek_seller_listings`**    | **0**             | ✗ MISS |
+| **`seatgeek_event_metrics`**      | **0**             | ✗ MISS |
+| **`sg_events_canonical`**         | not present       | ✗ MISS |
+| **`seatdata_sales_snapshots`**    | **0**             | ✗ MISS |
+| **`seatdata_listings_snapshots`** | **0**             | ✗ MISS |
+| **`seatdata_event_xref`**         | not present       | ✗ MISS |
+| `weather_observations`            | depends on lat/lon round | likely 0 (Crypto.com not in geocode set) |
+
+**What "should" be on this event:** TEvo listings + metrics, ESPN
+status, performer wiki, weather. We have all of those.
+
+**What's missing despite being collectable:** SG marketplace pricing
++ SD historic comps. Both pipelines are running (crons active) and
+both have data in their raw tables. The xref join is the failure.
+
+## SG xref failure — root cause
+
+```
+sg_listings_snapshots:   7,298 total | 527 (7.2%) xref'd to tevo_event_id
+sg_orders:                 400 total | 0 (0%)     xref'd
+sg_seller_listings:        200 total | 1 (0.5%)   xref'd
+sg_events_canonical:       211 total | 3 (1.4%)   xref'd
+```
+
+Joining `events` to `sg_events_canonical` on `(date, name fragments)`
+finds **72 obvious matches**, of which only **3 are correctly xref'd**
+and **69 are not.** The matcher is leaving money on the table.
+
+The matcher cron `sg_canonical_auto_match_30min` is active; it isn't
+matching because the SG event names are different shapes from TEvo's
+("Oklahoma City Thunder at Los Angeles Lakers (Game 3, …)" vs the
+SG-side phrasing). The fuzzy-match threshold or the candidate window
+is too narrow.
+
+**Fix path** (P1): widen matcher to compare strip-of-parentheticals
++ use venue when name match is weak. 69 → ~3 unmatched would
+unlock most of the hidden SG depth on TEvo events.
+
+## SeatData near-empty
+
+```
+seatdata_event_xref:         1 row (with tevo_event_id)
+seatdata_sales_snapshots:  254 rows on 1 event
+seatdata_listings_snapshots: 0 rows
+```
+
+SD has the smallest footprint by far. The single covered event is
+Knicks/76ers G5 (tevo 3345925, the "if necessary" Game 5). Either:
+- SD pull pipeline isn't iterating its event list, OR
+- We're not feeding it our event list (and it's only finding what we
+  manually pulled)
+
+**Fix path** (P2): identify why SD pulls aren't fanning out. The
+`seatdata_pull_log` table has 0 rows, which is the smoking gun — no
+pulls are even being logged.
+
+## Cross-source xref scoreboard
+
+| Pair | Status |
+|---|---|
+| TEvo ↔ ESPN | **100% clean** — 81 espn events, 430 xref rows, 0 espn orphans |
+| TEvo ↔ Wikipedia (performer-level) | 183 enriched performers; works ✓ |
+| TEvo ↔ SeatGeek | **broken** — see above |
+| TEvo ↔ SeatData | **near-empty** — see above |
+| SG ↔ SD | not directly attempted (everything goes via TEvo) |
+
+## Datasets that exist but nothing reads
+
+These tables hold data but no view or function references them.
+Either they're abandoned, or they're waiting on a consumer to be
+built. Verdict for each:
+
+| Table | Rows | Verdict |
+|---|---|---|
+| `wiki_summary`            | 127 | **DROP** — superseded by `performer_wikipedia` |
+| `wiki_rivalries`          | 25  | **DROP** — proposal artifact, no consumer planned |
+| `event_sentiment`         | 18  | **WIRE** — sentiment_index column should feed `v_event_full`; trivial fix |
+| `seatgeek_event_metrics`  | 494 | **WIRE** — being computed by SG cron, never JOINed; should appear in `v_pricing_cross_source` |
+| `performer_baselines`     | 72  | **WIRE OR DROP** — used by `event_metrics` deltas? unclear |
+| `venue_baselines`         | 67  | **WIRE OR DROP** — same question |
+| `major_event_calendar`    | 14  | **WIRE** — could feed `v_competing_events` for major-event awareness (Super Bowl week, All-Star, etc.) |
+| `espn_athletes`           | 857 | **WIRE FOR AI** — useful as RAG context (player rosters); not for SQL analytics |
+
+The `*_pending` tables and `*_runs` log tables ARE supposed to have no
+view consumer — they're operational scaffolding. Excluded from above.
+
+## Active data plane (for reference)
+
+39 active cron jobs in supabase. Categorized:
+
+- **TEvo listings (windowed by event proximity)**: 5 crons (`collect-listings-0-24h` through `60d+`)
+- **SeatGeek listings (matching cadence)**: 5 crons (`sg_listings_*`)
+- **EVO orders**: 2 (`evo_orders_queue_30min`, `evo_orders_process_30min`)
+- **SG seller orders + listings**: 3 (`sg_seller_*_30min`)
+- **ESPN**: 3 (`crawl-espn-team-assets-3min`, `espn-team-daily`, `master-cascade-2min`)
+- **Performer Wikipedia (enrichment only)**: 3 (search → process → summary)
+- **Venue geocode + weather**: 4 (`venue_geocode_*`, `weather_*`)
+- **SG canonical matcher**: 1 (`sg_canonical_auto_match_30min`) ← **the broken one**
+- **Chat / corpus**: 4
+- **Sweeps + maintenance**: 5
+
+Zero crons hitting forbidden write paths (RULE 2 verified by static
+audit + plpgsql scan).
+
+## What a "complete" event SHOULD have
+
+Using Thunder/Lakers G3 as the template, a fully-wired TEvo event has:
+
+```
+Tier 1 (must have, currently does):
+  ✓ events row with venue + performer + type
+  ✓ listings_snapshots: hundreds-to-thousands per capture
+  ✓ event_metrics aggregates per capture
+  ✓ section_metrics + zone_metrics
+  ✓ event_xref → ESPN (for sports)
+  ✓ espn_event_snapshots (game-day score / status)
+  ✓ performer_wikipedia (text + image_url)
+  ✓ performer_home_venues
+  ✓ event_sentiment row(s)
+  ✓ watch_sources (if tracked)
+
+Tier 2 (should have, often missing):
+  ✗ seatgeek_listings_snapshots with tevo_event_id set
+  ✗ seatgeek_event_metrics
+  ✗ sg_events_canonical with tevo_event_id set
+  ✗ seatdata_event_xref + seatdata_sales_snapshots
+  ✗ weather_observations (only populated within 16d of event)
+
+Tier 3 (nice to have, deferred):
+  – major_event_calendar tag (Super Bowl week etc.)
+  – espn_athletes for player-level context (AI consumer)
+  – evo_order_items aggregated by ticket_group
+```
+
+## Action items ranked by impact
+
+| # | Action | Effort | Why it matters |
+|---|---|---|---|
+| 1 | Fix `sg_canonical_auto_match_30min` matcher (parentheticals + venue tiebreak) | small | unlocks ~69 cross-source pairs immediately, growing daily |
+| 2 | Diagnose why `seatdata_pull_log` is empty (cron not running? not iterating?) | small-medium | SD comps are real money signal; right now we have ~zero |
+| 3 | Wire `seatgeek_event_metrics` into `v_pricing_cross_source` | small | data exists, just needs JOIN |
+| 4 | Wire `event_sentiment` into `v_event_full` | small | data exists, currently invisible |
+| 5 | Drop `wiki_summary` + `wiki_rivalries` | trivial | dead tables |
+| 6 | Decide fate of `performer_baselines` + `venue_baselines` (wire or drop) | small | unclear ownership |
+| 7 | Investigate weather coverage for non-NYC venues | medium | Crypto.com Arena likely missing geocode |
+
+Items 1, 2, 5 are the most productive — high signal, low complexity.
+Items 3, 4 are pure plumbing.

--- a/docs/database-audit-2026-05-09.md
+++ b/docs/database-audit-2026-05-09.md
@@ -10,10 +10,12 @@ gaps are, and which tables we collect into but never read from.
    plus an ESPN xref plus performer Wikipedia text. End to end this
    side just works.
 
-2. **SeatGeek cross-reference is broken.** We pull 7,298 listing
-   snapshots, 400 orders, 200 seller listings — but only ~7%, 0%, and
-   0.5% respectively are linked back to a `tevo_event_id`. The data is
-   in the database. Day-trader views can't see it.
+2. **SeatGeek cross-reference is sparse — but correct.** Initially
+   reported as broken; on re-check the matcher correctly refuses to
+   pair unrelated events sharing a date (e.g. BTS concert at Stanford
+   vs WNBA game at Moda Center). The 208 unmatched `sg_events_canonical`
+   rows are mostly events without a TEvo equivalent (concerts,
+   non-major sports). See "SG xref state — corrected" below.
 
 3. **SeatData is essentially silent.** 1 event xref'd, 254 sales rows
    on that one event. Either the SD pull pipeline isn't iterating
@@ -63,7 +65,26 @@ status, performer wiki, weather. We have all of those.
 + SD historic comps. Both pipelines are running (crons active) and
 both have data in their raw tables. The xref join is the failure.
 
-## SG xref failure — root cause
+## SG xref state — corrected
+
+Initial finding ("69 obvious cross-source matches not xref'd") was a
+**false positive** in the audit query. The fuzzy match used loose
+substring overlap on event names, which produced spurious pairs like:
+
+- SG "BTS" at Stanford Stadium ↔ TEvo "Connecticut Sun at Portland
+  Fire" at Moda Center — different sport, different venue, same date.
+- SG "Palomazo Norteno" at Kia Forum ↔ TEvo "Texas Rangers at Toronto
+  Blue Jays" at Rogers Centre — different sport, different venue.
+
+After re-querying with **same-venue + same-date**, only **1** legit
+SG↔TEvo collision exists today, and the existing matcher correctly
+rejects it (SG WNBA game vs TEvo Timberwolves at Target Center on the
+same date — different performers, gated against ghost-matching).
+
+The 208 unmatched `sg_events_canonical` rows are real cross-source
+gaps in the TEvo catalog: SG carries lots of concerts and MLS/NCAAF
+games that we don't pull into TEvo. Not a matcher bug — a coverage
+choice.
 
 ```
 sg_listings_snapshots:   7,298 total | 527 (7.2%) xref'd to tevo_event_id
@@ -72,19 +93,13 @@ sg_seller_listings:        200 total | 1 (0.5%)   xref'd
 sg_events_canonical:       211 total | 3 (1.4%)   xref'd
 ```
 
-Joining `events` to `sg_events_canonical` on `(date, name fragments)`
-finds **72 obvious matches**, of which only **3 are correctly xref'd**
-and **69 are not.** The matcher is leaving money on the table.
+The low xref rates reflect that most SG events simply don't have a
+TEvo equivalent in our event list. The matcher is doing its job —
+correctly NOT pairing unrelated events that share a date.
 
-The matcher cron `sg_canonical_auto_match_30min` is active; it isn't
-matching because the SG event names are different shapes from TEvo's
-("Oklahoma City Thunder at Los Angeles Lakers (Game 3, …)" vs the
-SG-side phrasing). The fuzzy-match threshold or the candidate window
-is too narrow.
-
-**Fix path** (P1): widen matcher to compare strip-of-parentheticals
-+ use venue when name match is weak. 69 → ~3 unmatched would
-unlock most of the hidden SG depth on TEvo events.
+**No fix needed.** The unified `cross_source_match_tick_30min` cron
+(mig 20260509350000) keeps running the existing matcher and will pick
+up new pairs whenever TEvo's event coverage and SG's overlap.
 
 ## SeatData near-empty
 
@@ -186,7 +201,7 @@ Tier 3 (nice to have, deferred):
 
 | # | Action | Effort | Why it matters |
 |---|---|---|---|
-| 1 | Fix `sg_canonical_auto_match_30min` matcher (parentheticals + venue tiebreak) | small | unlocks ~69 cross-source pairs immediately, growing daily |
+| 1 | ~~Fix SG matcher~~ — withdrawn, matcher is correct. Replaced by `cross_source_match_tick_30min` unified cron (mig 350000) | done | logs orphans across all sources for visibility |
 | 2 | Diagnose why `seatdata_pull_log` is empty (cron not running? not iterating?) | small-medium | SD comps are real money signal; right now we have ~zero |
 | 3 | Wire `seatgeek_event_metrics` into `v_pricing_cross_source` | small | data exists, just needs JOIN |
 | 4 | Wire `event_sentiment` into `v_event_full` | small | data exists, currently invisible |

--- a/docs/database-map-2026-05-09.md
+++ b/docs/database-map-2026-05-09.md
@@ -1,0 +1,312 @@
+# Terminal-2 — Database Map (2026-05-09)
+
+Comprehensive structural reference for the Supabase data plane. This file
+is the answer to "what tables exist, what feeds what, what reads what."
+Update when you add/remove a table, view, function, or cron.
+
+The map is organized by **layer**, top-down:
+
+```
+  +-----------------------------------------------------------------+
+  |  CONSUMER INTERFACE  (single-call functions, AI/RAG bundles)    |
+  +-----------------------------------------------------------------+
+                              ^
+  +-----------------------------------------------------------------+
+  |  INTELLIGENCE  (alerts, velocity windows, arbitrage, competitors)|
+  +-----------------------------------------------------------------+
+                              ^
+  +-----------------------------------------------------------------+
+  |  CANONICAL VIEWS  (cross-source unified surfaces)               |
+  +-----------------------------------------------------------------+
+                              ^
+  +-----------------------------------------------------------------+
+  |  PER-SOURCE METRICS  (rolled-up event/section/zone aggregates)  |
+  +-----------------------------------------------------------------+
+                              ^
+  +-----------------------------------------------------------------+
+  |  RAW SNAPSHOTS  (listings, sales, orders, ESPN, weather)        |
+  +-----------------------------------------------------------------+
+                              ^
+  +-----------------------------------------------------------------+
+  |  PULL PIPELINE  (queue tables -> pg_net -> process functions)   |
+  +-----------------------------------------------------------------+
+                              ^
+  +-----------------------------------------------------------------+
+  |  DATA SOURCES  (TEvo, SG, SD, ESPN, Wiki, Open-Meteo, Nominatim)|
+  +-----------------------------------------------------------------+
+```
+
+## Layer 1 — Data sources
+
+| Source | Auth | Endpoint(s) used | RULE 2 |
+|---|---|---|---|
+| **TEvo** (api.ticketevolution.com) | HMAC-SHA256 (X-Token + X-Signature) via `tevo_sign_get()` | `/v9/events`, `/v9/events/:id`, `/v9/orders` | GET only |
+| **SeatGeek brokerdata** (brokerdata.seatgeek.com) | token query param | `/v2/listings`, `/v2/events` | GET only |
+| **SeatGeek sellerdirect** (sellerdirect-api.seatgeek.com) | token query param | `/orders`, `/listings` | GET only |
+| **SeatData** (vendor TBD) | API key | **MISSING** — no plpgsql pull function exists. See `seatdata-blocker-2026-05-09.md` | — |
+| **ESPN** (site.api.espn.com) | none (public) | scoreboard, teams, news, athletes | Edge Function `espn-collect` |
+| **Wikipedia** (en.wikipedia.org + wikimedia.org REST) | UA header only | `/api/rest_v1/page/summary/:title`, `/w/api.php?action=opensearch` | GET only |
+| **Open-Meteo** (api.open-meteo.com + archive-api) | none | `/v1/forecast`, archive `/v1/era5` | GET only |
+| **Nominatim** (nominatim.openstreetmap.org) | UA header only | `/search?q=...` | GET only |
+
+Vault secrets whitelisted in `get_app_secret()`:
+`SEATDATA_API_KEY`, `TEVO_API_TOKEN`, `TEVO_SECRET`, `SEATGEEK_API_TOKEN`.
+
+## Layer 2 — Pull pipeline
+
+The async pattern everywhere: `*_queue()` fires `net.http_get(...)` and
+inserts a `*_pending` row; `*_process()` reads back from `net._http_response`
+and persists into a snapshot/canonical table; pending row marked resolved.
+
+| Family | Queue fn | Process fn | Pending table | Cron(s) |
+|---|---|---|---|---|
+| TEvo listings (windowed) | (Edge Function `collect-listings`) | (Edge Function) | — | `collect-listings-0-24h..60d+` (5 crons) |
+| TEvo orders | `evo_orders_queue` | `evo_orders_process` | `evo_orders_pending` | `evo_orders_queue_30min` + `_process_30min` |
+| TEvo orphan-event backfill | `evo_event_backfill_queue` | `evo_event_backfill_process` | `evo_event_backfill_pending` | `orphan_event_backfill_queue_15min` + `_process_15min` |
+| SG broker listings (windowed) | `sg_listings_queue_window` | `sg_listings_process` | `sg_listings_pending` | `sg_listings_0-24h..60d+` (5 crons) + `sg_listings_process_5min` |
+| SG sellerdirect | `sg_seller_orders_queue`, `sg_seller_listings_queue` | `sg_seller_process` | `sg_seller_pending` | `sg_seller_orders_queue_30min`, `sg_seller_listings_queue_30min`, `sg_seller_process_30min` |
+| SG orphan-event backfill | `sg_event_backfill_queue` | `sg_event_backfill_process` | `sg_event_backfill_pending` | (shared with EVO orphan crons) |
+| Wikipedia enrichment | `queue_performer_wiki_searches` -> `process_performer_wiki_searches` -> `process_performer_wiki_summaries` | (3-stage) | `performer_wiki_pending` | 3 crons at 5-min cadence + `wiki_pending_sweep_daily` |
+| Weather forecast | `weather_forecast_queue` | `weather_forecast_process` | `weather_forecast_pending` | `weather_forecast_queue_30min` + `_process_30min` |
+| Weather climatology | `weather_historical_backfill_outdoor` | `weather_historical_process` | (uses pull_log) | `weather_climatology_weekly` |
+| Venue geocoding | `venue_geocode_queue` | `venue_geocode_process` | `venue_geocode_pending` | `venue_geocode_queue_5min` + `_process_5min` |
+| ESPN | (Edge Function `espn-collect`) | — | — | `crawl-espn-team-assets-3min`, `espn-team-daily`, `master-cascade-2min` |
+| **SeatData** | **MISSING** | **MISSING** | — | — |
+
+## Layer 3 — Raw snapshots (immutable history)
+
+| Table | Rows | Size | Purpose |
+|---|---:|---:|---|
+| `listings_snapshots` | 8.67M | 2,157 MB | TEvo listings, every capture, every ticket_group |
+| `section_metrics` | 2.07M | 418 MB | TEvo section-level rollups per capture |
+| `zone_metrics` | 21.6K | 6.5 MB | TEvo zone-level rollups per capture |
+| `event_metrics` | 29.2K | 9.6 MB | TEvo event-level rollup per capture |
+| `seatgeek_listings_snapshots` | 11.8K | 9.3 MB | SG /v2/listings, every capture |
+| `seatgeek_event_metrics` | 515 | 248 kB | SG event-level cost percentiles + orders by status |
+| `seatgeek_sales_snapshots` | 1.8K | 1.0 MB | SG /v2/sales (legacy/orphan; we don't have access) |
+| `seatgeek_orders` | 400 | 1.1 MB | OUR SG sellerdirect orders |
+| `seatgeek_seller_listings` | 200 | 576 kB | OUR SG sellerdirect listings |
+| `seatgeek_historic_sales` | 400 | 496 kB | SG historic sales for similar events |
+| `seatdata_sales_snapshots` | 254 | 144 kB | SD historic sales (1 event only — pipeline broken) |
+| `seatdata_listings_snapshots` | 0 | 32 kB | SD listings (empty — pipeline broken) |
+| `seatdata_event_stats` | 0 | 32 kB | SD event-level stats (empty) |
+| `evo_orders` | 41 | 400 kB | OUR TEvo orders |
+| `evo_order_items` | 40 | 184 kB | Line items per order |
+| `espn_event_snapshots` | 663 | 392 kB | ESPN game state + score + odds per capture |
+| `espn_team_snapshots` | 365 | 264 kB | ESPN team record + form per capture |
+| `espn_injuries_snapshots` | 4.2K | 4.6 MB | Per-player injury state per capture |
+| `espn_news` | 594 | 512 kB | ESPN news articles |
+| `espn_athletes` | 857 | 472 kB | Player roster (AI-context only) |
+| `weather_observations` | 145K | 46 MB | Open-Meteo forecast + ERA5 historical |
+| `event_alerts` | 445 | 328 kB | Append-only alert log |
+| `snapshots` | 223 | 88 kB | (legacy event-level snapshots; mostly used by `event_velocity`) |
+
+## Layer 4 — Cross-source xref (id mapping)
+
+These are the connection tables that make multi-source views possible.
+
+| Xref | Rows | What | Status |
+|---|---:|---|---|
+| `event_xref` | 432 | TEvo <-> ESPN event ids | **100% clean** — 430/432 with both sides |
+| `sg_events_canonical` | 211 | SG event metadata + tevo_event_id when matched | matcher correct, only 3 xref'd (SG carries different catalog) |
+| `seatgeek_event_xref` | 3 | (Older xref table — sparse) | superseded by sg_events_canonical |
+| `seatdata_event_xref` | 1 | SD <-> TEvo + SD's own id schemes | only 1 row (pipeline broken) |
+| `seatgeek_performer_xref` | 91 | SG performer ids -> TEvo performer | active |
+| `seatgeek_venue_xref` | 22 | SG venue ids -> TEvo venue | active |
+| `seatdata_performer_xref` | 0 | SD performers -> TEvo | empty |
+| `seatdata_venue_xref` | 0 | SD venues -> TEvo | empty |
+| `seatdata_section_xref` | 0 | SD sections -> TEvo (mapping for `normalize_sd_listing`) | empty |
+| `seatdata_zone_xref` | 0 | SD zones -> TEvo | empty |
+| `matchup_xref` | 445 | TEvo team-name pair -> league-canonical | active |
+| `taxonomy_xref` | 12 | TEvo category -> SG category mapping | active |
+| `order_status_xref` | 13 | per-source status -> canonical (`fulfilled`/`pending`/etc.) | active |
+| `data_source_field_map` | 200 | source field name -> canonical column | drift-detection target |
+
+## Layer 5 — Canonical views
+
+Single sources of truth that paper over per-source quirks.
+
+```
+v_canonical_event       <-- entity_event_map + sg_events_canonical + taxonomy_xref
+v_canonical_performer   <-- entity_performer_map + performer_wikipedia
+v_canonical_venue       <-- entity_venue_map + sg_events_canonical + venue_assets
+v_canonical_coverage    <-- sources-per-entity rollup
+
+v_event_full            <-- v_canonical_event + raw snapshots (TEvo+SG+SD pricing)
+v_event_full_sports     <-- v_event_full + ESPN team state + injuries + news + home/away
+v_event_full_v2         <-- v_event_full + seatgeek_event_metrics + event_sentiment
+v_pricing_cross_source  <-- section-level TEvo+SG+SG-seller+SD pricing with sg_vs_tevo_pct
+
+v_event_home_away       <-- events + performer_home_venues + performer_metadata
+v_unmatched_events      <-- UNION of orphans across SG, SD, EVO
+```
+
+## Layer 6 — Per-source metrics views
+
+| View | Source | What |
+|---|---|---|
+| `latest_event_metrics` | TEvo | Latest event_metrics row per event (every column: getin, percentiles, owned_share, top5_concentration, dispersion) |
+| `broker_event_metrics` | TEvo | Same shape; alias |
+| `retail_event_metrics` | TEvo | Lighter cut: tickets/listings/price_from/price_to/getin |
+| `event_velocity` | TEvo | Latest vs immediately-previous capture (`snapshots` table) |
+| `seatgeek_event_latest` | SG | Latest sg_listings + sg_sales + xref per event |
+| `seatdata_event_latest` | SD | Latest SD stats + sales |
+| `latest_zone_metrics` | TEvo | Latest zone_metrics per (event, zone) |
+| `retail_event_zones`, `retail_event_sections` | TEvo | Public-facing slices |
+| `unified_listings` | All | UNION listings_snapshots + seatgeek + seatdata |
+| `unified_orders`, `unified_orders_by_event` | All | UNION evo_order_items + seatgeek_orders + seatdata_sales |
+
+## Layer 7 — Intelligence layer
+
+Built from the canonical layer + raw snapshots.
+
+| Object | Type | Source | Purpose |
+|---|---|---|---|
+| `v_event_velocity_windows` | view | event_metrics + seatgeek_event_metrics | 1h/6h/24h price + inventory deltas across TEvo+SG |
+| `v_arbitrage_opportunities` | view | v_pricing_cross_source | Section-level TEvo<->SG gap with depth filter |
+| `v_competing_events` | view | events + v_venue_neighbors | ±24h × 20mi neighbors live |
+| `event_competitors_snapshot` | table | refresh_event_competitors() | Pre-computed neighbors, hourly refresh |
+| `event_alerts` | table | compute_alerts_tick() | Append-only alert log |
+| `v_open_alerts` | view | event_alerts + events | Unacknowledged, severity-sorted |
+| `v_event_weather_with_fallback` | view | weather_observations + v_venue_climatology + venue_assets | Forecast within 16d, climatology fallback |
+| `v_canonical_coverage` | view | entity_event_map + entity_performer_map | Sources-present-per-entity scoreboard |
+| `v_unmatched_events` | view | events + sg_events_canonical + seatdata_event_xref + evo_order_items | Orphan bucket across all sources |
+
+Alert rules currently firing (compute_alerts_tick_15min):
+1. `tevo_getin_drop_1h` — get-in dropped >10% in last hour
+2. `tevo_getin_surge_1h` — get-in jumped >10%
+3. `tevo_inventory_low_48h` — <25 tickets within 48h of event
+4. `arbitrage_opportunity` — TEvo<->SG section gap >=15%
+5. `espn_status_change` — ESPN status_short flipped to postponed/delayed/canceled
+6. `competing_event_added` — new event landed within 20mi×24h of a tracked event
+
+## Layer 8 — Consumer interface
+
+Single-call entry points that hide the schema from callers.
+
+| Function | Returns | Use |
+|---|---|---|
+| `get_event_context(event_id)` | jsonb (event + pricing + ESPN + Wiki + weather + competitors + our_orders) | AI/RAG prompt-time enrichment, single-event dashboards |
+| `get_broker_event_detail(event_id)` | jsonb | Broker UI event detail |
+| `get_broker_events_upcoming(...)` | table | Broker UI list |
+| `get_event_listings_public(event_id)` | table | Public listings surface |
+| `get_event_movers(...)` | table | Movers / heatmap surface |
+| `get_event_zones_public/_rollup(event_id)` | table | Zone heatmap |
+| `get_team_context(team)`, `get_team_playoff_context(team)`, `get_team_roster(team)` | jsonb | Team-level AI/UI bundles |
+| `get_player_info(...)` | jsonb | Player-level AI/UI |
+| `get_wiki_context(performer_id)` | jsonb | Wikipedia summary (AI prompt) |
+| `get_chat_suggestion_chips(...)` | table | Chat-driven UI chips |
+
+## Order-side modeling (gross + net)
+
+```
+evo_orders + evo_order_items     \
+seatgeek_orders                   ─-> our_orders (UNION, source-tagged)
+                                       │
+                                       ├─-> our_orders_by_event
+                                       │
+                                       └─-> our_orders_with_net (joins order_fee_schedule)
+                                              │
+                                              └─-> our_orders_by_event_with_net
+                                                     (gross_fulfilled AND net_fulfilled)
+```
+
+`order_fee_schedule` (placeholder rates — verify against contracts):
+- `tevo`: 6% seller commission
+- `sg_seller`: 10% seller fee
+- `seatdata`: 0% (observation-only)
+
+## Active crons (47 total)
+
+Categorized:
+
+- **TEvo listings (windowed)**: `collect-listings-0-24h..60d+` (5)
+- **TEvo orders**: `evo_orders_queue_30min`, `evo_orders_process_30min`
+- **SG broker listings (windowed)**: `sg_listings_0-24h..60d+` (5) + `sg_listings_process_5min`
+- **SG sellerdirect**: `sg_seller_*_30min` (3)
+- **Orphan event backfill**: `orphan_event_backfill_queue/process_15min` + `orphan_backfill_sweep_daily`
+- **Cross-source matcher**: `cross_source_match_tick_30min`
+- **Competitor snapshot**: `event_competitors_refresh_hourly`
+- **Alerts**: `compute_alerts_tick_15min`
+- **ESPN**: `crawl-espn-team-assets-3min`, `espn-team-daily`, `master-cascade-2min`
+- **Wikipedia**: 3 enrichment + `wiki_pending_sweep_daily`
+- **Weather**: `weather_forecast_queue/process_30min`, `weather_climatology_weekly`
+- **Venue geocoding**: `venue_geocode_queue/process_5min`
+- **Chat**: `refresh-chat-corpus`, `refresh-chat-term-freq-split-hourly`, `run-daily-chat-audit`, `sweep-bot-messages`
+- **Maintenance**: `master-cascade-2min`, `midnight-catchup-sweep`, `sweep-old-listings`, `sweep_tevo_ticket_groups_cache`, `ensure-watchlist-coverage-daily`, `backfill-event-configurations-5min`, `zone-backfill-isolated-10min`
+
+## Function inventory by family
+
+(184 functions total in public schema)
+
+| Family | Count |
+|---|---:|
+| other (utility / trgm / cascade / sync) | 91 |
+| helpers (get_* consumer-facing) | 21 |
+| seatgeek (pull + match) | 15 |
+| matchers (cross-source) | 10 |
+| tevo | 9 |
+| weather | 7 |
+| wikipedia | 6 |
+| chat | 9 |
+| venue | 9 |
+| seatdata | 3 (gate + audit only — no pull) |
+| espn (upserters; pulls live in Edge Functions) | 3 |
+| alerts | 2 |
+| competitors | 1 |
+
+## RULE 2 enforcement
+
+3-layer:
+- **Runtime**: `evo_client.py`, `seatgeek_client.py` deny non-GET methods
+- **Static**: `scripts/check_readonly.py` scans .py + .ts + plpgsql migrations
+- **Tests**: `tests/test_readonly_guards.py` synthesizes a violation, asserts the audit catches it
+
+Last audit: 127 plpgsql migrations clean, no write paths to TEvo or SG hosts.
+
+## Foreign keys actually declared
+
+Most cross-source linkage is via **convention** (e.g. `tevo_event_id` columns
+in many tables), not declared FKs. Declared FKs:
+
+| From | To |
+|---|---|
+| `event_xref.tevo_event_id` -> `events.id` |
+| `evo_order_items.evo_order_id` -> `evo_orders.evo_order_id` |
+| `seatgeek_historic_sales.sg_order_row_id` -> `seatgeek_orders.id` |
+| `seatgeek_order_tickets.sg_order_id` -> `seatgeek_orders.sg_order_id` |
+| `sg_events_canonical.tevo_event_id` -> `events.id` |
+| `snapshots.event_id` -> `events.id` |
+| `watch_sources.event_id` -> `events.id` |
+| `zone_metrics.event_id` -> `events.id` |
+| `weather_observations.source_key` -> `data_sources.source_key` |
+| `data_source_field_map.source_key` -> `data_sources.source_key` |
+| `canonical_external_ids.source_key` -> `data_sources.source_key` |
+| `chat_corpus.user_msg_id` / `bot_msg_id` -> `bot_messages.id` |
+| `chat_audit_findings.bot_message_id` -> `bot_messages.id` |
+| `leads.event_id` -> `events.id` |
+| `performer_zone_rules.zone_id` -> `performer_zones.id` |
+
+**Convention-only joins** (most multi-source connections):
+- `*.tevo_event_id` -> `events.id` (in 25+ tables)
+- `*.tevo_performer_id` -> performer ids
+- `event_xref.espn_event_id` <-> `espn_event_snapshots.espn_event_id`
+- `seatdata_event_xref.tevo_event_id` <-> `events.id`
+- `sg_events_canonical.sg_event_id` <-> `seatgeek_*.sg_event_id`
+
+## Storage footprint
+
+Total ~2.65 GB:
+- `listings_snapshots`: 2,157 MB (81%)
+- `section_metrics`: 418 MB (16%)
+- `weather_observations`: 46 MB (2%)
+- All other tables combined: ~30 MB (1%)
+
+The TEvo listings firehose dominates. Sweep cron `sweep-old-listings` runs
+daily but retention policy needs review as we move past 90 days of history.
+
+## Known gaps (referenced in other docs)
+
+- **SeatData pull pipeline missing** — see `docs/seatdata-blocker-2026-05-09.md`
+- **SG `payment_total` NULL on every order** — see kanban card in `docs/phase2-ui-kanban.md`
+- **Phase 2 backlog** — full list in `docs/phase2-ui-kanban.md`

--- a/docs/knicks-next-home-event-snapshot-2026-05-09.md
+++ b/docs/knicks-next-home-event-snapshot-2026-05-09.md
@@ -1,0 +1,199 @@
+# Next Knicks home game — full data snapshot (2026-05-09)
+
+Companion to `database-map-2026-05-09.md` — runs the audit on a real event
+to demonstrate what data the system has on a high-coverage TEvo event.
+
+## The event
+
+| Field | Value |
+|---|---|
+| `tevo_event_id` | **3345925** |
+| Name | Philadelphia 76ers at New York Knicks (Game 5, NY Home Game 3) (If Necessary) |
+| Date | **2026-05-12** 00:00 ET (Mon → tip 7:00 PM ET, naming differs) |
+| Venue | Madison Square Garden |
+| Home performer | New York Knicks |
+| Event type | game |
+| State | shown |
+| Watch-tracked | yes |
+
+## Data we have on this event
+
+### TEvo (the firehose)
+
+```
+Listings snapshots:    122,197
+Distinct ticket groups: 2,930
+Capture times:           173 (since pulls began)
+Latest capture:        2026-05-09 20:05 UTC (5 min before audit)
+Tickets in latest snap:  900 (across 877 distinct groups, 79 sections)
+Get-in (latest):       $493.58
+Highest listing:       $28,000
+Median retail:         $977.96
+P75 retail:            $1,628.03
+P90 retail:            $2,924.51
+Owned share:           33.04% (we have 249 groups / 934 tix listed)
+Owned median retail:   $1,131.17
+Top-5 concentration:    0.22
+Tail premium:           2.99x
+Price dispersion:       2.25
+```
+
+Per-source aggregates:
+- 173 `event_metrics` rows
+- 11,106 `section_metrics` rows
+- 243 `zone_metrics` rows
+
+### Velocity (multi-window)
+
+```
+TEvo get-in 1h delta:   $0       (0%)   — flat
+TEvo get-in 6h delta:   $0       (0%)
+TEvo get-in 24h delta:  $0       (0%)
+TEvo tickets 1h delta:  -4
+TEvo tickets 24h delta: -98
+SG side:                NULL — no SG data on this event
+```
+
+Get-in price stable but inventory is bleeding — 98 tickets came off in
+24h, 4 in the last hour. That's the kind of slow-burn pattern an alert
+rule could catch ("inventory falling >5%/24h with stable price").
+
+### EVO orders
+
+**0 orders** on this event. We're not currently selling Knicks G5.
+
+### SeatGeek
+
+```
+sg_listings_snapshots:   0
+sg_orders:               0
+sg_seller_listings:      0
+sg_event_metrics:        0
+sg_canonical present:    no
+```
+
+SG carries this game on the consumer side but our broker pull doesn't
+have it. This is the "SG xref naturally sparse" pattern — not a matcher
+bug, just a coverage choice. Worth surfacing on a future product surface.
+
+### SeatData (the only event we have)
+
+```
+sd_event_id:           1247184 (xref'd to TEvo on 2026-05-09)
+SD sales rows:         254
+SD sales price range:  $378 – $3,756
+SD sales median:       $668.50
+```
+
+This is the **only event with SD coverage** in the entire database.
+The 254 sales were pulled manually before the SD pipeline broke.
+Useful as a comp benchmark: SD median sold price ($668.50) vs TEvo
+median listed price ($977.96) = market is paying ~32% below ask.
+
+### ESPN
+
+```
+espn_event_id:    401871162
+Snapshots:        1
+Latest state:     pre  (pre-game)
+Latest status:    "5/10 - 3:30 PM EDT"
+```
+
+ESPN is reporting a 3:30 PM EDT start on 5/10 — TEvo lists 5/12.
+This is the "If Necessary" Game 5 — TEvo is showing the latest possible
+date; ESPN has the actual scheduled date once it became necessary.
+The mismatch is informative, not broken.
+
+### Wikipedia (AI/RAG context)
+
+```
+Performer Wikipedia present: yes
+Extract (first 120 chars):
+  "The New York Knickerbockers, shortened and more commonly referred
+   to as the New York Knicks, are an American professiona..."
+```
+
+### Weather (indoor — no live forecast needed)
+
+```
+Venue:         Madison Square Garden  (40.7505, -73.9935)
+is_indoor:     true
+weather_kind:  indoor_no_weather
+```
+
+System correctly identifies MSG as indoor and skips the forecast.
+Geocoding present (lat/lon set), days_to_event = 3.
+
+### Competing events (±24h × 20mi)
+
+```
+Count: 1
+  - Detroit Tigers at New York Mets (Citi Field, 7.7 mi away, +19.2 hr offset)
+```
+
+One competing event tomorrow night across town. At 19.2 hours offset and
+7.7 miles, modest demand overlap — Mets fans and Knicks fans aren't
+typically the same crowd, but the alert is logged for completeness.
+
+### Alerts
+
+```
+Open alerts on this event: 1
+```
+
+(`competing_event_added` rule fired when the Mets game appeared in the
+neighbor list.)
+
+### Sentiment
+
+```
+sentiment_index: 54.15  (neutral-positive — 50 is baseline)
+```
+
+## What's missing
+
+- **SG data** — naturally sparse (this game isn't in SG broker catalog)
+- **EVO orders** — we haven't sold any tickets on this event yet
+- **Live ESPN game state** — game hasn't started; will populate once tip
+- **Inbound demand sentiment** — we have one row; chat-driven sentiment
+  needs more interactions to be meaningful
+
+## Coverage scorecard
+
+| Source | Status |
+|---|---|
+| TEvo listings | ✓ 122K snapshots, dense capture history |
+| TEvo metrics (event/section/zone) | ✓ |
+| TEvo orders / EVO | — (no sales yet) |
+| SeatGeek listings | ✗ (catalog gap, not a bug) |
+| SeatGeek orders | ✗ |
+| SeatData sales | ✓ 254 historic sales (only event with SD) |
+| ESPN xref | ✓ 401871162 |
+| ESPN game state | ✓ 1 snapshot, pre-game |
+| Wikipedia | ✓ Knicks article enriched |
+| Weather | ✓ correctly classified indoor |
+| Competitors | ✓ 1 competing event listed |
+| Alerts | ✓ 1 open |
+| Sentiment | ✓ 1 row |
+
+This is a **representative high-coverage event**. The gaps (SG, EVO orders)
+are coverage choices and timing, not infrastructure failures.
+
+## How to get the same view yourself
+
+```sql
+-- Single-call AI/RAG bundle:
+SELECT jsonb_pretty(get_event_context(3345925));
+
+-- Per-section pricing (TEvo + SG + SG-seller + SD):
+SELECT * FROM v_pricing_cross_source WHERE tevo_event_id = 3345925;
+
+-- Velocity:
+SELECT * FROM v_event_velocity_windows WHERE tevo_event_id = 3345925;
+
+-- Open alerts:
+SELECT * FROM v_open_alerts WHERE tevo_event_id = 3345925;
+
+-- Competitors:
+SELECT * FROM event_competitors_snapshot WHERE tevo_event_id = 3345925;
+```

--- a/docs/phase2-ui-kanban.md
+++ b/docs/phase2-ui-kanban.md
@@ -1,0 +1,197 @@
+# Phase 2 UI rebuild — backlog (2026-05-09)
+
+Phase 1 = data collection; UI on full reboot. This file collects items
+deferred from Phase 1 that should land alongside or after the UI rebuild.
+
+Each card is **stand-alone** — the spawned task / future Claude session
+shouldn't need this conversation's context to act on it.
+
+---
+
+## CARD: Data quality dashboard
+
+**Why:** silent failures (like the SD pull pipeline being completely
+missing, or SG `payment_total` being NULL on every order) are the
+class of bug that costs us money. We notice them on audit, never live.
+
+**Build:** Daily cron `data_quality_tick` writes a `data_quality_runs`
+row with these checks:
+- % of upcoming events with listings <30min old
+- % of upcoming sports events with ESPN xref
+- % of upcoming events with weather observation (within 16d window)
+- % of SG orders with non-NULL `payment_total`
+- % of TEvo orders with at least one `evo_order_items` row
+- Matcher orphan-rate trend (rows in v_unmatched_events vs yesterday)
+- Cron run-counts per family (was each family invoked > X times in 24h?)
+
+**Surface:** new view `v_data_quality_today` reading the latest run.
+UI lands a single banner "data plane health: 94%" with drill-down.
+
+**Effort:** 1 day to build cron + view + 6 checks. Add more checks
+incrementally.
+
+**Dependencies:** none (purely additive).
+
+---
+
+## CARD: Cost meter (pg_net + cron + API call counts)
+
+**Why:** as the data plane scales, we want to know which cron is eating
+egress / API-call budget. Cheap to add now, hard to retrofit later.
+
+**Build:** scheduled task `cost_meter_tick` (daily) aggregates:
+- `pg_net._http_response` row counts grouped by URL host (TEvo / SG /
+  Wikipedia / Open-Meteo / Nominatim / SD)
+- Total response bytes per host per day
+- pg_cron.job_run_details job durations per cron
+- Persist into `data_plane_cost_daily` table for trending
+
+**Surface:** view `v_data_plane_cost_30d` — rolling 30d cost per source.
+
+**Effort:** half-day. Mostly aggregation queries; the data is already
+in pg_net + pg_cron internal tables.
+
+**Dependencies:** none.
+
+---
+
+## CARD: Wikipedia rivalries — re-add for AI context only
+
+**Why:** rivalries (Yankees vs Red Sox, Knicks vs Celtics, Cubs vs
+Cardinals, etc.) shape demand for sports tickets. Currently dropped
+(mig 20260509370000) but the user said "add later for context."
+
+**Build:** new `performer_rivalries` table:
+```
+home_performer_id  bigint
+away_performer_id  bigint
+rivalry_name       text       -- e.g. "Subway Series"
+strength           numeric    -- 0..1, optional
+notes              text
+source             text       -- 'manual' | 'wikipedia'
+```
+Surface as enrichment field in `get_event_context()` — when a TEvo
+event's two performers have a rivalries-table row, include
+`rivalry: { name, strength }` in the AI context bundle.
+
+**Effort:** 2 hours for schema + manual seed (~30 well-known rivalries);
+optional Wikipedia auto-discovery cron later.
+
+**Dependencies:** Phase 2 UI for an admin "manage rivalries" surface.
+
+---
+
+## CARD: Alert delivery (Slack / email / push)
+
+**Why:** `event_alerts` is now firing rules but there's no consumer.
+A trader needs to *receive* alerts, not query for them.
+
+**Build:** `alert_subscriptions` table — rules user wants delivered,
+how (slack channel / email / push), and any per-rule overrides
+(severity threshold, mute window).
+
+`alert_delivery_tick` cron polls `event_alerts` for unsent + matching
+subscriptions, fires webhooks, marks `delivered_at`.
+
+**Effort:** 1 day. Slack first (single webhook URL); email/push later.
+
+**Dependencies:** UI for subscription management; secret for Slack
+webhook URL.
+
+---
+
+## CARD: SD pull pipeline (BLOCKED)
+
+**Why:** historical sales comps are real money signal. See
+`docs/seatdata-blocker-2026-05-09.md` for why this is blocked.
+
+**Build:** when API spec arrives, write `seatdata_event_pull_queue` +
+`seatdata_event_pull_process` following the EVO/SG pattern in mig
+20260509280000 / 290000. Wire to `cross_source_match_tick`.
+
+**Effort:** half-day once spec is provided.
+
+**Dependencies:** SD vendor API spec OR resurrected Edge Function source.
+
+---
+
+## CARD: SeatGeek `payment_total` data-quality fix
+
+**Why:** smoke test on `our_orders_with_net` showed all 400 sg_seller
+orders have NULL `payment_total`. Either the SG /orders endpoint isn't
+returning that field for our token, or the `sg_seller_process()`
+function's INSERT is reading the wrong JSON path.
+
+**Investigate:** Pull a raw SG order row from net._http_response,
+inspect the JSON, compare to the INSERT path in
+`sg_seller_process()` (mig 20260509290000). Fix path or set
+`payment_total` from a different field (`sale_price` × `sale_quantity`
+might be the right derivation if the API doesn't surface a total).
+
+**Effort:** 2 hours.
+
+**Dependencies:** none — can do anytime.
+
+---
+
+## CARD: Inventory churn view (groups appearing/disappearing per capture)
+
+**Why:** velocity views capture price + count Δ but not WHICH
+ticket_groups are new vs disappearing. A group disappearing is either
+sold or pulled — different signals. Knowing "8 new groups listed in
+last hour" is different from "8 groups disappeared."
+
+**Build:** view `v_event_inventory_churn` joining latest captures,
+exposing `groups_added`, `groups_removed`, `groups_repriced`,
+`net_change`. Likely needs a stable group identifier (tevo_ticket_group_id)
+across captures.
+
+**Effort:** half-day. The data is in `listings_snapshots`; just
+diff-on-key arithmetic.
+
+**Dependencies:** none.
+
+---
+
+## CARD: Time-decay curves per venue × performer
+
+**Why:** "what's the typical price 7 days out for this team at this
+venue" is the universal pricing baseline question. Currently no view
+answers it.
+
+**Build:** view `v_price_decay_baseline` — for each venue × performer
+combo with ≥3 historical events, compute median price by `days_to_event`
+buckets (0d, 1d, 3d, 7d, 14d, 30d+). Compare current event's track
+to baseline.
+
+**Effort:** 1 day. Real value once we have ≥6 months of history.
+
+**Dependencies:** sufficient history accumulation (~3 months minimum).
+
+---
+
+## CARD: Seatgeek_event_metrics retention/sweep
+
+**Why:** SG metrics table will grow unbounded. Need policy.
+
+**Build:** sweep cron deleting `seatgeek_event_metrics` rows older
+than X days for events past their date.
+
+**Effort:** 1 hour.
+
+**Dependencies:** none, but only urgent once table is >1M rows
+(currently 494).
+
+---
+
+## Priority order if we did one card per week
+
+1. SeatGeek `payment_total` fix — money signal correctness.
+2. Data quality dashboard — protects against silent failures.
+3. Alert delivery — turns alerts into product.
+4. Inventory churn view — high-value pricing signal.
+5. Time-decay baselines — needs history first.
+6. Cost meter — nice to have, no immediate pain.
+7. Rivalries — easy when prioritized; not urgent.
+8. SD pull — blocked on external input.
+9. SG metrics retention — pre-emptive only.

--- a/docs/seatdata-blocker-2026-05-09.md
+++ b/docs/seatdata-blocker-2026-05-09.md
@@ -1,0 +1,76 @@
+# SeatData pull pipeline — blocker (2026-05-09)
+
+## State
+
+The SD ingestion pipeline is **missing**, not "silent." On audit:
+
+```
+seatdata_event_xref          1 row (manually populated)
+seatdata_event_stats         0 rows
+seatdata_listings_snapshots  0 rows
+seatdata_sales_snapshots     254 rows (one event, manually populated)
+seatdata_pull_log            0 rows
+seatdata_pull_budget         0 rows  (never even initialized)
+```
+
+What exists in plpgsql:
+
+- `seatdata_check_budget(endpoint)` — gate function (works)
+- `seatdata_increment_budget(endpoint)` — counter (works)
+- `normalize_sd_listing(...)` — section/zone normalization helper
+- `sd_xref_resolve()` — orphan audit (added 2026-05-09)
+
+What does **not** exist:
+
+- Any `seatdata_*_queue()` function
+- Any `seatdata_*_process()` function
+- Any cron firing SD pulls
+- Documentation of the SD vendor's API endpoint, auth shape, or
+  rate-limit contract
+
+## What happened
+
+`SEATDATA_API_KEY` is whitelisted in `get_app_secret()` and the
+schema is fully provisioned, so SD was clearly **planned**. The 254
+sales rows on Knicks/76ers G5 (tevo 3345925) suggest at least one
+ad-hoc pull worked once. But nothing automated runs today and the
+pull function source-of-truth was never committed to plpgsql.
+
+Two possibilities:
+1. The SD pull was an Edge Function that lived on Railway and got
+   deprecated when we moved the data plane to Supabase.
+2. It was always a manual one-off and never automated.
+
+Either way, **rebuilding it correctly requires the SD vendor's
+current API spec** — endpoint URL, auth header shape, request/response
+JSON, rate-limit contract (since it's metered/paid).
+
+## Why this isn't fixable inline
+
+SD is a **paid** API (the `last_paid_pull_at` and `daily_cap` /
+`monthly_cap` columns in `seatdata_pull_budget` make that clear).
+Writing a pull function with guessed endpoints would either 404 or
+silently burn paid credits. Worth blocking on a real spec.
+
+## What unblocks it
+
+Provide one of:
+- The Edge Function source if SD pull existed on Railway (we can
+  port it to plpgsql/pg_net 1:1)
+- The SD vendor's API documentation (URL + auth pattern + rate limit)
+- An old commit hash where SD pull was working (we can resurrect)
+
+Once we have any of those, the pull function is a half-day's work —
+the schema is already there, the budget gate already works, and the
+unified `cross_source_match_tick` is already wired to call into SD
+once data lands.
+
+## What we lose without it
+
+SD provides historical sales comps the other sources can't. Without
+SD the price-arbitrage views (`v_arbitrage_opportunities`) work on
+TEvo↔SG only, and the `sd_sold_vs_tevo_listed_pct` column in
+`v_pricing_cross_source` will stay NULL for all but one event.
+
+For pricing decisions on events without recent comparable history,
+we have no fallback today.

--- a/docs/wikipedia-usage-2026-05-09.md
+++ b/docs/wikipedia-usage-2026-05-09.md
@@ -1,9 +1,21 @@
-# Wikipedia data — what we pull, what we use it for (2026-05-09)
+# Wikipedia data — what we keep, why, and how AI connectors should use it (2026-05-09)
 
-## What we pull (already wired)
+## TL;DR
 
-`performer_wikipedia` table — one row per TEvo performer, populated by the
-3-stage cron pipeline in mig 20260509170000:
+We keep Wikipedia summary text + image_url + canonical title per TEvo
+performer. We do NOT do SQL analytics on it (no spike multipliers, no
+trend views, no JOINs against pageviews). The consumer is **AI/RAG
+connectors** that want plain-English context about a performer at
+prompt time.
+
+If you're writing a SQL query and reaching for `performer_wiki_*`,
+stop — there's almost certainly a more direct signal in price/order
+deltas, ESPN, or SeatGeek volume.
+
+## What we pull (active)
+
+`performer_wikipedia` table — one row per TEvo performer, populated by
+the 3-stage cron pipeline in mig 20260509170000:
 
 | Column | What |
 |---|---|
@@ -15,78 +27,78 @@
 | `image_url` | Thumbnail image URL |
 | `match_method` | `search_top_summary` (good) / `rejected` (no good article) |
 
-Cron cadence:
-- `performer_wiki_queue_searches_5min` (every 5 min)
-- `performer_wiki_process_searches_5min` (every 5 min, +1m offset)
-- `performer_wiki_process_summaries_5min` (every 5 min, +2m offset)
+Cron cadence (still running):
+- `performer_wiki_queue_searches_5min`     (every 5 min)
+- `performer_wiki_process_searches_5min`   (every 5 min, +1m offset)
+- `performer_wiki_process_summaries_5min`  (every 5 min, +2m offset)
 
-## What we DO with it (active, as of mig 20260509330000)
+These keep `extract` and `image_url` fresh as new TEvo performers land.
 
-**1. Pageviews trend extraction — buzz signal beyond storage.**
+## What we DON'T do anymore (reverted in mig 20260509340000)
 
-New pipeline pulls daily Wikipedia pageviews for every enriched performer:
-- `performer_wiki_pageviews` table — (tevo_performer_id, date, views)
-- `wiki_pageviews_queue_daily` cron at 06:30 UTC
-- `wiki_pageviews_process_daily` cron at 06:35 UTC
-- `v_performer_pageview_trend` view exposes spike multipliers
+| Was | Reason for revert |
+|---|---|
+| `performer_wiki_pageviews` table | Unused — no day-trader query reaches for it |
+| `wiki_pageviews_queue/process` functions | Same |
+| `v_performer_pageview_trend` view (spike_multiplier) | Same — buzz lives in price/order deltas, not Wikipedia readership |
+| `wiki_pageviews_queue_daily` + `_process_daily` crons | No consumer = no point spending the API budget |
 
-The pageviews API is free, no auth, UA-required (same pattern as the
-existing summary fetch). Pulls a 30-day rolling window per performer per
-day. Wikipedia's `wikimedia.org/api/rest_v1/metrics/pageviews/per-article/`
-endpoint returns daily counts.
+The pageviews experiment was a YAGNI: building "rising buzz" detection
+into SQL when the actual signal we trade on is `event_metrics` deltas
+(listing prices moving, our orders accelerating). Wikipedia readership
+is a noisy proxy for that, downstream of news cycles, not leading them.
 
-**Day-trader query:**
+## What it IS used for (active)
 
-```sql
--- Performers with sudden buzz (recent 7d avg > 1.5× baseline 14-30d avg)
-SELECT performer_name, recent_daily_views, baseline_daily_views,
-       spike_multiplier, wiki_url
-FROM v_performer_pageview_trend
-WHERE spike_multiplier > 1.5
-ORDER BY spike_multiplier DESC LIMIT 20;
-```
-
-**2. Cross-source enrichment in `v_canonical_performer`** — already wired.
-The performer canonical view exposes wiki_extract + image_url alongside
-ESPN/SD/SG identifiers. Used for:
+**1. Cross-source enrichment in `v_canonical_performer`** — already wired.
+The performer canonical view exposes `wiki_extract` + `image_url`
+alongside ESPN/SD/SG identifiers. Used for:
 - Description on any performer-detail surface (when UI rebuilds)
 - Image URL fallback for non-sports performers (ESPN doesn't cover them)
-- Sentiment-search corpus seed (concert performers without ESPN coverage)
 
-## What we DON'T do (deferred — phase 2+)
+**2. AI-connector / RAG context** — intended primary consumer.
+When a future AI assistant gets asked "should I price the Knicks game
+higher" or "what's going on with Bad Bunny," the prompt-time
+enrichment can pull `extract` so the model has plain-English context
+without us having to teach it every team and artist explicitly. The
+extract is a self-contained paragraph — no JOIN, no analytics, just
+text → prompt.
 
-| Use case | Why deferred |
+Likely call shape from a future AI connector:
+
+```sql
+SELECT performer_name, extract, wiki_url, image_url
+FROM performer_wikipedia
+WHERE tevo_performer_id = $1 AND extract IS NOT NULL;
+```
+
+That's it. No aggregates, no windowing, no trend math.
+
+## What we still don't do (deferred)
+
+| Use case | Why |
 |---|---|
-| **Wikipedia infobox extraction** (genre, founded year, primary venue, roster) | Requires Wikidata API or HTML parsing; richer than summary endpoint |
-| **Edit frequency as buzz signal** | Pageviews give a stronger signal at lower complexity |
-| **Wikipedia categories / sister-projects** | Categories useful for cross-performer similarity but adds API calls |
-| **Multi-language pageview rollup** | Most of our market is en.wikipedia; en-only is fine for v1 |
-| **Tour-mate detection** ("touring with X") | Could parse from extract but error-prone |
-| **Player-level injury cross-check** | ESPN handles this directly; Wiki adds noise |
+| Wikipedia infobox extraction (genre, founded year, primary venue, roster) | Requires Wikidata API or HTML parsing; only a couple of UI surfaces would use it |
+| Edit frequency as buzz signal | Same noise problem as pageviews — too downstream |
+| Wikipedia categories / sister-projects | Useful for similarity but adds API calls; unclear consumer |
+| Multi-language pageview rollup | Most of our market is en.wikipedia |
+| Tour-mate detection ("touring with X") | Could parse from extract but error-prone |
+| Player-level injury cross-check | ESPN handles this directly; Wiki adds noise |
 
 ## RULE 2 compliance
 
-All Wikipedia + Wikimedia traffic is GET-only via pg_net. The endpoints don't
-accept POST anyway (they're public read APIs). The audit script
-(`scripts/check_readonly.py`) now scans plpgsql migrations too, catching any
-future drift toward write methods.
-
-## How spike_multiplier should be read
-
-| Multiplier | Interpretation |
-|---|---|
-| < 0.7 | Performer is cooling off — interest dropped 30%+ |
-| 0.7–1.3 | Stable — typical fluctuation |
-| 1.3–2.0 | Moderate buzz spike — news cycle, signing, etc. |
-| 2.0–5.0 | Strong buzz — likely a real event (trade/scandal/album drop) |
-| > 5.0 | Likely viral — verify the cause manually |
-
-For ticket-pricing, a spike >2.0 within 7 days of a performer's home game
-is a meaningful demand signal independent of price action — use it as a
-sanity check on `event_metrics` deltas.
+All Wikipedia + Wikimedia traffic is GET-only via pg_net. The endpoints
+don't accept POST anyway (public read APIs). The audit script
+(`scripts/check_readonly.py`) scans plpgsql migrations too, catching
+any future drift toward write methods.
 
 ## Storage retention
 
-`performer_wiki_pageviews` is keyed on `(tevo_performer_id, date)` with no
-retention policy. ~200 performers × 365 days = ~73K rows/year — trivial.
-No sweep needed.
+`performer_wikipedia` is keyed on `tevo_performer_id` (PK). One row per
+performer, refreshed in place when the search/summary cron re-runs.
+~200–500 rows total — trivial.
+
+The dropped `performer_wiki_pageviews` would have been ~73K rows/year
+at full coverage, also trivial. The reason for dropping isn't storage
+cost — it's that no SQL surface ever queried it, and signals we already
+trade on are stronger.

--- a/supabase/migrations/20260509280000_server_side_pulls_evo_orders_sg_listings_sales.sql
+++ b/supabase/migrations/20260509280000_server_side_pulls_evo_orders_sg_listings_sales.sql
@@ -1,4 +1,23 @@
 -- ============================================================================
+-- ⚠️ PARTIALLY SUPERSEDED BY 20260509290000 (consolidation pass).
+-- Net effect after both migrations apply on a fresh DB:
+--   ✓ tevo_sign_get(...)                        — KEPT
+--   ✓ evo_orders_pending + evo_orders_queue/process — KEPT (cadence later
+--                                                changed to 30min in 290000)
+--   ✓ sg_listings_pending + sg_listings_queue_window/process — KEPT
+--   ✗ sg_sales_queue_daily + sg_sales_process_daily crons — DROPPED in 290000
+--   ✗ sg_sales_queue + sg_sales_process functions — DROPPED in 290000
+--   ✗ sg_sales_pending table — DROPPED in 290000
+--   ✗ evo_orders_queue_10min + evo_orders_process_10min crons — REPLACED
+--                                                by _30min variants in 290000
+--   ✓ Schema relaxations on tevo_event_id / sale_at_utc — KEPT
+--
+-- Why the churn: the SG broker /sales endpoint requires a scope our token
+-- doesn't have (only sellerdirect /orders works for OUR sales). Caught
+-- during live verification post-migration; the dead parts were torn down
+-- in 290000 same-day rather than fully rewriting this file. Future
+-- migration consolidation pass can squash the redundancy.
+-- ============================================================================
 -- Migration 20260509280000 — Migrate Railway-bound crons to Supabase pg_net
 --                            + add SG listings windowed cron + SG /sales cron
 --

--- a/supabase/migrations/20260509340000_revert_wiki_pageviews_pipeline.sql
+++ b/supabase/migrations/20260509340000_revert_wiki_pageviews_pipeline.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- Migration 20260509340000 — Revert Wikipedia pageviews SQL pipeline
+--
+-- Per product directive: "for wikipedia keep the data but allow future ai
+-- connectors to use as additional context, dont think it's useful in a sql
+-- environment."
+--
+-- The pageviews trend math (spike_multiplier vs baseline) was overkill for
+-- a SQL surface — the actual day-trader workflow doesn't run "show me
+-- performers with rising buzz" SELECTs. The buzz signal lives in actual
+-- price/order deltas, which we already have. The summary text + image_url
+-- in performer_wikipedia is more useful as raw context for future AI
+-- connectors (RAG corpus, prompt-time enrichment) than as numbers to JOIN.
+--
+-- WHAT THIS MIGRATION DROPS (added 5h ago in 20260509330000):
+--   ✗ wiki_pageviews_queue_daily   cron
+--   ✗ wiki_pageviews_process_daily cron
+--   ✗ wiki_pageviews_queue(int)    function
+--   ✗ wiki_pageviews_process()     function
+--   ✗ v_performer_pageview_trend   view
+--   ✗ performer_wiki_pageviews         table
+--   ✗ performer_wiki_pageviews_pending table
+--
+-- WHAT THIS MIGRATION KEEPS:
+--   ✓ performer_wikipedia      — title, extract, image_url, wiki_url
+--   ✓ performer_wiki_searches  — search-side state for the enrichment cron
+--   ✓ Three enrichment crons   — performer_wiki_queue_searches_5min etc.
+--     (these still populate wiki_title / extract / image_url for new
+--     performers; useful as AI-connector context)
+--   ✓ v_unmatched_events       — orphan-events bucket from same migration
+--   ✓ event_match_attempts     — match-audit log from same migration
+-- ============================================================================
+
+-- (1) Unschedule pageview crons. Wrap in DO blocks so partial state on
+--     retries doesn't blow up.
+DO $$
+BEGIN
+  PERFORM cron.unschedule('wiki_pageviews_queue_daily');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('wiki_pageviews_process_daily');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- (2) Drop trend view first (depends on the table)
+DROP VIEW IF EXISTS v_performer_pageview_trend;
+
+-- (3) Drop functions
+DROP FUNCTION IF EXISTS wiki_pageviews_queue(int);
+DROP FUNCTION IF EXISTS wiki_pageviews_process();
+
+-- (4) Drop tables
+DROP TABLE IF EXISTS performer_wiki_pageviews;
+DROP TABLE IF EXISTS performer_wiki_pageviews_pending;
+
+-- (5) Marker comment on the kept summary table so future readers know the
+--     intended consumer is AI-connector context, not SQL analytics.
+COMMENT ON TABLE performer_wikipedia IS
+  'Wikipedia summary enrichment per TEvo performer (title, extract, image_url, '
+  'wiki_url). Intended consumer: AI/RAG connectors that want plain-English '
+  'context about a performer (e.g. "who is this team / artist"). NOT intended '
+  'as a SQL analytics surface — buzz/trend signals live in price/order deltas. '
+  'See docs/wikipedia-usage-2026-05-09.md.';

--- a/supabase/migrations/20260509350000_wiki_lean_xref_match_competitor_snapshot.sql
+++ b/supabase/migrations/20260509350000_wiki_lean_xref_match_competitor_snapshot.sql
@@ -1,0 +1,329 @@
+-- ============================================================================
+-- Migration 20260509350000 — Wiki lean storage + cross-source auto-match cron
+--                            + competitor analysis snapshot table
+--
+-- Three product directives:
+--
+-- (1) WIKI LEAN STORAGE — "dont store every pull only store latest, we dont
+--     need to store every edit made, just the final results."
+--     - Drop deprecated wiki_summary table (126 rows, schema from prior
+--       generation, never read by anything).
+--     - Drop the raw_summary_jsonb column from performer_wikipedia. We
+--       already extract title/extract/image_url/url to first-class columns
+--       and never query the raw blob.
+--     - Modify process_performer_wiki_summaries() to stop populating
+--       raw_summary_jsonb (the column is going away).
+--     - Add wiki_pending_sweep() function + daily cron — keeps
+--       performer_wiki_pending lean by deleting resolved rows >24h old.
+--       Currently 339/339 rows are resolved and accumulating.
+--
+-- (2) CROSS-SOURCE AUTO-MATCH CRON — "write crons to auto connect
+--     evo/sg/sd events ... so it doesnt get stale"
+--     - SG side already has auto_match_sg_canonical() running at
+--       sg_canonical_auto_match_30min — keep as-is (verified working).
+--     - Add evo_orphan_event_resolve() — finds evo_order_items.event_id
+--       not in events table, logs to event_match_attempts so the orphan
+--       is auditable. Real backfill (TEvo /v9/events lookup) happens via
+--       existing backfill-event-configurations-5min cron, but logging
+--       gives us a paper trail.
+--     - SD: no separate matcher needed — seatdata_event_xref is pure
+--       id-based (no name/date/venue columns). Matching happens at SD
+--       pull time via existing seatdata_pull infrastructure when it
+--       receives an sd_event_id paired with a tevo_event_id. No-op
+--       matcher function included as a placeholder for shape parity.
+--     - Add unified cross_source_match_tick() that runs SG canonical
+--       match + EVO orphan log + SD audit (which will mostly be empty
+--       until the SD pull pipeline is fixed).
+--     - Cron cross_source_match_tick_30min replaces the standalone
+--       SG cron (which is folded into the unified tick).
+--
+-- (3) COMPETITOR ANALYSIS SNAPSHOT — "to get competitor analysis as we
+--     get more events added so it doesnt get stale"
+--     - v_competing_events is already a view (always fresh) but every
+--       call hits the haversine math live. As event count grows, lookups
+--       get slower.
+--     - event_competitors_snapshot table — pre-computes the ±24h × 20mi
+--       neighbor list per upcoming event, so day-trader lookups are
+--       O(1) per event.
+--     - refresh_event_competitors() — full rebuild from the view.
+--     - Cron event_competitors_refresh_hourly — refresh every hour. As
+--       new events land, they appear in the snapshot within 60min.
+-- ============================================================================
+
+-- ============================================================================
+-- (1) WIKI LEAN STORAGE
+-- ============================================================================
+
+-- (1a) Drop deprecated wiki_summary table (replaced by performer_wikipedia
+--     long ago; not referenced by any view or function).
+DROP TABLE IF EXISTS wiki_summary;
+
+-- (1b) Drop raw_summary_jsonb column. We already pulled out everything we
+--      need into first-class columns. The blob just bloats storage.
+ALTER TABLE performer_wikipedia DROP COLUMN IF EXISTS raw_summary_jsonb;
+
+-- (1c) Replace summaries processor — drops the raw_summary_jsonb assignment.
+CREATE OR REPLACE FUNCTION process_performer_wiki_summaries()
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r RECORD;
+  v_body jsonb;
+  v_count int := 0;
+BEGIN
+  FOR r IN
+    SELECT pwp.tevo_performer_id, pwp.summary_request_id, h.content, h.status_code
+    FROM performer_wiki_pending pwp
+    JOIN net._http_response h ON h.id = pwp.summary_request_id
+    WHERE pwp.stage = 'summary' AND pwp.resolved_at IS NULL
+  LOOP
+    v_count := v_count + 1;
+    BEGIN
+      v_body := r.content::jsonb;
+    EXCEPTION WHEN OTHERS THEN
+      v_body := NULL;
+    END;
+
+    IF r.status_code = 200 AND v_body IS NOT NULL THEN
+      UPDATE performer_wikipedia SET
+        wiki_pageid       = COALESCE((v_body->>'pageid')::bigint, wiki_pageid),
+        wiki_title        = COALESCE(v_body->>'title', wiki_title),
+        wiki_url          = COALESCE(v_body->'content_urls'->'desktop'->>'page',
+                                     'https://en.wikipedia.org/wiki/' ||
+                                     replace(COALESCE(v_body->>'title', wiki_title), ' ', '_')),
+        description       = v_body->>'description',
+        extract           = v_body->>'extract',
+        image_url         = v_body->'thumbnail'->>'source',
+        match_method      = 'search_top_summary',
+        match_confidence  = 0.85,
+        last_refreshed_at = now(),
+        is_rejected       = false,
+        updated_at        = now()
+      WHERE tevo_performer_id = r.tevo_performer_id;
+    ELSIF r.status_code = 404 THEN
+      UPDATE performer_wikipedia SET
+        is_rejected = true,
+        reject_reason = 'summary 404 — title unresolvable',
+        match_method = 'rejected',
+        last_refreshed_at = now(),
+        updated_at = now()
+      WHERE tevo_performer_id = r.tevo_performer_id;
+    END IF;
+
+    UPDATE performer_wiki_pending SET resolved_at = now()
+      WHERE tevo_performer_id = r.tevo_performer_id AND stage = 'summary';
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+-- (1d) Sweep resolved wiki pending rows. Resolved rows older than 24h are
+--      pure history — no consumer reads them.
+CREATE OR REPLACE FUNCTION wiki_pending_sweep()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
+DECLARE v_deleted int;
+BEGIN
+  DELETE FROM performer_wiki_pending
+  WHERE resolved_at IS NOT NULL AND resolved_at < now() - interval '24 hours';
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+COMMENT ON FUNCTION wiki_pending_sweep IS
+  'Delete resolved performer_wiki_pending rows older than 24h. Consumer-less '
+  'history; the actual results live in performer_wikipedia.';
+
+-- ============================================================================
+-- (2) CROSS-SOURCE AUTO-MATCH
+-- ============================================================================
+
+-- (2a) Log EVO order_items whose event_id has no row in events. The
+--      backfill-event-configurations-5min cron handles the actual fetch;
+--      this gives us auditability (which orphan event_ids we've seen and
+--      when they first appeared in orders).
+CREATE OR REPLACE FUNCTION evo_orphan_event_resolve()
+RETURNS TABLE(orphans_seen int, attempts_logged int)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r RECORD;
+  v_seen int := 0;
+  v_logged int := 0;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT it.event_id, max(it.event_name) AS event_name,
+                    max(it.occurs_at)::date AS event_date,
+                    max(it.venue_name) AS venue_name
+    FROM evo_order_items it
+    WHERE it.event_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM events e WHERE e.id = it.event_id)
+    GROUP BY it.event_id
+  LOOP
+    v_seen := v_seen + 1;
+    -- Only log if we haven't logged this orphan in the past 24h
+    IF NOT EXISTS (
+      SELECT 1 FROM event_match_attempts
+      WHERE source_key = 'tevo_orphan_in_orders'
+        AND source_event_id = r.event_id::text
+        AND attempted_at > now() - interval '24 hours'
+    ) THEN
+      INSERT INTO event_match_attempts (
+        source_key, source_event_id, attempted_at,
+        match_method, reason_unmatched, notes
+      ) VALUES (
+        'tevo_orphan_in_orders', r.event_id::text, now(),
+        'awaiting_backfill', 'event not in events table',
+        jsonb_build_object(
+          'event_name', r.event_name,
+          'event_date', r.event_date,
+          'venue_name', r.venue_name)
+      );
+      v_logged := v_logged + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT v_seen, v_logged;
+END;
+$$;
+
+-- (2b) SeatData xref audit. seatdata_event_xref is pure id-based — no
+--      name/date/venue columns to match on, so the actual pairing must
+--      happen upstream (at SD pull time). This function just COUNTS
+--      orphans for visibility / alerting.
+CREATE OR REPLACE FUNCTION sd_xref_resolve()
+RETURNS TABLE(orphan_xref_rows int, sd_pulls_logged int)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_orphans int;
+  v_pulls   int;
+BEGIN
+  SELECT count(*) INTO v_orphans FROM seatdata_event_xref WHERE tevo_event_id IS NULL;
+  SELECT count(*) INTO v_pulls FROM seatdata_pull_log;
+  RETURN QUERY SELECT v_orphans, v_pulls;
+END;
+$$;
+
+COMMENT ON FUNCTION sd_xref_resolve IS
+  'SD audit only — xref table is id-based, no fields to match on. Returns '
+  'count of orphan xref rows + pull log size so the unified tick can '
+  'surface "SD pipeline silent" without a per-row matcher.';
+
+-- (2c) Unified cross-source match tick. Runs every 30 min.
+CREATE OR REPLACE FUNCTION cross_source_match_tick()
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_sg jsonb; v_evo record; v_sd record;
+BEGIN
+  v_sg  := sg_canonical_auto_match_tick();
+  SELECT * INTO v_evo FROM evo_orphan_event_resolve();
+  SELECT * INTO v_sd  FROM sd_xref_resolve();
+
+  RETURN jsonb_build_object(
+    'sg', v_sg,
+    'evo', jsonb_build_object(
+      'orphans_seen', v_evo.orphans_seen,
+      'attempts_logged', v_evo.attempts_logged
+    ),
+    'sd', jsonb_build_object(
+      'orphan_xref_rows', v_sd.orphan_xref_rows,
+      'sd_pulls_logged', v_sd.sd_pulls_logged
+    ),
+    'ran_at', now()
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION cross_source_match_tick IS
+  'Unified cross-source matcher. Runs SG canonical match + EVO orphan log + '
+  'SD xref resolve. Cron: cross_source_match_tick_30min.';
+
+-- ============================================================================
+-- (3) COMPETITOR ANALYSIS SNAPSHOT
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS event_competitors_snapshot (
+  tevo_event_id     bigint PRIMARY KEY,
+  competitors_count int,
+  competitors       jsonb,    -- array of {tevo_event_id, name, venue_name, distance_mi, hours_offset}
+  refreshed_at      timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS event_competitors_snapshot_refresh_idx
+  ON event_competitors_snapshot(refreshed_at DESC);
+
+COMMENT ON TABLE event_competitors_snapshot IS
+  'Pre-computed competing-events list per upcoming TEvo event (±24h × 20mi). '
+  'Refreshed hourly by event_competitors_refresh_hourly cron. Use this for '
+  'fast lookups; v_competing_events for fresh ad-hoc analysis.';
+
+CREATE OR REPLACE FUNCTION refresh_event_competitors()
+RETURNS int
+LANGUAGE plpgsql
+AS $$
+DECLARE v_rows int;
+BEGIN
+  -- Full rebuild — small enough table that incremental isn't worth the
+  -- complexity. ~300 upcoming events × small jsonb = trivial.
+  TRUNCATE event_competitors_snapshot;
+
+  INSERT INTO event_competitors_snapshot(tevo_event_id, competitors_count, competitors, refreshed_at)
+  SELECT
+    tevo_event_id,
+    count(*)::int,
+    jsonb_agg(
+      jsonb_build_object(
+        'tevo_event_id', competing_event_id,
+        'name', competing_event_name,
+        'venue_name', competing_venue_name,
+        'distance_mi', round(distance_miles::numeric, 1),
+        'hours_offset', round(hours_offset::numeric, 1)
+      ) ORDER BY distance_miles, abs(hours_offset)
+    ),
+    now()
+  FROM v_competing_events
+  GROUP BY tevo_event_id;
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RETURN v_rows;
+END;
+$$;
+
+COMMENT ON FUNCTION refresh_event_competitors IS
+  'Rebuild event_competitors_snapshot from v_competing_events. Hourly cron.';
+
+-- ============================================================================
+-- (4) WIRE THE CRONS
+-- ============================================================================
+
+-- Replace the old SG-only matcher with the unified one
+DO $$
+BEGIN
+  PERFORM cron.unschedule('sg_canonical_auto_match_30min');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+SELECT cron.schedule(
+  'cross_source_match_tick_30min',
+  '*/30 * * * *',
+  $$ SELECT cross_source_match_tick(); $$
+);
+
+-- Wiki pending sweep — daily at 03:30 UTC (off-peak)
+SELECT cron.schedule(
+  'wiki_pending_sweep_daily',
+  '30 3 * * *',
+  $$ SELECT wiki_pending_sweep(); $$
+);
+
+-- Competitor snapshot refresh — hourly at :40
+SELECT cron.schedule(
+  'event_competitors_refresh_hourly',
+  '40 * * * *',
+  $$ SELECT refresh_event_competitors(); $$
+);

--- a/supabase/migrations/20260509360000_orphan_event_auto_backfill.sql
+++ b/supabase/migrations/20260509360000_orphan_event_auto_backfill.sql
@@ -1,0 +1,382 @@
+-- ============================================================================
+-- Migration 20260509360000 — Auto-backfill events from TEvo / SG orders
+--
+-- Product directive: "have a chron run where in ticket evo or seatgeek order
+-- comes in that isnt in system have the cron start collecting data for our
+-- event cron policies."
+--
+-- TODAY'S BEHAVIOR:
+--   When a new TEvo or SG order arrives for an event we don't have in our
+--   `events` table (TEvo) or `sg_events_canonical` (SG), the order itself
+--   lands but no listing pulls fire — because all our listing crons iterate
+--   over `events` / `sg_events_canonical`. Result: orphan event sits in
+--   v_unmatched_events with no price-history collection.
+--
+-- NEW BEHAVIOR (this migration):
+--   1. Detect orphan event_ids on the orders side.
+--   2. Fire signed GET to TEvo /v9/events/:id (or SG /v2/events?id=:id) to
+--      fetch full event metadata.
+--   3. Persist into `events` / `sg_events_canonical`.
+--   4. The existing listing crons (collect-listings-0-24h through 60d+,
+--      sg_listings_*) automatically pick up the new event on their next
+--      tick — no further wiring needed.
+--
+-- RULE 2 compliance: all calls are GET. Audit script extended to plpgsql.
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Pending tables — track in-flight backfill requests
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS evo_event_backfill_pending (
+  tevo_event_id  bigint PRIMARY KEY,
+  request_id     bigint NOT NULL,
+  reason         text,                 -- 'order_orphan' | 'listing_orphan' | 'manual'
+  fired_at       timestamptz DEFAULT now(),
+  resolved_at    timestamptz,
+  status         text                  -- 'success' | 'http_404' | 'http_other' | 'json_err'
+);
+
+CREATE INDEX IF NOT EXISTS evo_event_backfill_pending_unresolved_idx
+  ON evo_event_backfill_pending(fired_at) WHERE resolved_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS sg_event_backfill_pending (
+  sg_event_id    bigint PRIMARY KEY,
+  request_id     bigint NOT NULL,
+  reason         text,                 -- 'order_orphan' | 'listing_orphan' | 'seller_orphan'
+  fired_at       timestamptz DEFAULT now(),
+  resolved_at    timestamptz,
+  status         text
+);
+
+CREATE INDEX IF NOT EXISTS sg_event_backfill_pending_unresolved_idx
+  ON sg_event_backfill_pending(fired_at) WHERE resolved_at IS NULL;
+
+COMMENT ON TABLE evo_event_backfill_pending IS
+  'In-flight TEvo /v9/events/:id requests. Populated when an order references '
+  'an event_id not in the events table. Resolved by evo_event_backfill_process.';
+
+COMMENT ON TABLE sg_event_backfill_pending IS
+  'In-flight SG /v2/events?id=:id requests. Populated when an SG order or '
+  'listing references an sg_event_id not in sg_events_canonical.';
+
+-- ============================================================================
+-- (2) TEvo orphan event backfill — queue
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION evo_event_backfill_queue(p_limit int DEFAULT 20)
+RETURNS int
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_token  text := get_app_secret('TEVO_API_TOKEN');
+  v_secret text := get_app_secret('TEVO_SECRET');
+  v_query  text;
+  v_sig    text;
+  v_req_id bigint;
+  v_count  int := 0;
+  r        RECORD;
+BEGIN
+  -- Find unique TEvo event_ids referenced by orders/order_items but
+  -- NOT in events table AND NOT in flight.
+  FOR r IN
+    WITH orphans AS (
+      SELECT DISTINCT it.event_id AS tevo_event_id, 'order_orphan' AS reason
+      FROM evo_order_items it
+      WHERE it.event_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM events e WHERE e.id = it.event_id)
+    )
+    SELECT o.tevo_event_id, o.reason
+    FROM orphans o
+    LEFT JOIN evo_event_backfill_pending p ON p.tevo_event_id = o.tevo_event_id
+        AND p.fired_at > now() - interval '6 hours'
+    WHERE p.tevo_event_id IS NULL
+    LIMIT p_limit
+  LOOP
+    -- TEvo /v9/events/:id — empty query string for path-only endpoint
+    v_query := '';
+    v_sig := tevo_sign_get('/v9/events/' || r.tevo_event_id, v_query, v_secret);
+    SELECT net.http_get(
+      url := 'https://api.ticketevolution.com/v9/events/' || r.tevo_event_id,
+      headers := jsonb_build_object(
+        'X-Token', v_token,
+        'X-Signature', v_sig,
+        'Accept', 'application/vnd.ticketevolution.api+json; version=9'
+      ),
+      timeout_milliseconds := 20000
+    ) INTO v_req_id;
+
+    INSERT INTO evo_event_backfill_pending(tevo_event_id, request_id, reason, fired_at)
+    VALUES (r.tevo_event_id, v_req_id, r.reason, now())
+    ON CONFLICT (tevo_event_id) DO UPDATE SET
+      request_id = EXCLUDED.request_id, fired_at = now(),
+      resolved_at = NULL, status = NULL, reason = EXCLUDED.reason;
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.3);
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+-- ============================================================================
+-- (3) TEvo orphan event backfill — process
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION evo_event_backfill_process()
+RETURNS TABLE(processed int, persisted int)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r RECORD;
+  v_body jsonb;
+  v_processed int := 0;
+  v_persisted int := 0;
+  v_status text;
+BEGIN
+  FOR r IN
+    SELECT p.tevo_event_id, p.request_id, h.content, h.status_code
+    FROM evo_event_backfill_pending p
+    JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1;
+
+    IF r.status_code = 200 THEN
+      BEGIN
+        v_body := r.content::jsonb;
+        v_status := 'success';
+      EXCEPTION WHEN OTHERS THEN
+        v_body := NULL;
+        v_status := 'json_err';
+      END;
+
+      IF v_body IS NOT NULL THEN
+        -- TEvo /v9/events/:id returns the event object directly (not nested).
+        INSERT INTO events (
+          id, name, occurs_at_local, state,
+          venue_id, venue_name, venue_location,
+          primary_performer_id, primary_performer_name, performer_ids,
+          configuration_id, configuration_name,
+          seating_chart_medium, seating_chart_large,
+          popularity_score, long_term_popularity_score,
+          event_type, last_seen
+        )
+        SELECT
+          (v_body->>'id')::bigint,
+          v_body->>'name',
+          v_body->>'occurs_at_local',
+          v_body->>'state',
+          NULLIF(v_body->'venue'->>'id','')::bigint,
+          v_body->'venue'->>'name',
+          v_body->'venue'->>'location',
+          NULLIF(v_body->'performances'->0->'performer'->>'id','')::bigint,
+          v_body->'performances'->0->'performer'->>'name',
+          ARRAY(SELECT (perf->'performer'->>'id')::bigint
+                  FROM jsonb_array_elements(COALESCE(v_body->'performances','[]'::jsonb)) AS perf
+                 WHERE perf->'performer'->>'id' IS NOT NULL),
+          NULLIF(v_body->'configuration'->>'id','')::int,
+          v_body->'configuration'->>'name',
+          v_body->'configuration'->>'seating_chart_medium',
+          v_body->'configuration'->>'seating_chart_large',
+          NULLIF(v_body->>'popularity_score','')::numeric,
+          NULLIF(v_body->>'long_term_popularity_score','')::numeric,
+          v_body->>'category_id_text',
+          now()
+        ON CONFLICT (id) DO UPDATE SET
+          name = COALESCE(EXCLUDED.name, events.name),
+          occurs_at_local = COALESCE(EXCLUDED.occurs_at_local, events.occurs_at_local),
+          state = COALESCE(EXCLUDED.state, events.state),
+          venue_id = COALESCE(EXCLUDED.venue_id, events.venue_id),
+          venue_name = COALESCE(EXCLUDED.venue_name, events.venue_name),
+          venue_location = COALESCE(EXCLUDED.venue_location, events.venue_location),
+          primary_performer_id = COALESCE(EXCLUDED.primary_performer_id, events.primary_performer_id),
+          primary_performer_name = COALESCE(EXCLUDED.primary_performer_name, events.primary_performer_name),
+          last_seen = now();
+        v_persisted := v_persisted + 1;
+      END IF;
+    ELSIF r.status_code = 404 THEN
+      v_status := 'http_404';
+    ELSE
+      v_status := 'http_other';
+    END IF;
+
+    UPDATE evo_event_backfill_pending
+       SET resolved_at = now(), status = v_status
+     WHERE tevo_event_id = r.tevo_event_id;
+  END LOOP;
+  RETURN QUERY SELECT v_processed, v_persisted;
+END;
+$$;
+
+-- ============================================================================
+-- (4) SG orphan event backfill — queue
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION sg_event_backfill_queue(p_limit int DEFAULT 20)
+RETURNS int
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_token text := get_app_secret('SEATGEEK_API_TOKEN');
+  r RECORD;
+  v_req_id bigint;
+  v_count  int := 0;
+BEGIN
+  FOR r IN
+    WITH orphans AS (
+      -- SG order references with no canonical row
+      SELECT DISTINCT sg_event_id, 'order_orphan' AS reason
+      FROM seatgeek_orders
+      WHERE sg_event_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM sg_events_canonical c WHERE c.sg_event_id = seatgeek_orders.sg_event_id)
+      UNION
+      SELECT DISTINCT sg_event_id, 'seller_orphan'
+      FROM seatgeek_seller_listings
+      WHERE sg_event_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM sg_events_canonical c WHERE c.sg_event_id = seatgeek_seller_listings.sg_event_id)
+      UNION
+      SELECT DISTINCT sg_event_id, 'listing_orphan'
+      FROM seatgeek_listings_snapshots
+      WHERE sg_event_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM sg_events_canonical c WHERE c.sg_event_id = seatgeek_listings_snapshots.sg_event_id)
+    )
+    SELECT o.sg_event_id, o.reason
+    FROM orphans o
+    LEFT JOIN sg_event_backfill_pending p ON p.sg_event_id = o.sg_event_id
+        AND p.fired_at > now() - interval '6 hours'
+    WHERE p.sg_event_id IS NULL
+    LIMIT p_limit
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/v2/events?id=' || r.sg_event_id || '&token=' || v_token,
+      timeout_milliseconds := 20000
+    ) INTO v_req_id;
+
+    INSERT INTO sg_event_backfill_pending(sg_event_id, request_id, reason, fired_at)
+    VALUES (r.sg_event_id, v_req_id, r.reason, now())
+    ON CONFLICT (sg_event_id) DO UPDATE SET
+      request_id = EXCLUDED.request_id, fired_at = now(),
+      resolved_at = NULL, status = NULL, reason = EXCLUDED.reason;
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.4);
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+-- ============================================================================
+-- (5) SG orphan event backfill — process
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION sg_event_backfill_process()
+RETURNS TABLE(processed int, persisted int)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r RECORD;
+  v_body jsonb;
+  v_evt jsonb;
+  v_processed int := 0;
+  v_persisted int := 0;
+  v_status text;
+BEGIN
+  FOR r IN
+    SELECT p.sg_event_id, p.request_id, h.content, h.status_code
+    FROM sg_event_backfill_pending p
+    JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1;
+
+    IF r.status_code = 200 THEN
+      BEGIN
+        v_body := r.content::jsonb;
+        v_status := 'success';
+      EXCEPTION WHEN OTHERS THEN
+        v_body := NULL;
+        v_status := 'json_err';
+      END;
+
+      IF v_body IS NOT NULL THEN
+        -- brokerdata /v2/events returns { events: [...] } or single object
+        v_evt := COALESCE(v_body->'events'->0, v_body);
+        IF v_evt ? 'id' THEN
+          INSERT INTO sg_events_canonical (
+            sg_event_id, sg_event_name, sg_event_date, sg_venue_name, sg_category,
+            has_seller_listings, has_orders, has_v2_listings_pulled,
+            updated_at
+          )
+          SELECT
+            (v_evt->>'id')::bigint,
+            COALESCE(NULLIF(v_evt->>'title',''), 'sg_' || (v_evt->>'id')),
+            NULLIF(left(v_evt->>'datetime_local',10), '')::date,
+            v_evt->'venue'->>'name',
+            v_evt->'taxonomies'->0->>'name',
+            false, false, false,
+            now()
+          ON CONFLICT (sg_event_id) DO UPDATE SET
+            sg_event_name = COALESCE(EXCLUDED.sg_event_name, sg_events_canonical.sg_event_name),
+            sg_event_date = COALESCE(EXCLUDED.sg_event_date, sg_events_canonical.sg_event_date),
+            sg_venue_name = COALESCE(EXCLUDED.sg_venue_name, sg_events_canonical.sg_venue_name),
+            sg_category   = COALESCE(EXCLUDED.sg_category, sg_events_canonical.sg_category),
+            updated_at    = now();
+          v_persisted := v_persisted + 1;
+        END IF;
+      END IF;
+    ELSIF r.status_code = 404 THEN
+      v_status := 'http_404';
+    ELSE
+      v_status := 'http_other';
+    END IF;
+
+    UPDATE sg_event_backfill_pending
+       SET resolved_at = now(), status = v_status
+     WHERE sg_event_id = r.sg_event_id;
+  END LOOP;
+  RETURN QUERY SELECT v_processed, v_persisted;
+END;
+$$;
+
+-- ============================================================================
+-- (6) Sweep — keep backfill_pending lean (resolved >7d gone)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION orphan_backfill_sweep()
+RETURNS TABLE(evo_deleted int, sg_deleted int)
+LANGUAGE plpgsql
+AS $$
+DECLARE v_e int; v_s int;
+BEGIN
+  DELETE FROM evo_event_backfill_pending
+  WHERE resolved_at IS NOT NULL AND resolved_at < now() - interval '7 days';
+  GET DIAGNOSTICS v_e = ROW_COUNT;
+  DELETE FROM sg_event_backfill_pending
+  WHERE resolved_at IS NOT NULL AND resolved_at < now() - interval '7 days';
+  GET DIAGNOSTICS v_s = ROW_COUNT;
+  RETURN QUERY SELECT v_e, v_s;
+END;
+$$;
+
+-- ============================================================================
+-- (7) Wire crons
+-- ============================================================================
+
+-- Backfill queue + process — every 15 min, offset by 2m to let queue settle.
+SELECT cron.schedule(
+  'orphan_event_backfill_queue_15min',
+  '*/15 * * * *',
+  $$ SELECT evo_event_backfill_queue(20), sg_event_backfill_queue(20); $$
+);
+
+SELECT cron.schedule(
+  'orphan_event_backfill_process_15min',
+  '2-59/15 * * * *',
+  $$ SELECT * FROM evo_event_backfill_process(); SELECT * FROM sg_event_backfill_process(); $$
+);
+
+-- Daily sweep at 03:35 UTC (just after wiki sweep)
+SELECT cron.schedule(
+  'orphan_backfill_sweep_daily',
+  '35 3 * * *',
+  $$ SELECT orphan_backfill_sweep(); $$
+);

--- a/supabase/migrations/20260509370000_data_fixes_phase1.sql
+++ b/supabase/migrations/20260509370000_data_fixes_phase1.sql
@@ -1,0 +1,231 @@
+-- ============================================================================
+-- Migration 20260509370000 — Data fixes + AI context + net-amount modeling
+--
+-- Acts on directives from the suggestions review:
+--   "first we fix the data, do 1-2, drop rivalries for now,
+--    add later for context, do 4 ... 8 keep gross and net"
+--
+-- This migration covers:
+--   (A) DROP wiki_rivalries (no consumer; can re-add later for AI context)
+--   (B) WIRE seatgeek_event_metrics into v_event_full (event-level rollup
+--       was being computed but never JOINed from the canonical view)
+--   (C) WIRE event_sentiment into v_event_full (18 rows, never queried)
+--   (D) GET_EVENT_CONTEXT(event_id) — single JSON for AI/RAG consumers
+--       bundling TEvo + SG + ESPN + Wikipedia + weather + competitors
+--   (E) ORDER_FEE_SCHEDULE + net_amount on our_orders — keep gross AND
+--       net so trader can read either side without doing math live
+--
+-- SD note: SeatData pull pipeline is genuinely missing (not just silent)
+-- — no pull function exists in plpgsql. Documented as blocker in
+-- docs/seatdata-blocker-2026-05-09.md. Not fixing here without API spec.
+-- ============================================================================
+
+-- ============================================================================
+-- (A) Drop wiki_rivalries
+-- ============================================================================
+DROP TABLE IF EXISTS wiki_rivalries;
+
+-- ============================================================================
+-- (B+C) Extend v_event_full to surface SG event metrics + sentiment
+--
+-- Strategy: don't rewrite v_event_full (it's complex and used elsewhere).
+-- Build a thin v_event_full_v2 that LEFT JOINs the orphan tables. Existing
+-- v_event_full callers keep working; new callers can opt into v_event_full_v2.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_event_full_v2 AS
+SELECT
+  ef.*,
+  -- SG event-level metrics (latest snapshot per event)
+  sgm.captured_at         AS sg_metrics_captured_at,
+  sgm.listings_count      AS sg_metrics_listings,
+  sgm.tickets_count       AS sg_metrics_tickets,
+  sgm.cost_min            AS sg_metrics_cost_min,
+  sgm.cost_median         AS sg_metrics_cost_median,
+  sgm.cost_p90            AS sg_metrics_cost_p90,
+  sgm.orders_open         AS sg_metrics_orders_open,
+  sgm.orders_fulfilled    AS sg_metrics_orders_fulfilled,
+  sgm.sold_quantity       AS sg_metrics_sold_qty,
+  sgm.sold_gross          AS sg_metrics_sold_gross,
+  sgm.fill_rate           AS sg_metrics_fill_rate,
+  -- event sentiment (latest)
+  es.captured_at          AS sentiment_captured_at,
+  es.sentiment_index,
+  es.tix_per_hour,
+  es.getin_per_hour,
+  es.owned_share_change,
+  es.pairs_change_per_hour
+FROM v_event_full ef
+LEFT JOIN LATERAL (
+  SELECT * FROM seatgeek_event_metrics WHERE tevo_event_id = ef.tevo_event_id
+  ORDER BY captured_at DESC LIMIT 1
+) sgm ON true
+LEFT JOIN LATERAL (
+  SELECT * FROM event_sentiment WHERE event_id = ef.tevo_event_id
+  ORDER BY captured_at DESC LIMIT 1
+) es ON true;
+
+COMMENT ON VIEW v_event_full_v2 IS
+  'v_event_full extended with SG event-level metrics + latest sentiment row. '
+  'Use this when you want every aggregate signal we have on an event.';
+
+-- ============================================================================
+-- (D) get_event_context(p_event_id) — AI/RAG consumer interface
+--
+-- Single function that bundles everything we know about an event into one
+-- JSON. Future AI connectors call this at prompt time to enrich context
+-- without having to know our schema. Designed for RAG over a single event.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_event_context(p_event_id bigint)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  v_event       jsonb;
+  v_pricing     jsonb;
+  v_espn        jsonb;
+  v_performer   jsonb;
+  v_weather     jsonb;
+  v_competitors jsonb;
+  v_orders      jsonb;
+BEGIN
+  -- Event basics
+  SELECT to_jsonb(e) - 'performer_ids'
+    INTO v_event FROM events e WHERE id = p_event_id;
+  IF v_event IS NULL THEN
+    RETURN jsonb_build_object('error', 'event_not_found', 'tevo_event_id', p_event_id);
+  END IF;
+
+  -- Pricing rollup from v_event_full_v2 (which now includes SG + sentiment)
+  SELECT to_jsonb(ef) INTO v_pricing
+    FROM v_event_full_v2 ef WHERE ef.tevo_event_id = p_event_id;
+
+  -- ESPN context (if sports + xref'd)
+  SELECT jsonb_build_object(
+    'espn_event_id', x.espn_event_id,
+    'latest_state',  (SELECT state FROM espn_event_snapshots ee
+                       WHERE ee.espn_event_id = x.espn_event_id
+                       ORDER BY captured_at DESC LIMIT 1),
+    'latest_status', (SELECT status_short FROM espn_event_snapshots ee
+                       WHERE ee.espn_event_id = x.espn_event_id
+                       ORDER BY captured_at DESC LIMIT 1),
+    'latest_score',  (SELECT home_score::text || '-' || away_score::text
+                       FROM espn_event_snapshots ee
+                       WHERE ee.espn_event_id = x.espn_event_id
+                       ORDER BY captured_at DESC LIMIT 1)
+  ) INTO v_espn
+  FROM event_xref x WHERE x.tevo_event_id = p_event_id LIMIT 1;
+
+  -- Wikipedia context for primary performer
+  SELECT jsonb_build_object(
+    'tevo_performer_id', pw.tevo_performer_id,
+    'wiki_title', pw.wiki_title,
+    'wiki_url', pw.wiki_url,
+    'description', pw.description,
+    'extract', pw.extract,
+    'image_url', pw.image_url
+  ) INTO v_performer
+  FROM performer_wikipedia pw
+  JOIN events e ON e.primary_performer_id = pw.tevo_performer_id
+  WHERE e.id = p_event_id AND NOT pw.is_rejected
+  LIMIT 1;
+
+  -- Weather (if event ≤16d out and venue geocoded)
+  SELECT to_jsonb(w) INTO v_weather
+  FROM v_event_weather_with_fallback w WHERE w.tevo_event_id = p_event_id;
+
+  -- Competing events (from snapshot)
+  SELECT competitors INTO v_competitors
+  FROM event_competitors_snapshot WHERE tevo_event_id = p_event_id;
+
+  -- Our orders for this event
+  SELECT to_jsonb(o) INTO v_orders
+  FROM our_orders_by_event o WHERE o.tevo_event_id = p_event_id;
+
+  RETURN jsonb_build_object(
+    'tevo_event_id', p_event_id,
+    'event', v_event,
+    'pricing', COALESCE(v_pricing, '{}'::jsonb),
+    'espn', COALESCE(v_espn, jsonb_build_object('present', false)),
+    'performer', COALESCE(v_performer, jsonb_build_object('present', false)),
+    'weather', COALESCE(v_weather, jsonb_build_object('present', false)),
+    'competitors', COALESCE(v_competitors, '[]'::jsonb),
+    'our_orders', COALESCE(v_orders, jsonb_build_object('present', false)),
+    'generated_at', now()
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION get_event_context IS
+  'Single-call event-context bundle for AI/RAG consumers. Returns one JSON '
+  'with TEvo basics + pricing rollup + ESPN status + Wikipedia text + '
+  'weather + competing events + our orders. Designed for prompt-time '
+  'enrichment; no schema knowledge required by the caller.';
+
+-- ============================================================================
+-- (E) Net-amount modeling: keep gross AND net side-by-side
+--
+-- order_fee_schedule — per-source fee structure. Default rates are best-guess
+-- placeholders; update per actual contract terms.
+-- our_orders_with_net — wraps our_orders adding net_amount = gross * (1 - fee)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS order_fee_schedule (
+  source             text PRIMARY KEY,
+  buyer_fee_pct      numeric(5,4) DEFAULT 0,    -- buyer-side markup
+  seller_fee_pct     numeric(5,4) DEFAULT 0,    -- seller-side commission
+  fixed_fee_per_order numeric(8,2) DEFAULT 0,
+  notes              text,
+  effective_from     date DEFAULT current_date
+);
+
+COMMENT ON TABLE order_fee_schedule IS
+  'Fee structure per sales channel. Used to compute net_amount alongside '
+  'gross_amount in our_orders_with_net. Update entries to reflect actual '
+  'contract terms — defaults are placeholders.';
+
+INSERT INTO order_fee_schedule(source, buyer_fee_pct, seller_fee_pct, fixed_fee_per_order, notes)
+VALUES
+  ('tevo',      0.00, 0.06, 0,    'TEvo: ~6% seller commission (placeholder; verify)'),
+  ('sg_seller', 0.00, 0.10, 0,    'SeatGeek sellerdirect: ~10% seller fee (placeholder; verify)'),
+  ('seatdata',  0.00, 0.00, 0,    'SD is observation-only, not our sale')
+ON CONFLICT (source) DO NOTHING;
+
+CREATE OR REPLACE VIEW our_orders_with_net AS
+SELECT
+  o.*,
+  ofs.seller_fee_pct,
+  ofs.fixed_fee_per_order,
+  ROUND(
+    (o.gross_amount * (1 - COALESCE(ofs.seller_fee_pct, 0)) - COALESCE(ofs.fixed_fee_per_order, 0))::numeric,
+    2
+  ) AS net_amount
+FROM our_orders o
+LEFT JOIN order_fee_schedule ofs ON ofs.source = o.source;
+
+COMMENT ON VIEW our_orders_with_net IS
+  'our_orders + computed net_amount per order_fee_schedule. Keeps gross and '
+  'net side-by-side so traders can read either without re-deriving.';
+
+CREATE OR REPLACE VIEW our_orders_by_event_with_net AS
+SELECT
+  tevo_event_id,
+  count(*)                                   AS our_orders_total,
+  count(*) FILTER (WHERE source='tevo')       AS tevo_orders,
+  count(*) FILTER (WHERE source='sg_seller')  AS sg_seller_orders,
+  sum(gross_amount) FILTER (WHERE canonical_status='fulfilled') AS gross_fulfilled,
+  sum(net_amount)   FILTER (WHERE canonical_status='fulfilled') AS net_fulfilled,
+  count(*) FILTER (WHERE canonical_status='fulfilled') AS count_fulfilled,
+  count(*) FILTER (WHERE canonical_status='pending')   AS count_pending,
+  count(*) FILTER (WHERE canonical_status='accepted')  AS count_accepted,
+  count(*) FILTER (WHERE canonical_status='cancelled') AS count_cancelled,
+  count(*) FILTER (WHERE canonical_status='rejected')  AS count_rejected,
+  max(source_updated_at) AS latest_activity
+FROM our_orders_with_net
+GROUP BY tevo_event_id;
+
+COMMENT ON VIEW our_orders_by_event_with_net IS
+  'Per-event rollup with both gross_fulfilled and net_fulfilled. Replaces '
+  'our_orders_by_event for surfaces that care about take-home vs face value.';

--- a/supabase/migrations/20260509380000_pricing_intel_unified_and_arbitrage.sql
+++ b/supabase/migrations/20260509380000_pricing_intel_unified_and_arbitrage.sql
@@ -1,0 +1,154 @@
+-- ============================================================================
+-- Migration 20260509380000 — Unified pricing intelligence + arbitrage view
+--
+-- Per directive: "5 should already exist for each data source need to
+-- connect, do 6-7" — this migration UNIFIES the per-source pricing
+-- intelligence we already have, then adds the cross-source arbitrage view.
+--
+-- WHAT EXISTS PER-SOURCE (ALREADY):
+--   TEvo:   latest_event_metrics (event-level), section_metrics, zone_metrics,
+--           event_velocity (vs immediately-prior capture)
+--   SG:     seatgeek_event_metrics (494 rows; cost percentiles, orders by
+--           status, sold quantity, fill_rate)
+--   SD:     seatdata_event_stats (snapshot ts, get_in, total_listings, etc.)
+--   Cross:  v_pricing_cross_source (section-level TEvo↔SG↔SD)
+--
+-- WHAT THIS ADDS:
+--   v_event_velocity_windows — 1h/6h/24h price + inventory deltas, PER source
+--                              (not just "vs previous capture")
+--   v_arbitrage_opportunities — section-level TEvo↔SG price gap > threshold
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Unified velocity windows
+--
+-- Computes Δ price + Δ tickets over 1h / 6h / 24h windows for both TEvo and
+-- SG event-level metrics. This is what a day-trader actually wants to read
+-- ("what moved in the last hour"), not "vs whatever the previous capture
+-- was, which could be 5 min ago or 12 hours ago."
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_event_velocity_windows AS
+WITH tevo_now AS (
+  SELECT DISTINCT ON (event_id)
+    event_id, captured_at, getin_price, retail_median, tickets_count
+  FROM latest_event_metrics
+  ORDER BY event_id, captured_at DESC
+),
+tevo_lookback AS (
+  SELECT
+    event_id, captured_at, getin_price, retail_median, tickets_count,
+    LAG(getin_price)    OVER (PARTITION BY event_id ORDER BY captured_at) AS prev_getin,
+    LAG(retail_median)  OVER (PARTITION BY event_id ORDER BY captured_at) AS prev_median,
+    LAG(tickets_count)  OVER (PARTITION BY event_id ORDER BY captured_at) AS prev_tickets
+  FROM event_metrics
+),
+tevo_w AS (
+  SELECT
+    n.event_id,
+    n.captured_at AS tevo_now_at, n.getin_price AS tevo_getin_now,
+    n.retail_median AS tevo_median_now, n.tickets_count AS tevo_tix_now,
+    -- 1h window
+    (SELECT getin_price FROM event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '1 hour'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_getin_1h_ago,
+    (SELECT tickets_count FROM event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '1 hour'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_tix_1h_ago,
+    -- 6h window
+    (SELECT getin_price FROM event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '6 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_getin_6h_ago,
+    (SELECT tickets_count FROM event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '6 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_tix_6h_ago,
+    -- 24h window
+    (SELECT getin_price FROM event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '24 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_getin_24h_ago,
+    (SELECT tickets_count FROM event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '24 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_tix_24h_ago
+  FROM tevo_now n
+),
+sg_w AS (
+  SELECT
+    sgm.tevo_event_id AS event_id,
+    sgm.captured_at AS sg_now_at,
+    sgm.cost_min AS sg_getin_now,
+    sgm.cost_median AS sg_median_now,
+    sgm.tickets_count AS sg_tix_now,
+    (SELECT cost_min FROM seatgeek_event_metrics x
+      WHERE x.tevo_event_id = sgm.tevo_event_id AND x.captured_at <= sgm.captured_at - interval '1 hour'
+      ORDER BY x.captured_at DESC LIMIT 1) AS sg_getin_1h_ago,
+    (SELECT cost_min FROM seatgeek_event_metrics x
+      WHERE x.tevo_event_id = sgm.tevo_event_id AND x.captured_at <= sgm.captured_at - interval '6 hours'
+      ORDER BY x.captured_at DESC LIMIT 1) AS sg_getin_6h_ago,
+    (SELECT cost_min FROM seatgeek_event_metrics x
+      WHERE x.tevo_event_id = sgm.tevo_event_id AND x.captured_at <= sgm.captured_at - interval '24 hours'
+      ORDER BY x.captured_at DESC LIMIT 1) AS sg_getin_24h_ago
+  FROM (SELECT DISTINCT ON (tevo_event_id) * FROM seatgeek_event_metrics
+        WHERE tevo_event_id IS NOT NULL ORDER BY tevo_event_id, captured_at DESC) sgm
+)
+SELECT
+  e.id AS tevo_event_id, e.name, e.occurs_at_local, e.venue_name,
+  -- TEvo
+  t.tevo_now_at, t.tevo_getin_now, t.tevo_median_now, t.tevo_tix_now,
+  (t.tevo_getin_now - t.tevo_getin_1h_ago)  AS tevo_getin_d1h,
+  (t.tevo_getin_now - t.tevo_getin_6h_ago)  AS tevo_getin_d6h,
+  (t.tevo_getin_now - t.tevo_getin_24h_ago) AS tevo_getin_d24h,
+  (t.tevo_tix_now   - t.tevo_tix_1h_ago)    AS tevo_tix_d1h,
+  (t.tevo_tix_now   - t.tevo_tix_24h_ago)   AS tevo_tix_d24h,
+  CASE WHEN t.tevo_getin_1h_ago > 0
+    THEN round(((t.tevo_getin_now - t.tevo_getin_1h_ago)::numeric / t.tevo_getin_1h_ago) * 100, 2)
+    END AS tevo_getin_d1h_pct,
+  CASE WHEN t.tevo_getin_24h_ago > 0
+    THEN round(((t.tevo_getin_now - t.tevo_getin_24h_ago)::numeric / t.tevo_getin_24h_ago) * 100, 2)
+    END AS tevo_getin_d24h_pct,
+  -- SG
+  s.sg_now_at, s.sg_getin_now, s.sg_median_now, s.sg_tix_now,
+  (s.sg_getin_now - s.sg_getin_1h_ago)  AS sg_getin_d1h,
+  (s.sg_getin_now - s.sg_getin_24h_ago) AS sg_getin_d24h
+FROM events e
+LEFT JOIN tevo_w t ON t.event_id = e.id
+LEFT JOIN sg_w   s ON s.event_id = e.id
+WHERE t.event_id IS NOT NULL OR s.event_id IS NOT NULL;
+
+COMMENT ON VIEW v_event_velocity_windows IS
+  'Multi-window velocity per event across TEvo + SG. Windows: 1h, 6h, 24h. '
+  'Read tevo_getin_d1h_pct < -10 to find "get-in dropped >10% in last hour". '
+  'NULL fields mean we do not have a snapshot in that window yet.';
+
+-- ============================================================================
+-- (2) Arbitrage opportunities (section-level TEvo↔SG)
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_arbitrage_opportunities AS
+SELECT
+  tevo_event_id,
+  section,
+  tevo_retail_median,
+  sg_retail_median,
+  sg_seller_cost_median,
+  -- TEvo retail vs SG retail (consumer-side gap)
+  (sg_retail_median - tevo_retail_median) AS sg_minus_tevo,
+  CASE WHEN tevo_retail_median > 0
+    THEN round(((sg_retail_median - tevo_retail_median) / tevo_retail_median * 100)::numeric, 2)
+    END AS sg_vs_tevo_gap_pct,
+  -- Buy-on-SG-sell-on-TEvo arb (rough; ignores fees this calc, see fee schedule)
+  CASE WHEN sg_seller_cost_median > 0 AND tevo_retail_median > 0
+    THEN round(((tevo_retail_median - sg_seller_cost_median) / sg_seller_cost_median * 100)::numeric, 2)
+    END AS our_cost_vs_tevo_retail_pct,
+  tevo_listings, sg_listings, sg_seller_listings,
+  GREATEST(tevo_latest, sg_latest) AS data_freshness
+FROM v_pricing_cross_source
+WHERE tevo_retail_median IS NOT NULL
+  AND sg_retail_median   IS NOT NULL
+  AND tevo_listings >= 2 AND sg_listings >= 2;     -- need depth on both sides
+
+COMMENT ON VIEW v_arbitrage_opportunities IS
+  'Section-level pricing gaps between TEvo and SG. Filtered to sections with '
+  '>=2 listings on each side for noise reduction. sg_vs_tevo_gap_pct positive '
+  '= SG more expensive (sell on SG, buy on TEvo). Negative = inverse. '
+  'our_cost_vs_tevo_retail_pct is a simple buy-on-SG-cost / sell-on-TEvo '
+  'spread — apply order_fee_schedule before treating as net profit.';

--- a/supabase/migrations/20260509390000_alerts_engine.sql
+++ b/supabase/migrations/20260509390000_alerts_engine.sql
@@ -1,0 +1,196 @@
+-- ============================================================================
+-- Migration 20260509390000 — Alerts engine
+--
+-- Per directive: "do 6-7" — turn the data plane into "the system tells me
+-- what to look at" rather than "I have to query for it."
+--
+-- DESIGN:
+--   event_alerts — append-only log of every fired alert
+--   compute_alerts_tick() — runs rule set, emits new alerts, dedupes within
+--                           a cool-down window so the same signal doesn't
+--                           re-fire every cron tick
+--   Cron compute_alerts_tick_15min — every 15 min
+--
+-- RULES (v1):
+--   1. tevo_getin_drop_1h        — get-in dropped >10% in 1 hour
+--   2. tevo_getin_surge_1h       — get-in jumped >10% in 1 hour
+--   3. tevo_inventory_low_48h    — inventory <25 tickets within 48h of event
+--   4. arbitrage_opportunity     — TEvo↔SG section gap >15% with depth on both
+--   5. espn_status_change        — ESPN status flipped to postponed/delayed/canceled
+--   6. competing_event_added     — new event landed within 20mi×24h of an
+--                                   already-tracked event
+--
+-- All rules dedupe per (rule_key, event_id) within a 6h window.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS event_alerts (
+  id              bigserial PRIMARY KEY,
+  rule_key        text NOT NULL,            -- e.g. 'tevo_getin_drop_1h'
+  tevo_event_id   bigint NOT NULL,
+  fired_at        timestamptz DEFAULT now(),
+  severity        text DEFAULT 'info',      -- 'info'|'warn'|'critical'
+  message         text NOT NULL,
+  payload         jsonb,                    -- rule-specific numbers
+  acknowledged_at timestamptz,
+  acknowledged_by text
+);
+
+CREATE INDEX IF NOT EXISTS event_alerts_event_idx ON event_alerts(tevo_event_id, fired_at DESC);
+CREATE INDEX IF NOT EXISTS event_alerts_rule_idx  ON event_alerts(rule_key, fired_at DESC);
+CREATE INDEX IF NOT EXISTS event_alerts_open_idx  ON event_alerts(fired_at DESC) WHERE acknowledged_at IS NULL;
+
+COMMENT ON TABLE event_alerts IS
+  'Append-only alert log. Each row is a fired rule. Use acknowledged_at to '
+  'mark seen. Cool-down dedup: a (rule_key, event_id) pair will not re-fire '
+  'within 6 hours.';
+
+CREATE OR REPLACE FUNCTION _alert_dedupe_ok(p_rule_key text, p_event_id bigint, p_window interval DEFAULT interval '6 hours')
+RETURNS boolean LANGUAGE sql STABLE AS $$
+  SELECT NOT EXISTS (
+    SELECT 1 FROM event_alerts
+    WHERE rule_key = p_rule_key AND tevo_event_id = p_event_id
+      AND fired_at > now() - p_window
+  );
+$$;
+
+-- ============================================================================
+-- compute_alerts_tick — runs all rules, emits new alerts
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION compute_alerts_tick()
+RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE
+  v_fired jsonb := '{}'::jsonb;
+  v_n int;
+BEGIN
+  -- Rule 1: TEvo get-in dropped >10% in 1h
+  INSERT INTO event_alerts(rule_key, tevo_event_id, severity, message, payload)
+  SELECT
+    'tevo_getin_drop_1h', vw.tevo_event_id, 'warn',
+    format('Get-in dropped %s%% in last hour ($%s -> $%s)',
+      vw.tevo_getin_d1h_pct, (vw.tevo_getin_now - vw.tevo_getin_d1h)::int, vw.tevo_getin_now::int),
+    jsonb_build_object(
+      'getin_now', vw.tevo_getin_now, 'd1h', vw.tevo_getin_d1h,
+      'd1h_pct', vw.tevo_getin_d1h_pct, 'tevo_now_at', vw.tevo_now_at)
+  FROM v_event_velocity_windows vw
+  WHERE vw.tevo_getin_d1h_pct IS NOT NULL
+    AND vw.tevo_getin_d1h_pct <= -10
+    AND vw.tevo_getin_now > 0
+    AND _alert_dedupe_ok('tevo_getin_drop_1h', vw.tevo_event_id);
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_fired := v_fired || jsonb_build_object('tevo_getin_drop_1h', v_n);
+
+  -- Rule 2: TEvo get-in surged >10% in 1h
+  INSERT INTO event_alerts(rule_key, tevo_event_id, severity, message, payload)
+  SELECT
+    'tevo_getin_surge_1h', vw.tevo_event_id, 'info',
+    format('Get-in surged %s%% in last hour ($%s -> $%s)',
+      vw.tevo_getin_d1h_pct, (vw.tevo_getin_now - vw.tevo_getin_d1h)::int, vw.tevo_getin_now::int),
+    jsonb_build_object(
+      'getin_now', vw.tevo_getin_now, 'd1h', vw.tevo_getin_d1h,
+      'd1h_pct', vw.tevo_getin_d1h_pct, 'tevo_now_at', vw.tevo_now_at)
+  FROM v_event_velocity_windows vw
+  WHERE vw.tevo_getin_d1h_pct IS NOT NULL
+    AND vw.tevo_getin_d1h_pct >= 10
+    AND vw.tevo_getin_now > 0
+    AND _alert_dedupe_ok('tevo_getin_surge_1h', vw.tevo_event_id);
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_fired := v_fired || jsonb_build_object('tevo_getin_surge_1h', v_n);
+
+  -- Rule 3: Inventory low <25 tickets within 48h of event start
+  INSERT INTO event_alerts(rule_key, tevo_event_id, severity, message, payload)
+  SELECT
+    'tevo_inventory_low_48h', e.id, 'warn',
+    format('Inventory low: %s tickets, event in %s hours',
+      lem.tickets_count, round(extract(epoch from (e.occurs_at_local::timestamptz - now()))/3600)),
+    jsonb_build_object('tickets', lem.tickets_count, 'occurs_at', e.occurs_at_local)
+  FROM events e
+  JOIN latest_event_metrics lem ON lem.event_id = e.id
+  WHERE e.occurs_at_local::timestamptz BETWEEN now() AND now() + interval '48 hours'
+    AND lem.tickets_count < 25 AND lem.tickets_count > 0
+    AND _alert_dedupe_ok('tevo_inventory_low_48h', e.id);
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_fired := v_fired || jsonb_build_object('tevo_inventory_low_48h', v_n);
+
+  -- Rule 4: Arbitrage opportunity >15% with depth on both sides
+  INSERT INTO event_alerts(rule_key, tevo_event_id, severity, message, payload)
+  SELECT
+    'arbitrage_opportunity', ao.tevo_event_id, 'info',
+    format('Arb in section %s: SG vs TEvo gap %s%% (TEvo $%s, SG $%s)',
+      ao.section, ao.sg_vs_tevo_gap_pct, ao.tevo_retail_median::int, ao.sg_retail_median::int),
+    jsonb_build_object(
+      'section', ao.section, 'gap_pct', ao.sg_vs_tevo_gap_pct,
+      'tevo_median', ao.tevo_retail_median, 'sg_median', ao.sg_retail_median)
+  FROM v_arbitrage_opportunities ao
+  WHERE abs(ao.sg_vs_tevo_gap_pct) >= 15
+    AND _alert_dedupe_ok('arbitrage_opportunity', ao.tevo_event_id);
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_fired := v_fired || jsonb_build_object('arbitrage_opportunity', v_n);
+
+  -- Rule 5: ESPN status_short flipped to postponed/delayed/canceled
+  INSERT INTO event_alerts(rule_key, tevo_event_id, severity, message, payload)
+  SELECT
+    'espn_status_change', x.tevo_event_id, 'critical',
+    format('ESPN status: %s', ee.status_short),
+    jsonb_build_object('espn_status', ee.status_short, 'state', ee.state, 'captured_at', ee.captured_at)
+  FROM event_xref x
+  JOIN LATERAL (
+    SELECT * FROM espn_event_snapshots ee
+    WHERE ee.espn_event_id = x.espn_event_id
+    ORDER BY captured_at DESC LIMIT 1
+  ) ee ON true
+  WHERE lower(ee.status_short) IN ('postponed','delayed','canceled','cancelled','suspended')
+    AND _alert_dedupe_ok('espn_status_change', x.tevo_event_id);
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_fired := v_fired || jsonb_build_object('espn_status_change', v_n);
+
+  -- Rule 6: New competing event added within 20mi × 24h of a tracked event
+  -- (uses event_competitors_snapshot — fires when an event newly appears
+  -- with competitors_count > 0 if it didn't have any in last 24h)
+  INSERT INTO event_alerts(rule_key, tevo_event_id, severity, message, payload)
+  SELECT
+    'competing_event_added', ecs.tevo_event_id, 'info',
+    format('%s competing event(s) within ±24h × 20mi', ecs.competitors_count),
+    jsonb_build_object('competitors', ecs.competitors)
+  FROM event_competitors_snapshot ecs
+  WHERE ecs.competitors_count > 0
+    AND _alert_dedupe_ok('competing_event_added', ecs.tevo_event_id, interval '24 hours');
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  v_fired := v_fired || jsonb_build_object('competing_event_added', v_n);
+
+  RETURN jsonb_build_object('fired_counts', v_fired, 'ran_at', now());
+END;
+$$;
+
+COMMENT ON FUNCTION compute_alerts_tick IS
+  'Run all alert rules and emit new alerts. Per-rule dedup via 6h cool-down '
+  'so the same signal does not re-fire each tick. Returns count fired per '
+  'rule for telemetry.';
+
+-- ============================================================================
+-- Cron: every 15 min, +5 offset from cross_source_match_tick
+-- ============================================================================
+
+SELECT cron.schedule(
+  'compute_alerts_tick_15min',
+  '5-59/15 * * * *',
+  $$ SELECT compute_alerts_tick(); $$
+);
+
+-- ============================================================================
+-- Convenience view: open alerts only
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_open_alerts AS
+SELECT
+  ea.id, ea.rule_key, ea.severity, ea.fired_at,
+  ea.tevo_event_id, e.name AS event_name, e.occurs_at_local, e.venue_name,
+  ea.message, ea.payload
+FROM event_alerts ea
+LEFT JOIN events e ON e.id = ea.tevo_event_id
+WHERE ea.acknowledged_at IS NULL
+ORDER BY ea.severity DESC, ea.fired_at DESC;
+
+COMMENT ON VIEW v_open_alerts IS
+  'Unacknowledged alerts. Default landing surface for any "what should I '
+  'look at" UI or AI assistant. Order: critical first, then most-recent.';


### PR DESCRIPTION
## Summary

Wraps Phase 1 (data collection) on a stable baseline. The data plane is
complete on Supabase with no Railway dependency, and the intelligence
layer (alerts, velocity windows, arbitrage view, competitor snapshot,
AI-context bundle) is wired and verified live.

5 commits, all RULE 2 compliant (127 plpgsql migrations clean, no write
paths to TEvo or SG hosts).

### What landed

- **Wiki lean storage** — dropped pageviews SQL pipeline + raw_summary_jsonb
  blob; performer_wikipedia kept as AI/RAG context only. Daily sweep cron.
- **Unified cross-source matcher cron** (`cross_source_match_tick_30min`)
  replacing the standalone SG matcher; logs EVO orphans + audits SD.
- **`event_competitors_snapshot`** — pre-computed ±24h × 20mi neighbors
  per event, hourly refresh. 377 events seeded.
- **Auto-backfill from orphan orders** — TEvo or SG order arrives for an
  unknown event → fetches event metadata via `/v9/events/:id` →
  windowed listing crons pick up automatically. Verified 20/20 success
  on first run.
- **`v_event_full_v2`** — extends v_event_full with seatgeek_event_metrics
  + event_sentiment (492 + 18 previously-orphan rows now visible).
- **`get_event_context(event_id)`** — single JSON for AI/RAG: event +
  pricing + ESPN + Wikipedia + weather + competitors + our orders.
- **`order_fee_schedule`** + **`our_orders_with_net`** — gross AND net
  side-by-side. Verified: TEvo $40,694 gross → $38,252 net (6%).
- **`v_event_velocity_windows`** — 1h/6h/24h price + inventory deltas
  across TEvo+SG, replacing "vs previous capture" velocity. 640 rows.
- **`v_arbitrage_opportunities`** — section-level TEvo↔SG gap with
  depth filter.
- **Alerts engine** — `event_alerts` table + 6h dedupe + 6 rules
  (get-in drop/surge, inventory low, arbitrage, ESPN status change,
  competing event added). Cron every 15 min.

### Docs added

- `database-map-2026-05-09.md` — 8-layer structural reference
- `database-audit-2026-05-09.md` — per-event audit + corrections
- `wikipedia-usage-2026-05-09.md` — reframed as AI-connector context
- `seatdata-blocker-2026-05-09.md` — SD pull missing, blocked on spec
- `phase2-ui-kanban.md` — 9 cards for Phase 2 UI rebuild
- `knicks-next-home-event-snapshot-2026-05-09.md` — proof of life

## Test plan

- [x] RULE 2 audit script clean (127 plpgsql migrations)
- [x] All 3 new functions seeded live and verified
- [x] Orphan backfill round-trip verified (20/20 events fetched + persisted)
- [x] get_event_context returns 9 top-level keys on Thunder@Lakers + Knicks
- [x] our_orders_with_net math verified (6% TEvo commission)
- [x] event_competitors_snapshot populated (377 rows)
- [x] compute_alerts_tick runs cleanly (6 rules, 0 fired in quiet state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)