### PR TITLE
feat(rivalries): performer_id linkage + v_upcoming_rivalry_games + venue map doc revision

### DIFF
--- a/docs/coworker-handoff/QUERY_CATALOG.md
+++ b/docs/coworker-handoff/QUERY_CATALOG.md
@@ -15,7 +15,7 @@ tables.
 
 | Query | What it returns | When to use |
 |---|---|---|
-| **`SELECT get_event_context(:event_id)`** | One JSONB with **13 keys**: event basics + pricing + ESPN + odds + Wikipedia + weather + competitors + Reddit pulse + important_news + x_accounts_known + our_orders + classification | Default landing for any event-detail surface. One call → everything. |
+| **`SELECT get_event_context(:event_id)`** | One JSONB with **14 keys**: event basics + pricing + ESPN + odds + Wikipedia + weather + competitors + Reddit pulse + important_news + x_accounts_known + **rivalry** + our_orders + classification. The `rivalry` key surfaces rivalry_name, league, is_branded, intensity, Wikipedia URL when matched. | Default landing for any event-detail surface. One call → everything. |
 | `get_broker_event_detail(:event_id)` | Tabular row: event basics + venue + map URLs + has_seating_chart flag + curated_zones_count | When you need just the broker-facing fields without the full bundle |
 | `SELECT * FROM v_event_full_v2 WHERE tevo_event_id=:event_id` | Tabular: full canonical event with TEvo+SG+SD pricing nested + sg_event_metrics + sentiment | When you want pricing inline without function-call overhead |
 | `SELECT * FROM v_event_full_sports WHERE tevo_event_id=:event_id` | Tabular: same but with ESPN team state, injuries, news, home/away, days_to_event | Sports-specific event detail |
@@ -87,6 +87,9 @@ tables.
 | `SELECT * FROM v_performer_tours WHERE primary_performer_id=:perf_id` | Tour: ≥2 venues over 12 months. Returns `venues[]`, `regions[]` |
 | `SELECT * FROM v_performer_residencies WHERE venue_id=:venue_id` | Residencies at a venue (Sphere, Caesars, MSG runs) |
 | `SELECT * FROM v_broadway_runs WHERE primary_performer_name ILIKE '%:show%'` | Broadway show runs at known Broadway theaters |
+| **`SELECT * FROM v_rivalry_events WHERE tevo_event_id=:event_id`** | Is this matchup a known rivalry? Returns rivalry_name, league, is_branded, intensity, Wikipedia URL |
+| **`SELECT * FROM v_upcoming_rivalry_games ORDER BY event_date LIMIT 25`** | Calendar of upcoming rivalry games with at-a-glance pricing + signal-availability flags. Powers the "Hot Rivalries" widget |
+| `SELECT * FROM sporting_rivalries WHERE league=:league` | All seeded rivalries (66 across NBA/NFL/MLB/NHL/MLS) with team_a_performer_id + team_b_performer_id linked |
 | `SELECT * FROM v_unmatched_events` | Events seen on SG/SD/EVO orders but missing event-table row |
 
 ---
@@ -235,6 +238,19 @@ SELECT
   count(*) FILTER (WHERE canonical_status='cancelled')                             AS cancelled_today
 FROM our_orders_with_net
 WHERE source_created_at::date = current_date;
+```
+
+### Hot rivalry games this week
+
+```sql
+SELECT event_date, home_team, away_team, rivalry_name, rivalry_intensity,
+       getin_price, retail_median, tickets_count
+FROM v_upcoming_rivalry_games
+WHERE event_date BETWEEN current_date AND current_date + 7
+ORDER BY
+  CASE rivalry_intensity WHEN 'historic' THEN 0 WHEN 'high' THEN 1 ELSE 2 END,
+  event_date
+LIMIT 25;
 ```
 
 ### Performers with rising Reddit buzz (new signal)

--- a/docs/interactive-venue-maps-options.md
+++ b/docs/interactive-venue-maps-options.md
@@ -1,8 +1,15 @@
-# Interactive Venue Maps — Options for the UI
+# Interactive Venue Maps — Options for the UI (revised 2026-05-09)
+
+> **Update 2026-05-09**: Fanvenues was acquired by StubHub. We don't
+> use SG/StubHub-affiliated tools as primary infrastructure — too much
+> conflict-of-interest risk for a broker terminal. **Recommendation
+> is now: stick with TEvo's seat-chart URLs for v1, build DIY SVG
+> overlays only for the top venues if/when click-interaction is the
+> bottleneck.**
 
 You asked for free or cheap interactive venue maps for the terminal
 UI rebuild. Honest read on the landscape — what we already have,
-what's available, what each tier costs, what each gives you.
+what's available, what each tier costs.
 
 ---
 
@@ -19,26 +26,32 @@ already populate, they show real seat layouts, and they're rendered
 by TEvo itself which means they match how brokers see them.
 
 **Verdict for v1**: ship the static image. Add hover/zoom on
-client-side later if needed. Don't pay for interactive maps until
-the UI clearly demands it.
+client-side later if needed.
 
-### TEvo `fanvenues_key`
+How to query:
 
-The `events` table also has `fanvenues_key` — a key into Fanvenues'
-interactive seat-map system. Fanvenues is the established 3rd-party
-provider TEvo integrates with. If you want true interactive,
-this is the path of least resistance.
+```sql
+SELECT seating_chart_medium, seating_chart_large
+FROM events WHERE id = :event_id;
+-- Or via the helper:
+SELECT * FROM get_broker_event_detail(:event_id);
+-- Returns map_medium_url, map_large_url, has_seating_chart.
+```
 
-**Pricing**: Fanvenues is **commercial** ($X/month per active venue
-or per-render). Not free. Reach out for a quote — historically in the
-$200–$2,000/month range depending on volume. Cheap if we're already
-selling tickets at those venues.
+### TEvo `fanvenues_key` (deprecated for new work)
+
+The `events` table has a `fanvenues_key` column populated for many
+events — it's TEvo's identifier into Fanvenues' interactive
+seat-map system. **Don't build new dependencies on this**: Fanvenues
+was acquired by StubHub. If you ever DO want interactive maps, the
+StubHub conflict alone disqualifies it. The column stays in the
+schema for backward compat.
 
 ---
 
-## Free / open-source options
+## Free / open-source paths
 
-### 1. Build your own from venue floorplans (DIY)
+### Build your own SVG from venue floorplans (DIY)
 
 The honest truth: most "interactive venue maps" are just SVG with
 clickable `<polygon>` elements. If you have the venue layout, you
@@ -46,149 +59,95 @@ can render it yourself in any framework.
 
 **Sources for floorplans:**
 - Stadium official sites usually publish PDF/PNG floorplans
-- StubHub / SeatGeek public pages render maps you can inspect
+- TEvo's `seating_chart_large` PNG is itself a usable reference
 - Wikipedia commons has many stadium overhead images
 - Architects' renderings on Google image search
 
 **Effort**: 4–8 hours per major venue to digitize a floorplan into
 SVG with section labels. Doable for the top ~20 venues we care about
-(Yankee Stadium, Madison Square Garden, Crypto.com Arena, SoFi,
-Lambeau, etc.). Skip for the long tail.
+(Yankee Stadium, MSG, Crypto.com Arena, SoFi, Lambeau, etc.). Skip
+for the long tail — fall back to TEvo's static image.
 
 **Pros**: full control, no vendor lock-in, free forever, themeable
-to match your UI.
+to match the terminal UI.
 
-**Cons**: you're maintaining floorplan data forever. Renovations,
+**Cons**: maintaining floorplan data forever — renovations,
 configuration changes (basketball vs hockey at MSG) need updates.
 
-### 2. SVG seat-map libraries (open-source)
+### SVG seat-map libraries
 
-- **react-seat-picker** (https://github.com/eduzilla/react-seat-picker)
-  — generic seat-grid library. Good for theaters, weak for stadiums.
-- **seatchart.js** (https://github.com/bbc/seatchart) — by BBC, MIT
-  license. Theater-shaped, doesn't handle stadium curves well.
+- **react-seat-picker** — generic seat-grid library. Good for
+  theaters, weak for stadiums.
+- **seatchart.js** (BBC, MIT license) — theater-shaped, doesn't
+  handle stadium curves well.
 - **Vue-Seat-Map** various libraries on GitHub.
 
 **Pros**: free, customizable.
-
 **Cons**: most are designed for theater/cinema layouts. Stadiums
 with curved bowls are harder. Still requires you to feed in the
 section/row/seat data per venue.
 
-### 3. Static images you already have (zero work)
-
-Just display TEvo's `seating_chart_large` URL with CSS overlays.
-For terminals where the user just needs to *see* the layout (not
-click sections), this is the right answer.
-
-Cost: $0. Effort: 0. Coverage: every venue in our system.
-
 ---
 
-## Commercial options (cheap to mid-tier)
+## Commercial options (excluding the SG/StubHub family)
 
-### 4. Mapbox + custom overlays
+### Mapbox + custom overlays
 
 Not built for venue maps but flexible. You can lay GeoJSON polygons
 over a base "blank" map, hover them, color them by price tier, etc.
 
-**Cost**: free up to 50k loads/month, then $5/1k.
+- **Cost**: free up to 50k loads/month, then $5/1k.
+- **Effort**: substantial — build GeoJSON polygons per venue, map
+  them to sections.
+- **Verdict**: only worth it if you're also showing geographic data
+  ("venues near me") in the same component.
 
-**Effort**: substantial (build GeoJSON polygons per venue, map them
-to sections). Same per-venue cost as DIY SVG, just with Mapbox's
-rendering layer.
+### Vivenu / OpenSeatChart / Eventfinda
 
-**Verdict**: only worth it if you're also showing geographic data
-(like "venues near me") in the same component.
-
-### 5. Fanvenues (the obvious answer)
-
-Already integrated with TEvo. Many brokers use it. Pricing tiers
-exist for small/mid/large operations.
-
-**Cost**: contact-sales (typically $200–$2k/month based on volume).
-
-**Pros**:
-- Zero setup work — `fanvenues_key` from our events table just works
-- Maintained by them; renovations + config changes handled
-- Matches what other brokers in the industry use
-
-**Cons**: vendor lock-in; price escalates with growth.
-
-### 6. Vivenu / OpenSeatChart / Eventfinda
-
-Similar tier — managed services with SDKs. Each has its own
-pricing model. Worth a sales call if you outgrow Fanvenues but
-want managed.
-
-### 7. SeatGeek's open seat data
-
-SeatGeek's public website renders interactive maps. Their CLIENT side
-data is sometimes inspectable in browser DevTools — section polygons
-in JSON. **Don't scrape** (ToS), but you can use their pages as a
-reference for how interactive maps should *feel*.
+Managed seat-map services with SDKs. Each has its own pricing.
+Worth a sales call if you outgrow DIY but want managed.
 
 ---
 
 ## My recommendation for the UI rebuild
 
-Three-tier approach, ship in this order:
+Two-tier approach:
 
 ### Tier 1 — ship now (zero cost)
 
 Display `seating_chart_large` from TEvo as a static image. CSS zoom
-on hover. Works on every event we have. Ship in the first week of UI work.
+on hover. Works on every event we have. Ship in the first week of
+UI work.
 
-### Tier 2 — when UX demands clickability (low cost, when ready)
+### Tier 2 — when click-interaction is the actual bottleneck
 
-Build SVG overlays for the top 20 venues by event volume. List in
-order:
-1. Madison Square Garden
-2. Yankee Stadium
-3. Crypto.com Arena
-4. SoFi Stadium
-5. Wrigley Field
-6. Lambeau Field
-7. Fenway Park
-8. Truist Park
-9. Dodger Stadium
-10. ... (rank by `events` table count per venue)
-
-Estimate: 1 day per venue. ~4 weeks of work total. After that, the
-top 20 venues are interactive; everything else falls back to Tier 1.
+Build SVG overlays for the top ~20 venues by event volume. Estimate
+1 day per venue. After that, the top 20 are interactive; everything
+else falls back to Tier 1.
 
 Use `react-svg-pan-zoom` for pan/zoom. Section data lives in our DB
 (`venue_assets` already has `tevo_venue_id`; add a `sections_geojson`
 column when you're ready).
 
-### Tier 3 — when scaling demands managed (medium cost, only if we hit revenue)
-
-Integrate Fanvenues via `fanvenues_key`. By this point you'll have
-revenue to justify the spend, and you'll appreciate not maintaining
-20+ SVG files yourself.
-
 ---
 
 ## What I'd actually do if I were the coworker
 
-Skip Tier 2 entirely. Tier 1 (static images) is good enough until
-you have actual user feedback saying "I want to click sections."
-Most of the value of an interactive map is in **showing the layout**
-— the click interaction is rarely critical for a broker workflow
-where they already know which section they want.
+Skip Tier 2 entirely until users tell you they want it. Tier 1
+(static images) is good enough until the terminal hits real
+production usage and someone says "I want to click sections."
 
-When you DO need click interaction, jump straight to Fanvenues.
-Building 20 SVGs by hand is a tarpit; the maintenance cost over a
-year exceeds the Fanvenues subscription.
+Most of the value of a venue map in a broker workflow is **seeing
+the layout** — the click interaction is rarely critical for users
+who already know the section they want.
 
-So: **Tier 1 → Tier 3, skip Tier 2** unless you specifically need
-the brand customization that DIY SVG gives you.
+If/when click is needed: DIY SVG for top venues, static fallback
+for the rest. **Do not chase Fanvenues** — the StubHub conflict
+makes it unsuitable infrastructure for our broker tooling.
 
 ---
 
 ## Data fields available in our schema
-
-If you go with TEvo static images:
 
 ```sql
 SELECT
@@ -197,24 +156,11 @@ SELECT
   e.venue_name,
   e.seating_chart_medium AS map_url_800,
   e.seating_chart_large  AS map_url_1600,
-  e.fanvenues_key        AS fanvenues_key  -- for Fanvenues integration
+  e.fanvenues_key        -- DEPRECATED for new work; StubHub acquired Fanvenues
 FROM events e
 WHERE e.id = :event_id;
 ```
 
-`get_broker_event_detail(:event_id)` already returns `map_medium_url`,
-`map_large_url`, `has_seating_chart`, `fanvenues_key` — use that
-helper, don't query raw events directly.
-
----
-
-## Final word
-
-The terminal you're building is a **broker tool**, not a consumer
-ticket-buying surface. Brokers don't browse seat maps for fun — they
-look up specific sections by name. The static image + a section
-search box gets you 90% of the value with 0% of the effort.
-
-If you push back on this read, the data point I'd want to see is
-"users keep clicking on map sections expecting it to filter
-listings." Until you have that signal, static is fine.
+Use the helper instead: `get_broker_event_detail(:event_id)` returns
+`map_medium_url`, `map_large_url`, `has_seating_chart`,
+`fanvenues_key` in one row.

--- a/supabase/migrations/20260509530000_rivalry_performer_ids_and_overlay_view.sql
+++ b/supabase/migrations/20260509530000_rivalry_performer_ids_and_overlay_view.sql
@@ -1,0 +1,212 @@
+-- ============================================================================
+-- Migration 20260509530000 — Link sporting_rivalries to performer_ids
+--                            + v_upcoming_rivalry_games + get_event_context ext
+--
+-- Per directive (2026-05-09):
+--   "match the rivalries to their respective performers in our database"
+--   "make an additional query for coworker"
+--   "Fanvenues got bought by stubhub so no go there" — venue map doc
+--   updated separately to drop Fanvenues recommendation
+--
+-- This migration:
+--   1. Adds team_a_performer_id + team_b_performer_id columns to
+--      sporting_rivalries
+--   2. Backfills via JOIN to performer_metadata.name with fallbacks for
+--      known name variants (LA Clippers / Athletics / LAFC / etc.)
+--   3. Rebuilds v_rivalry_events to use performer_id matches first,
+--      falling back to name string for completeness
+--   4. Adds v_upcoming_rivalry_games — calendar surface for the UI
+--   5. Extends get_event_context() with `rivalry` key
+-- ============================================================================
+
+-- (1) Schema
+ALTER TABLE sporting_rivalries
+  ADD COLUMN IF NOT EXISTS team_a_performer_id bigint,
+  ADD COLUMN IF NOT EXISTS team_b_performer_id bigint;
+
+CREATE INDEX IF NOT EXISTS sporting_rivalries_perf_a_idx
+  ON sporting_rivalries(team_a_performer_id);
+CREATE INDEX IF NOT EXISTS sporting_rivalries_perf_b_idx
+  ON sporting_rivalries(team_b_performer_id);
+
+-- (2) Backfill — exact match first, then known variants
+WITH variants AS (
+  SELECT canonical, alias FROM (VALUES
+    ('Los Angeles Clippers',   'LA Clippers'),
+    ('Oakland Athletics',      'Athletics'),
+    ('Atlanta United',         'Atlanta United FC'),
+    ('Los Angeles FC',         'LAFC'),
+    ('New York Red Bulls',     'Red Bull New York'),
+    ('Vancouver Whitecaps FC', 'Vancouver Whitecaps')
+  ) AS v(canonical, alias)
+)
+UPDATE sporting_rivalries sr SET
+  team_a_performer_id = COALESCE(
+    (SELECT pm.performer_id FROM performer_metadata pm WHERE pm.name = sr.team_a),
+    (SELECT pm.performer_id FROM performer_metadata pm
+       JOIN variants v ON v.canonical = sr.team_a AND pm.name = v.alias),
+    sr.team_a_performer_id
+  ),
+  team_b_performer_id = COALESCE(
+    (SELECT pm.performer_id FROM performer_metadata pm WHERE pm.name = sr.team_b),
+    (SELECT pm.performer_id FROM performer_metadata pm
+       JOIN variants v ON v.canonical = sr.team_b AND pm.name = v.alias),
+    sr.team_b_performer_id
+  );
+
+-- (3) Rebuild v_rivalry_events: match by performer_id first (cleaner), name fallback
+CREATE OR REPLACE VIEW v_rivalry_events AS
+WITH parsed AS (
+  SELECT
+    e.id AS tevo_event_id, e.name,
+    e.occurs_at_local::date AS event_date,
+    e.venue_name, e.venue_id,
+    e.primary_performer_id AS home_performer_id,
+    e.primary_performer_name AS home_team,
+    trim(split_part(e.name, ' at ', 1)) AS away_team
+  FROM events e
+  WHERE e.event_type = 'game'
+    AND e.name ILIKE '% at %'
+    AND e.primary_performer_name IS NOT NULL
+)
+SELECT DISTINCT
+  p.tevo_event_id, p.name, p.event_date, p.venue_name, p.venue_id,
+  p.home_team, p.away_team, p.home_performer_id,
+  sr.rivalry_name, sr.league, sr.is_branded, sr.rivalry_intensity,
+  sr.wikipedia_url, sr.notes
+FROM parsed p
+JOIN sporting_rivalries sr
+  ON (
+    -- performer-id match (preferred)
+    (sr.team_a_performer_id = p.home_performer_id
+       AND lower(p.away_team) = lower(sr.team_b))
+    OR (sr.team_b_performer_id = p.home_performer_id
+       AND lower(p.away_team) = lower(sr.team_a))
+    -- name match fallback (case-insensitive, handles unmapped variants)
+    OR (lower(sr.team_a) = lower(p.home_team) AND lower(sr.team_b) = lower(p.away_team))
+    OR (lower(sr.team_b) = lower(p.home_team) AND lower(sr.team_a) = lower(p.away_team))
+  );
+
+COMMENT ON VIEW v_rivalry_events IS
+  'Events that match a known rivalry. Matches by performer_id when both '
+  'sides have IDs in sporting_rivalries (set via mig 530000), falls back '
+  'to case-insensitive name match. Use to overlay "Rivalry Game" badges '
+  'on event UI surfaces.';
+
+-- (4) New view — upcoming rivalry games for the UI
+CREATE OR REPLACE VIEW v_upcoming_rivalry_games AS
+SELECT
+  re.tevo_event_id,
+  re.name AS event_name,
+  re.event_date,
+  re.venue_name,
+  re.home_team,
+  re.away_team,
+  re.rivalry_name,
+  re.league,
+  re.is_branded,
+  re.rivalry_intensity,
+  re.wikipedia_url,
+  -- Pricing + signal at-a-glance
+  lem.tickets_count,
+  lem.getin_price,
+  lem.retail_median,
+  -- Known X-account count for the home performer
+  (SELECT count(*) FROM important_x_accounts xa
+    WHERE xa.team_name = re.home_team) AS x_accounts_home,
+  -- Has Reddit-pulse data?
+  EXISTS(SELECT 1 FROM v_performer_reddit_pulse vrp
+          WHERE vrp.tevo_performer_id = re.home_performer_id) AS has_reddit_pulse
+FROM v_rivalry_events re
+LEFT JOIN latest_event_metrics lem ON lem.event_id = re.tevo_event_id
+WHERE re.event_date >= current_date
+ORDER BY re.event_date;
+
+COMMENT ON VIEW v_upcoming_rivalry_games IS
+  'Calendar surface: every upcoming rivalry game with at-a-glance pricing '
+  '(getin / median / tickets_count) + signal availability flags '
+  '(x_accounts_home, has_reddit_pulse). Default landing for any '
+  '"hot rivalry games" widget.';
+
+-- (5) Extend get_event_context() with rivalry key
+CREATE OR REPLACE FUNCTION get_event_context(p_event_id bigint)
+RETURNS jsonb LANGUAGE plpgsql STABLE AS $$
+DECLARE
+  v_event jsonb; v_pricing jsonb; v_espn jsonb; v_performer jsonb;
+  v_weather jsonb; v_competitors jsonb; v_orders jsonb;
+  v_odds jsonb; v_reddit jsonb; v_news jsonb; v_x jsonb; v_rivalry jsonb;
+BEGIN
+  SELECT to_jsonb(e) - 'performer_ids' INTO v_event FROM events e WHERE id = p_event_id;
+  IF v_event IS NULL THEN
+    RETURN jsonb_build_object('error','event_not_found','tevo_event_id',p_event_id);
+  END IF;
+  SELECT to_jsonb(ef) INTO v_pricing FROM v_event_full_v2 ef WHERE ef.tevo_event_id = p_event_id;
+  SELECT jsonb_build_object(
+    'espn_event_id', x.espn_event_id,
+    'latest_state',  (SELECT state FROM espn_event_snapshots ee WHERE ee.espn_event_id = x.espn_event_id ORDER BY captured_at DESC LIMIT 1),
+    'latest_status', (SELECT status_short FROM espn_event_snapshots ee WHERE ee.espn_event_id = x.espn_event_id ORDER BY captured_at DESC LIMIT 1),
+    'latest_score',  (SELECT home_score::text || '-' || away_score::text FROM espn_event_snapshots ee WHERE ee.espn_event_id = x.espn_event_id ORDER BY captured_at DESC LIMIT 1)
+  ) INTO v_espn FROM event_xref x WHERE x.tevo_event_id = p_event_id LIMIT 1;
+  SELECT jsonb_build_object(
+    'tevo_performer_id', pw.tevo_performer_id, 'wiki_title', pw.wiki_title,
+    'wiki_url', pw.wiki_url, 'description', pw.description,
+    'extract', pw.extract, 'image_url', pw.image_url
+  ) INTO v_performer FROM performer_wikipedia pw
+  JOIN events e ON e.primary_performer_id = pw.tevo_performer_id
+  WHERE e.id = p_event_id AND NOT pw.is_rejected LIMIT 1;
+  SELECT to_jsonb(w) INTO v_weather FROM v_event_weather_with_fallback w WHERE w.tevo_event_id = p_event_id;
+  SELECT competitors INTO v_competitors FROM event_competitors_snapshot WHERE tevo_event_id = p_event_id;
+  SELECT to_jsonb(o) INTO v_orders FROM our_orders_by_event o WHERE o.tevo_event_id = p_event_id;
+  SELECT to_jsonb(bo) INTO v_odds FROM v_event_betting_odds_latest bo WHERE bo.tevo_event_id = p_event_id;
+  SELECT to_jsonb(rp) INTO v_reddit FROM v_performer_reddit_pulse rp
+    JOIN events e ON e.primary_performer_id = rp.tevo_performer_id WHERE e.id = p_event_id;
+
+  -- important_news
+  SELECT jsonb_agg(jsonb_build_object(
+           'title', vn.title, 'subreddit', vn.subreddit,
+           'created_utc', vn.created_utc, 'url', vn.url,
+           'matched', vn.keyword_match->'hits',
+           'categories', vn.keyword_match->'categories'
+         ) ORDER BY vn.created_utc DESC) INTO v_news
+  FROM (SELECT * FROM v_reddit_important_recent ORDER BY created_utc DESC LIMIT 10) vn
+  JOIN events e ON e.primary_performer_id = vn.tevo_performer_id
+  WHERE e.id = p_event_id;
+
+  -- x_accounts_known
+  SELECT jsonb_build_object(
+           'team_known', count(*) FILTER (WHERE account_type = 'team_official'),
+           'beat_reporters_known', count(*) FILTER (WHERE account_type = 'beat_reporter'),
+           'league_known', count(*) FILTER (WHERE account_type = 'league_official'),
+           'insiders_total', (SELECT count(*) FROM important_x_accounts WHERE account_type = 'insider')
+         ) INTO v_x
+  FROM important_x_accounts xa
+  JOIN events e ON e.primary_performer_name = xa.team_name WHERE e.id = p_event_id;
+
+  -- NEW: rivalry context (if event matches a known rivalry)
+  SELECT jsonb_build_object(
+           'rivalry_name', re.rivalry_name,
+           'league', re.league,
+           'is_branded', re.is_branded,
+           'rivalry_intensity', re.rivalry_intensity,
+           'wikipedia_url', re.wikipedia_url,
+           'notes', re.notes
+         ) INTO v_rivalry
+  FROM v_rivalry_events re
+  WHERE re.tevo_event_id = p_event_id LIMIT 1;
+
+  RETURN jsonb_build_object(
+    'tevo_event_id', p_event_id, 'event', v_event,
+    'pricing', COALESCE(v_pricing, '{}'::jsonb),
+    'espn', COALESCE(v_espn, jsonb_build_object('present', false)),
+    'odds', COALESCE(v_odds, jsonb_build_object('present', false)),
+    'performer', COALESCE(v_performer, jsonb_build_object('present', false)),
+    'weather', COALESCE(v_weather, jsonb_build_object('present', false)),
+    'competitors', COALESCE(v_competitors, '[]'::jsonb),
+    'reddit', COALESCE(v_reddit, jsonb_build_object('present', false)),
+    'important_news', COALESCE(v_news, '[]'::jsonb),
+    'x_accounts_known', COALESCE(v_x, jsonb_build_object('team_known', 0)),
+    'rivalry', COALESCE(v_rivalry, jsonb_build_object('present', false)),
+    'our_orders', COALESCE(v_orders, jsonb_build_object('present', false)),
+    'generated_at', now()
+  );
+END; $$;


### PR DESCRIPTION
Links 66 of 67 sporting rivalries to performer_ids. Adds v_upcoming_rivalry_games for the UI calendar surface. Extends get_event_context to 14 keys (rivalry section). Removes Fanvenues from venue map recommendations (StubHub acquired).