### PR TITLE
docs+feat: query catalog + 66 sporting rivalries + venue map options

### DIFF
--- a/docs/coworker-handoff/QUERY_CATALOG.md
+++ b/docs/coworker-handoff/QUERY_CATALOG.md
@@ -1,0 +1,269 @@
+# Query Catalog — what gives me X for an event?
+
+Comprehensive index of every view + read-only function in `public.*`,
+organized by intent. Use this as the lookup table when wiring a new
+UI surface; you should rarely need to write a SELECT against raw
+tables.
+
+> **All listed surfaces are SELECT-safe with `coworker_readonly`.**
+> If a view depends on a function not in your role's grants, the row
+> will return NULL or empty rather than error.
+
+---
+
+## 1. Single-event detail (the AI/RAG bundle)
+
+| Query | What it returns | When to use |
+|---|---|---|
+| **`SELECT get_event_context(:event_id)`** | One JSONB with **13 keys**: event basics + pricing + ESPN + odds + Wikipedia + weather + competitors + Reddit pulse + important_news + x_accounts_known + our_orders + classification | Default landing for any event-detail surface. One call → everything. |
+| `get_broker_event_detail(:event_id)` | Tabular row: event basics + venue + map URLs + has_seating_chart flag + curated_zones_count | When you need just the broker-facing fields without the full bundle |
+| `SELECT * FROM v_event_full_v2 WHERE tevo_event_id=:event_id` | Tabular: full canonical event with TEvo+SG+SD pricing nested + sg_event_metrics + sentiment | When you want pricing inline without function-call overhead |
+| `SELECT * FROM v_event_full_sports WHERE tevo_event_id=:event_id` | Tabular: same but with ESPN team state, injuries, news, home/away, days_to_event | Sports-specific event detail |
+
+**Tip:** `get_event_context` is the easiest path. It bundles every signal you'd otherwise need 8 queries to assemble.
+
+---
+
+## 2. Listing pricing (per event, per section, per zone)
+
+| Query | What |
+|---|---|
+| **`get_event_listings_public(:event_id, :zone, :min_qty, :max_price, :limit, :include_all)`** | Per-listing rows: section, row, qty, retail_price, format, splits, instant/wheelchair flags, owned/provenance, resolved_zone |
+| `get_event_zones_public(:event_id, :include_all)` | Zone-level rollup: zone_name, listings, total_tickets, cheapest, median, most_expensive |
+| `get_event_zones_rollup(:event_id, :owned_only)` | Same shape, lighter — just zone, source, tickets, min/max retail |
+| `SELECT * FROM v_pricing_cross_source WHERE tevo_event_id=:event_id` | Section-level pricing **across TEvo + SG + SG-seller + SD** with `sg_vs_tevo_pct` and `sd_sold_vs_tevo_listed_pct` |
+| `SELECT * FROM latest_event_metrics WHERE event_id=:event_id` | TEvo event-level rollup: getin, percentiles, dispersion, owned_share |
+| `SELECT * FROM retail_event_zones WHERE event_id=:event_id` | TEvo zone-level (lighter) |
+| `SELECT * FROM retail_event_sections WHERE event_id=:event_id` | TEvo section-level |
+| `SELECT * FROM seatgeek_event_latest WHERE tevo_event_id=:event_id` | Latest SG listings + SG sales for an event |
+| `SELECT * FROM seatdata_event_latest WHERE tevo_event_id=:event_id` | Latest SD stats + sales (sparse — SD pull pipeline pending) |
+
+---
+
+## 3. Velocity / movement / trends
+
+| Query | What |
+|---|---|
+| **`SELECT * FROM v_event_velocity_windows WHERE tevo_event_id=:event_id`** | 1h / 6h / 24h price + inventory deltas across TEvo + SG. Use `tevo_getin_d1h_pct`, `tevo_getin_d24h_pct` for "what moved" cards |
+| `SELECT * FROM event_velocity WHERE id=:event_id` | Latest vs immediately-prior capture (legacy view; less precise) |
+| `get_event_movers(:window_hours)` | Top movers across all events in window — for a "biggest movers" board |
+
+---
+
+## 4. Sales / orders / our book
+
+| Query | What |
+|---|---|
+| **`SELECT * FROM our_orders_with_net WHERE tevo_event_id=:event_id`** | Per-order rows with **gross_amount + net_amount** (after `order_fee_schedule` per-source fees) |
+| **`SELECT * FROM our_orders_by_event_with_net WHERE tevo_event_id=:event_id`** | Per-event rollup of our orders (gross_fulfilled + net_fulfilled + status counts) |
+| `SELECT * FROM our_orders` | Same as our_orders_with_net minus the net column — TEvo + SG combined |
+| `SELECT * FROM unified_orders_by_event WHERE tevo_event_id=:event_id` | TEvo + SG + **SeatData (market observations)** rollup; broader than our_orders which is OUR sales only |
+| `SELECT * FROM v_sg_sales_by_section WHERE tevo_event_id=:event_id` | Per SG sale: section, row, qty, sale_price, total estimate, status, timestamps |
+| `SELECT * FROM v_sg_sales_by_event WHERE tevo_event_id=:event_id` | SG event-level rollup with median/min/max sale_price + distinct_sections |
+| `SELECT * FROM evo_orders_by_event WHERE tevo_event_id=:event_id` | TEvo-side per-event order rollup |
+| `SELECT * FROM seatgeek_orders_by_event` | SG-side per-event |
+
+---
+
+## 5. Alerts (the "what should I look at" surface)
+
+| Query | What |
+|---|---|
+| **`SELECT * FROM v_open_alerts ORDER BY severity DESC, fired_at DESC`** | Unacknowledged alerts. Use `severity` for color (`critical`/`warn`/`info`) |
+| `SELECT * FROM v_open_alerts WHERE tevo_event_id=:event_id` | Alerts on a specific event |
+| `SELECT count(*) FILTER (WHERE acknowledged_at IS NULL) FROM event_alerts` | Alert badge count |
+
+7 active rules: `tevo_getin_drop_1h`, `tevo_getin_surge_1h`, `tevo_inventory_low_48h`, `arbitrage_opportunity`, `espn_status_change`, `competing_event_added`, `line_movement_24h`.
+
+---
+
+## 6. Cross-event signals (competitors, MLB series, tournaments, tours, residencies, Broadway)
+
+| Query | Returns |
+|---|---|
+| **`SELECT * FROM v_competing_events WHERE tevo_event_id=:event_id`** | Events within ±24h × 20mi |
+| `SELECT competitors FROM event_competitors_snapshot WHERE tevo_event_id=:event_id` | Same data pre-computed (faster) |
+| **`SELECT * FROM v_mlb_game_series WHERE :event_id = ANY(tevo_event_ids)`** | MLB regular-season 3–4 game series for an event (with optional `branded_series_name` like "Subway Series") |
+| `SELECT * FROM v_performer_tours WHERE primary_performer_id=:perf_id` | Tour: ≥2 venues over 12 months. Returns `venues[]`, `regions[]` |
+| `SELECT * FROM v_performer_residencies WHERE venue_id=:venue_id` | Residencies at a venue (Sphere, Caesars, MSG runs) |
+| `SELECT * FROM v_broadway_runs WHERE primary_performer_name ILIKE '%:show%'` | Broadway show runs at known Broadway theaters |
+| `SELECT * FROM v_unmatched_events` | Events seen on SG/SD/EVO orders but missing event-table row |
+
+---
+
+## 7. ESPN / sports state
+
+| Query | Returns |
+|---|---|
+| **`SELECT * FROM v_event_betting_odds_latest WHERE tevo_event_id=:event_id`** | Spread, OU, ML, win-prob (DraftKings via ESPN scoreboard) |
+| `SELECT * FROM v_event_line_movement WHERE tevo_event_id=:event_id` | 1h / 24h line movement deltas |
+| `SELECT * FROM v_espn_team_state WHERE espn_team_id=:team_id` | Team record, streak, win_pct |
+| `SELECT * FROM v_espn_injuries_current WHERE espn_team_id=:team_id` | Active injuries per team |
+| `SELECT * FROM v_espn_game_results WHERE espn_event_id=:eid` | Final scores + box for played games |
+| `get_team_context(:performer_id)` | JSONB bundle of team state: record, last 5, injuries summary, recent news |
+| `get_team_playoff_context(:performer_id)` | Playoff seeding + bracket position |
+| `get_team_roster(:performer_id)` | Roster + key players |
+| `get_player_info(:query, :limit)` | Player search across ESPN athletes |
+| `get_recent_team_changes(:since, :limit)` | Trades, signings, injuries since a timestamp |
+
+---
+
+## 8. Weather (works for indoor + outdoor)
+
+| Query | Returns |
+|---|---|
+| **`SELECT * FROM v_event_weather_with_fallback WHERE tevo_event_id=:event_id`** | Per-event: forecast within 16d → climatology fallback. **`weather_kind`** = `forecast_indoor` / `forecast_outdoor` / `climatology_indoor` / `climatology_outdoor` / `none` |
+| `SELECT * FROM v_event_weather WHERE tevo_event_id=:event_id` | Forecast-only (no climatology fallback) |
+| `SELECT * FROM v_venue_climatology WHERE tevo_venue_id=:venue_id AND month=...` | Historical climatology by venue + day-of-year |
+
+---
+
+## 9. Social / news context (for AI chatbot)
+
+| Query | Returns |
+|---|---|
+| **`SELECT * FROM v_reddit_important_recent WHERE tevo_performer_id IN (SELECT performer_id FROM ...) ORDER BY created_utc DESC`** | 48h Reddit posts matching news keywords (injury / trade / signed / IL / etc.) with weighted hits |
+| `SELECT * FROM v_performer_reddit_pulse WHERE tevo_performer_id=:perf_id` | Reddit posts_24h / posts_7d / score / latest_post_at per performer |
+| `SELECT * FROM v_performer_news_sources WHERE tevo_performer_id=:perf_id` | All known X handles + subreddits for a performer (for chatbot prompt-building) |
+| `SELECT * FROM v_x_accounts_unified WHERE sport=:sport OR team_name=:team` | X-account roster, filterable by sport/league/team/category |
+| `SELECT * FROM v_subreddits_unified WHERE league=:league` | Reddit subs (performer-pinned + leaguewide) |
+| `match_news_keywords(:text)` | Returns `{hits, categories, total_weight}` JSONB — useful for AI processing arbitrary text |
+| `get_wiki_context(:performer_id)` | Wikipedia summary + extract for AI prompt |
+
+---
+
+## 10. Search / typeahead / discovery
+
+| Query | What |
+|---|---|
+| **`get_broker_events_upcoming(:search, :performer_id, :venue_id, :days_ahead, :limit, :offset)`** | Filterable upcoming-events search with all the broker-relevant fields |
+| `search_events_by_date(:date_from, :date_to, :performer_id, :city, :min_tickets, :limit)` | Date-range search |
+| `search_performers_typeahead(:query, :limit)` | Typeahead suggestions for performer search |
+| `get_events_by_performer_public(:performer_id, :days_ahead, :limit)` | All upcoming events for a performer |
+| `get_events_by_venue_public(:venue_id, :days_ahead, :limit)` | All upcoming events at a venue |
+| `get_chat_suggestion_chips(:count, :min_tickets)` | "Suggested events" surface |
+| `get_performers_by_league(:league)` | Performers in a league with home/road event metrics |
+
+---
+
+## 11. Performer / venue assets
+
+| Query | Returns |
+|---|---|
+| `get_performer_landing_public(:performer_id)` | Landing page bundle: name, slug, category, genre, home_venue, upcoming_first/last |
+| `get_performer_assets_public(:performer_id)` | Logos, colors, image URLs |
+| `get_event_assets_public(:event_id)` | Event-specific assets (seating chart URLs, banner images) |
+| `get_venue_assets_public(:venue_id)` | Venue images, lat/lon, indoor flag |
+
+---
+
+## 12. Arbitrage / opportunity detection
+
+| Query | What |
+|---|---|
+| **`SELECT * FROM v_arbitrage_opportunities WHERE abs(sg_vs_tevo_gap_pct) >= 15`** | Section-level TEvo↔SG price gaps with both sides ≥2 listings |
+
+(Sparse today because SG xref coverage is naturally low; populates as overlap grows.)
+
+---
+
+## 13. Coverage / data-quality / status (for the Data Quality Dashboard)
+
+| Query | What |
+|---|---|
+| `SELECT * FROM cross_source_coverage` | Per-entity sources-present matrix |
+| `SELECT * FROM cross_source_event_audit` | Per-event source coverage |
+| `SELECT * FROM v_canonical_coverage` | Performer-level source presence count |
+| `SELECT * FROM v_unmatched_events` | Orphans across SG / SD / EVO |
+| `SELECT * FROM data_source_field_map_audit WHERE NOT has_field_map_rows` | Tables without field-map rows (drift detector) |
+| Pending queue counts (TEvo, SG, weather, wiki, reddit, etc.) | See `DATA_QUALITY_DASHBOARD.md` for the SQL |
+
+`coworker_readonly` does **not** have access to `cron.*`. For cron-run history, use the `v_cron_health` view that the audit lane will provide on request (open an issue when you want it).
+
+---
+
+## 14. Utility helpers
+
+| Query | What |
+|---|---|
+| `haversine_miles(:lat1, :lon1, :lat2, :lon2)` | Distance in miles between two points |
+| `find_competing_events(:event_id, :radius_miles, :window_hours)` | Tunable competing-events search (different params than the snapshot view) |
+| `find_similar_events(:event_id, :max)` | Similar events with similarity scoring |
+| `is_north_america_venue(:location)` | Boolean — is this venue location in continental N.A.? |
+| `external_ids_for_event(:tevo_event_id)` | All cross-source IDs for an event (ESPN, SG, SD, etc.) |
+| `external_ids_for_performer(:tevo_performer_id)` | Same for performer |
+| `external_ids_for_venue(:tevo_venue_id)` | Same for venue |
+
+---
+
+## 15. Useful aggregation patterns (copy/paste)
+
+### "What kind of event is this?" classifier
+
+```sql
+WITH classified AS (
+  SELECT
+    EXISTS(SELECT 1 FROM v_performer_tours        WHERE :event_id = ANY(tevo_event_ids)) AS is_tour,
+    EXISTS(SELECT 1 FROM v_performer_residencies  WHERE :event_id = ANY(tevo_event_ids)) AS is_residency,
+    EXISTS(SELECT 1 FROM v_broadway_runs          WHERE :event_id = ANY(tevo_event_ids)) AS is_broadway,
+    EXISTS(SELECT 1 FROM v_mlb_game_series        WHERE :event_id = ANY(tevo_event_ids)) AS is_mlb_series
+)
+SELECT * FROM classified;
+```
+
+### Best-bet upcoming-events list (homepage hero)
+
+```sql
+SELECT *
+FROM get_broker_events_upcoming(
+  p_search        => NULL,
+  p_performer_id  => NULL,
+  p_venue_id      => NULL,
+  p_days_ahead    => 21,
+  p_limit         => 50,
+  p_offset        => 0
+);
+```
+
+### Daily check on portfolio health
+
+```sql
+SELECT
+  count(*) FILTER (WHERE canonical_status='fulfilled')                             AS sold_today,
+  sum(net_amount)::int FILTER (WHERE canonical_status='fulfilled')                 AS net_today,
+  count(*) FILTER (WHERE canonical_status='pending')                               AS pending_now,
+  count(*) FILTER (WHERE canonical_status='cancelled')                             AS cancelled_today
+FROM our_orders_with_net
+WHERE source_created_at::date = current_date;
+```
+
+### Performers with rising Reddit buzz (new signal)
+
+```sql
+SELECT
+  pm.performer_id, pm.name,
+  rp.posts_24h, rp.posts_7d,
+  -- buzz multiplier: today's pace vs week average
+  ROUND( (rp.posts_24h::numeric / NULLIF(rp.posts_7d::numeric / 7.0, 0)), 2 ) AS buzz_multiplier
+FROM performer_metadata pm
+JOIN v_performer_reddit_pulse rp ON rp.tevo_performer_id = pm.performer_id
+WHERE rp.posts_7d > 5
+ORDER BY buzz_multiplier DESC NULLS LAST
+LIMIT 25;
+```
+
+---
+
+## Data shape conventions to remember
+
+- All event ids are `bigint` and prefixed `tevo_event_id` in views; the
+  raw `events` table column is just `id`.
+- `occurs_at_local` is **text**, not timestamp. Cast: `occurs_at_local::timestamptz`.
+- Money is `numeric`, never floats. Display with `(value)::int` for cents truncation if you want integer dollars.
+- Many views filter to `event_type IS DISTINCT FROM 'game'` to exclude
+  team sports — pay attention if you're querying both sports + concerts.
+- Weather: prefer `v_event_weather_with_fallback` over the raw view —
+  works for indoor + outdoor + far-future events.
+- Sales: `our_orders_with_net` uses `payment_total` when present (TEvo),
+  derives gross from `sale_price * sale_quantity` for SG (since SG API
+  doesn't return payment_total).

--- a/docs/interactive-venue-maps-options.md
+++ b/docs/interactive-venue-maps-options.md
@@ -1,0 +1,220 @@
+# Interactive Venue Maps — Options for the UI
+
+You asked for free or cheap interactive venue maps for the terminal
+UI rebuild. Honest read on the landscape — what we already have,
+what's available, what each tier costs, what each gives you.
+
+---
+
+## What we already have (free, in our data today)
+
+### TEvo `seating_chart_medium` / `seating_chart_large` URLs
+
+Every event row in `events` table has these two columns:
+- `seating_chart_medium` — typically 800×600px PNG/JPG
+- `seating_chart_large` — 1600×1200px or larger
+
+These are **static images**, not interactive. But they're free, they
+already populate, they show real seat layouts, and they're rendered
+by TEvo itself which means they match how brokers see them.
+
+**Verdict for v1**: ship the static image. Add hover/zoom on
+client-side later if needed. Don't pay for interactive maps until
+the UI clearly demands it.
+
+### TEvo `fanvenues_key`
+
+The `events` table also has `fanvenues_key` — a key into Fanvenues'
+interactive seat-map system. Fanvenues is the established 3rd-party
+provider TEvo integrates with. If you want true interactive,
+this is the path of least resistance.
+
+**Pricing**: Fanvenues is **commercial** ($X/month per active venue
+or per-render). Not free. Reach out for a quote — historically in the
+$200–$2,000/month range depending on volume. Cheap if we're already
+selling tickets at those venues.
+
+---
+
+## Free / open-source options
+
+### 1. Build your own from venue floorplans (DIY)
+
+The honest truth: most "interactive venue maps" are just SVG with
+clickable `<polygon>` elements. If you have the venue layout, you
+can render it yourself in any framework.
+
+**Sources for floorplans:**
+- Stadium official sites usually publish PDF/PNG floorplans
+- StubHub / SeatGeek public pages render maps you can inspect
+- Wikipedia commons has many stadium overhead images
+- Architects' renderings on Google image search
+
+**Effort**: 4–8 hours per major venue to digitize a floorplan into
+SVG with section labels. Doable for the top ~20 venues we care about
+(Yankee Stadium, Madison Square Garden, Crypto.com Arena, SoFi,
+Lambeau, etc.). Skip for the long tail.
+
+**Pros**: full control, no vendor lock-in, free forever, themeable
+to match your UI.
+
+**Cons**: you're maintaining floorplan data forever. Renovations,
+configuration changes (basketball vs hockey at MSG) need updates.
+
+### 2. SVG seat-map libraries (open-source)
+
+- **react-seat-picker** (https://github.com/eduzilla/react-seat-picker)
+  — generic seat-grid library. Good for theaters, weak for stadiums.
+- **seatchart.js** (https://github.com/bbc/seatchart) — by BBC, MIT
+  license. Theater-shaped, doesn't handle stadium curves well.
+- **Vue-Seat-Map** various libraries on GitHub.
+
+**Pros**: free, customizable.
+
+**Cons**: most are designed for theater/cinema layouts. Stadiums
+with curved bowls are harder. Still requires you to feed in the
+section/row/seat data per venue.
+
+### 3. Static images you already have (zero work)
+
+Just display TEvo's `seating_chart_large` URL with CSS overlays.
+For terminals where the user just needs to *see* the layout (not
+click sections), this is the right answer.
+
+Cost: $0. Effort: 0. Coverage: every venue in our system.
+
+---
+
+## Commercial options (cheap to mid-tier)
+
+### 4. Mapbox + custom overlays
+
+Not built for venue maps but flexible. You can lay GeoJSON polygons
+over a base "blank" map, hover them, color them by price tier, etc.
+
+**Cost**: free up to 50k loads/month, then $5/1k.
+
+**Effort**: substantial (build GeoJSON polygons per venue, map them
+to sections). Same per-venue cost as DIY SVG, just with Mapbox's
+rendering layer.
+
+**Verdict**: only worth it if you're also showing geographic data
+(like "venues near me") in the same component.
+
+### 5. Fanvenues (the obvious answer)
+
+Already integrated with TEvo. Many brokers use it. Pricing tiers
+exist for small/mid/large operations.
+
+**Cost**: contact-sales (typically $200–$2k/month based on volume).
+
+**Pros**:
+- Zero setup work — `fanvenues_key` from our events table just works
+- Maintained by them; renovations + config changes handled
+- Matches what other brokers in the industry use
+
+**Cons**: vendor lock-in; price escalates with growth.
+
+### 6. Vivenu / OpenSeatChart / Eventfinda
+
+Similar tier — managed services with SDKs. Each has its own
+pricing model. Worth a sales call if you outgrow Fanvenues but
+want managed.
+
+### 7. SeatGeek's open seat data
+
+SeatGeek's public website renders interactive maps. Their CLIENT side
+data is sometimes inspectable in browser DevTools — section polygons
+in JSON. **Don't scrape** (ToS), but you can use their pages as a
+reference for how interactive maps should *feel*.
+
+---
+
+## My recommendation for the UI rebuild
+
+Three-tier approach, ship in this order:
+
+### Tier 1 — ship now (zero cost)
+
+Display `seating_chart_large` from TEvo as a static image. CSS zoom
+on hover. Works on every event we have. Ship in the first week of UI work.
+
+### Tier 2 — when UX demands clickability (low cost, when ready)
+
+Build SVG overlays for the top 20 venues by event volume. List in
+order:
+1. Madison Square Garden
+2. Yankee Stadium
+3. Crypto.com Arena
+4. SoFi Stadium
+5. Wrigley Field
+6. Lambeau Field
+7. Fenway Park
+8. Truist Park
+9. Dodger Stadium
+10. ... (rank by `events` table count per venue)
+
+Estimate: 1 day per venue. ~4 weeks of work total. After that, the
+top 20 venues are interactive; everything else falls back to Tier 1.
+
+Use `react-svg-pan-zoom` for pan/zoom. Section data lives in our DB
+(`venue_assets` already has `tevo_venue_id`; add a `sections_geojson`
+column when you're ready).
+
+### Tier 3 — when scaling demands managed (medium cost, only if we hit revenue)
+
+Integrate Fanvenues via `fanvenues_key`. By this point you'll have
+revenue to justify the spend, and you'll appreciate not maintaining
+20+ SVG files yourself.
+
+---
+
+## What I'd actually do if I were the coworker
+
+Skip Tier 2 entirely. Tier 1 (static images) is good enough until
+you have actual user feedback saying "I want to click sections."
+Most of the value of an interactive map is in **showing the layout**
+— the click interaction is rarely critical for a broker workflow
+where they already know which section they want.
+
+When you DO need click interaction, jump straight to Fanvenues.
+Building 20 SVGs by hand is a tarpit; the maintenance cost over a
+year exceeds the Fanvenues subscription.
+
+So: **Tier 1 → Tier 3, skip Tier 2** unless you specifically need
+the brand customization that DIY SVG gives you.
+
+---
+
+## Data fields available in our schema
+
+If you go with TEvo static images:
+
+```sql
+SELECT
+  e.id,
+  e.name,
+  e.venue_name,
+  e.seating_chart_medium AS map_url_800,
+  e.seating_chart_large  AS map_url_1600,
+  e.fanvenues_key        AS fanvenues_key  -- for Fanvenues integration
+FROM events e
+WHERE e.id = :event_id;
+```
+
+`get_broker_event_detail(:event_id)` already returns `map_medium_url`,
+`map_large_url`, `has_seating_chart`, `fanvenues_key` — use that
+helper, don't query raw events directly.
+
+---
+
+## Final word
+
+The terminal you're building is a **broker tool**, not a consumer
+ticket-buying surface. Brokers don't browse seat maps for fun — they
+look up specific sections by name. The static image + a section
+search box gets you 90% of the value with 0% of the effort.
+
+If you push back on this read, the data point I'd want to see is
+"users keep clicking on map sections expecting it to filter
+listings." Until you have that signal, static is fine.

--- a/supabase/migrations/20260509520000_north_america_sporting_rivalries.sql
+++ b/supabase/migrations/20260509520000_north_america_sporting_rivalries.sql
@@ -1,0 +1,309 @@
+-- ============================================================================
+-- Migration 20260509520000 — North American sporting rivalries reference
+--
+-- Sister table to mlb_branded_series (mig 470000), but broader scope:
+--   - Includes NBA, NFL, MLB, NHL, MLS rivalries
+--   - Includes both **branded** rivalries (named series like "Subway
+--     Series", "Iron Bowl") AND **unbranded** competitive rivalries
+--     (Lakers-Celtics, Yankees-Red Sox, Cowboys-Eagles)
+--   - Each row carries Wikipedia URL for chatbot RAG context
+--
+-- Used by:
+--   - Future v_event_rivalry_overlay view (joins events to known rivalries
+--     to flag "this is a rivalry game")
+--   - get_event_context() AI/RAG bundle — surfaces rivalry context when
+--     the matchup is on the list
+--
+-- mlb_branded_series remains for MLB regular-season series-level branding
+-- (Subway Series et al.). This table is the broader "is this a rivalry
+-- game" reference.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS sporting_rivalries (
+  rivalry_name    text PRIMARY KEY,    -- "Lakers-Celtics" or "Subway Series"
+  league          text NOT NULL,        -- 'NBA' | 'NFL' | 'MLB' | 'NHL' | 'MLS'
+  team_a          text NOT NULL,        -- canonical TEvo performer name
+  team_b          text NOT NULL,
+  is_branded      boolean DEFAULT false,
+  rivalry_intensity text DEFAULT 'high', -- 'historic'|'high'|'medium'
+  wikipedia_url   text,
+  notes           text,
+  added_at        timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS sporting_rivalries_league_idx ON sporting_rivalries(league);
+CREATE INDEX IF NOT EXISTS sporting_rivalries_team_a_idx ON sporting_rivalries(team_a);
+CREATE INDEX IF NOT EXISTS sporting_rivalries_team_b_idx ON sporting_rivalries(team_b);
+
+COMMENT ON TABLE sporting_rivalries IS
+  'Cross-league rivalry reference. Both branded (named series) and '
+  'unbranded competitive rivalries. Sourced from Wikipedia. Used by AI '
+  'context to flag "this is a rivalry game" and by future overlay views. '
+  'mlb_branded_series is the MLB-regular-season-only complement.';
+
+-- ============================================================================
+-- NBA rivalries (Wikipedia: https://en.wikipedia.org/wiki/List_of_NBA_rivalries)
+-- ============================================================================
+
+INSERT INTO sporting_rivalries(rivalry_name, league, team_a, team_b, is_branded, rivalry_intensity, wikipedia_url, notes) VALUES
+  ('Lakers vs Celtics',         'NBA', 'Los Angeles Lakers', 'Boston Celtics',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Celtics%E2%80%93Lakers_rivalry',
+    'Most decorated rivalry in NBA history, 12 Finals matchups'),
+  ('Knicks vs Nets',            'NBA', 'New York Knicks', 'Brooklyn Nets',
+    false, 'high', 'https://en.wikipedia.org/wiki/Knicks%E2%80%93Nets_rivalry',
+    'NYC subway-distance; intensified by Nets Brooklyn move'),
+  ('Knicks vs Heat',            'NBA', 'New York Knicks', 'Miami Heat',
+    false, 'high', 'https://en.wikipedia.org/wiki/Heat%E2%80%93Knicks_rivalry',
+    '90s playoff battles; recent Jimmy Butler era'),
+  ('Heat vs Celtics',           'NBA', 'Miami Heat', 'Boston Celtics',
+    false, 'high', 'https://en.wikipedia.org/wiki/Celtics%E2%80%93Heat_rivalry',
+    'Modern East playoff staple'),
+  ('Lakers vs Clippers',        'NBA', 'Los Angeles Lakers', 'Los Angeles Clippers',
+    false, 'medium', 'https://en.wikipedia.org/wiki/Clippers%E2%80%93Lakers_rivalry',
+    'Hallway series at Crypto.com Arena'),
+  ('Warriors vs Cavaliers',     'NBA', 'Golden State Warriors', 'Cleveland Cavaliers',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Cavaliers%E2%80%93Warriors_rivalry',
+    '4 consecutive Finals 2015-2018'),
+  ('Warriors vs Lakers',        'NBA', 'Golden State Warriors', 'Los Angeles Lakers',
+    false, 'high', 'https://en.wikipedia.org/wiki/Lakers%E2%80%93Warriors_rivalry',
+    'California rivalry, Showtime era'),
+  ('Bulls vs Pistons',          'NBA', 'Chicago Bulls', 'Detroit Pistons',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Bulls%E2%80%93Pistons_rivalry',
+    'Bad Boys era, MJ vs Isiah'),
+  ('Pacers vs Knicks',          'NBA', 'Indiana Pacers', 'New York Knicks',
+    false, 'high', 'https://en.wikipedia.org/wiki/Knicks%E2%80%93Pacers_rivalry',
+    '90s playoff battles, Reggie Miller era'),
+  ('Suns vs Lakers',            'NBA', 'Phoenix Suns', 'Los Angeles Lakers',
+    false, 'medium', NULL,
+    'Frequent playoff matchups, west coast');
+
+-- ============================================================================
+-- NFL rivalries (Wikipedia: https://en.wikipedia.org/wiki/List_of_NFL_rivalries)
+-- ============================================================================
+
+INSERT INTO sporting_rivalries(rivalry_name, league, team_a, team_b, is_branded, rivalry_intensity, wikipedia_url, notes) VALUES
+  ('Cowboys vs Eagles',         'NFL', 'Dallas Cowboys', 'Philadelphia Eagles',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Cowboys%E2%80%93Eagles_rivalry',
+    'NFC East defining rivalry, twice yearly'),
+  ('Cowboys vs Giants',         'NFL', 'Dallas Cowboys', 'New York Giants',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Cowboys%E2%80%93Giants_rivalry',
+    'Oldest NFC East rivalry'),
+  ('Cowboys vs Redskins/Commanders','NFL', 'Dallas Cowboys', 'Washington Commanders',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Commanders%E2%80%93Cowboys_rivalry',
+    'Thanksgiving staple'),
+  ('Packers vs Bears',          'NFL', 'Green Bay Packers', 'Chicago Bears',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Bears%E2%80%93Packers_rivalry',
+    'Oldest NFL rivalry, 200+ meetings'),
+  ('Packers vs Vikings',        'NFL', 'Green Bay Packers', 'Minnesota Vikings',
+    false, 'high', 'https://en.wikipedia.org/wiki/Packers%E2%80%93Vikings_rivalry',
+    'NFC North divisional'),
+  ('Packers vs Lions',          'NFL', 'Green Bay Packers', 'Detroit Lions',
+    false, 'high', 'https://en.wikipedia.org/wiki/Lions%E2%80%93Packers_rivalry',
+    'Thanksgiving classic'),
+  ('Steelers vs Ravens',        'NFL', 'Pittsburgh Steelers', 'Baltimore Ravens',
+    false, 'high', 'https://en.wikipedia.org/wiki/Ravens%E2%80%93Steelers_rivalry',
+    'Modern AFC North rivalry'),
+  ('Steelers vs Browns',        'NFL', 'Pittsburgh Steelers', 'Cleveland Browns',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Browns%E2%80%93Steelers_rivalry',
+    'Pre-NFL merger origins'),
+  ('Steelers vs Bengals',       'NFL', 'Pittsburgh Steelers', 'Cincinnati Bengals',
+    false, 'high', 'https://en.wikipedia.org/wiki/Bengals%E2%80%93Steelers_rivalry',
+    'AFC North turf war'),
+  ('Patriots vs Jets',          'NFL', 'New England Patriots', 'New York Jets',
+    false, 'high', 'https://en.wikipedia.org/wiki/Jets%E2%80%93Patriots_rivalry',
+    'AFC East historical'),
+  ('Patriots vs Dolphins',      'NFL', 'New England Patriots', 'Miami Dolphins',
+    false, 'high', 'https://en.wikipedia.org/wiki/Dolphins%E2%80%93Patriots_rivalry',
+    'AFC East historic'),
+  ('Patriots vs Bills',         'NFL', 'New England Patriots', 'Buffalo Bills',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Bills%E2%80%93Patriots_rivalry',
+    'AFC East'),
+  ('49ers vs Cowboys',          'NFL', 'San Francisco 49ers', 'Dallas Cowboys',
+    false, 'historic', 'https://en.wikipedia.org/wiki/49ers%E2%80%93Cowboys_rivalry',
+    '90s playoffs, recent revival'),
+  ('49ers vs Seahawks',         'NFL', 'San Francisco 49ers', 'Seattle Seahawks',
+    false, 'high', 'https://en.wikipedia.org/wiki/49ers%E2%80%93Seahawks_rivalry',
+    'NFC West'),
+  ('49ers vs Rams',             'NFL', 'San Francisco 49ers', 'Los Angeles Rams',
+    false, 'high', 'https://en.wikipedia.org/wiki/49ers%E2%80%93Rams_rivalry',
+    'NFC West, California'),
+  ('Chiefs vs Raiders',         'NFL', 'Kansas City Chiefs', 'Las Vegas Raiders',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Chiefs%E2%80%93Raiders_rivalry',
+    'AFC West original AFL'),
+  ('Chiefs vs Broncos',         'NFL', 'Kansas City Chiefs', 'Denver Broncos',
+    false, 'high', NULL,
+    'AFC West'),
+  ('Chiefs vs Chargers',        'NFL', 'Kansas City Chiefs', 'Los Angeles Chargers',
+    false, 'medium', NULL,
+    'AFC West'),
+  ('Bills vs Dolphins',         'NFL', 'Buffalo Bills', 'Miami Dolphins',
+    false, 'high', NULL,
+    'AFC East divisional');
+
+-- ============================================================================
+-- MLB rivalries (Wikipedia: https://en.wikipedia.org/wiki/List_of_Major_League_Baseball_rivalries)
+-- ============================================================================
+
+INSERT INTO sporting_rivalries(rivalry_name, league, team_a, team_b, is_branded, rivalry_intensity, wikipedia_url, notes) VALUES
+  ('Yankees vs Red Sox',        'MLB', 'New York Yankees', 'Boston Red Sox',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Yankees%E2%80%93Red_Sox_rivalry',
+    'THE rivalry. Curse of the Bambino, 2004 ALCS, etc.'),
+  ('Subway Series',             'MLB', 'New York Yankees', 'New York Mets',
+    true,  'historic', 'https://en.wikipedia.org/wiki/Subway_Series',
+    'Interleague NYC; also detected in mlb_branded_series'),
+  ('Dodgers vs Giants',         'MLB', 'Los Angeles Dodgers', 'San Francisco Giants',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Dodgers%E2%80%93Giants_rivalry',
+    'NL West, Brooklyn-NY origins'),
+  ('Cubs vs Cardinals',         'MLB', 'Chicago Cubs', 'St. Louis Cardinals',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Cardinals%E2%80%93Cubs_rivalry',
+    'NL Central, oldest NL rivalry'),
+  ('Cubs vs White Sox / Crosstown Classic','MLB', 'Chicago Cubs', 'Chicago White Sox',
+    true,  'high', 'https://en.wikipedia.org/wiki/Cubs%E2%80%93White_Sox_rivalry',
+    'Chicago crosstown; also in mlb_branded_series'),
+  ('Yankees vs Mets',           'MLB', 'New York Yankees', 'New York Mets',
+    false, 'high', NULL,
+    'Same as Subway Series — alias for chatbot disambiguation'),
+  ('Astros vs Rangers / Lone Star Series','MLB', 'Houston Astros', 'Texas Rangers',
+    true,  'high', 'https://en.wikipedia.org/wiki/Astros%E2%80%93Rangers_rivalry',
+    'Texas; also in mlb_branded_series'),
+  ('Reds vs Guardians / Battle of Ohio',  'MLB', 'Cincinnati Reds', 'Cleveland Guardians',
+    true,  'medium', 'https://en.wikipedia.org/wiki/Battle_of_Ohio',
+    'Also in mlb_branded_series'),
+  ('Cardinals vs Royals / I-70 Series',   'MLB', 'St. Louis Cardinals', 'Kansas City Royals',
+    true,  'medium', 'https://en.wikipedia.org/wiki/I-70_Series',
+    'Also in mlb_branded_series; 1985 World Series'),
+  ('Dodgers vs Angels / Freeway Series',  'MLB', 'Los Angeles Dodgers', 'Los Angeles Angels',
+    true,  'medium', 'https://en.wikipedia.org/wiki/Freeway_Series',
+    'I-5; also in mlb_branded_series'),
+  ('Giants vs Athletics / Bay Bridge Series','MLB', 'San Francisco Giants', 'Oakland Athletics',
+    true,  'medium', 'https://en.wikipedia.org/wiki/Bay_Bridge_Series',
+    'Disrupted by Athletics Sacramento move'),
+  ('Phillies vs Mets',          'MLB', 'Philadelphia Phillies', 'New York Mets',
+    false, 'high', 'https://en.wikipedia.org/wiki/Mets%E2%80%93Phillies_rivalry',
+    'NL East'),
+  ('Braves vs Mets',            'MLB', 'Atlanta Braves', 'New York Mets',
+    false, 'high', 'https://en.wikipedia.org/wiki/Braves%E2%80%93Mets_rivalry',
+    'NL East, late 90s playoff battles'),
+  ('Braves vs Phillies',        'MLB', 'Atlanta Braves', 'Philadelphia Phillies',
+    false, 'high', 'https://en.wikipedia.org/wiki/Braves%E2%80%93Phillies_rivalry',
+    'NL East'),
+  ('Yankees vs Astros',         'MLB', 'New York Yankees', 'Houston Astros',
+    false, 'high', NULL,
+    'Modern AL rivalry, sign-stealing era'),
+  ('Brewers vs Cubs',           'MLB', 'Milwaukee Brewers', 'Chicago Cubs',
+    false, 'medium', NULL,
+    'NL Central');
+
+-- ============================================================================
+-- NHL rivalries (Wikipedia: https://en.wikipedia.org/wiki/List_of_NHL_rivalries)
+-- ============================================================================
+
+INSERT INTO sporting_rivalries(rivalry_name, league, team_a, team_b, is_branded, rivalry_intensity, wikipedia_url, notes) VALUES
+  ('Rangers vs Islanders',      'NHL', 'New York Rangers', 'New York Islanders',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Islanders%E2%80%93Rangers_rivalry',
+    'Battle of New York'),
+  ('Rangers vs Devils',         'NHL', 'New York Rangers', 'New Jersey Devils',
+    false, 'high', 'https://en.wikipedia.org/wiki/Devils%E2%80%93Rangers_rivalry',
+    'Hudson River, Metropolitan Division'),
+  ('Bruins vs Canadiens',       'NHL', 'Boston Bruins', 'Montreal Canadiens',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Bruins%E2%80%93Canadiens_rivalry',
+    'Original Six, oldest NHL rivalry, 700+ meetings'),
+  ('Bruins vs Maple Leafs',     'NHL', 'Boston Bruins', 'Toronto Maple Leafs',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Bruins%E2%80%93Maple_Leafs_rivalry',
+    'Original Six'),
+  ('Maple Leafs vs Canadiens',  'NHL', 'Toronto Maple Leafs', 'Montreal Canadiens',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Canadiens%E2%80%93Maple_Leafs_rivalry',
+    'Original Six, Battle of Ontario-Quebec'),
+  ('Penguins vs Capitals',      'NHL', 'Pittsburgh Penguins', 'Washington Capitals',
+    false, 'high', 'https://en.wikipedia.org/wiki/Capitals%E2%80%93Penguins_rivalry',
+    'Crosby vs Ovechkin'),
+  ('Penguins vs Flyers',        'NHL', 'Pittsburgh Penguins', 'Philadelphia Flyers',
+    false, 'high', 'https://en.wikipedia.org/wiki/Flyers%E2%80%93Penguins_rivalry',
+    'Battle of Pennsylvania'),
+  ('Flames vs Oilers / Battle of Alberta','NHL', 'Calgary Flames', 'Edmonton Oilers',
+    true,  'historic', 'https://en.wikipedia.org/wiki/Battle_of_Alberta',
+    'Provincial rivalry, 80s dynasty era'),
+  ('Senators vs Maple Leafs / Battle of Ontario','NHL', 'Ottawa Senators', 'Toronto Maple Leafs',
+    true,  'high', 'https://en.wikipedia.org/wiki/Battle_of_Ontario',
+    'Ontario provincial'),
+  ('Avalanche vs Red Wings',    'NHL', 'Colorado Avalanche', 'Detroit Red Wings',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Avalanche%E2%80%93Red_Wings_rivalry',
+    'Late 90s blood feud'),
+  ('Blackhawks vs Red Wings',   'NHL', 'Chicago Blackhawks', 'Detroit Red Wings',
+    false, 'historic', 'https://en.wikipedia.org/wiki/Blackhawks%E2%80%93Red_Wings_rivalry',
+    'Original Six'),
+  ('Sharks vs Kings',           'NHL', 'San Jose Sharks', 'Los Angeles Kings',
+    false, 'medium', NULL,
+    'California Pacific Division'),
+  ('Kings vs Ducks / Freeway Faceoff','NHL', 'Los Angeles Kings', 'Anaheim Ducks',
+    true,  'medium', 'https://en.wikipedia.org/wiki/Freeway_Faceoff',
+    'Southern California');
+
+-- ============================================================================
+-- MLS rivalries (Wikipedia: https://en.wikipedia.org/wiki/List_of_Major_League_Soccer_rivalries)
+-- ============================================================================
+
+INSERT INTO sporting_rivalries(rivalry_name, league, team_a, team_b, is_branded, rivalry_intensity, wikipedia_url, notes) VALUES
+  ('LAFC vs LA Galaxy / El Trafico','MLS', 'Los Angeles FC', 'LA Galaxy',
+    true,  'high', 'https://en.wikipedia.org/wiki/El_Tr%C3%A1fico',
+    'LA crosstown'),
+  ('NYCFC vs Red Bulls / Hudson River Derby','MLS', 'New York City FC', 'New York Red Bulls',
+    true,  'high', 'https://en.wikipedia.org/wiki/Hudson_River_Derby',
+    'NYC metropolitan'),
+  ('Sounders vs Timbers / Cascadia Cup','MLS', 'Seattle Sounders FC', 'Portland Timbers',
+    true,  'historic', 'https://en.wikipedia.org/wiki/Cascadia_Cup',
+    '3-team trophy with Vancouver'),
+  ('Sounders vs Whitecaps / Cascadia Cup','MLS', 'Seattle Sounders FC', 'Vancouver Whitecaps FC',
+    true,  'high', 'https://en.wikipedia.org/wiki/Cascadia_Cup',
+    'Pacific NW'),
+  ('Timbers vs Whitecaps / Cascadia Cup', 'MLS', 'Portland Timbers', 'Vancouver Whitecaps FC',
+    true,  'high', 'https://en.wikipedia.org/wiki/Cascadia_Cup',
+    'Pacific NW'),
+  ('Atlanta United vs Orlando City','MLS', 'Atlanta United', 'Orlando City SC',
+    false, 'high', 'https://en.wikipedia.org/wiki/Atlanta_United_FC%E2%80%93Orlando_City_SC_rivalry',
+    'Southeast'),
+  ('Inter Miami vs Orlando City','MLS', 'Inter Miami CF', 'Orlando City SC',
+    false, 'high', NULL,
+    'Florida derby'),
+  ('Sporting KC vs FC Dallas',  'MLS', 'Sporting Kansas City', 'FC Dallas',
+    false, 'medium', NULL,
+    'Original MLS, central rivalry'),
+  ('Toronto FC vs Montreal',    'MLS', 'Toronto FC', 'CF Montreal',
+    false, 'high', 'https://en.wikipedia.org/wiki/Canadian_Classique',
+    'Canadian Classique'),
+  ('Chicago Fire vs Columbus Crew','MLS', 'Chicago Fire FC', 'Columbus Crew',
+    false, 'high', NULL,
+    'Trillium Cup');
+
+-- ============================================================================
+-- Helper view: rivalry overlay on events
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_rivalry_events AS
+WITH parsed AS (
+  SELECT
+    e.id AS tevo_event_id,
+    e.name,
+    e.occurs_at_local::date AS event_date,
+    e.venue_name,
+    e.primary_performer_name AS home_team,
+    trim(split_part(e.name, ' at ', 1)) AS away_team
+  FROM events e
+  WHERE e.event_type = 'game'
+    AND e.name ILIKE '% at %'
+    AND e.primary_performer_name IS NOT NULL
+)
+SELECT
+  p.tevo_event_id, p.name, p.event_date, p.venue_name,
+  p.home_team, p.away_team,
+  sr.rivalry_name, sr.league, sr.is_branded, sr.rivalry_intensity,
+  sr.wikipedia_url, sr.notes
+FROM parsed p
+JOIN sporting_rivalries sr
+  ON (sr.team_a = p.home_team AND sr.team_b = p.away_team)
+  OR (sr.team_b = p.home_team AND sr.team_a = p.away_team);
+
+COMMENT ON VIEW v_rivalry_events IS
+  'Events that match a known rivalry. Use this to overlay "Rivalry Game" '
+  'badge on any event UI surface. Returns all rivalries that match either '
+  'team-direction (home-away or away-home).';


### PR DESCRIPTION
Three Phase 2 handoff deliverables: (1) query catalog organized by intent for the UI coworker; (2) 66 sporting rivalries across NBA/NFL/MLB/NHL/MLS with Wikipedia URLs + v_rivalry_events overlay view; (3) interactive venue map options doc recommending TEvo static images for v1.