### PR TITLE
feat(events): tours/residencies/Broadway runs + venue-specific pulls

### DIFF
--- a/docs/concerts-broadway-tours-residencies.md
+++ b/docs/concerts-broadway-tours-residencies.md
@@ -1,0 +1,206 @@
+# Concerts / Broadway / Tours / Residencies — Detection (2026-05-09)
+
+Three structural patterns detected automatically from the `events`
+table, each with its own view. Companion to:
+- `docs/mlb-game-series-detection.md` (team-vs-team series)
+- `docs/tournament-event-detection.md` (multi-day single-tournament)
+
+## Three patterns + their detection rules
+
+| Pattern | Shape | View | Threshold |
+|---|---|---|---|
+| **Tour** | Same performer at ≥2 distinct venues, multi-city | `v_performer_tours` | `venue_count >= 2`, future 12 months |
+| **Residency** | Same performer at ONE venue, ≥3 dates over ≥14 days | `v_performer_residencies` | `show_count >= 3`, span ≥14 days |
+| **Broadway run** | Subset of residencies at known Broadway theaters | `v_broadway_runs` | residency + venue match |
+
+Each is a query against the events table, no separate storage.
+
+## Examples (verified live 2026-05-09)
+
+### Tours
+
+```
+UB40                  | 27 venues | 28 shows | Oct 2 → Nov 15 2026 | 17 regions (US + Canada)
+Bayonne               | 27 venues | 27 shows | Sep 27 → Nov 24 2026 | 24 states
+Madison Beer          | 12 venues | 12 shows | Jun 23 → Jul 13 2026 | 11 regions
+Suffs (Musical)       |  4 venues | 23 shows | May 9 → Jun 5 2026   | 4 regions (Broadway-on-tour)
+```
+
+### Residencies
+
+```
+Sphere (Las Vegas, NV — venue_id 44984):
+  The Wizard of Oz at Sphere   | 256 shows | May 9 → Aug 27 2026 (110 days)
+  Backstreet Boys              |  18 shows | Jul 16 → Aug 22 (37 days)
+  No Doubt                     |  16 shows | May 9 → Jun 13  (35 days)
+  Kenny Chesney                |   9 shows | Jun 19 → Jul 11 (22 days)
+```
+
+### Broadway runs
+
+```
+The Lion King — Minskoff Theatre   | 32 shows | May 9 → Jun 5 2026 (27 days)
+Wicked — Gershwin Theatre          | 33 shows
+Hadestown — Walter Kerr Theatre    | 33 shows
+MJ The Musical — Neil Simon        | 33 shows
+Maybe Happy Ending — Belasco       | 32 shows
+Stranger Things — Marquis Theatre  | 32 shows
+... (10+ more)
+```
+
+## Why we needed venue-specific pulls (`venue_pulls` table)
+
+TEvo's `/v9/events?category_id=54` is **popularity-sorted**. With
+`pages_to_pull=20` (= 2000 events), we cover the most-popular global
+concerts. But:
+
+- **Bruce Springsteen tour stops** outside MSG — not in top 2000
+- **Sphere residencies** — niche venue, lower aggregate popularity than
+  individual major-arena concerts
+- **MSG residencies** (Phish, Billy Joel runs) — same problem
+
+**Solution:** seed `venue_pulls` table with TEvo `venue_id`s for venues
+we want full coverage on, regardless of popularity. The companion
+function `venue_pull_queue()` fires `/v9/events?venue_id=X&page=N`
+paginated.
+
+Initial seeds (mig 510000):
+| TEvo venue_id | Venue | Reason |
+|---:|---|---|
+| 44984 | Sphere (Las Vegas, NV) | Residency venue |
+| 896 | Madison Square Garden | Major arena, Bruce/Phish/Billy Joel runs |
+| 1262 | Hard Rock Stadium | Major arena (also tennis Miami Open) |
+
+To add a venue: look up the `venue_id` via `/v9/venues?name=<query>`,
+then `INSERT INTO venue_pulls(...)`. Weekly cron picks it up.
+
+## Schema reuse
+
+`venue_pulls` reuses the existing `tournament_category_pending` queue
+table by storing rows with `category_id = -venue_id` as a sentinel.
+The existing `tournament_pull_process()` function processes both
+category-based and venue-based pulls identically — same UPSERT shape
+into `events`. This avoided creating a parallel queue/process pair.
+
+## Detection logic (in plain English)
+
+### `v_performer_tours`
+
+Group all future events (next 12 months) by `primary_performer_id`.
+Keep rows where `count(DISTINCT venue_id) >= 2`. Output:
+- `venue_count`, `show_count`, `tour_first_show`, `tour_last_show`,
+  `tour_span_days`
+- `venues[]` array (alphabetical)
+- `regions[]` array (state codes / countries)
+- `tevo_event_ids[]` (chronological)
+
+Excludes `event_type = 'game'` so MLB road trips don't pollute.
+
+### `v_performer_residencies`
+
+Group all future events (next 24 months — longer because Broadway
+runs span years) by `(primary_performer_id, venue_id)`. Keep where:
+- `count(*) >= 3`
+- `(max_date - min_date) >= 14`
+
+Output: same shape as tours, plus `venue_id`, `venue_name`,
+`venue_location`.
+
+Includes both Vegas-style residencies and Broadway runs.
+
+### `v_broadway_runs`
+
+Subset of `v_performer_residencies` where venue_name matches a known
+Broadway theater (hardcoded list in the view). Adds
+`broadway_theater_name` column derived from `important_x_accounts`
+where `account_type='broadway_theater'`.
+
+The hardcoded venue list is in the WHERE clause (`venue_name ILIKE
+ANY (ARRAY[...])`). Adding a new Broadway theater means editing the
+view, not just inserting data — TODO: refactor to a reference table
+when the list outgrows ~30 entries.
+
+## Edge cases / caveats
+
+- **A residency that's also touring**: rare but possible (artist
+  has Vegas residency dates AND tour stops). Both views will show
+  them; consumer needs to disambiguate. Acceptable today.
+
+- **Broadway "tour" labeling**: a Broadway show on national tour
+  (e.g. "Mean Girls — National Tour") will appear in both
+  `v_performer_tours` (multiple cities) AND potentially
+  `v_performer_residencies` if the touring production sits at a
+  single regional venue for ≥14 days. That's the right behavior —
+  it IS a residency at that regional venue while being a tour overall.
+
+- **Concert pull popularity coverage**: the 2000-event ceiling means
+  niche tours (regional folk artists, small venues) won't surface.
+  The trade-off: more pages = more API cost + storage. 20 pages is
+  fine for current needs.
+
+- **N. America filter applies here too** (from mig 490000). Non-NA
+  venues filtered at INSERT time. International tours (Coldplay's
+  Paris dates, Taylor Swift's Tokyo) won't appear unless they hit a
+  N.A. stop.
+
+- **TEvo rate limits**: live-tested today, hit 429 after ~30 paged
+  GETs in quick succession. The weekly cron stagger
+  (04:00 / 04:05 / 04:15 / 04:25) should keep us under the budget.
+  If we add many more venue pulls, may need to spread firing over
+  multiple cron windows.
+
+## Sample queries
+
+### Bruce Springsteen tour visibility (after weekly cron lands his data)
+
+```sql
+SELECT * FROM v_performer_tours
+WHERE primary_performer_name ILIKE '%bruce springsteen%';
+```
+
+### Find all Broadway shows currently running
+
+```sql
+SELECT primary_performer_name, venue_name, show_count, residency_span_days
+FROM v_broadway_runs
+ORDER BY residency_start;
+```
+
+### Compare Sphere residency demand
+
+```sql
+SELECT pr.primary_performer_name, pr.show_count,
+       lem.getin_price, lem.retail_median
+FROM v_performer_residencies pr
+JOIN events e ON e.id = pr.tevo_event_ids[1]      -- first show
+LEFT JOIN latest_event_metrics lem ON lem.event_id = e.id
+WHERE pr.venue_id = 44984
+ORDER BY lem.retail_median DESC NULLS LAST;
+```
+
+### "What kind of event is this?" — chatbot context
+
+```sql
+-- Given a tevo_event_id, classify as tour/residency/broadway/none
+WITH classified AS (
+  SELECT
+    EXISTS(SELECT 1 FROM v_performer_tours        WHERE $1 = ANY(tevo_event_ids)) AS is_tour,
+    EXISTS(SELECT 1 FROM v_performer_residencies  WHERE $1 = ANY(tevo_event_ids)) AS is_residency,
+    EXISTS(SELECT 1 FROM v_broadway_runs          WHERE $1 = ANY(tevo_event_ids)) AS is_broadway,
+    EXISTS(SELECT 1 FROM v_mlb_game_series        WHERE $1 = ANY(tevo_event_ids)) AS is_mlb_series
+)
+SELECT * FROM classified;
+```
+
+## Future work
+
+- **`get_event_context()` extension**: surface tour/residency/Broadway
+  classification + position-in-run ("Game 4 of 6 at Sphere",
+  "Show 17 of Lion King's run"). Easy add when AI/RAG calls demand it.
+- **Reference table for Broadway theaters**: move the hardcoded
+  `venue_name ILIKE ANY (...)` list to a queryable table.
+- **Rate-limit-aware queue**: detect 429 responses and exponentially
+  back off. Currently we just retry next week.
+- **More residency venues**: add Caesars Palace Colosseum, Dolby Live
+  at Park MGM, Resorts World Theatre, BleauLive Theater at
+  Fontainebleau when their TEvo venue_ids are confirmed.

--- a/supabase/migrations/20260509500000_concerts_broadway_tours_residencies.sql
+++ b/supabase/migrations/20260509500000_concerts_broadway_tours_residencies.sql
@@ -1,0 +1,156 @@
+-- ============================================================================
+-- Migration 20260509500000 — Concerts + Broadway pull + tour/residency
+--                            /Broadway-run detection views
+--
+-- Reuses the tournament_categories + tournament_pull_queue/_process
+-- infrastructure from mig 490000. Adds 4 new categories:
+--   54   = Concerts (parent, covers all genres)
+--   1908 = Broadway Musicals
+--   1067 = Broadway Plays
+--   998  = Off-Broadway
+--
+-- Then exposes 3 detection views with different shapes:
+--
+--   v_performer_tours        — same performer at ≥2 distinct venues
+--                              within a 12-month rolling window. The
+--                              "Eras Tour" / "Bruce Springsteen 2026"
+--                              shape.
+--   v_performer_residencies  — same performer at SAME venue with ≥3
+--                              dates and ≥14 day span. The "U2 at
+--                              Sphere" / "Adele at Caesars" shape.
+--   v_broadway_runs          — subset of residencies where venue is a
+--                              known Broadway theater (Lion King at
+--                              Minskoff, Hamilton at Richard Rodgers,
+--                              etc.) Long-running, 8 shows/week.
+--
+-- All three are filterable by performer or venue. AI/RAG consumers
+-- can use these in get_event_context to label "this event is the 17th
+-- show of Lion King's run at Minskoff" or "this is stop 4 of Bruce's
+-- 2026 tour."
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Add concert + Broadway categories to existing tournament_categories
+-- ============================================================================
+
+INSERT INTO tournament_categories(category_id, tevo_label, genre, pages_to_pull, notes) VALUES
+  (54,   'Concerts',           'concert',          20, 'Parent category; covers all music genres'),
+  (1908, 'Broadway Musicals',  'broadway_musical',  5, 'Lion King, Hamilton, Wicked, etc.'),
+  (1067, 'Broadway Plays',     'broadway_play',     3, 'Straight plays on Broadway'),
+  (998,  'Off-Broadway',       'off_broadway',      3, 'Smaller NYC theatre productions')
+ON CONFLICT (category_id) DO NOTHING;
+
+-- ============================================================================
+-- (2) v_performer_tours — same performer at ≥2 distinct venues
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_performer_tours AS
+WITH future AS (
+  SELECT
+    e.primary_performer_id,
+    e.primary_performer_name,
+    e.id AS tevo_event_id,
+    e.venue_id, e.venue_name, e.venue_location,
+    e.occurs_at_local::date AS event_date
+  FROM events e
+  WHERE e.primary_performer_id IS NOT NULL
+    AND e.primary_performer_name IS NOT NULL
+    AND e.occurs_at_local::timestamptz BETWEEN now() - interval '7 days'
+                                            AND now() + interval '12 months'
+    AND COALESCE(e.event_type, '') NOT IN ('game')
+)
+SELECT
+  primary_performer_id,
+  primary_performer_name,
+  count(DISTINCT venue_id)              AS venue_count,
+  count(*)                              AS show_count,
+  min(event_date)                       AS tour_first_show,
+  max(event_date)                       AS tour_last_show,
+  (max(event_date) - min(event_date))   AS tour_span_days,
+  array_agg(DISTINCT venue_name ORDER BY venue_name) AS venues,
+  array_agg(DISTINCT coalesce(regexp_replace(venue_location, '^[^,]+,\s*', ''), 'unknown')) AS regions,
+  array_agg(tevo_event_id ORDER BY event_date) AS tevo_event_ids
+FROM future
+GROUP BY primary_performer_id, primary_performer_name
+HAVING count(DISTINCT venue_id) >= 2;
+
+COMMENT ON VIEW v_performer_tours IS
+  'Performers playing at 2+ distinct venues in the next 12 months. '
+  'The "Bruce Springsteen 2026 / Eras Tour" shape. venues array shows '
+  'every venue; regions shows state/country grouping. Filter by '
+  'primary_performer_id for a single tour, by venue_count for headline '
+  'tours (>=10 stops).';
+
+-- ============================================================================
+-- (3) v_performer_residencies — same performer at SAME venue, ≥3 dates,
+--                               ≥14 day span. Includes Broadway runs.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_performer_residencies AS
+WITH future AS (
+  SELECT
+    e.primary_performer_id,
+    e.primary_performer_name,
+    e.id AS tevo_event_id,
+    e.venue_id, e.venue_name, e.venue_location,
+    e.occurs_at_local::date AS event_date
+  FROM events e
+  WHERE e.primary_performer_id IS NOT NULL
+    AND e.primary_performer_name IS NOT NULL
+    AND e.venue_id IS NOT NULL
+    AND e.occurs_at_local::timestamptz BETWEEN now() - interval '7 days'
+                                            AND now() + interval '24 months'
+    AND COALESCE(e.event_type, '') NOT IN ('game')
+)
+SELECT
+  primary_performer_id,
+  primary_performer_name,
+  venue_id,
+  max(venue_name)                       AS venue_name,
+  max(venue_location)                   AS venue_location,
+  count(*)                              AS show_count,
+  min(event_date)                       AS residency_start,
+  max(event_date)                       AS residency_end,
+  (max(event_date) - min(event_date))   AS residency_span_days,
+  array_agg(tevo_event_id ORDER BY event_date) AS tevo_event_ids
+FROM future
+GROUP BY primary_performer_id, primary_performer_name, venue_id
+HAVING count(*) >= 3
+   AND (max(event_date) - min(event_date)) >= 14;
+
+COMMENT ON VIEW v_performer_residencies IS
+  'Same performer at same venue, 3+ dates, 14+ day span. Catches both '
+  'Vegas residencies (U2 at Sphere, Adele at Caesars) and Broadway '
+  'long-runs (Lion King at Minskoff). Use v_broadway_runs for the '
+  'Broadway-only subset.';
+
+-- ============================================================================
+-- (4) v_broadway_runs — residencies at known Broadway theaters
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_broadway_runs AS
+SELECT
+  r.*,
+  -- Pull the Broadway theater "brand" name from important_x_accounts
+  (SELECT xa.name FROM important_x_accounts xa
+    WHERE xa.account_type = 'broadway_theater'
+      AND lower(r.venue_name) LIKE '%' || lower(replace(xa.name, ' Theatre', '')) || '%'
+    LIMIT 1) AS broadway_theater_name
+FROM v_performer_residencies r
+WHERE
+  -- Heuristic: known Broadway-theater venues by name match
+  r.venue_name ILIKE ANY (ARRAY[
+    '%minskoff%','%majestic%','%gershwin%','%lyric%','%shubert%',
+    '%palace theatre%','%winter garden%','%new amsterdam%','%st. james%',
+    '%st james%','%broadhurst%','%imperial theatre%','%al hirschfeld%',
+    '%hirschfeld%','%longacre%','%music box%','%walter kerr%',
+    '%belasco%','%friedman%','%booth theatre%','%ethel barrymore%',
+    '%richard rodgers%','%neil simon%','%nederlander%','%marquis theatre%',
+    '%circle in the square%','%vivian beaumont%','%studio 54%',
+    '%lena horne%','%james earl jones%'
+  ]);
+
+COMMENT ON VIEW v_broadway_runs IS
+  'Broadway-theater-specific residencies. Subset of v_performer_residencies '
+  'filtered by venue name match against known Broadway venues. Lion King '
+  'at Minskoff, Hamilton at Richard Rodgers, etc.';

--- a/supabase/migrations/20260509510000_venue_specific_pulls_residency_venues.sql
+++ b/supabase/migrations/20260509510000_venue_specific_pulls_residency_venues.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- Migration 20260509510000 — Venue-specific event pulls (residency venues)
+--
+-- Why: TEvo's category-based pulls are popularity-sorted, so even with
+-- 20 pages × 100 = 2000 events for category=54 (Concerts), niche but
+-- high-priority residency venues like Sphere don't surface. Bruce
+-- Springsteen at MSG also got missed for the same reason.
+--
+-- Solution: a parallel pull infrastructure keyed on venue_id. Seed
+-- with known residency / high-value venues. Same async pattern
+-- (queue + pending + process) as tournament_pull_queue.
+--
+-- Reuses tournament_category_pending table by storing venue-pulls
+-- with negative category_id (= -venue_id) as a sentinel. Process
+-- function is unchanged because the row shape is identical.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS venue_pulls (
+  tevo_venue_id  bigint PRIMARY KEY,
+  venue_label    text NOT NULL,
+  reason         text,                     -- 'residency_venue' | 'major_arena' | 'broadway_anchor'
+  pages_to_pull  int DEFAULT 3,
+  enabled        boolean DEFAULT true,
+  added_at       timestamptz DEFAULT now()
+);
+
+INSERT INTO venue_pulls(tevo_venue_id, venue_label, reason, pages_to_pull) VALUES
+  (44984, 'Sphere',                       'residency_venue', 3),
+  (896,   'Madison Square Garden',        'major_arena',     5),
+  (1262,  'Hard Rock Stadium',            'major_arena',     2)
+ON CONFLICT (tevo_venue_id) DO NOTHING;
+
+COMMENT ON TABLE venue_pulls IS
+  'Venues we pull individually because category-based pulls (popularity-'
+  'sorted) miss them. Sphere / Caesars Palace / Dolby Live / Resorts World '
+  'Theatre / BleauLive are residency venues; MSG is dense enough to need '
+  'its own venue pull for visibility into Bruce / Phish / Billy Joel runs.';
+
+-- ============================================================================
+-- venue_pull_queue — fire signed GETs per venue, paginated
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION venue_pull_queue(p_max_pages int DEFAULT 25)
+RETURNS int LANGUAGE plpgsql AS $$
+DECLARE
+  v_token  text := get_app_secret('TEVO_API_TOKEN');
+  v_secret text := get_app_secret('TEVO_SECRET');
+  r RECORD; v_q text; v_sig text; v_req bigint; v_count int := 0;
+BEGIN
+  FOR r IN
+    SELECT vp.tevo_venue_id, gs.page
+    FROM venue_pulls vp
+    JOIN LATERAL generate_series(1, vp.pages_to_pull) AS gs(page) ON true
+    WHERE vp.enabled
+      AND NOT EXISTS (
+        SELECT 1 FROM tournament_category_pending p
+        WHERE p.category_id = -vp.tevo_venue_id  -- sentinel: negative cat = venue pull
+          AND p.page = gs.page
+          AND p.fired_at > now() - interval '24 hours'
+      )
+    ORDER BY vp.tevo_venue_id, gs.page
+    LIMIT p_max_pages
+  LOOP
+    v_q := 'occurs_at.gte=' || to_char(current_date, 'YYYY-MM-DD')
+        || '&page=' || r.page
+        || '&per_page=100'
+        || '&venue_id=' || r.tevo_venue_id;
+    v_sig := tevo_sign_get('/v9/events', v_q, v_secret);
+    SELECT net.http_get(
+      url := 'https://api.ticketevolution.com/v9/events?' || v_q,
+      headers := jsonb_build_object('X-Token', v_token, 'X-Signature', v_sig,
+        'Accept', 'application/vnd.ticketevolution.api+json; version=9'),
+      timeout_milliseconds := 25000) INTO v_req;
+    INSERT INTO tournament_category_pending(category_id, page, request_id, fired_at)
+    VALUES (-r.tevo_venue_id, r.page, v_req, now());
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.4);
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION venue_pull_queue IS
+  'Fires signed /v9/events?venue_id=X pulls for each enabled venue in '
+  'venue_pulls table. Uses tournament_category_pending with negative '
+  'category_id sentinel so the existing tournament_pull_process picks '
+  'these up unchanged. Paginated; weekly cron.';
+
+-- ============================================================================
+-- Cron: weekly + slightly offset from category pulls
+-- ============================================================================
+
+SELECT cron.schedule(
+  'venue_pull_queue_weekly',
+  '15 4 * * 0',    -- Sundays 04:15 UTC (after category queue 04:00 + process 04:05)
+  $$ SELECT venue_pull_queue(25); $$
+);


### PR DESCRIPTION
Three detection views over events table + venue-pull infra for residency venues. Bruce/Sphere/Lion King pattern verified live (Sphere: 4 residencies including Wizard of Oz 256 shows; Lion King at Minskoff 32 shows; tours up to 27 venues like UB40).