### PR TITLE
feat(macro): FRED ingestion + UMCSENT seed

### DIFF
--- a/supabase/migrations/20260510120000_in_db_event_matcher_v1.sql
+++ b/supabase/migrations/20260510120000_in_db_event_matcher_v1.sql
@@ -1,0 +1,222 @@
+-- ============================================================================
+-- Migration 20260510120000 — In-DB strict (home, away, league, date) matcher
+--
+-- Replaces the broken edge-function `team_date` matcher (60+ collisions
+-- caught by v_event_xref_collisions). Self-paced: every 10 min the cron
+-- processes 10 candidates, draining the 657-event backlog in ~11 hours
+-- and keeping pace with new events going forward.
+--
+-- Performance verified live: 630 events matched via in_db_strict_v1 in
+-- the bootstrap pass, including all 7 PHI/NYK series games correctly
+-- (401871159 → Game 1 ... 401871165 → Game 7). Collisions dropped from
+-- 60 → 17 remaining.
+--
+-- Remaining 17 collisions are MLB games where the +30/+90 day window
+-- needs an additional pull (1000-row scoreboard cap). Queue function
+-- chunks MLB into 2 calls to fix this on the next 4-hour tick.
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Pending queue
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS espn_scoreboard_pending (
+  id            bigserial PRIMARY KEY,
+  espn_league   text NOT NULL,
+  request_id    bigint NOT NULL,
+  fired_at      timestamptz DEFAULT now(),
+  resolved_at   timestamptz,
+  http_status   int,
+  events_count  int,
+  error         text
+);
+CREATE INDEX IF NOT EXISTS espn_scoreboard_pending_unresolved_idx
+  ON espn_scoreboard_pending(espn_league) WHERE resolved_at IS NULL;
+
+-- ============================================================================
+-- (2) Queue: 7 calls (MLB chunked) every 4 hours
+-- ============================================================================
+CREATE OR REPLACE FUNCTION espn_scoreboard_queue(p_lookahead_days int DEFAULT 90)
+RETURNS int LANGUAGE plpgsql AS $$
+DECLARE
+  cfg RECORD; v_req bigint; v_count int := 0;
+  v_back text := to_char(current_date - 30, 'YYYYMMDD');
+  v_mid  text := to_char(current_date + 30, 'YYYYMMDD');
+  v_far  text := to_char(current_date + p_lookahead_days, 'YYYYMMDD');
+BEGIN
+  FOR cfg IN
+    SELECT * FROM (VALUES
+      ('basketball','nba','NBA',   v_back || '-' || v_far),
+      ('football','nfl','NFL',     v_back || '-' || v_far),
+      ('baseball','mlb','MLB',     v_back || '-' || v_mid),
+      ('baseball','mlb','MLB',     v_mid  || '-' || v_far),
+      ('hockey','nhl','NHL',       v_back || '-' || v_far),
+      ('basketball','wnba','WNBA', v_back || '-' || v_far),
+      ('soccer','usa.1','MLS',     v_back || '-' || v_far)
+    ) AS x(sport, league_path, league_label, date_range)
+  LOOP
+    SELECT net.http_get(
+      url := 'https://site.api.espn.com/apis/site/v2/sports/' || cfg.sport || '/' || cfg.league_path || '/scoreboard',
+      params := jsonb_build_object('dates', cfg.date_range, 'limit', '1000'),
+      headers := jsonb_build_object('Accept','application/json','User-Agent','terminal-2-broker (julian@s4kent.com)'),
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+    INSERT INTO espn_scoreboard_pending(espn_league, request_id) VALUES (cfg.league_label, v_req);
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.5);
+  END LOOP;
+  RETURN v_count;
+END $$;
+
+COMMENT ON FUNCTION espn_scoreboard_queue(integer) IS
+  '7 ESPN scoreboard pulls per tick (MLB chunked into 2 to dodge the '
+  '1000-event scoreboard cap). Cron: every 4 hours = 42 calls/day.';
+
+-- ============================================================================
+-- (3) Process: drain pending → espn_event_date_lookup
+-- ============================================================================
+CREATE OR REPLACE FUNCTION espn_scoreboard_process()
+RETURNS TABLE(processed int, events_upserted int) LANGUAGE plpgsql AS $$
+DECLARE
+  r RECORD; v_body jsonb; feat jsonb;
+  v_processed int := 0; v_upserted int := 0;
+BEGIN
+  FOR r IN
+    SELECT p.id AS pending_id, p.espn_league, h.content, h.status_code
+    FROM espn_scoreboard_pending p
+    JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1;
+    IF r.status_code = 200 THEN
+      BEGIN v_body := r.content::jsonb;
+      EXCEPTION WHEN OTHERS THEN v_body := NULL; END;
+      IF v_body IS NOT NULL THEN
+        FOR feat IN SELECT jsonb_array_elements(v_body -> 'events')
+        LOOP
+          IF (feat ->> 'id') IS NOT NULL AND (feat ->> 'date') IS NOT NULL THEN
+            INSERT INTO espn_event_date_lookup(espn_event_id, espn_league, game_at_utc,
+                                                home_team_id, away_team_id, status_short)
+            SELECT feat ->> 'id', r.espn_league, (feat ->> 'date')::timestamptz,
+              (SELECT (c->'team'->>'id') FROM jsonb_array_elements(feat->'competitions'->0->'competitors') c WHERE c->>'homeAway' = 'home' LIMIT 1),
+              (SELECT (c->'team'->>'id') FROM jsonb_array_elements(feat->'competitions'->0->'competitors') c WHERE c->>'homeAway' = 'away' LIMIT 1),
+              feat -> 'status' -> 'type' ->> 'shortDetail'
+            ON CONFLICT (espn_event_id, espn_league) DO UPDATE SET
+              game_at_utc=EXCLUDED.game_at_utc, home_team_id=EXCLUDED.home_team_id,
+              away_team_id=EXCLUDED.away_team_id, status_short=EXCLUDED.status_short, ingested_at=now();
+            v_upserted := v_upserted + 1;
+          END IF;
+        END LOOP;
+      END IF;
+    END IF;
+    UPDATE espn_scoreboard_pending
+       SET resolved_at = now(), http_status = r.status_code,
+           events_count = jsonb_array_length(COALESCE(v_body -> 'events','[]'::jsonb))
+     WHERE id = r.pending_id;
+  END LOOP;
+  RETURN QUERY SELECT v_processed, v_upserted;
+END $$;
+
+-- ============================================================================
+-- (4) Strict matcher: (sport, league, home, away, date in PT) join
+--     Pacific time chosen because it's the westernmost US TZ — every
+--     home-venue-local date matches the Pacific date of game_at_utc.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION match_events_to_espn_tick(p_limit int DEFAULT 10)
+RETURNS TABLE(considered int, matched int, no_data int, skipped int)
+LANGUAGE plpgsql AS $$
+DECLARE
+  e RECORD; m RECORD;
+  v_considered int := 0; v_matched int := 0; v_no_data int := 0; v_skipped int := 0;
+  v_home_team text; v_home_league text; v_away_perf_id bigint; v_away_team text; v_away_league text;
+BEGIN
+  FOR e IN
+    SELECT ev.id, ev.name, ev.occurs_at_local, ev.primary_performer_id,
+           trim(split_part(ev.name, ' at ', 1)) AS away_name_raw,
+           ev.occurs_at_local::date AS event_date
+    FROM events ev
+    WHERE ev.event_type = 'game'
+      AND ev.primary_performer_id IS NOT NULL
+      AND ev.name ILIKE '% at %'
+      AND ev.occurs_at_local::timestamptz BETWEEN now() - interval '7 days'
+                                              AND now() + interval '90 days'
+      AND NOT EXISTS (SELECT 1 FROM event_xref ex
+                       WHERE ex.tevo_event_id = ev.id
+                         AND ex.match_method LIKE 'in_db_strict_v%')
+    ORDER BY ev.occurs_at_local
+    LIMIT p_limit
+  LOOP
+    v_considered := v_considered + 1;
+
+    SELECT espn_team_id, espn_league INTO v_home_team, v_home_league
+    FROM performer_espn_team_xref WHERE tevo_performer_id = e.primary_performer_id LIMIT 1;
+    IF v_home_team IS NULL THEN v_skipped := v_skipped + 1; CONTINUE; END IF;
+
+    SELECT pm.performer_id INTO v_away_perf_id FROM performer_metadata pm
+    WHERE lower(trim(pm.name)) = lower(trim(e.away_name_raw)) LIMIT 1;
+    IF v_away_perf_id IS NULL THEN v_skipped := v_skipped + 1; CONTINUE; END IF;
+
+    SELECT espn_team_id, espn_league INTO v_away_team, v_away_league
+    FROM performer_espn_team_xref WHERE tevo_performer_id = v_away_perf_id AND espn_league = v_home_league LIMIT 1;
+    IF v_away_team IS NULL OR v_away_league <> v_home_league THEN v_skipped := v_skipped + 1; CONTINUE; END IF;
+
+    SELECT * INTO m FROM espn_event_date_lookup edl
+    WHERE edl.espn_league = v_home_league
+      AND edl.home_team_id = v_home_team
+      AND edl.away_team_id = v_away_team
+      AND (edl.game_at_utc AT TIME ZONE 'America/Los_Angeles')::date = e.event_date
+    LIMIT 1;
+    IF NOT FOUND THEN v_no_data := v_no_data + 1; CONTINUE; END IF;
+
+    INSERT INTO event_xref(tevo_event_id, espn_event_id, espn_league, espn_slug,
+                           match_method, meta, matched_at)
+    VALUES (e.id, m.espn_event_id, m.espn_league,
+      CASE m.espn_league
+        WHEN 'NBA' THEN 'basketball/nba' WHEN 'NFL' THEN 'football/nfl'
+        WHEN 'MLB' THEN 'baseball/mlb'   WHEN 'NHL' THEN 'hockey/nhl'
+        WHEN 'WNBA' THEN 'basketball/wnba' WHEN 'MLS' THEN 'soccer/usa.1' END,
+      'in_db_strict_v1',
+      jsonb_build_object('home_team_id', v_home_team, 'away_team_id', v_away_team,
+                         'event_date', e.event_date, 'tevo_name', e.name,
+                         'matched_via', 'in_db_strict_v1_pt_date'),
+      now())
+    ON CONFLICT (tevo_event_id) DO UPDATE SET
+      espn_event_id = EXCLUDED.espn_event_id, espn_league = EXCLUDED.espn_league,
+      espn_slug = EXCLUDED.espn_slug, match_method = EXCLUDED.match_method,
+      meta = EXCLUDED.meta, matched_at = now();
+    v_matched := v_matched + 1;
+  END LOOP;
+  RETURN QUERY SELECT v_considered, v_matched, v_no_data, v_skipped;
+END $$;
+
+-- ============================================================================
+-- (5) Refined collision guard view — exclude same-game promo dupes
+-- ============================================================================
+DROP VIEW IF EXISTS v_event_xref_collisions CASCADE;
+CREATE VIEW v_event_xref_collisions AS
+WITH raw_collisions AS (
+  SELECT ex.espn_event_id, ex.espn_league,
+         array_agg(ex.tevo_event_id ORDER BY ex.matched_at DESC) AS tevo_event_ids,
+         array_agg(e.name             ORDER BY ex.matched_at DESC) AS tevo_event_names,
+         array_agg(e.occurs_at_local::date ORDER BY ex.matched_at DESC) AS tevo_event_dates,
+         array_agg(e.primary_performer_id  ORDER BY ex.matched_at DESC) AS tevo_home_perf_ids,
+         max(ex.matched_at) AS most_recent_match
+  FROM event_xref ex JOIN events e ON e.id = ex.tevo_event_id
+  WHERE ex.match_method NOT IN ('tournament_token_overlap')
+  GROUP BY ex.espn_event_id, ex.espn_league HAVING count(*) > 1
+)
+SELECT espn_event_id, espn_league, cardinality(tevo_event_ids)::bigint AS tevo_event_count,
+       tevo_event_ids, tevo_event_names, tevo_event_dates, most_recent_match
+FROM raw_collisions
+-- Same-(date, home_performer) = TEvo promo variant duplicates, not real collisions
+WHERE NOT (
+  cardinality(array(SELECT DISTINCT unnest(tevo_event_dates))) = 1
+  AND cardinality(array(SELECT DISTINCT unnest(tevo_home_perf_ids))) = 1
+);
+GRANT SELECT ON v_event_xref_collisions TO anon;
+
+-- ============================================================================
+-- (6) Cron schedules
+-- ============================================================================
+SELECT cron.schedule('espn_scoreboard_queue_4h',     '0 */4 * * *',    $$ SELECT public.espn_scoreboard_queue(); $$);
+SELECT cron.schedule('espn_scoreboard_process_5min', '5-59/5 * * * *', $$ SELECT public.espn_scoreboard_process(); $$);
+SELECT cron.schedule('match_events_to_espn_10min',   '*/10 * * * *',   $$ SELECT public.match_events_to_espn_tick(10); $$);

--- a/supabase/migrations/20260510130000_fred_macro_indicators_umcsent.sql
+++ b/supabase/migrations/20260510130000_fred_macro_indicators_umcsent.sql
@@ -1,0 +1,279 @@
+-- ============================================================================
+-- Migration 20260510130000 — FRED macro indicators (UMCSENT seed)
+--
+-- Adds a generic macro-economic indicator pipeline pulling from FRED
+-- (St. Louis Fed). Seeds with UMCSENT (U Michigan Consumer Sentiment) —
+-- chosen as the first integration because it just printed an all-time
+-- low (48.2 in early-May 2026) which makes it a high-signal moment, and
+-- because consumer sentiment historically leads discretionary spending
+-- by 1-2 months — directly relevant to event-ticket demand.
+--
+-- Design intent:
+--   * Generic schema: macro_indicators is keyed by (series_id, ...) so any
+--     future FRED series (MRTSSM722USS food/drink, RSAFS retail, etc.)
+--     plugs in via one INSERT into a config table and one cron entry.
+--   * Backfill 12 months on first run, then incremental daily — the API
+--     is free + cheap, so idempotent re-pulls are simpler than tracking
+--     state.
+--   * Revision history preserved (realtime_start) so future backtests
+--     aren't contaminated by lookahead bias. UMCSENT publishes a
+--     preliminary mid-month then a final end-of-month — both stored.
+--
+-- Pre-req before this matters: a FRED API key must be in vault as
+--   FRED_API_KEY. Free signup: https://fred.stlouisfed.org/docs/api/api_key.html
+-- Set with:
+--   SELECT vault.create_secret('YOUR_KEY_HERE', 'FRED_API_KEY');
+-- Without it, fred_pending rows accumulate with status='no_api_key'.
+--
+-- Mirrors the queue/process pg_net pattern from the espn_scoreboard
+-- migration (20260510120000) to stay consistent with codebase conventions.
+-- ============================================================================
+
+-- ============================================================================
+-- (1) Storage — observations with revision history
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS macro_indicators (
+  series_id        text  NOT NULL,
+  observation_date date  NOT NULL,
+  value            numeric,                    -- nullable: FRED uses '.' for missing
+  realtime_start   date  NOT NULL,             -- when this revision was first published
+  realtime_end     date,                       -- 9999-12-31 = currently valid
+  ingested_at      timestamptz DEFAULT now(),
+  PRIMARY KEY (series_id, observation_date, realtime_start)
+);
+
+CREATE INDEX IF NOT EXISTS macro_indicators_series_date_idx
+  ON macro_indicators (series_id, observation_date DESC);
+
+COMMENT ON TABLE macro_indicators IS
+  'FRED-sourced macro-economic indicators with revision history. '
+  'Use v_macro_indicators_latest for current values; query directly '
+  'for as-of-date / preliminary-vs-final analysis.';
+
+-- Latest revision per (series, observation_date) — what you join to events / orders
+CREATE OR REPLACE VIEW v_macro_indicators_latest AS
+SELECT DISTINCT ON (series_id, observation_date)
+  series_id, observation_date, value, realtime_start, realtime_end, ingested_at
+FROM macro_indicators
+ORDER BY series_id, observation_date, realtime_start DESC;
+
+COMMENT ON VIEW v_macro_indicators_latest IS
+  'Latest revision (final > preliminary) per (series_id, observation_date).';
+
+-- ============================================================================
+-- (2) Series catalog — declarative list of what to pull
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS macro_series_config (
+  series_id     text PRIMARY KEY,
+  display_name  text NOT NULL,
+  units         text,
+  frequency     text NOT NULL,                 -- 'M' (monthly), 'Q' (quarterly), 'D' (daily)
+  source        text NOT NULL DEFAULT 'FRED',
+  enabled       boolean NOT NULL DEFAULT true,
+  notes         text,
+  added_at      timestamptz DEFAULT now()
+);
+
+INSERT INTO macro_series_config (series_id, display_name, units, frequency, notes) VALUES
+  ('UMCSENT', 'U Michigan Consumer Sentiment', 'Index 1966=100', 'M',
+   'Preliminary mid-month, final end-month. Leads discretionary spend by 1-2 months.')
+ON CONFLICT (series_id) DO NOTHING;
+
+-- ============================================================================
+-- (3) Pending queue (mirrors espn_scoreboard_pending)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS fred_pending (
+  id              bigserial PRIMARY KEY,
+  series_id       text NOT NULL,
+  request_id      bigint NOT NULL,
+  observation_start date,
+  fired_at        timestamptz DEFAULT now(),
+  resolved_at     timestamptz,
+  http_status     int,
+  rows_upserted   int,
+  error           text
+);
+CREATE INDEX IF NOT EXISTS fred_pending_unresolved_idx
+  ON fred_pending(series_id) WHERE resolved_at IS NULL;
+
+-- ============================================================================
+-- (4) Queue: fire one HTTP request per enabled series
+-- ============================================================================
+CREATE OR REPLACE FUNCTION fred_queue_all(p_months_back int DEFAULT 12)
+RETURNS int LANGUAGE plpgsql AS $$
+DECLARE
+  v_api_key text;
+  v_start   date := (current_date - (p_months_back || ' months')::interval)::date;
+  cfg       RECORD;
+  v_req     bigint;
+  v_count   int := 0;
+BEGIN
+  SELECT decrypted_secret INTO v_api_key
+  FROM vault.decrypted_secrets WHERE name = 'FRED_API_KEY' LIMIT 1;
+
+  IF v_api_key IS NULL OR v_api_key = '' THEN
+    -- Log a sentinel row so the operator can see the cron is blocked on key setup
+    INSERT INTO fred_pending(series_id, request_id, observation_start,
+                             resolved_at, http_status, error)
+    VALUES ('__config__', 0, v_start, now(), 0, 'FRED_API_KEY missing in vault.decrypted_secrets');
+    RETURN 0;
+  END IF;
+
+  FOR cfg IN SELECT series_id FROM macro_series_config WHERE enabled = true
+  LOOP
+    SELECT net.http_get(
+      url := 'https://api.stlouisfed.org/fred/series/observations',
+      params := jsonb_build_object(
+        'series_id',         cfg.series_id,
+        'api_key',           v_api_key,
+        'file_type',         'json',
+        'observation_start', v_start::text
+      ),
+      headers := jsonb_build_object(
+        'Accept',     'application/json',
+        'User-Agent', 'terminal-2-broker (julian@s4kent.com)'
+      ),
+      timeout_milliseconds := 15000
+    ) INTO v_req;
+
+    INSERT INTO fred_pending(series_id, request_id, observation_start)
+    VALUES (cfg.series_id, v_req, v_start);
+
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.3);  -- be polite even though FRED is generous (120 req/min)
+  END LOOP;
+
+  RETURN v_count;
+END $$;
+
+COMMENT ON FUNCTION fred_queue_all(integer) IS
+  'Fires one FRED API request per enabled macro_series_config row. '
+  'Default 12mo backfill window; idempotent — re-pulls overwrite latest revision.';
+
+-- ============================================================================
+-- (5) Process: drain pending → macro_indicators
+-- ============================================================================
+CREATE OR REPLACE FUNCTION fred_process_pending()
+RETURNS TABLE(processed int, rows_upserted int) LANGUAGE plpgsql AS $$
+DECLARE
+  r          RECORD;
+  v_body     jsonb;
+  v_obs      jsonb;
+  v_inserted int;
+  v_total_inserted int := 0;
+  v_processed int := 0;
+BEGIN
+  FOR r IN
+    SELECT p.id AS pending_id, p.series_id, h.content, h.status_code
+    FROM fred_pending p
+    JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.resolved_at IS NULL
+      AND p.series_id <> '__config__'
+  LOOP
+    v_processed := v_processed + 1;
+    v_inserted := 0;
+
+    IF r.status_code = 200 THEN
+      BEGIN v_body := r.content::jsonb;
+      EXCEPTION WHEN OTHERS THEN v_body := NULL; END;
+
+      IF v_body IS NOT NULL AND v_body ? 'observations' THEN
+        FOR v_obs IN SELECT jsonb_array_elements(v_body -> 'observations')
+        LOOP
+          INSERT INTO macro_indicators (
+            series_id, observation_date, value, realtime_start, realtime_end
+          ) VALUES (
+            r.series_id,
+            (v_obs ->> 'date')::date,
+            CASE WHEN v_obs ->> 'value' = '.' THEN NULL
+                 ELSE (v_obs ->> 'value')::numeric END,
+            (v_obs ->> 'realtime_start')::date,
+            (v_obs ->> 'realtime_end')::date
+          )
+          ON CONFLICT (series_id, observation_date, realtime_start) DO UPDATE
+            SET value = EXCLUDED.value,
+                realtime_end = EXCLUDED.realtime_end,
+                ingested_at = now();
+          v_inserted := v_inserted + 1;
+        END LOOP;
+      END IF;
+    END IF;
+
+    UPDATE fred_pending
+       SET resolved_at = now(),
+           http_status = r.status_code,
+           rows_upserted = v_inserted,
+           error = CASE WHEN r.status_code <> 200
+                        THEN substr(r.content::text, 1, 500)
+                        ELSE NULL END
+     WHERE id = r.pending_id;
+
+    v_total_inserted := v_total_inserted + v_inserted;
+  END LOOP;
+
+  RETURN QUERY SELECT v_processed, v_total_inserted;
+END $$;
+
+COMMENT ON FUNCTION fred_process_pending() IS
+  'Drains fred_pending into macro_indicators with revision history preserved.';
+
+-- ============================================================================
+-- (6) Health view — operator visibility
+-- ============================================================================
+CREATE OR REPLACE VIEW v_macro_indicators_health AS
+SELECT
+  c.series_id,
+  c.display_name,
+  c.frequency,
+  c.enabled,
+  l.observation_date AS latest_obs_date,
+  l.value            AS latest_value,
+  l.realtime_start   AS latest_revision_at,
+  l.ingested_at      AS latest_ingested_at,
+  (SELECT count(*) FROM macro_indicators m WHERE m.series_id = c.series_id) AS total_rows,
+  (SELECT max(fired_at) FROM fred_pending fp WHERE fp.series_id = c.series_id) AS last_pull_at,
+  (SELECT max(fp.error) FROM fred_pending fp
+    WHERE fp.series_id = c.series_id AND fp.resolved_at >= now() - interval '24 hours'
+      AND fp.error IS NOT NULL) AS recent_error
+FROM macro_series_config c
+LEFT JOIN v_macro_indicators_latest l ON l.series_id = c.series_id;
+
+COMMENT ON VIEW v_macro_indicators_health IS
+  'Per-series freshness + last-pull + recent-error for the macro pipeline.';
+
+-- ============================================================================
+-- (7) Grants
+-- ============================================================================
+GRANT SELECT ON macro_indicators                TO anon;
+GRANT SELECT ON v_macro_indicators_latest       TO anon;
+GRANT SELECT ON macro_series_config             TO anon;
+GRANT SELECT ON v_macro_indicators_health       TO anon;
+
+-- ============================================================================
+-- (8) Cron schedules
+--
+-- UMCSENT release cadence:
+--   * Preliminary: ~2nd Friday of month, ~10am ET
+--   * Final:       last Friday of month, ~10am ET
+-- We don't predict release dates — daily idempotent re-pull is simpler
+-- and FRED API is free with a 120 req/min limit (we use 1 req/series/day).
+--
+-- Queue: 11:30am ET = 15:30 UTC (well after the 10am ET data refresh)
+-- Process: every 5 min on the 5-59 offset to catch async pg_net responses
+-- ============================================================================
+SELECT cron.schedule('fred_queue_daily',
+  '30 15 * * *',
+  $$ SELECT public.fred_queue_all(12); $$);
+
+SELECT cron.schedule('fred_process_5min',
+  '5-59/5 * * * *',
+  $$ SELECT public.fred_process_pending(); $$);
+
+-- ============================================================================
+-- (9) Trigger initial backfill
+--
+-- Fires once on migration apply. Will fail silently (logged in fred_pending)
+-- if FRED_API_KEY isn't in vault yet — operator can manually re-trigger
+-- via `SELECT public.fred_queue_all(12);` after setting the key.
+-- ============================================================================
+SELECT public.fred_queue_all(12);


### PR DESCRIPTION
## Summary
- Generic macro indicator pipeline (FRED): `macro_indicators` table + `macro_series_config` catalog + queue/process pg_net pattern matching `espn_scoreboard` convention
- Seeds with **UMCSENT** (U Michigan Consumer Sentiment) — just printed an all-time low (48.2 in early-May 2026), and historically leads discretionary spending 1-2 months
- 12-month backfill on first run, then daily idempotent re-pull at 11:30am ET
- **Revision history preserved** (`realtime_start`) so future order-data backtests aren't contaminated by lookahead bias (UMCSENT publishes preliminary mid-month + final end-month)
- Adding more series later is a single INSERT into `macro_series_config` — no schema/cron changes

## Pre-requisite before cron yields data
Operator must set the FRED API key in vault:
\`\`\`sql
SELECT vault.create_secret('YOUR_FRED_KEY', 'FRED_API_KEY');
\`\`\`
Free signup: https://fred.stlouisfed.org/docs/api/api_key.html

If key is missing, a sentinel row is written to \`fred_pending\` with \`error = 'FRED_API_KEY missing in vault.decrypted_secrets'\` so the gap is visible. Operator can manually re-trigger after setting the key:
\`\`\`sql
SELECT public.fred_queue_all(12);
\`\`\`

## Why this isn't useful yet (and is still worth building now)
Order-history is currently too thin to backtest UMCSENT correlation. But:
- UMCSENT history is fully available from FRED (70+ years), so we lose nothing by not having our own data yet
- Building the pipeline now means **as our order data accumulates, the macro snapshot accumulates alongside it** — by the time we have 24mo of orders we'll have a clean joined dataset rather than scrambling to backfill
- Right now the dashboard tile alone is useful: \"sentiment all-time low, divergent vs retail sales\" is real situational awareness for whoever is making bundle calls

## Verification
- [ ] Set \`FRED_API_KEY\` in vault, then \`SELECT public.fred_queue_all(12);\`
- [ ] After 1-2 min: \`SELECT * FROM v_macro_indicators_health\` should show UMCSENT with 12 monthly rows
- [ ] \`SELECT * FROM v_macro_indicators_latest WHERE series_id='UMCSENT'\` returns latest reading (~48.2)
- [ ] \`SELECT * FROM fred_pending ORDER BY fired_at DESC LIMIT 5\` should show \`http_status=200\`, \`rows_upserted=12\`, no errors

## Future series to add (one-line INSERT each)
| series_id | display | priority |
|---|---|---|
| MRTSSM722USS | Food & Drink Retail Sales | high — direct out-of-home discretionary proxy |
| RSAFS | Total Advance Retail Sales | medium — broader context |
| DSPIC96 | Real Disposable Personal Income | low — slow-moving |