### PR TITLE
Phase 2 UI coworker scaffolding (separate repo + audit gate)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# CODEOWNERS — Terminal-2 backend
+#
+# GitHub auto-assigns review on PRs touching matched paths. Combined with
+# branch protection on main (Settings -> Branches -> Branch protection
+# rules -> require review from Code Owners), this blocks merge of any
+# backend-touching PR without owner approval.
+#
+# Coworker UI work happens in a SEPARATE repo (Terminal-2-ui). They never
+# push here directly; they propose changes that I (the audit lane) review
+# and commit. So the rules below assume only owners merge here.
+
+# Default: everything requires owner review
+*                                           @JulianS4K
+
+# Backend code — explicit (so GitHub UI shows the rule clearly)
+/app.py                                     @JulianS4K
+/evo_client.py                              @JulianS4K
+/seatgeek_client.py                         @JulianS4K
+/seatdata_client.py                         @JulianS4K
+/requirements.txt                           @JulianS4K
+/Procfile                                   @JulianS4K
+
+# Database
+/supabase/                                  @JulianS4K
+/supabase/migrations/                       @JulianS4K
+/supabase/functions/                        @JulianS4K
+
+# Tooling / audit
+/scripts/                                   @JulianS4K
+/bin/                                       @JulianS4K
+/tests/                                     @JulianS4K
+
+# CI
+/.github/                                   @JulianS4K
+/.github/workflows/                         @JulianS4K
+/.github/CODEOWNERS                         @JulianS4K
+
+# Schema + onboarding contracts
+/AGENTS.md                                  @JulianS4K
+/SCHEMA.md                                  @JulianS4K
+/COWORKER_ONBOARDING.md                     @JulianS4K
+/KANBAN.md                                  @JulianS4K
+/README.md                                  @JulianS4K
+
+# Docs that the coworker reads but doesn't write
+/docs/                                      @JulianS4K

--- a/.github/workflows/forbidden-paths-check.yml
+++ b/.github/workflows/forbidden-paths-check.yml
@@ -1,0 +1,79 @@
+name: forbidden-paths-check
+
+# Belt-and-suspenders gate beyond CODEOWNERS. Fails the PR if a non-owner
+# author touches files that should only be modified by the audit lane.
+# CODEOWNERS handles 99% of this via review requirement; this workflow
+# catches the 1% (PRs auto-merged by bots, branch protection misconfiguration,
+# repo-admin override, etc.).
+#
+# Allowed authors: list below. Add coworker GitHub handles to OWNERS env
+# only if you intend to grant them backend-write privileges (we don't).
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      OWNERS: "JulianS4K"
+      FORBIDDEN_PATHS: |
+        ^app\.py$
+        ^evo_client\.py$
+        ^seatgeek_client\.py$
+        ^seatdata_client\.py$
+        ^requirements\.txt$
+        ^Procfile$
+        ^supabase/
+        ^scripts/
+        ^bin/
+        ^tests/
+        ^\.github/
+        ^AGENTS\.md$
+        ^SCHEMA\.md$
+        ^COWORKER_ONBOARDING\.md$
+        ^KANBAN\.md$
+        ^README\.md$
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Identify changed files
+        id: diff
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/changed.txt
+          echo "Changed files:"
+          cat /tmp/changed.txt
+
+      - name: Check forbidden paths
+        run: |
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          if echo "$OWNERS" | grep -wq "$AUTHOR"; then
+            echo "Author $AUTHOR is an owner — backend writes allowed."
+            exit 0
+          fi
+
+          # Build a single regex from FORBIDDEN_PATHS
+          PATTERN=$(echo "$FORBIDDEN_PATHS" | sed '/^$/d' | tr '\n' '|' | sed 's/|$//')
+
+          if grep -E "$PATTERN" /tmp/changed.txt > /tmp/violations.txt; then
+            echo ""
+            echo "❌ Non-owner author '$AUTHOR' touched protected backend files:"
+            cat /tmp/violations.txt
+            echo ""
+            echo "Coworker UI work belongs in the Terminal-2-ui repo."
+            echo "If you need a backend change, open an issue describing"
+            echo "the need; the audit lane will write + apply it."
+            exit 1
+          fi
+
+          echo "✅ No forbidden paths touched."

--- a/COWORKER_ONBOARDING.md
+++ b/COWORKER_ONBOARDING.md
@@ -1,219 +1,148 @@
-# COWORKER_ONBOARDING.md — Terminal Design Coworker
+# COWORKER_ONBOARDING.md — Phase 2 (UI handoff)
 
-> **Read this top-to-bottom before touching any file.** This is the contract. Violations cause backend drift and force the audit lane (me, "code") to reject your work.
-
----
-
-## 1. What you're working on
-
-**Terminal-2** is a sports-ticket broker terminal for S4K Entertainment (NBA, NFL, MLB, NHL, MLS, WNBA, plus major-event single-week stuff like F1/Tennis/Golf). Two products share one backend:
-
-- **Broker terminal** (live URL: `https://terminal-2-production.railway.app/`, Google-OAuth gated to `@s4kent.com`) — full data, all S4K-owned + market depth, served by FastAPI on Railway.
-- **Retail chatbot** (same domain, `/chat`) — public, S4K-owned tickets only.
-
-You are working on the **broker terminal frontend**. You do NOT touch the chatbot, the API, or the DB.
-
-**Stack you'll see**:
-- Single-file vanilla JS + Chart.js 4.4 in `static/index.html` (~3000 lines). No bundler, no React.
-- Backend hands you JSON over Bearer-token auth via `/api/broker/*` routes.
-- Styling is CSS variables in `<style>` blocks at the top of `static/index.html`.
-
-**Why no React/build step**: speed + audit simplicity. One file, one diff, no bundle drift.
+> **This document was rewritten 2026-05-09 for Phase 2.** Phase 1 (data
+> collection) is complete and stable. The prior version of this file
+> referenced `static/index.html` and a single-repo design lane that no
+> longer exists — that whole UI was deleted in the Phase 1 cleanup.
+> Phase 2 starts fresh with a separate UI repo.
 
 ---
 
-## 2. Your role — frontend only, no push
+## TL;DR
 
-You design and implement the broker terminal UI: layout, components, charts, search, watchlist, mover panels, event/performer/venue pages.
+You are the UI coworker for Terminal-2. **You don't push to this repo.**
+You work in `Terminal-2-ui` (separate repo, link below) and call this
+backend's read-only Postgres role + JSON API. The audit lane (me) reviews
+and merges your changes.
 
-You **DO NOT**:
-- Push to git. Ever. (The audit-and-push lane is owned by **code**, who reviews your diffs first.)
-- Write to prod DB tables (`public.*`). Read-only via Supabase MCP for diagnostics is fine.
-- Deploy edge functions.
-- Schedule or modify pg_cron jobs.
-- Edit backend Python (`app.py`, `evo_client.py`).
-- Edit SQL migrations or the schema doc.
+Three places to look:
 
-You **DO**:
-- Edit HTML / CSS / JS in the files listed in Section 3.
-- Use the `design_test` schema for any sandbox data (NOT `public.*`).
-- Drop diffs / file content into `KANBAN.md` under "DOING" with a "FROM design" header so code can pick them up.
-- Read `SCHEMA.md` to understand backend data shape before designing.
-- Read this file's Section 7 to know what good work looks like.
+| Where | What |
+|---|---|
+| **Terminal-2-ui** repo | Your codebase. Frontend stack is your choice. |
+| **`docs/coworker-handoff/`** in this repo | My notes and instructions for you (the canonical reference) |
+| `SCHEMA.md`, `docs/database-map-2026-05-09.md`, `docs/phase2-ui-kanban.md` in this repo | Background reading: schema, data model, kanban backlog |
 
 ---
 
-## 3. Ownership — what you can edit
+## What Phase 2 is
 
-| file / glob                              | who edits     | notes |
-|------------------------------------------|---------------|-------|
-| `static/index.html`                      | **design**    | broker terminal — your primary canvas |
-| `static/event.html`                      | **design**    | legacy event page, may be deprecated; check kanban before touching |
-| `static/movers.html`                     | **design**    | full Movers report |
-| `static/chat.html`                       | **design**    | retail chatbot UI |
-| `static/legacy.html`                     | **design** (frozen) | old terminal kept at `/legacy`; only touch if asked |
-| `design/**`                              | **design**    | design notes, mockups, Figma exports |
-| `docs/retail-ui-kit.md`                  | **design**    | retail UI kit doc |
-| `app.py`, `evo_client.py`, `Procfile`, `requirements.txt` | **code (review only)** | backend; if you need a new endpoint or field, write a `NEXT (design): need <endpoint/field>` entry in `KANBAN.md` |
-| `supabase/functions/**`                  | **code**      | edge functions |
-| `supabase/migrations/**`                 | **code**      | SQL migrations |
-| `SCHEMA.md`                              | **code**      | backend canonical schema lock — read-only for design |
-| `AGENTS.md`                              | **code**      | process doc |
-| `KANBAN.md`                              | **shared**    | append your own DOING/DONE rows under the design column |
-| `COWORKER_ONBOARDING.md` (this file)     | **code**      | read-only |
-| `bin/**`, `.github/**`                   | **code**      | infra/CI |
+Phase 1 built the data plane (TEvo + SeatGeek + ESPN + Reddit + Wikipedia +
+weather + alerts + odds + AI context bundle). **No UI was built.** Phase 2
+is the UI rebuild from scratch.
 
-**Rule of thumb**: if it ends in `.html`, `.css`, or is in `design/`, you can edit it. Everything else, ask.
+The first kanban card you'll work on is the **Data Quality Dashboard** —
+the dashboard the team uses to know whether the data plane is healthy day
+to day. Scope is in `docs/phase2-ui-kanban.md` (sections "Data quality
+dashboard" + the priority order at the bottom).
 
 ---
 
-## 4. Environment & access
+## What you have access to
 
-### What you have access to (Supabase MCP)
+### 1. Read-only Supabase Postgres role: `coworker_readonly`
 
-- **Read** any table in the `public.*` schema. Use it to understand data shape before designing UI.
-- **Write** any table in `design_test.*`. Use this for stub/mock data when prototyping.
-- **No write** to `public.*` — even if MCP lets you, the rule is strict. Code's audit pass will revert it.
+Connection string + password are delivered out-of-band (see hand-off
+package from Julian).
 
-### Test schema setup
+**Can do:**
+- `SELECT` on every table and view in `public.*` (~99 tables, ~92 views)
+- `EXECUTE` ~23 read-only helper functions including
+  `get_event_context(event_id)` — the AI/RAG-style single-call bundle
+- Full create/read/update/delete in your own sandbox schema:
+  `design_test.*`
 
-```sql
--- Run this once to confirm your sandbox is healthy:
-SELECT * FROM design_test._readme;
-```
+**Can NOT do:**
+- Insert/update/delete on `public.*` (data plane is owned by audit lane)
+- Read `vault.*` or touch `cron.*`
+- Execute any function that fires `net.http_*` (data-plane writers, paid pulls)
 
-Use `design_test` for:
-- Stubbed event_metrics rows when you want to test rendering with synthetic data.
-- Feature-flag tables for A/B'ing new layouts.
-- Mock data for UI states the real prod data doesn't currently exercise.
+### 2. JSON API on the FastAPI backend
 
-### Local dev workflow
+`https://<railway-deploy>.railway.app/api/*` — 60 read-only routes.
+The contract is the route signature; backend semantics are stable.
+Bearer-token auth. Token in hand-off package.
 
-You can develop against live prod data — `static/index.html` calls `/api/broker/*` which is open to any browser tab on the deployed Railway URL once you've Google-signed-in.
+Common ones:
+- `GET /api/events` — upcoming events list
+- `GET /api/events/{event_id}` — single event detail
+- `GET /api/broker/event/{event_id}/overview` — full broker bundle
+- `GET /api/portfolio` — our orders rollup
 
-For local iteration:
-```bash
-# Terminal 1 — serve the static files locally
-cd static && py -3 -m http.server 8080
-# Terminal 2 — point your browser at http://localhost:8080/index.html
-# But: API calls will fail because there's no FastAPI running.
-```
+You'll see the full list in `app.py` (read-only — link from your repo's
+README).
 
-To get full local stack with auth + API, ask code to spin up Railway with a preview branch — DO NOT try to run `app.py` yourself; it requires service-role secrets you don't have.
+### 3. Supabase MCP (for diagnostic queries during development)
 
-**Easier**: edit `static/index.html` directly, ping code in `KANBAN.md` to push, then test on the deployed Railway URL. Cycle time ~3 min.
-
----
-
-## 5. Backend handoff — when you need something new
-
-If your UI needs:
-- A new field in an existing endpoint
-- A new endpoint
-- A new data shape from the API
-- A schema column
-
-**DO NOT** add it yourself. Drop a row in `KANBAN.md` under the **NEXT (code)** column with this format:
-
-```
-### NEXT (code) — <short title>
-
-**Need**: <what data/endpoint you need>
-**Why**: <UI feature it unblocks>
-**Shape**: <example JSON or SQL the frontend would consume>
-**Deadline**: <if any>
-**Filed by**: design · 2026-MM-DD
-```
-
-Code reviews, implements, ships. Once the new endpoint is live in prod, code moves the row to **DONE** with the commit SHA. You can then wire your UI to it.
+Same `coworker_readonly` role; lets you run ad-hoc SELECTs from your IDE
+without writing app code. Useful for designing a query before wiring it up.
 
 ---
 
-## 6. Hand-off pattern — how your work reaches main
+## What's expected of you
 
-You don't push. Here's how your edits land:
+1. **All UI work happens in `Terminal-2-ui`.** Frontend stack is your
+   choice (React/Svelte/Vue/Astro/HTMX/vanilla — doesn't matter, pick
+   what you'll be productive in).
 
-1. **You edit** `static/index.html` (or whichever owned file).
-2. **You append to KANBAN.md DOING column**:
-   ```
-   ### DOING (design) — <short title>
-   - **What**: <one-line summary>
-   - **Files touched**: static/index.html (lines ~XXXX-YYYY)
-   - **Status**: ready for review
-   - **Started**: 2026-MM-DD HH:MM
-   ```
-3. **Code reviews** the diff:
-   - Runs `py -3 -c "import ast; ast.parse(open('app.py').read())"` (sanity, even though you didn't touch it)
-   - Eyeballs the HTML diff for backend coupling, XSS, broken event handlers
-   - Checks the Launch preview panel renders cleanly
-4. **Code commits** in your name with a `Co-Authored-By: design` trailer:
-   ```
-   git commit -m "feat(terminal): <your subject>
+2. **Open PRs against `main` of `Terminal-2-ui`.** I review and merge.
+   Don't merge your own PRs.
 
-   Co-Authored-By: design <design@s4kent.local>"
-   ```
-5. **Code pushes** to `main`. Railway redeploys automatically.
-6. **You verify** on the live URL.
-7. **Both move the row** to DONE in `KANBAN.md` with the commit SHA.
+3. **You don't push to this repo (`Terminal-2`).** A `CODEOWNERS` file
+   + branch-protection rule + CI guard would all reject the PR anyway.
+   If you genuinely need a backend change (schema gap, missing API
+   route, new function), **open an issue in this repo** describing what
+   and why; I'll write + apply it.
 
-If code finds a bug, the row goes to **BLOCKED** with the bug reason. You fix and re-submit.
+4. **Use `design_test.*` for any sandbox tables.** Never `CREATE TABLE
+   public.foo` — the role doesn't allow it, but the convention is also
+   that `public.*` is owned by the data plane, not UI.
+
+5. **Treat the connection string and Bearer token like any secret.**
+   Don't commit them. `.env.local` is your friend; commit `.env.example`
+   instead. The hand-off package shows the shape.
 
 ---
 
-## 7. What good work looks like
+## What's deprecated from prior onboarding
 
-### Visual quality bar
+If you ever see references to:
+- `static/index.html`, `templates/`, "design lane editing the broker
+  terminal frontend"
+- `COWORKER_ONBOARDING.md` mentioning `static/index.html` ownership
 
-- **Robinhood / Bloomberg Terminal feel**: dense, monospaced where appropriate, no wasted space, instant feedback on hover/click.
-- **Smooth transitions**: range switches fade rather than blank-flash. Hover states are crisp, not draggy.
-- **Dark theme is the only theme**. Terminal users don't want light mode.
-- **Mobile-responsive is NOT a goal** for the broker terminal. This is a desk tool — assume 1440px+ widescreen.
-
-### Data hygiene
-
-- **Never hardcode data** that should come from the API. If the data isn't in an endpoint yet, file a NEXT (code).
-- **Never assume data is non-null**. Backend can return `null` for any metric column. Show "—" or hide the row.
-- **Respect the product wall**: broker terminal sees everything (S4K-owned + competitor listings + wholesale). Retail chatbot must NEVER see wholesale, brokerage names, or non-S4K listings. If you ever find yourself rendering wholesale data in `chat.html`, **stop and file a `BLOCKED` row** — that's the wall and breaking it has legal implications.
-
-### Code style
-
-- **Single file**: keep new components inline in `static/index.html`. No bundler.
-- **Vanilla JS only**: no React, Vue, jQuery, etc.
-- **CSS variables for theming**: `--surface`, `--surface-2`, `--border`, `--text`, `--dim`, `--accent`, `--pos`, `--neg`. Defined at the top of `static/index.html`.
-- **No external assets** unless they're already in the codebase. Inline SVGs > external images.
-- **Comment sparingly**: explain WHY, not WHAT. Future-you can read the code; future-you can't read your mind.
+Those are pre-Phase-2 and **gone**. The Phase 2 reality is: there is no
+frontend code in this repo. The frontend lives in `Terminal-2-ui`.
 
 ---
 
-## 8. Common pitfalls
+## First-day sequence
 
-- **Don't break the auth bootstrap** — `/api/public/config` is the first call; it returns Supabase URL + anon key for browser auth init. The Bearer token comes from `supabase.auth.getSession()`. If you see 401s everywhere, the bootstrap is broken.
-- **Don't introduce new localStorage keys without a version suffix** — bumping `evt_chart_visible_v3` to `_v4` is the pattern when defaults change. Existing users get fresh defaults on next load.
-- **Don't auto-discover series and rename them** — `_autoDiscoverSeries` lets the backend ship new metrics without a frontend deploy. If you rename a backend series, the auto-discover catches it as a new pill labeled `[auto]`. Don't try to "fix" this — it's the feature.
-- **Don't add tracking / analytics** — desk tool. Internal use only.
-- **Don't add user-input forms that POST to `public.*`** — all writes go through code-owned API endpoints. Frontend forms call `api(...)` which calls `/api/broker/*`.
-
----
-
-## 9. Where to find things
-
-- **What needs work next**: `KANBAN.md`
-- **Backend data shape**: `SCHEMA.md` (don't edit, just read)
-- **Process rules**: `AGENTS.md`
-- **Past UI decisions**: `docs/broker-audit-2026-05-08.md`, `docs/terminal-data-inventory.md`, `design/main.fig.md`
-- **Live URL**: `https://terminal-2-production.railway.app/`
-- **Project on Supabase**: `hzrizjeaxlqcxfrtczpq` (Terminal .5)
+1. Accept the GitHub invite to `Terminal-2-ui`.
+2. Clone it. Read the README; it points to everything else.
+3. Read `docs/phase2-ui-kanban.md` (in `Terminal-2`, linked from your repo's README).
+4. Read the Data Quality Dashboard scope in particular.
+5. Open an issue in `Terminal-2-ui` describing your design + stack
+   choice. Wait for ack before building.
+6. Build, PR, review, merge.
 
 ---
 
-## 10. First-day checklist
+## Where my notes live
 
-1. [ ] Read this file end-to-end.
-2. [ ] Read `KANBAN.md` to see what's NEXT (design).
-3. [ ] Skim `SCHEMA.md`'s "Active crons" + "Backend API surface" sections so you know what data is available.
-4. [ ] Open `static/index.html` and orient yourself. The structure is: CSS variables → header → hero search → 3-tab watchlist → mover panels → footer. Event detail page is rendered by `loadEvent(id)` (~line 880 onward).
-5. [ ] Sign in to the live Railway URL with your `@s4kent.com` Google account to see the deployed terminal.
-6. [ ] Run `SELECT * FROM design_test._readme;` via Supabase MCP to confirm sandbox access.
-7. [ ] Pick the top **NEXT (design)** row from KANBAN, move it to **DOING (design)**, and start.
+| Document | Purpose |
+|---|---|
+| `Terminal-2/docs/coworker-handoff/SCOPE.md` | What you can/can't touch, in plain prose |
+| `Terminal-2/docs/coworker-handoff/QUERY_COOKBOOK.md` | Ready-to-paste SQL examples for common UI needs |
+| `Terminal-2/docs/coworker-handoff/DATA_QUALITY_DASHBOARD.md` | Full scope for your first card |
+| `Terminal-2/docs/database-map-2026-05-09.md` | Full schema topology |
+| `Terminal-2/docs/phase2-ui-kanban.md` | Backlog (after Data Quality Dashboard) |
+| `Terminal-2/SCHEMA.md` | Per-table column reference |
+| `Terminal-2-ui/README.md` | Quick start for your repo |
 
-Welcome aboard. Ask via KANBAN entries — code reads it on every commit cycle.
+---
+
+## Questions
+
+Open an issue in `Terminal-2-ui` and tag me. Don't DM Slack — issues
+keep the discussion attached to the work.

--- a/docs/coworker-handoff/DATA_QUALITY_DASHBOARD.md
+++ b/docs/coworker-handoff/DATA_QUALITY_DASHBOARD.md
@@ -1,0 +1,174 @@
+# DATA_QUALITY_DASHBOARD — first kanban card
+
+This is your first build. Goal: a UI that answers, at a glance,
+"is the data plane healthy today?" — and surfaces any silent
+failure within the cycle (not weeks later, when the audit catches
+it manually).
+
+---
+
+## Why this card first
+
+Every silent failure I've caught manually so far cost something:
+- SeatData pull pipeline missing for weeks → no historical comps
+- `sg_listings_process` cron failing 49% → 10K listings backlogged
+- SG API not returning `payment_total` → all orders showing $0 gross
+- MSG weather pull stuck on a 429 → no forecast for the Knicks game
+
+A dashboard catches these the day they happen. Audit time goes from
+"I'll get to it next week" to "the banner is red, check it now."
+
+---
+
+## What the dashboard shows
+
+A single page with these signals, top-to-bottom:
+
+### 1. Headline — overall data plane health (0–100%)
+
+A computed score combining all check buckets. Three states with color:
+- **Green** ≥ 95
+- **Yellow** 80–94
+- **Red** < 80
+
+Display: big number + status word + last-refreshed timestamp.
+
+### 2. Pull pipeline freshness (per source)
+
+For each source, when did the most recent data land?
+
+| Source | Expected freshness | Query basis |
+|---|---|---|
+| TEvo listings | <30 min | `max(captured_at)` from `listings_snapshots` for upcoming events |
+| SeatGeek listings | <30 min | `max(captured_at)` from `seatgeek_listings_snapshots` |
+| EVO orders | <1h | `max(pulled_at)` from `evo_orders` |
+| SG seller orders | <1h | `max(pulled_at)` from `seatgeek_orders` |
+| ESPN snapshots | <10 min (game-day) / <24h (off-day) | `max(captured_at)` from `espn_event_snapshots` |
+| Wikipedia enrichment | <24h | `max(last_refreshed_at)` from `performer_wikipedia` |
+| Weather forecast | <60 min | `max(observed_at)` from `weather_observations` where `is_forecast` |
+| Reddit RSS | <60 min | `max(pulled_at)` from `reddit_posts` |
+
+Show each as a row with: source, last update, age, status (green/yellow/red).
+
+### 3. Cron health (last 24h)
+
+Top-level: "47/48 crons ran cleanly in the last 24h" with drill-down
+table for any failing crons.
+
+> **Note:** `coworker_readonly` does NOT have access to `cron.*`.
+> The audit lane will create a `v_cron_health` view in `public`
+> exposing per-cron stats. Open an issue in `Terminal-2` when you're
+> ready for it; provided shape will be:
+> `(jobname text, runs_24h int, ok_24h int, fail_24h int, pct_ok numeric, latest_run timestamptz, latest_error text)`
+
+### 4. Pending queue depths
+
+Each pull pipeline has a `*_pending` queue. Stale unresolved rows mean
+something's stuck. Show counts:
+
+```sql
+SELECT 'evo_orders_pending'         AS queue, count(*) FILTER (WHERE resolved_at IS NULL) AS stuck FROM evo_orders_pending
+UNION ALL SELECT 'sg_listings_pending',     count(*) FILTER (WHERE resolved_at IS NULL) FROM sg_listings_pending
+UNION ALL SELECT 'sg_seller_pending',       count(*) FILTER (WHERE resolved_at IS NULL) FROM sg_seller_pending
+UNION ALL SELECT 'weather_forecast_pending',count(*) FILTER (WHERE resolved_at IS NULL) FROM weather_forecast_pending
+UNION ALL SELECT 'performer_wiki_pending',  count(*) FILTER (WHERE resolved_at IS NULL) FROM performer_wiki_pending
+UNION ALL SELECT 'reddit_pending',          count(*) FILTER (WHERE resolved_at IS NULL) FROM reddit_pending
+UNION ALL SELECT 'evo_event_backfill_pending', count(*) FILTER (WHERE resolved_at IS NULL) FROM evo_event_backfill_pending
+UNION ALL SELECT 'sg_event_backfill_pending',  count(*) FILTER (WHERE resolved_at IS NULL) FROM sg_event_backfill_pending;
+```
+
+Threshold: any queue >50 unresolved is yellow; >200 is red. (Tune
+after a week of observation.)
+
+### 5. Cross-source coverage scoreboard
+
+For upcoming sports events in the next 30 days:
+- % with TEvo listings <60min old
+- % with ESPN xref'd
+- % with Wikipedia enrichment
+- % with weather observation (events ≤16d only)
+- % of SG-canonical events with `tevo_event_id` mapped (currently low; see below)
+
+Use these as drift detectors. Sudden drop in % = something broke.
+
+### 6. Open alerts (5 newest)
+
+Pull from `v_open_alerts` ordered by severity desc, fired_at desc.
+Show event name, rule, message, fired-at-relative-time.
+
+### 7. Today's writes
+
+Number of new rows in last 24h per major table:
+`listings_snapshots`, `seatgeek_listings_snapshots`, `evo_orders`,
+`seatgeek_orders`, `espn_event_snapshots`, `reddit_posts`,
+`weather_observations`. If any of these are 0, that source is silent.
+
+---
+
+## Specific queries you'll need
+
+The QUERY_COOKBOOK has the patterns. Here's the freshness check
+one explicitly:
+
+```sql
+SELECT
+  'tevo_listings' AS source,
+  max(captured_at) AS latest,
+  EXTRACT(epoch FROM now() - max(captured_at))/60 AS age_minutes
+FROM listings_snapshots
+UNION ALL
+SELECT 'seatgeek_listings', max(captured_at), EXTRACT(epoch FROM now() - max(captured_at))/60
+FROM seatgeek_listings_snapshots
+UNION ALL
+SELECT 'evo_orders', max(pulled_at), EXTRACT(epoch FROM now() - max(pulled_at))/60
+FROM evo_orders
+UNION ALL
+SELECT 'sg_orders', max(pulled_at), EXTRACT(epoch FROM now() - max(pulled_at))/60
+FROM seatgeek_orders
+UNION ALL
+SELECT 'espn_snapshots', max(captured_at), EXTRACT(epoch FROM now() - max(captured_at))/60
+FROM espn_event_snapshots
+UNION ALL
+SELECT 'wikipedia', max(last_refreshed_at), EXTRACT(epoch FROM now() - max(last_refreshed_at))/60
+FROM performer_wikipedia
+UNION ALL
+SELECT 'weather_forecast', max(observed_at), EXTRACT(epoch FROM now() - max(observed_at))/60
+FROM weather_observations WHERE is_forecast
+UNION ALL
+SELECT 'reddit', max(pulled_at), EXTRACT(epoch FROM now() - max(pulled_at))/60
+FROM reddit_posts
+ORDER BY age_minutes DESC NULLS LAST;
+```
+
+---
+
+## Stack-agnostic shape
+
+Whatever framework you pick, the dashboard wants:
+- A backend route or direct DB call returning a single jsonb / json blob
+  with all the numbers (~50 KB max)
+- A 60-second auto-refresh on the page (or websocket if you go that way)
+- Mobile-readable layout (Julian checks this on phone during games)
+- One-click drill-down on any red row → full table of that signal's
+  history
+
+You can either:
+- Call Terminal-2's `/api/*` and add a new route (open issue), or
+- Connect directly to Supabase via `coworker_readonly` and run queries
+  client-side (faster iteration, no backend coordination)
+
+For the prototype, **direct Supabase via supabase-js / postgrest** is
+probably easiest. We can add a backend route later if performance
+demands it.
+
+---
+
+## Done criteria
+
+1. The page renders all 7 sections from real live data
+2. All thresholds (fresh/yellow/red) are documented inline so they can
+   be tuned without code changes (config object at top of file)
+3. Mobile + desktop both work
+4. Auto-refresh works
+5. PR is in `Terminal-2-ui` with a screenshot in the description
+6. Audit lane reviews + merges

--- a/docs/coworker-handoff/HANDOFF_INSTRUCTIONS.md
+++ b/docs/coworker-handoff/HANDOFF_INSTRUCTIONS.md
@@ -1,0 +1,149 @@
+# Hand-off package — what to send the coworker
+
+This is the doc you forward to your UI coworker. Everything below is
+ready to copy/paste into Slack, email, or a Notion page.
+
+---
+
+## What to send (the message)
+
+> Hey — Phase 2 of Terminal-2 (the broker tool) is starting. Phase 1
+> built the data plane; you're owning the UI from here.
+>
+> Three things you need to read **before** building anything:
+>
+> 1. https://github.com/JulianS4K/Terminal-2-ui — your repo. Clone this. The README points to everything else.
+> 2. https://github.com/JulianS4K/Terminal-2/blob/main/COWORKER_ONBOARDING.md — the contract. Read top-to-bottom.
+> 3. https://github.com/JulianS4K/Terminal-2/blob/main/docs/coworker-handoff/DATA_QUALITY_DASHBOARD.md — your first card.
+>
+> Frontend stack is your choice (React/Svelte/Vue/Astro/HTMX/vanilla — whatever you'll be productive in). Commit your stack decision in `Terminal-2-ui/docs/stack.md` once you pick.
+>
+> Access shapes:
+> - **Read-only Supabase Postgres role** `coworker_readonly` — credentials in the encrypted message I sent you separately.
+> - **JSON API Bearer token** for the FastAPI backend — also encrypted message.
+> - **GitHub push** on `Terminal-2-ui` only. Backend repo blocks your PRs at CODEOWNERS + branch protection + CI guard.
+>
+> Workflow: branch off `main` in `Terminal-2-ui`, build, PR. I review and merge — don't self-merge. If you need a backend change, open an issue in `Terminal-2`.
+>
+> Questions: open an issue (in whichever repo applies), tag `@JulianS4K`. Don't DM Slack — issues keep the discussion attached to the work.
+
+---
+
+## What to send out-of-band (encrypted / 1Password / similar)
+
+**Never put these in Slack/email plaintext.** Use 1Password sharing,
+encrypted message, or in-person.
+
+### Supabase connection
+
+```
+SUPABASE_URL=https://hzrizjeaxlqcxfrtczpq.supabase.co
+SUPABASE_ANON_KEY=<the anon JWT from Supabase dashboard - Project Settings - API>
+DATABASE_URL=postgresql://coworker_readonly:<ROTATED_PASSWORD>@db.hzrizjeaxlqcxfrtczpq.supabase.co:6543/postgres?sslmode=require
+```
+
+**You must rotate the password before sending.** The migration created
+the role with placeholder password `CHANGE_ME_BEFORE_HANDOFF`. To
+rotate:
+
+```sql
+ALTER ROLE coworker_readonly PASSWORD '<strong-random-string>';
+```
+
+(Do this in Supabase SQL Editor as a service-role user.)
+
+### Backend API
+
+```
+API_BASE_URL=https://<your-railway-deploy>.railway.app
+API_BEARER_TOKEN=<bearer token used by /api/* routes>
+```
+
+Generate the token in `app.py`'s auth config or whatever your auth
+flow expects. If you haven't set up Bearer auth yet, the `coworker`
+just hits the API with whatever's currently configured.
+
+---
+
+## What you (Julian) need to do in the GitHub UI
+
+These can't be done via CLI; settings live in the GitHub web app.
+
+### On `Terminal-2` (the backend):
+
+1. **Settings → Branches → Branch protection rules → Add rule**
+   - Pattern: `main`
+   - Check: ✅ Require a pull request before merging
+   - Check: ✅ Require approvals (1)
+   - Check: ✅ Require review from Code Owners
+   - Check: ✅ Require status checks to pass before merging
+   - Status check: select `forbidden-paths-check / check`
+   - Save.
+
+2. **Settings → Collaborators and teams**
+   - Do NOT add the coworker here. They get no push access on the
+     backend repo. CODEOWNERS does the rest.
+
+### On `Terminal-2-ui` (the new UI repo):
+
+1. **Settings → Collaborators**
+   - Add the coworker as collaborator with **Write** role.
+
+2. **Settings → Branches → Branch protection rules → Add rule**
+   - Pattern: `main`
+   - Check: ✅ Require a pull request before merging
+   - Check: ✅ Require approvals (1) — this forces audit-lane review
+   - (Optional) Check: ✅ Require linear history if you want squash-only
+
+3. **Settings → General → Default branch** — confirm it's `main`.
+
+---
+
+## What I (audit lane) commit to
+
+- Review every PR in `Terminal-2-ui` within 24h on weekdays
+- Reject PRs that try to write to forbidden paths in `Terminal-2`
+- Open an issue in `Terminal-2` for any backend gap the coworker reports;
+  ack within 24h, ship within a week unless flagged otherwise
+- Keep `docs/coworker-handoff/*.md` up to date as the canonical contract
+- Run `scripts/check_readonly.py` on every backend PR (already in CI)
+- Tag a new `phase1-baseline` if any backend change preserves stability;
+  otherwise create a new tag (`phase2-r1`, etc.)
+
+---
+
+## Where everything lives (quick reference for you)
+
+| Where | What | Coworker reads? | Coworker writes? |
+|---|---|---|---|
+| `Terminal-2/COWORKER_ONBOARDING.md` | The contract | Yes | No |
+| `Terminal-2/docs/coworker-handoff/SCOPE.md` | Scope rules in prose | Yes | No |
+| `Terminal-2/docs/coworker-handoff/QUERY_COOKBOOK.md` | Ready SQL examples | Yes | No |
+| `Terminal-2/docs/coworker-handoff/DATA_QUALITY_DASHBOARD.md` | First card scope | Yes | No |
+| `Terminal-2/docs/coworker-handoff/HANDOFF_INSTRUCTIONS.md` | This file | No | No (your reference) |
+| `Terminal-2/docs/database-map-2026-05-09.md` | Schema topology | Yes | No |
+| `Terminal-2/docs/phase2-ui-kanban.md` | Backlog | Yes | No |
+| `Terminal-2/SCHEMA.md` | Per-table column reference | Yes | No |
+| `Terminal-2/.github/CODEOWNERS` | Enforces backend ownership | n/a | No (CI rejects) |
+| `Terminal-2/.github/workflows/forbidden-paths-check.yml` | CI guard | n/a | No (CI rejects) |
+| `Terminal-2/supabase/migrations/20260509460000_coworker_readonly_role.sql` | DB role definition | n/a | No (cannot apply) |
+| `Terminal-2-ui/README.md` | Their repo's quick start | Yes | Yes |
+| `Terminal-2-ui/.env.example` | Env shape | Yes | Yes (if they need to add vars) |
+| `Terminal-2-ui/docs/scope.md` | Mirror of backend SCOPE.md | Yes | No (kept in sync from backend) |
+
+---
+
+## Sanity checklist before you send the message
+
+- [ ] `coworker_readonly` password rotated from placeholder
+- [ ] Branch protection enabled on `Terminal-2` `main`
+- [ ] Branch protection enabled on `Terminal-2-ui` `main`
+- [ ] Coworker invited to `Terminal-2-ui` (Settings → Collaborators)
+- [ ] Coworker NOT added to `Terminal-2`
+- [ ] Out-of-band encrypted message contains: Supabase DB URL +
+      password, API base URL, API Bearer token
+- [ ] Coworker has working access to Supabase MCP / their preferred
+      query tool (their problem to solve, but mention it)
+
+After sending, Phase 2 is officially in their hands. You and I move to
+backend-only work.

--- a/docs/coworker-handoff/QUERY_COOKBOOK.md
+++ b/docs/coworker-handoff/QUERY_COOKBOOK.md
@@ -1,0 +1,267 @@
+# QUERY_COOKBOOK — ready-to-paste SQL for common UI needs
+
+Every query here is `coworker_readonly`-safe (SELECT-only, no `net.http_*`
+calls). Designed for Supabase MCP or psql; copy + adjust.
+
+If a query you need isn't here, prototype in `design_test.*` and the
+audit lane can promote it to a public view if it's reusable.
+
+---
+
+## Quick orientation
+
+```sql
+-- How big is everything?
+SELECT
+  (SELECT count(*) FROM events)                     AS events,
+  (SELECT count(*) FROM events WHERE occurs_at_local::timestamptz BETWEEN now() AND now() + interval '60 days') AS upcoming_60d,
+  (SELECT count(*) FROM listings_snapshots)         AS tevo_listings_total,
+  (SELECT count(*) FROM listings_snapshots WHERE captured_at > now() - interval '24 hours') AS tevo_listings_24h,
+  (SELECT count(*) FROM seatgeek_listings_snapshots) AS sg_listings_total,
+  (SELECT count(*) FROM evo_orders)                  AS evo_orders,
+  (SELECT count(*) FROM seatgeek_orders)             AS sg_orders,
+  (SELECT count(*) FROM v_open_alerts)               AS open_alerts,
+  (SELECT count(*) FROM cron.job WHERE active)       AS active_crons;
+```
+
+---
+
+## Single-event AI/RAG bundle
+
+```sql
+-- Returns everything we know about an event in one JSON.
+-- Pass any tevo_event_id from the events table.
+SELECT jsonb_pretty(get_event_context(3345925));
+```
+
+Top-level keys: `event`, `pricing`, `espn`, `odds`, `performer`,
+`weather`, `competitors`, `reddit`, `important_news`, `x_accounts_known`,
+`our_orders`, `generated_at`.
+
+---
+
+## Upcoming events for the home page
+
+```sql
+SELECT
+  e.id, e.name, e.occurs_at_local, e.venue_name,
+  e.primary_performer_name, e.event_type,
+  -- Are there fresh listings?
+  EXISTS(SELECT 1 FROM listings_snapshots ls
+         WHERE ls.event_id = e.id
+           AND ls.captured_at > now() - interval '60 minutes') AS has_fresh_listings,
+  -- Get-in price right now
+  (SELECT min(retail_price) FROM listings_snapshots ls
+    WHERE ls.event_id = e.id
+      AND ls.captured_at = (SELECT max(captured_at) FROM listings_snapshots
+                            WHERE event_id = e.id)) AS getin_now
+FROM events e
+WHERE e.occurs_at_local::timestamptz BETWEEN now() AND now() + interval '14 days'
+ORDER BY e.occurs_at_local::timestamptz
+LIMIT 50;
+```
+
+---
+
+## Today's open alerts (for dashboards)
+
+```sql
+SELECT id, severity, rule_key, fired_at,
+       tevo_event_id, event_name, occurs_at_local, message
+FROM v_open_alerts
+ORDER BY
+  CASE severity WHEN 'critical' THEN 0 WHEN 'warn' THEN 1 ELSE 2 END,
+  fired_at DESC
+LIMIT 50;
+```
+
+---
+
+## Pricing — section-level cross-source view
+
+```sql
+-- TEvo vs SG vs SG-seller vs SD pricing per section, per event.
+SELECT *
+FROM v_pricing_cross_source
+WHERE tevo_event_id = 3344959  -- Thunder @ Lakers G3
+ORDER BY section;
+```
+
+---
+
+## Velocity — what's moving in the last hour / day
+
+```sql
+SELECT
+  tevo_event_id, name, venue_name,
+  tevo_getin_now, tevo_getin_d1h, tevo_getin_d1h_pct,
+  tevo_getin_d24h, tevo_getin_d24h_pct,
+  tevo_tix_now, tevo_tix_d1h, tevo_tix_d24h
+FROM v_event_velocity_windows
+WHERE tevo_getin_d1h_pct IS NOT NULL
+ORDER BY abs(tevo_getin_d1h_pct) DESC
+LIMIT 25;
+```
+
+---
+
+## Our orders + portfolio rollup
+
+```sql
+-- Per-event book: gross + net of fees
+SELECT * FROM our_orders_by_event_with_net
+WHERE tevo_event_id = 3345925;
+
+-- Every line item across TEvo + SG
+SELECT source, source_order_id, canonical_status,
+       gross_amount, net_amount, source_created_at
+FROM our_orders_with_net
+WHERE source_created_at > now() - interval '7 days'
+ORDER BY source_created_at DESC;
+
+-- SG-only sales detail per section/row
+SELECT * FROM v_sg_sales_by_section
+WHERE tevo_event_id = 3345925;
+```
+
+---
+
+## Reddit — what's getting flagged as important news
+
+```sql
+-- Posts in last 48h matching news keywords (injury/trade/IL/etc.)
+SELECT subreddit, title, author, created_utc,
+       keyword_match->'hits' AS keywords,
+       (keyword_match->>'total_weight')::numeric AS weight,
+       url
+FROM v_reddit_important_recent
+ORDER BY weight DESC, created_utc DESC
+LIMIT 25;
+
+-- Activity per performer (post counts)
+SELECT * FROM v_performer_reddit_pulse
+WHERE posts_24h > 0
+ORDER BY posts_24h DESC;
+```
+
+---
+
+## Competing events for any event in our catalog
+
+```sql
+SELECT competitors_count, competitors
+FROM event_competitors_snapshot
+WHERE tevo_event_id = 3345925;
+```
+
+`competitors` is a jsonb array of `{tevo_event_id, name, venue_name,
+distance_mi, hours_offset}`.
+
+---
+
+## Weather (works for indoor + outdoor, see mig 400000)
+
+```sql
+SELECT
+  tevo_event_id, event_name, venue_name, days_to_event,
+  weather_kind,    -- 'forecast_indoor' | 'forecast_outdoor' | etc.
+  is_indoor,
+  fcst_temp_f, fcst_precip_pct, fcst_wind_mph, fcst_summary
+FROM v_event_weather_with_fallback
+WHERE tevo_event_id = 3345925;
+```
+
+---
+
+## ESPN game state + betting odds
+
+```sql
+-- Latest ESPN state for any sports event
+SELECT
+  x.tevo_event_id, x.espn_event_id,
+  ee.captured_at, ee.state, ee.status_short,
+  ee.home_score, ee.away_score, ee.spread, ee.over_under,
+  ee.home_ml, ee.away_ml, ee.home_win_prob
+FROM event_xref x
+JOIN LATERAL (
+  SELECT * FROM espn_event_snapshots
+  WHERE espn_event_id = x.espn_event_id
+  ORDER BY captured_at DESC LIMIT 1
+) ee ON true
+WHERE x.tevo_event_id = 3346855;
+
+-- Line movement (1h / 24h)
+SELECT * FROM v_event_line_movement
+WHERE tevo_event_id = 3346855;
+```
+
+---
+
+## Coverage scoreboard — which events have which sources
+
+```sql
+-- For any event, which sources have data?
+WITH e AS (SELECT 3345925::bigint AS eid)
+SELECT
+  (SELECT count(*) FROM listings_snapshots WHERE event_id = e.eid)            AS tevo_listings,
+  (SELECT count(*) FROM event_metrics WHERE event_id = e.eid)                  AS tevo_metric_rows,
+  (SELECT count(*) FROM seatgeek_listings_snapshots WHERE tevo_event_id=e.eid) AS sg_listings,
+  (SELECT count(*) FROM seatgeek_orders WHERE tevo_event_id = e.eid)           AS sg_orders,
+  (SELECT count(*) FROM seatdata_sales_snapshots WHERE tevo_event_id = e.eid)  AS sd_sales,
+  (SELECT count(*) FROM evo_order_items WHERE event_id = e.eid)                AS evo_items,
+  (SELECT count(*) FROM espn_event_snapshots ee
+     JOIN event_xref x ON x.espn_event_id = ee.espn_event_id
+    WHERE x.tevo_event_id = e.eid)                                              AS espn_snapshots,
+  (SELECT count(*) FROM reddit_posts rp
+     JOIN performer_subreddits ps ON ps.subreddit = rp.subreddit
+     JOIN events ev ON ev.primary_performer_id = ps.tevo_performer_id
+    WHERE ev.id = e.eid AND rp.created_utc > now() - interval '7 days')         AS reddit_posts_7d
+FROM e;
+```
+
+---
+
+## Cron health (for the Data Quality Dashboard)
+
+```sql
+-- Last-24h success rate per cron (use in the dashboard)
+SELECT
+  j.jobname,
+  count(*) AS runs_24h,
+  count(*) FILTER (WHERE r.status = 'succeeded') AS ok,
+  count(*) FILTER (WHERE r.status != 'succeeded') AS fail,
+  round(100.0 * count(*) FILTER (WHERE r.status='succeeded') / NULLIF(count(*),0), 1) AS pct_ok,
+  max(r.start_time) AS latest_run
+FROM cron.job j
+LEFT JOIN cron.job_run_details r
+  ON r.jobid = j.jobid AND r.start_time > now() - interval '24 hours'
+WHERE j.active
+GROUP BY j.jobname
+ORDER BY pct_ok ASC NULLS LAST, j.jobname;
+```
+
+> Note: `coworker_readonly` does NOT have access to `cron.*`. For the
+> Data Quality Dashboard, the audit lane will provide a `v_cron_health`
+> view in `public` that exposes the same data. Open an issue when you're
+> ready to wire it.
+
+---
+
+## Sandbox example (design_test.*)
+
+```sql
+-- You can do anything you want in design_test
+CREATE TABLE design_test.my_dashboard_proto (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  payload jsonb,
+  created_at timestamptz DEFAULT now()
+);
+INSERT INTO design_test.my_dashboard_proto(name, payload)
+VALUES ('test', '{"hello":"world"}');
+SELECT * FROM design_test.my_dashboard_proto;
+DROP TABLE design_test.my_dashboard_proto;
+```
+
+The sandbox doesn't run on any cron and isn't read by any production
+view — it's truly your space.

--- a/docs/coworker-handoff/SCOPE.md
+++ b/docs/coworker-handoff/SCOPE.md
@@ -1,0 +1,87 @@
+# SCOPE — what you (UI coworker) can and can't touch
+
+This is the prose version of the rules. The mechanical enforcement
+is in:
+- `coworker_readonly` Postgres role (mig 20260509460000)
+- `.github/CODEOWNERS` on Terminal-2 backend repo
+- `.github/workflows/forbidden-paths-check.yml` CI guard
+- Branch protection on `main` requiring code-owner review
+
+---
+
+## Two repos
+
+| Repo | Yours? | What lives here |
+|---|---|---|
+| **Terminal-2** | No | Backend: FastAPI, plpgsql migrations, cron pipelines, RULE 2 enforcement |
+| **Terminal-2-ui** | **Yes** | Frontend: whatever stack you choose, calls Terminal-2's API + queries Supabase via `coworker_readonly` |
+
+You clone, branch, PR, and (if approved by audit lane) merge in
+`Terminal-2-ui`. You read but don't edit anything in `Terminal-2`.
+
+---
+
+## What you can read
+
+- All of `Terminal-2` source code (it's on GitHub; you have access).
+- All `public.*` tables and views in Supabase via `coworker_readonly`.
+- All read-only helper functions (e.g. `get_event_context(event_id)`).
+
+## What you can write
+
+- Anything in your `Terminal-2-ui` repo on a feature branch.
+- Anything in the `design_test.*` Postgres schema (your sandbox).
+- Issues + PRs in either repo.
+
+## What you can NOT write
+
+- `Terminal-2` repo files. CI guard rejects the PR; CODEOWNERS blocks
+  merge regardless. If you need a backend change, **open an issue** in
+  Terminal-2 describing the need, and the audit lane will write it.
+- `public.*` Postgres tables. Role doesn't allow it.
+- `vault.*` (secrets) or `cron.*` (scheduling). Role doesn't allow it.
+- Any function that calls `net.http_*` (paid pulls). Role denies execute.
+
+---
+
+## Three legal failure modes (for your sanity)
+
+### "I want to see if a query is fast enough"
+✓ Run it via Supabase MCP with `coworker_readonly`. EXPLAIN ANALYZE works.
+
+### "I want a new view that aggregates X"
+✗ Don't create it in `public.*` — role can't, and convention says no.
+✓ Prototype it in `design_test.*`, share the SQL in an issue, audit lane
+  decides whether to promote to `public` (and writes the migration).
+
+### "The API doesn't have an endpoint I need"
+✗ Don't add it to `app.py` — repo doesn't accept your PRs there.
+✓ Open an issue in `Terminal-2` describing what shape you need + why.
+  Audit lane writes the route.
+
+---
+
+## Why the constraints
+
+The data plane runs unattended on 48 active crons hitting paid APIs
+(TEvo + SeatGeek + SeatData when restored). A single rogue write (or
+misconfigured cron, or an experimental migration) can cost real money
+or corrupt the timeline of price data we depend on for trading
+decisions. **The cost of one accident is much higher than the friction
+of asking the audit lane.**
+
+This is also how the project audit (RULE 2: read-only enforcement on
+TEvo/SG hosts) survives: 3 layers of static analysis + runtime guards
++ tests catch any drift toward writes. UI work, by being on a separate
+repo with read-only DB access, can't drift this stack at all.
+
+---
+
+## When the friction is too high
+
+If "open an issue, wait for backend change" is blocking you for >24h,
+the right escalation is **DM Julian, not work-around**. Don't try to
+spin up your own Postgres or fork the API to add what you need — that
+fragments the data plane and creates a parallel reality where the UI
+shows numbers the rest of the team can't reproduce. The whole point of
+Terminal-2 is that there's one source of truth.

--- a/supabase/migrations/20260509460000_coworker_readonly_role.sql
+++ b/supabase/migrations/20260509460000_coworker_readonly_role.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- Migration 20260509460000 — coworker_readonly DB role for UI handoff
+--
+-- Phase 2 preamble: a UI coworker is starting on the Data Quality Dashboard
+-- (and will own UI from here forward). They need to:
+--   - SELECT from public.* tables and views
+--   - EXECUTE read-only helper functions (get_event_context etc.)
+--   - Sandbox in design_test schema (CREATE/SELECT/INSERT/UPDATE/DELETE)
+--
+-- They MUST NOT:
+--   - Write to public.*  (no INSERT/UPDATE/DELETE/TRUNCATE)
+--   - Touch vault.* (secrets)
+--   - Touch cron.* (scheduling)
+--   - Execute functions that fire net.http_* (data-plane writers)
+--
+-- This migration creates the role and grants. Connection string is given
+-- to the coworker out-of-band (treat the password like any other secret).
+-- ============================================================================
+
+-- (1) Create role with login + a placeholder password (rotated post-handoff)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'coworker_readonly') THEN
+    CREATE ROLE coworker_readonly LOGIN PASSWORD 'CHANGE_ME_BEFORE_HANDOFF';
+  END IF;
+END $$;
+
+-- (2) Read-only on public schema
+GRANT USAGE ON SCHEMA public TO coworker_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO coworker_readonly;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO coworker_readonly;
+
+-- New tables/views created later automatically pick up SELECT
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO coworker_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON SEQUENCES TO coworker_readonly;
+
+-- (3) EXECUTE on the AI/RAG-context + read helper functions.
+-- Conditional grant: signatures may evolve; skip without erroring.
+DO $$
+DECLARE r record; safe_funcs text[] := ARRAY[
+  'get_event_context','match_news_keywords','get_wiki_context',
+  'get_team_context','get_team_playoff_context','get_team_roster',
+  'get_player_info','haversine_miles','get_broker_event_detail',
+  'get_broker_events_upcoming','get_event_listings_public',
+  'get_event_zones_public','get_event_zones_rollup','get_event_movers',
+  'get_events_by_performer_public','get_performer_landing_public',
+  'get_performer_assets_public','get_performers_by_league',
+  'get_event_assets_public','get_recent_team_changes',
+  'get_chat_suggestion_chips','get_events_by_venue_public',
+  'get_venue_assets_public'
+];
+BEGIN
+  FOR r IN
+    SELECT p.oid,
+      n.nspname || '.' || p.proname || '(' ||
+      pg_get_function_identity_arguments(p.oid) || ')' AS sig
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = ANY(safe_funcs)
+  LOOP
+    EXECUTE 'GRANT EXECUTE ON FUNCTION ' || r.sig || ' TO coworker_readonly';
+  END LOOP;
+END $$;
+
+-- (4) Sandbox: full access to design_test for prototyping
+GRANT USAGE, CREATE ON SCHEMA design_test TO coworker_readonly;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRIGGER, REFERENCES
+  ON ALL TABLES IN SCHEMA design_test TO coworker_readonly;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA design_test TO coworker_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA design_test
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO coworker_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA design_test
+  GRANT EXECUTE ON FUNCTIONS TO coworker_readonly;
+
+-- (5) Hard denials — explicit revokes on dangerous surfaces
+REVOKE ALL ON SCHEMA cron FROM coworker_readonly;
+REVOKE ALL ON SCHEMA vault FROM coworker_readonly;
+REVOKE ALL ON ALL TABLES IN SCHEMA cron FROM coworker_readonly;
+REVOKE ALL ON ALL TABLES IN SCHEMA vault FROM coworker_readonly;
+
+-- Block functions that fire net.http_* (data-plane writers) + secret access.
+-- Conditional revoke for resilience to signature changes.
+DO $$
+DECLARE r record; danger_funcs text[] := ARRAY[
+  'evo_orders_queue','evo_orders_process','evo_event_backfill_queue',
+  'evo_event_backfill_process','sg_listings_queue_window','sg_listings_process',
+  'sg_seller_orders_queue','sg_seller_listings_queue','sg_seller_process',
+  'sg_event_backfill_queue','sg_event_backfill_process','weather_forecast_queue',
+  'weather_forecast_process','queue_performer_wiki_searches',
+  'process_performer_wiki_searches','process_performer_wiki_summaries',
+  'reddit_queue','reddit_process','cross_source_match_tick','compute_alerts_tick',
+  'refresh_event_competitors','get_app_secret','wiki_pageviews_queue',
+  'wiki_pageviews_process','venue_geocode_queue','venue_geocode_process'
+];
+BEGIN
+  FOR r IN
+    SELECT p.oid,
+      n.nspname || '.' || p.proname || '(' ||
+      pg_get_function_identity_arguments(p.oid) || ')' AS sig
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = ANY(danger_funcs)
+  LOOP
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION ' || r.sig || ' FROM coworker_readonly';
+  END LOOP;
+END $$;
+
+COMMENT ON ROLE coworker_readonly IS
+  'UI coworker role. SELECT-only on public, sandbox in design_test, blocked '
+  'from cron/vault and from any function that fires net.http_*. See '
+  'COWORKER_ONBOARDING.md for handoff terms.';


### PR DESCRIPTION
Phase 1 stable; spinning up Phase 2 UI handoff. Backend changes: coworker_readonly DB role, CODEOWNERS, CI guard workflow, rewritten onboarding, and full coworker-handoff docs bundle. Companion repo Terminal-2-ui created. Audit lane retains review-and-merge on both repos.