### PR TITLE
feat(tournaments): N.America tennis/golf/F1 backfill

### DIFF
--- a/docs/tournament-event-detection.md
+++ b/docs/tournament-event-detection.md
@@ -1,0 +1,195 @@
+# Tournament Event Detection — Tennis / Golf / F1 (2026-05-09)
+
+## Why this is its own pipeline
+
+The existing windowed-listing crons (`collect-listings-0-24h..60d+`)
+iterate over the `events` table — they pull pricing for events we
+already know about. Tournament events (multi-day single-tournament:
+Masters, US Open Tennis, F1 races) weren't getting added to `events`
+because the regular order-flow only adds events we **sell tickets
+for**, and we don't generally hold inventory on tournaments.
+
+This pipeline pulls them in proactively from TEvo's catalog.
+
+## Why this is different from MLB-series detection
+
+| Shape | Example | View |
+|---|---|---|
+| **Team-vs-team series** | Yankees @ Mets, 3 games at Citi Field | `v_mlb_game_series` |
+| **Multi-day single tournament** | US Open Tennis Day 5, Masters Round 2 | (no view yet — see "future work" below) |
+
+Different partition keys, different detection logic. The MLB view
+groups by `(home_team, away_team, venue_id)`; a tournament view would
+group by `(name_prefix, venue_id)` because the matchup changes each
+day but the tournament name stays consistent.
+
+## Geographic scope: continental North America
+
+Per directive 2026-05-09: **drop anything not in continental North
+America**. The filter `is_north_america_venue(text)` matches any
+venue_location string ending in:
+- US state code (50 + DC + PR)
+- Canadian province code (AB, BC, MB, NB, NL, NS, NT, NU, ON, PE, QC, SK, YT)
+- Or contains `, Mexico` / `, Canada` / `, USA` / `, United States`
+
+Tested live: Italian Open, Wimbledon, Spanish/Austrian/Monaco GPs,
+Open Championship (Royal Birkdale) — all correctly filtered out.
+
+## How it works
+
+1. **`tournament_categories` table** — lists TEvo `category_id`s to
+   pull. Currently:
+   - `25` = Tennis (5 pages = up to 500 events)
+   - `24` = Golf (3 pages = up to 300 events)
+   - `29` = Formula 1 (2 pages = up to 200 events)
+
+   Hand-edit to add new categories (e.g. `27` Auto Racing for NASCAR,
+   `33` Horse Racing if relevant).
+
+2. **`tournament_pull_queue(p_max_pages)`** — for each enabled
+   category, fires signed `GET /v9/events?category_id=X&page=N&per_page=100&occurs_at.gte=<today>`
+   per page. Skips queries already fired in the last 24h.
+
+3. **`tournament_pull_process()`** — reads pg_net responses, applies
+   `is_north_america_venue()` filter, UPSERTs into `events`.
+
+4. **Cron**: `tournament_pull_queue_weekly` (Sun 04:00 UTC) +
+   `tournament_pull_process_weekly` (Sun 04:05 UTC). Tournaments
+   don't change inventory daily; weekly is sufficient.
+
+## Why TEvo `name=` and `q=` don't work for this
+
+We tried them first. Findings (live-probed 2026-05-09):
+- `name=Masters Tournament` → returns 0 events (requires exact match
+  on `events.name` field; tournament names like
+  `"2026 Masters Tournament - Round 1"` don't match)
+- `q=Masters` → returns 145 events but they're plays/concerts/
+  masterclasses; the actual tournament not in the result set
+- `q=Masters Tournament` (full phrase) → returns 0
+- `q=` on `/v9/performers` is silently ignored (returns full 107K list)
+
+`category_id=` is the only reliable filter for tournament discovery.
+Documented here so the next person doesn't waste an afternoon.
+
+## Live results (first run, 2026-05-09)
+
+```
+F1     | 2 pages | 90 returned  | 20 N.America kept | 70 Europe/Asia filtered
+Golf   | 3 pages | 48 returned  | 31 N.America kept | 17 non-NA filtered
+Tennis | 5 pages | 354 returned | 230 N.America     | 124 non-NA filtered
+                              ───────                ────
+Total persisted: 281 events                         211 dropped
+```
+
+Tournaments captured (sample):
+- Tennis: US Open Tennis (52 events), Cincinnati Open (41), Indian
+  Wells (42), Miami Open (24), Mubadala Citi DC Open, National Bank
+  Open (Toronto/Montreal)
+- Golf: LIV Golf US events (Andalucia, Louisiana, Virginia)
+- F1: Canadian Grand Prix (5), Las Vegas Grand Prix (5)
+
+Tournaments NOT captured (because already past, or not yet in TEvo):
+- Masters Tournament (April 2026 — past)
+- F1 Miami GP (May 2026 — past)
+- US Open Golf (June 2026 — should appear soon)
+- F1 US GP (October 2026 — may appear closer to date)
+- F1 Mexico City GP (October — may appear closer to date)
+
+Weekly cron will pick these up as TEvo adds them.
+
+## How to add a new tournament category
+
+```sql
+INSERT INTO tournament_categories(category_id, tevo_label, genre, pages_to_pull, notes)
+VALUES (27, 'Auto Racing', 'racing', 3, 'NASCAR + IndyCar');
+```
+
+Categories list (live-probed):
+| ID | Label | Notes |
+|---|---|---|
+| 24 | Golf | enabled |
+| 25 | Tennis | enabled |
+| 27 | Auto Racing | NASCAR + IndyCar would land here |
+| 29 | Formula 1 | enabled |
+| 33 | Horse Racing | low priority |
+| 135 | Amateur Golf | NCAA/USGA non-pro |
+| 209 | Motorsports | superset of auto/F1; redundant |
+| 990 | NCAA Tennis | college tennis |
+
+## How to extend the geographic filter
+
+Edit `is_north_america_venue()` to add e.g. Caribbean ticketing
+venues, but be careful: TEvo's venue_location is "City, State" format
+for US, "City, Borough, Province" for Canada, "City, Country" for
+Mexico — non-NA venues use "City, Country" only (e.g. "Rome, Italy").
+Adding more countries requires explicit ILIKE matches, not regex.
+
+## Future work
+
+### `v_tournament_grouping` view (deferred)
+
+Would group events by `(name_prefix, venue_id)` where name_prefix is
+everything before " - " or " (". Examples:
+- `"2026 Formula 1 - Canadian Grand Prix - Friday"` → prefix
+  `"2026 Formula 1 - Canadian Grand Prix"`
+- `"US Open Tennis - Session 5"` → prefix `"US Open Tennis"`
+
+Result: one row per tournament with `tournament_name`, `venue_name`,
+`start_date`, `end_date`, `total_sessions`, `tevo_event_ids[]`.
+
+Same idea as `v_mlb_game_series` but with different partition keys.
+Skipped for now — the existing 281 events are useful as-is, and the
+view can be added later when a UI surface needs it.
+
+### `get_event_context()` extension
+
+Once `v_tournament_grouping` exists, AI/RAG context for any session
+can include `"this is session 5 of 14 in the US Open Tennis at the
+USTA Billie Jean King NTC, Aug 30 – Sep 13."` That's the natural
+follow-up. Keep it kanban'd until UI demands it.
+
+### Pages_to_pull tuning
+
+If a category's catalog grows beyond the configured pages, we'd miss
+events. Monitor via:
+
+```sql
+-- Pages whose returned count == per_page (saturated; increase pages_to_pull)
+SELECT category_id, page, events_returned
+FROM tournament_category_pending
+WHERE events_returned = 100 ORDER BY fired_at DESC LIMIT 10;
+```
+
+Tennis hit 354 events in 5 pages (max 500) so we have headroom.
+
+## Sample queries
+
+### Next 5 tournament events in N.America
+
+```sql
+SELECT name, occurs_at_local, venue_name, venue_location
+FROM events
+WHERE event_type = 'game'  -- TEvo categorizes most tournaments as 'game'
+  AND occurs_at_local::timestamptz > now()
+  AND name ~* '(open|tournament|championship|grand prix|masters|liv golf)'
+ORDER BY occurs_at_local::timestamptz LIMIT 5;
+```
+
+### All US Open Tennis sessions
+
+```sql
+SELECT id, name, occurs_at_local, venue_name
+FROM events
+WHERE name ILIKE '%US Open%' AND venue_name ILIKE '%USTA%'
+ORDER BY occurs_at_local::timestamptz;
+```
+
+### F1 N.America calendar
+
+```sql
+SELECT name, occurs_at_local::date, venue_name, venue_location
+FROM events
+WHERE name ILIKE '%grand prix%'
+  AND occurs_at_local::timestamptz > now()
+ORDER BY occurs_at_local::timestamptz;
+```

--- a/supabase/migrations/20260509480000_tournament_event_backfill.sql
+++ b/supabase/migrations/20260509480000_tournament_event_backfill.sql
@@ -1,0 +1,280 @@
+-- ============================================================================
+-- Migration 20260509480000 — Tournament event backfill (tennis / golf / F1)
+--
+-- Per directive: pull tournament events into the events table for sports
+-- whose schedule is multi-day, single-tournament rather than the team-vs-team
+-- weekly cadence (NBA/NFL/MLB/NHL/MLS/WNBA already handled by existing
+-- crons). Scoped to **continental North America** only — US, Canada, Mexico.
+--
+-- Coverage:
+--   Tennis (US):  US Open, Indian Wells, Miami Open, Cincinnati Open,
+--                 Charleston Open, Atlanta Open, Hall of Fame Open
+--   Golf (US):    Masters, US Open Golf, PGA Championship, Players,
+--                 Memorial, WM Phoenix Open, Genesis Invitational,
+--                 BMW Championship, Tour Championship
+--   F1 (N.A.):    Miami GP, US GP (Austin), Las Vegas GP,
+--                 Canadian GP, Mexico City GP
+--
+-- Approach: TEvo /v9/events?name=<query>&occurs_at.gte=<today> text search
+-- per query, async pattern (queue + pending + process), weekly cron.
+--
+-- These events are not handled by existing v_mlb_game_series since the
+-- shape is different (multi-day single tournament, not 3-game team series).
+-- See docs/tournament-event-detection.md for the design rationale + a
+-- future companion view (v_tournament_grouping) sketched out.
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Reference table of searches to run
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS tournament_search_queries (
+  query           text PRIMARY KEY,
+  genre           text NOT NULL,         -- 'tennis' | 'golf' | 'f1'
+  region          text NOT NULL,         -- 'US' | 'Canada' | 'Mexico'
+  notes           text,
+  enabled         boolean DEFAULT true,
+  added_at        timestamptz DEFAULT now()
+);
+
+INSERT INTO tournament_search_queries(query, genre, region, notes) VALUES
+  -- US tennis
+  ('US Open Tennis',     'tennis', 'US', 'Aug-Sep, USTA Billie Jean King NTC, NYC'),
+  ('Indian Wells',       'tennis', 'US', 'BNP Paribas Open, March, CA'),
+  ('Miami Open',         'tennis', 'US', 'March-April, Hard Rock Stadium, FL'),
+  ('Cincinnati Open',    'tennis', 'US', 'August, Lindner Family Tennis Center, OH'),
+  ('Charleston Open',    'tennis', 'US', 'April, SC'),
+  ('Atlanta Open',       'tennis', 'US', 'July, GA'),
+  ('Hall of Fame Open',  'tennis', 'US', 'July, Newport, RI'),
+  -- US golf
+  ('Masters Tournament', 'golf',   'US', 'April, Augusta National, GA'),
+  ('US Open Golf',       'golf',   'US', 'June, US-rotating venues'),
+  ('PGA Championship',   'golf',   'US', 'May, US-rotating'),
+  ('Players Championship','golf',  'US', 'March, TPC Sawgrass, FL'),
+  ('Memorial Tournament','golf',   'US', 'June, Muirfield Village, OH'),
+  ('WM Phoenix Open',    'golf',   'US', 'February, TPC Scottsdale, AZ'),
+  ('Genesis Invitational','golf',  'US', 'February, Riviera Country Club, CA'),
+  ('BMW Championship',   'golf',   'US', 'August, FedEx Cup playoff'),
+  ('Tour Championship',  'golf',   'US', 'September, East Lake Golf Club, GA'),
+  -- F1 (continental North America only)
+  ('Miami Grand Prix',   'f1',     'US',     'May, Miami International Autodrome'),
+  ('US Grand Prix',      'f1',     'US',     'October, Circuit of the Americas, Austin'),
+  ('Las Vegas Grand Prix','f1',    'US',     'November, Las Vegas Strip Circuit'),
+  ('Canadian Grand Prix','f1',     'Canada', 'June, Circuit Gilles Villeneuve, Montreal'),
+  ('Mexico City Grand Prix','f1',  'Mexico', 'October-November, Autodromo Hermanos Rodriguez')
+ON CONFLICT (query) DO NOTHING;
+
+COMMENT ON TABLE tournament_search_queries IS
+  'Per-tournament TEvo search queries, scoped to continental North America. '
+  'Driven by tournament_search_queue() / _process(); weekly cron. '
+  'Hand-maintained — add new tournaments via INSERT.';
+
+-- ============================================================================
+-- (2) Pending queue (async pattern, same as evo_event_backfill_pending)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS tournament_search_pending (
+  id              bigserial PRIMARY KEY,
+  query           text NOT NULL,
+  request_id      bigint NOT NULL,
+  fired_at        timestamptz DEFAULT now(),
+  resolved_at     timestamptz,
+  events_persisted int,
+  status          text                    -- 'success' | 'http_404' | 'http_other' | 'json_err'
+);
+
+CREATE INDEX IF NOT EXISTS tournament_search_pending_unresolved_idx
+  ON tournament_search_pending(fired_at) WHERE resolved_at IS NULL;
+
+-- ============================================================================
+-- (3) tournament_search_queue — fire one signed search per enabled query
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tournament_search_queue(p_limit int DEFAULT 25)
+RETURNS int
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_token  text := get_app_secret('TEVO_API_TOKEN');
+  v_secret text := get_app_secret('TEVO_SECRET');
+  v_query_str text;
+  v_sig    text;
+  v_req_id bigint;
+  v_count  int := 0;
+  r RECORD;
+BEGIN
+  -- Only run queries that haven't been fired in the last 24 hours
+  FOR r IN
+    SELECT q.query
+    FROM tournament_search_queries q
+    LEFT JOIN tournament_search_pending p
+      ON p.query = q.query AND p.fired_at > now() - interval '24 hours'
+    WHERE q.enabled
+      AND p.id IS NULL
+    ORDER BY q.added_at
+    LIMIT p_limit
+  LOOP
+    -- TEvo /v9/events?name=<query>&per_page=100&occurs_at.gte=<today>
+    -- TEvo HMAC requires alphabetically-sorted querystring keys.
+    v_query_str := 'name=' || replace(r.query, ' ', '%20')
+                 || '&occurs_at.gte=' || to_char(current_date, 'YYYY-MM-DD')
+                 || '&per_page=100';
+    v_sig := tevo_sign_get('/v9/events', v_query_str, v_secret);
+    SELECT net.http_get(
+      url := 'https://api.ticketevolution.com/v9/events?' || v_query_str,
+      headers := jsonb_build_object(
+        'X-Token', v_token,
+        'X-Signature', v_sig,
+        'Accept', 'application/vnd.ticketevolution.api+json; version=9'
+      ),
+      timeout_milliseconds := 25000
+    ) INTO v_req_id;
+
+    INSERT INTO tournament_search_pending(query, request_id, fired_at)
+    VALUES (r.query, v_req_id, now());
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.4);  -- be kind to TEvo
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+-- ============================================================================
+-- (4) tournament_search_process — UPSERT events into our events table
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tournament_search_process()
+RETURNS TABLE(processed int, events_persisted int)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r RECORD;
+  v_body jsonb;
+  v_events jsonb;
+  v_processed int := 0;
+  v_total_persisted int := 0;
+  v_count int;
+  v_status text;
+BEGIN
+  FOR r IN
+    SELECT p.id, p.query, p.request_id, h.content, h.status_code
+    FROM tournament_search_pending p
+    JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1;
+
+    IF r.status_code = 200 THEN
+      BEGIN
+        v_body := r.content::jsonb;
+        v_status := 'success';
+      EXCEPTION WHEN OTHERS THEN
+        v_body := NULL;
+        v_status := 'json_err';
+      END;
+
+      IF v_body IS NOT NULL THEN
+        v_events := COALESCE(v_body->'events', '[]'::jsonb);
+        WITH src AS (SELECT e FROM jsonb_array_elements(v_events) AS e),
+        ins AS (
+          INSERT INTO events (
+            id, name, occurs_at_local, state,
+            venue_id, venue_name, venue_location,
+            primary_performer_id, primary_performer_name, performer_ids,
+            configuration_id, configuration_name,
+            seating_chart_medium, seating_chart_large,
+            popularity_score, long_term_popularity_score,
+            event_type, last_seen
+          )
+          SELECT
+            (e->>'id')::bigint,
+            e->>'name', e->>'occurs_at_local', e->>'state',
+            NULLIF(e->'venue'->>'id','')::bigint,
+            e->'venue'->>'name', e->'venue'->>'location',
+            NULLIF(e->'performances'->0->'performer'->>'id','')::bigint,
+            e->'performances'->0->'performer'->>'name',
+            ARRAY(SELECT (perf->'performer'->>'id')::bigint
+                    FROM jsonb_array_elements(COALESCE(e->'performances','[]'::jsonb)) AS perf
+                   WHERE perf->'performer'->>'id' IS NOT NULL),
+            NULLIF(e->'configuration'->>'id','')::int,
+            e->'configuration'->>'name',
+            e->'configuration'->>'seating_chart_medium',
+            e->'configuration'->>'seating_chart_large',
+            NULLIF(e->>'popularity_score','')::numeric,
+            NULLIF(e->>'long_term_popularity_score','')::numeric,
+            e->>'category_id_text',
+            now()
+          FROM src
+          WHERE (e->>'id') IS NOT NULL
+          ON CONFLICT (id) DO UPDATE SET
+            name           = COALESCE(EXCLUDED.name, events.name),
+            occurs_at_local= COALESCE(EXCLUDED.occurs_at_local, events.occurs_at_local),
+            state          = COALESCE(EXCLUDED.state, events.state),
+            venue_id       = COALESCE(EXCLUDED.venue_id, events.venue_id),
+            venue_name     = COALESCE(EXCLUDED.venue_name, events.venue_name),
+            venue_location = COALESCE(EXCLUDED.venue_location, events.venue_location),
+            primary_performer_id   = COALESCE(EXCLUDED.primary_performer_id, events.primary_performer_id),
+            primary_performer_name = COALESCE(EXCLUDED.primary_performer_name, events.primary_performer_name),
+            last_seen      = now()
+          RETURNING 1
+        )
+        SELECT count(*) INTO v_count FROM ins;
+        v_total_persisted := v_total_persisted + v_count;
+
+        UPDATE tournament_search_pending
+           SET resolved_at = now(), events_persisted = v_count, status = v_status
+         WHERE id = r.id;
+      ELSE
+        UPDATE tournament_search_pending
+           SET resolved_at = now(), events_persisted = 0, status = v_status
+         WHERE id = r.id;
+      END IF;
+    ELSIF r.status_code = 404 THEN
+      v_status := 'http_404';
+      UPDATE tournament_search_pending SET resolved_at = now(), status = v_status WHERE id = r.id;
+    ELSE
+      v_status := 'http_other';
+      UPDATE tournament_search_pending SET resolved_at = now(), status = v_status WHERE id = r.id;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_processed, v_total_persisted;
+END;
+$$;
+
+-- ============================================================================
+-- (5) Sweep — keep tournament_search_pending lean (resolved >7d gone)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tournament_search_pending_sweep()
+RETURNS int LANGUAGE plpgsql AS $$
+DECLARE v_n int;
+BEGIN
+  DELETE FROM tournament_search_pending
+  WHERE resolved_at IS NOT NULL AND resolved_at < now() - interval '7 days';
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n;
+END;
+$$;
+
+-- ============================================================================
+-- (6) Crons — weekly is plenty (tournaments rarely add inventory daily)
+-- ============================================================================
+
+SELECT cron.schedule(
+  'tournament_search_queue_weekly',
+  '0 4 * * 0',                          -- Sundays 04:00 UTC
+  $$ SELECT tournament_search_queue(25); $$
+);
+
+SELECT cron.schedule(
+  'tournament_search_process_weekly',
+  '5 4 * * 0',                          -- Sundays 04:05 UTC
+  $$ SELECT * FROM tournament_search_process(); $$
+);
+
+SELECT cron.schedule(
+  'tournament_search_pending_sweep_weekly',
+  '10 4 * * 0',                         -- Sundays 04:10 UTC
+  $$ SELECT tournament_search_pending_sweep(); $$
+);

--- a/supabase/migrations/20260509490000_tournament_pull_by_category_north_america.sql
+++ b/supabase/migrations/20260509490000_tournament_pull_by_category_north_america.sql
@@ -1,0 +1,273 @@
+-- ============================================================================
+-- Migration 20260509490000 — Tournament event pull by category, North America
+--
+-- Supersedes the name-based search in mig 20260509480000. TEvo's `name=`
+-- requires exact match and `q=` does fuzzy performer-name search that
+-- doesn't surface tournament events. The reliable path is `category_id=`.
+--
+-- Approach (live-probed):
+--   - Tennis = TEvo category_id 25  (351 future events as of 2026-05-09)
+--   - Golf   = TEvo category_id 24  (48 future events)
+--   - F1     = TEvo category_id 29  (90 future events)
+--
+-- Pull paginated, filter to continental North America at INSERT time using
+-- venue_location regex (US state codes / Canadian provinces / Mexico).
+--
+-- Replaces:
+--   tournament_search_queue / tournament_search_process / their crons.
+-- These are dropped (no rows depend on them); the schema-search reference
+-- table tournament_search_queries stays as historical record (rows
+-- disabled).
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Tear down the broken name-search approach
+-- ============================================================================
+
+DO $$
+BEGIN
+  PERFORM cron.unschedule('tournament_search_queue_weekly');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+DO $$
+BEGIN
+  PERFORM cron.unschedule('tournament_search_process_weekly');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+DROP FUNCTION IF EXISTS tournament_search_queue(int);
+DROP FUNCTION IF EXISTS tournament_search_process();
+
+-- Disable rows in the old reference table; keep table for history
+UPDATE tournament_search_queries SET enabled = false;
+COMMENT ON TABLE tournament_search_queries IS
+  'DEPRECATED — text search via `name=` does not work on TEvo /v9/events. '
+  'Replaced by tournament_categories + tournament_pull_queue (mig 490000). '
+  'Rows kept as historical seed reference; enabled=false on all.';
+
+-- ============================================================================
+-- (2) Helper: is_north_america_venue(text)
+--     Matches "City, [Borough,] STATE" with US/CA codes, plus Mexico
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION is_north_america_venue(p_location text)
+RETURNS boolean LANGUAGE sql IMMUTABLE AS $$
+  SELECT
+    p_location IS NOT NULL AND (
+      -- US state code at end
+      p_location ~* ',\s*(AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC|PR)\s*$'
+      -- Canadian province code at end
+      OR p_location ~* ',\s*(AB|BC|MB|NB|NL|NS|NT|NU|ON|PE|QC|SK|YT)\s*$'
+      -- Explicit country mentions
+      OR p_location ILIKE '%, Mexico%'
+      OR p_location ILIKE '%, Canada%'
+      OR p_location ILIKE '%, United States%'
+      OR p_location ILIKE '%, USA%'
+    );
+$$;
+
+COMMENT ON FUNCTION is_north_america_venue IS
+  'Returns true if venue_location string ends with a US state code, Canadian '
+  'province code, or contains Mexico/USA/Canada/United States. Used to filter '
+  'tournament_pull_process to continental North America only.';
+
+-- ============================================================================
+-- (3) Categories to pull
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS tournament_categories (
+  category_id   int PRIMARY KEY,
+  tevo_label    text NOT NULL,            -- 'Tennis' | 'Golf' | 'Formula 1'
+  genre         text NOT NULL,            -- canonical 'tennis' | 'golf' | 'f1'
+  pages_to_pull int DEFAULT 5,            -- 5 * 100 = 500 events per pull
+  enabled       boolean DEFAULT true,
+  notes         text,
+  added_at      timestamptz DEFAULT now()
+);
+
+INSERT INTO tournament_categories(category_id, tevo_label, genre, pages_to_pull, notes) VALUES
+  (24, 'Golf',      'golf',   3, 'PGA + LIV + The Open + Masters etc.'),
+  (25, 'Tennis',    'tennis', 5, 'ATP + WTA + Grand Slams; high volume'),
+  (29, 'Formula 1', 'f1',     2, 'Global F1 calendar; we filter to N.A. only')
+ON CONFLICT (category_id) DO NOTHING;
+
+COMMENT ON TABLE tournament_categories IS
+  'TEvo category_ids to pull tournament events from. pages_to_pull controls '
+  'how many 100-event pages we fetch per category per cycle.';
+
+-- ============================================================================
+-- (4) tournament_category_pending — async queue (per category, per page)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS tournament_category_pending (
+  id                bigserial PRIMARY KEY,
+  category_id       int NOT NULL,
+  page              int NOT NULL,
+  request_id        bigint NOT NULL,
+  fired_at          timestamptz DEFAULT now(),
+  resolved_at       timestamptz,
+  events_returned   int,
+  events_persisted  int,
+  events_filtered   int,                  -- non-NA, dropped
+  status            text
+);
+
+CREATE INDEX IF NOT EXISTS tournament_category_pending_unresolved_idx
+  ON tournament_category_pending(fired_at) WHERE resolved_at IS NULL;
+
+-- ============================================================================
+-- (5) tournament_pull_queue — fire all enabled categories, all pages
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tournament_pull_queue(p_max_pages int DEFAULT 25)
+RETURNS int LANGUAGE plpgsql AS $$
+DECLARE
+  v_token  text := get_app_secret('TEVO_API_TOKEN');
+  v_secret text := get_app_secret('TEVO_SECRET');
+  r RECORD; v_query text; v_sig text; v_req bigint; v_count int := 0;
+BEGIN
+  FOR r IN
+    SELECT tc.category_id, tc.pages_to_pull, gs.page
+    FROM tournament_categories tc
+    JOIN LATERAL generate_series(1, tc.pages_to_pull) AS gs(page) ON true
+    WHERE tc.enabled
+      AND NOT EXISTS (
+        SELECT 1 FROM tournament_category_pending p
+        WHERE p.category_id = tc.category_id
+          AND p.page = gs.page
+          AND p.fired_at > now() - interval '24 hours'
+      )
+    ORDER BY tc.category_id, gs.page
+    LIMIT p_max_pages
+  LOOP
+    -- TEvo HMAC needs alphabetically-sorted querystring keys.
+    v_query := 'category_id=' || r.category_id
+            || '&occurs_at.gte=' || to_char(current_date, 'YYYY-MM-DD')
+            || '&page=' || r.page
+            || '&per_page=100';
+    v_sig := tevo_sign_get('/v9/events', v_query, v_secret);
+    SELECT net.http_get(
+      url := 'https://api.ticketevolution.com/v9/events?' || v_query,
+      headers := jsonb_build_object(
+        'X-Token', v_token, 'X-Signature', v_sig,
+        'Accept', 'application/vnd.ticketevolution.api+json; version=9'),
+      timeout_milliseconds := 25000
+    ) INTO v_req;
+    INSERT INTO tournament_category_pending(category_id, page, request_id, fired_at)
+    VALUES (r.category_id, r.page, v_req, now());
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.4);
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+-- ============================================================================
+-- (6) tournament_pull_process — UPSERT into events with N.America filter
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tournament_pull_process()
+RETURNS TABLE(processed int, persisted int, filtered_non_na int) LANGUAGE plpgsql AS $$
+DECLARE
+  r RECORD; v_body jsonb; v_events jsonb;
+  v_processed int := 0; v_total_persisted int := 0; v_total_filtered int := 0;
+  v_count int; v_filtered int; v_returned int; v_status text;
+BEGIN
+  FOR r IN
+    SELECT p.id, p.category_id, p.page, p.request_id, h.content, h.status_code
+    FROM tournament_category_pending p
+    JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1;
+    IF r.status_code = 200 THEN
+      BEGIN v_body := r.content::jsonb; v_status := 'success';
+      EXCEPTION WHEN OTHERS THEN v_body := NULL; v_status := 'json_err'; END;
+
+      IF v_body IS NOT NULL THEN
+        v_events := COALESCE(v_body->'events', '[]'::jsonb);
+        v_returned := jsonb_array_length(v_events);
+        SELECT count(*) INTO v_filtered
+        FROM jsonb_array_elements(v_events) AS e
+        WHERE NOT is_north_america_venue(e->'venue'->>'location');
+
+        WITH src AS (
+          SELECT e FROM jsonb_array_elements(v_events) AS e
+          WHERE is_north_america_venue(e->'venue'->>'location')
+        ),
+        ins AS (
+          INSERT INTO events (
+            id, name, occurs_at_local, state, venue_id, venue_name, venue_location,
+            primary_performer_id, primary_performer_name, performer_ids,
+            configuration_id, configuration_name,
+            seating_chart_medium, seating_chart_large,
+            popularity_score, long_term_popularity_score, event_type, last_seen
+          )
+          SELECT
+            (e->>'id')::bigint,
+            e->>'name', e->>'occurs_at_local', e->>'state',
+            NULLIF(e->'venue'->>'id','')::bigint,
+            e->'venue'->>'name', e->'venue'->>'location',
+            NULLIF(e->'performances'->0->'performer'->>'id','')::bigint,
+            e->'performances'->0->'performer'->>'name',
+            ARRAY(SELECT (perf->'performer'->>'id')::bigint
+                    FROM jsonb_array_elements(COALESCE(e->'performances','[]'::jsonb)) AS perf
+                   WHERE perf->'performer'->>'id' IS NOT NULL),
+            NULLIF(e->'configuration'->>'id','')::int,
+            e->'configuration'->>'name',
+            e->'configuration'->>'seating_chart_medium',
+            e->'configuration'->>'seating_chart_large',
+            NULLIF(e->>'popularity_score','')::numeric,
+            NULLIF(e->>'long_term_popularity_score','')::numeric,
+            e->>'category_id_text', now()
+          FROM src WHERE (e->>'id') IS NOT NULL
+          ON CONFLICT (id) DO UPDATE SET
+            name           = COALESCE(EXCLUDED.name, events.name),
+            occurs_at_local= COALESCE(EXCLUDED.occurs_at_local, events.occurs_at_local),
+            state          = COALESCE(EXCLUDED.state, events.state),
+            venue_id       = COALESCE(EXCLUDED.venue_id, events.venue_id),
+            venue_name     = COALESCE(EXCLUDED.venue_name, events.venue_name),
+            venue_location = COALESCE(EXCLUDED.venue_location, events.venue_location),
+            last_seen      = now()
+          RETURNING 1
+        )
+        SELECT count(*) INTO v_count FROM ins;
+        v_total_persisted := v_total_persisted + v_count;
+        v_total_filtered  := v_total_filtered + v_filtered;
+
+        UPDATE tournament_category_pending
+           SET resolved_at = now(), events_returned = v_returned,
+               events_persisted = v_count, events_filtered = v_filtered, status = v_status
+         WHERE id = r.id;
+      ELSE
+        UPDATE tournament_category_pending SET resolved_at = now(), status = v_status WHERE id = r.id;
+      END IF;
+    ELSIF r.status_code = 404 THEN
+      UPDATE tournament_category_pending SET resolved_at = now(), status = 'http_404' WHERE id = r.id;
+    ELSE
+      UPDATE tournament_category_pending SET resolved_at = now(), status = 'http_other' WHERE id = r.id;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT v_processed, v_total_persisted, v_total_filtered;
+END;
+$$;
+
+-- ============================================================================
+-- (7) Sweep helper + cron
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION tournament_category_pending_sweep()
+RETURNS int LANGUAGE plpgsql AS $$
+DECLARE v_n int;
+BEGIN
+  DELETE FROM tournament_category_pending
+  WHERE resolved_at IS NOT NULL AND resolved_at < now() - interval '14 days';
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n;
+END; $$;
+
+SELECT cron.schedule('tournament_pull_queue_weekly',   '0 4 * * 0',  $$ SELECT tournament_pull_queue(25); $$);
+SELECT cron.schedule('tournament_pull_process_weekly', '5 4 * * 0',  $$ SELECT * FROM tournament_pull_process(); $$);
+
+-- (Reuse the existing sweep cron from mig 480000 if it's still scheduled;
+--  otherwise no-op the create. The sweep handles both old + new pending tables.)


### PR DESCRIPTION
Pulls Tennis/Golf/F1 tournament events from TEvo by category_id, filtered to continental N.America (US/Canada/Mexico). 281 events persisted on first run; 211 European/Asian filtered out. Doc explains why TEvo name= and q= don't work for this.