### PR TITLE
feat(store): hybrid near-me endpoint + concierge share flow + consumer test harness

### DIFF
--- a/app.py
+++ b/app.py
@@ -4551,8 +4551,19 @@ def store_shares_page():
     return FileResponse(os.path.join(STATIC_DIR, "store", "shares.html"))
 
 
+def _require_non_prod():
+    """Test-harness gate: 404 in production. Test pages expose debug info
+    (source-mode dropdown, hybrid candidate counts, inventory_source pill)
+    that we don't want anonymous prod users to see. Per #57 A1 review:
+    'Either @require_auth or gate behind a non-prod env check' — taking
+    the non-prod gate so the test pages remain useful in staging without
+    a Bearer-token auth handshake on HTML page loads."""
+    if _is_production():
+        raise HTTPException(404, "not found")
+
+
 @app.get("/store/test")
-def store_test_index_page():
+def store_test_index_page(_=Depends(_require_non_prod)):
     """Multi-page wiring test harness — index. Sidebar navigates to one
     page per evo-doc workflow (search, performer, venue, event landing)
     plus storefront-specific share links. Useful for verifying the store
@@ -4561,27 +4572,27 @@ def store_test_index_page():
 
 
 @app.get("/store/test/search")
-def store_test_search_page():
+def store_test_search_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "search.html"))
 
 
 @app.get("/store/test/performer")
-def store_test_performer_page():
+def store_test_performer_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "performer.html"))
 
 
 @app.get("/store/test/venue")
-def store_test_venue_page():
+def store_test_venue_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "venue.html"))
 
 
 @app.get("/store/test/event")
-def store_test_event_page():
+def store_test_event_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "event.html"))
 
 
 @app.get("/store/test/share")
-def store_test_share_page():
+def store_test_share_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "share.html"))
 
 

--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ Optional:
 from __future__ import annotations
 
 import hmac
+import math
 import os
 import re
 import secrets
@@ -3521,33 +3522,88 @@ def _ticket_group_to_listing(tg: dict) -> dict:
 @app.get("/api/store/events")
 def store_events(
     q: str | None = None,
+    performer_id: int | None = None,
+    venue_id: int | None = None,
     limit: int = 60,
     offset: int = 0,
+    include_inactive: bool = False,
 ):
     """Catalog: events for which we have owned inventory in TEvo.
 
-    Driven by Supabase event_metrics (collector populates owned_tickets_count
-    via /v9/ticket_groups?owned=true on every run). Falling back to the bare
-    events table if Supabase is unavailable still keeps the page alive.
+    Driven by Supabase `latest_event_metrics` (collector populates
+    owned_tickets_count via /v9/ticket_groups?owned=true on every run).
+
+    Wiring:
+    - Filtered by `event_lifecycle.is_active` so ghosts / completed /
+      postponed events are dropped (set include_inactive=true to bypass).
+    - Performer assets (logos / brand colors) bulk-fetched from
+      performer_metadata so cards can render branding without N+1.
+    - Search is in-Python over the already-narrowed result set; cheap
+      because the DB query already caps at limit×2 candidate rows.
     """
     db = require_sb()
-    # Pull events ordered by upcoming first, only those with owned tickets
-    # available right now. The latest_event_metrics view exposes the
-    # most-recent event_metrics row per event.
+    # Cap raised from 200 -> 500 so consumer search pages can cover the full
+    # owned-inventory set in one fetch. Prod has ~270 events with owned
+    # tickets at any given time; capping at 200 was leaving ~25% invisible
+    # to anyone searching by performer name on the storefront. Pagination
+    # is the next step if the catalog grows past ~500.
+    cap = min(max(limit, 1), 500)
+
+    # Pull a wider candidate set so we can post-filter by lifecycle + search
+    # and still serve a full page.
+    candidate_limit = min(cap * 2, 1000) if not include_inactive else cap
     sel = (
         db.table("latest_event_metrics")
         .select(
             "event_id,owned_tickets_count,owned_groups_count,owned_median_retail,"
             "tickets_count,retail_min,captured_at,"
-            "events(id,name,occurs_at_local,venue_name,venue_location,"
-            "primary_performer_name)"
+            "events!inner(id,name,occurs_at_local,venue_id,venue_name,venue_location,"
+            "primary_performer_id,primary_performer_name)"
         )
         .gt("owned_tickets_count", 0)
-        .order("captured_at", desc=True)
-        .limit(min(limit, 200))
+        # Consumer ordering: soonest event first. StubHub / SeatGeek default.
+        # Older "captured_at desc" was internal collector freshness, the wrong
+        # signal for shoppers. Foreign-table column reachable via PostgREST
+        # because of the events!inner join above.
+        .order("occurs_at_local", desc=False, foreign_table="events", nullsfirst=False)
+        .limit(candidate_limit)
         .offset(max(offset, 0))
     )
+    # Optional filters — applied to the joined `events` table via PostgREST's
+    # `<table>.<column>` syntax (the !inner above makes this work).
+    if performer_id is not None:
+        sel = sel.eq("events.primary_performer_id", int(performer_id))
+    if venue_id is not None:
+        sel = sel.eq("events.venue_id", int(venue_id))
     rows = (sel.execute().data) or []
+
+    # Drop ghosts / completed / postponed unless caller opts in. Same
+    # pattern as broker_movers — small id-set, single roundtrip to the
+    # event_lifecycle view (over derive_event_lifecycle()).
+    if rows and not include_inactive:
+        ev_ids = [(r.get("events") or {}).get("id") for r in rows]
+        ev_ids = [e for e in ev_ids if e]
+        if ev_ids:
+            try:
+                lc_rows = (
+                    db.table("event_lifecycle")
+                    .select("event_id,status,is_active")
+                    .in_("event_id", ev_ids)
+                    .execute()
+                ).data or []
+                inactive = {r["event_id"] for r in lc_rows if not r.get("is_active")}
+                if inactive:
+                    rows = [r for r in rows
+                            if (r.get("events") or {}).get("id") not in inactive]
+            except Exception:
+                # event_lifecycle view missing in some envs; better to show
+                # everything than 500 the storefront.
+                pass
+
+    # Bulk-fetch performer assets so card branding doesn't N+1.
+    perf_ids = [(r.get("events") or {}).get("primary_performer_id") for r in rows]
+    perf_ids = [int(p) for p in perf_ids if p]
+    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
 
     out: list[dict] = []
     needle = (q or "").strip().lower()
@@ -3566,6 +3622,7 @@ def store_events(
             ).lower()
             if needle not in hay:
                 continue
+        a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
         out.append({
             "id": ev.get("id"),
             "name": ev.get("name"),
@@ -3573,12 +3630,239 @@ def store_events(
             "venue_name": ev.get("venue_name"),
             "venue_location": ev.get("venue_location"),
             "primary_performer_name": ev.get("primary_performer_name"),
+            "primary_performer_logo": (a or {}).get("logo_default_url"),
+            "primary_performer_color": (a or {}).get("color_primary"),
             "from_price": r.get("retail_min"),
             "owned_tickets_count": r.get("owned_tickets_count"),
             "owned_groups_count": r.get("owned_groups_count"),
             "captured_at": r.get("captured_at"),
         })
-    return {"count": len(out), "events": out}
+        if len(out) >= cap:
+            break
+    return {"count": len(out), "events": out, "limit": cap, "offset": offset}
+
+
+def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in miles between two (lat,lon) pairs."""
+    R_MI = 3958.7613  # Earth's mean radius in miles
+    lat1r, lat2r = math.radians(lat1), math.radians(lat2)
+    dlat = lat2r - lat1r
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1r) * math.cos(lat2r) * math.sin(dlon / 2) ** 2
+    return 2 * R_MI * math.asin(math.sqrt(a))
+
+
+def _attach_owned_metadata(
+    db,
+    candidate_ids: list[int],
+    user_lat: float,
+    user_lon: float,
+) -> list[dict]:
+    """Given a list of TEvo event_ids, intersect with our owned + active set
+    and decorate with metadata + display distance. Used by both 'hybrid' and
+    'supabase' near-me modes to keep response shape identical.
+    """
+    if not candidate_ids:
+        return []
+    rows = (
+        db.table("latest_event_metrics")
+        .select(
+            "event_id,owned_tickets_count,owned_groups_count,retail_min,"
+            "events!inner(id,name,occurs_at_local,venue_id,venue_name,venue_location,"
+            "primary_performer_id,primary_performer_name)"
+        )
+        .gt("owned_tickets_count", 0)
+        .in_("event_id", [int(e) for e in candidate_ids])
+        .execute().data
+    ) or []
+    if not rows:
+        return []
+
+    ev_ids = [r["event_id"] for r in rows]
+    try:
+        lc = (
+            db.table("event_lifecycle").select("event_id,is_active")
+            .in_("event_id", ev_ids).execute().data
+        ) or []
+        inactive = {r["event_id"] for r in lc if not r.get("is_active")}
+    except Exception:
+        inactive = set()
+
+    venue_ids = list({(r.get("events") or {}).get("venue_id") for r in rows
+                      if (r.get("events") or {}).get("venue_id")})
+    coord_map: dict[int, tuple[float, float]] = {}
+    if venue_ids:
+        try:
+            ca = (
+                db.table("venue_assets").select("tevo_venue_id,latitude,longitude")
+                .in_("tevo_venue_id", venue_ids).execute().data
+            ) or []
+            for c in ca:
+                if c.get("latitude") is not None and c.get("longitude") is not None:
+                    coord_map[int(c["tevo_venue_id"])] = (float(c["latitude"]), float(c["longitude"]))
+        except Exception:
+            coord_map = {}
+
+    perf_ids = [int((r.get("events") or {}).get("primary_performer_id"))
+                for r in rows
+                if (r.get("events") or {}).get("primary_performer_id")
+                and r["event_id"] not in inactive]
+    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
+
+    out: list[dict] = []
+    for r in rows:
+        eid = r["event_id"]
+        if eid in inactive:
+            continue
+        ev = r.get("events") or {}
+        coords = coord_map.get(int(ev.get("venue_id"))) if ev.get("venue_id") else None
+        dist = _haversine_miles(user_lat, user_lon, coords[0], coords[1]) if coords else None
+        a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
+        out.append({
+            "id": eid,
+            "name": ev.get("name"),
+            "occurs_at_local": ev.get("occurs_at_local"),
+            "venue_name": ev.get("venue_name"),
+            "venue_location": ev.get("venue_location"),
+            "primary_performer_name": ev.get("primary_performer_name"),
+            "primary_performer_logo": (a or {}).get("logo_default_url"),
+            "primary_performer_color": (a or {}).get("color_primary"),
+            "from_price": r.get("retail_min"),
+            "owned_tickets_count": r.get("owned_tickets_count"),
+            "distance_miles": round(dist, 1) if dist is not None else None,
+        })
+    return out
+
+
+@app.get("/api/store/events/near")
+def store_events_near(
+    lat: float,
+    lon: float,
+    within: float = 50.0,       # miles
+    limit: int = 10,
+    source: str = "hybrid",     # 'hybrid' | 'supabase' | 'tevo'
+):
+    """Owned-inventory events sorted by distance from (lat, lon).
+
+    Implements evo-docs §05 ("Displaying Events Near Your Users"). Three
+    modes selectable via `?source=`:
+
+    1. **hybrid** (default) — TEvo's `/v9/events?lat&lon&within` provides
+       authoritative geo filtering (100% venue coverage). We then intersect
+       the result with our `latest_event_metrics WHERE owned_tickets_count
+       > 0` and apply `event_lifecycle.is_active`. Best of both: TEvo's
+       geo authority + our owned/lifecycle filtering.
+
+    2. **supabase** — pure local: read our owned+active set, join
+       `venue_assets` for lat/lon (83% coverage), compute Python haversine,
+       filter by within. Faster (no TEvo round-trip), zero TEvo quota,
+       but caps coverage at venues we've geocoded.
+
+    3. **tevo** — raw TEvo geo result, no owned filter. Useful for
+       comparison/debug only; the storefront wall says we never show
+       inventory we don't own, so this mode is debug-only and excluded
+       from the consumer UI.
+
+    Distance display uses our `venue_assets` coords for both hybrid and
+    supabase modes (TEvo's events response doesn't include lat/lon on
+    the venue object). Events with no coord yield `distance_miles: null`
+    and sort to the end.
+    """
+    within = max(1.0, min(within, 500.0))
+    cap = max(1, min(limit, 50))
+
+    if source == "tevo":
+        # No Supabase needed for debug mode — straight passthrough.
+        # Debug mode: raw TEvo geo, NO owned filter. Returns whatever TEvo
+        # has nearby. Not used by the consumer UI.
+        try:
+            tevo_resp = client.list_events(
+                lat=lat, lon=lon, within=within,
+                only_with_available_tickets=True,
+                order_by="events.occurs_at ASC",
+                per_page=min(cap, 100),
+            )
+        except RuntimeError as e:
+            raise HTTPException(502, f"TEvo geo lookup failed: {e}")
+        evs = tevo_resp.get("events") or []
+        return {
+            "count": len(evs),
+            "events": [
+                {
+                    "id": e.get("id"),
+                    "name": e.get("name"),
+                    "occurs_at_local": e.get("occurs_at_local"),
+                    "venue_name": (e.get("venue") or {}).get("name"),
+                    "venue_location": (e.get("venue") or {}).get("location"),
+                    "distance_miles": None,
+                }
+                for e in evs
+            ],
+            "user_lat": lat, "user_lon": lon, "within_miles": within,
+            "source": "tevo",
+        }
+
+    db = require_sb()
+
+    if source == "hybrid":
+        # Step 1: TEvo geo query for events near (lat, lon) with available
+        # marketplace tickets. Authoritative venue coords; per_page is
+        # capped at 100 by TEvo so we take all of them as candidates.
+        try:
+            tevo_resp = client.list_events(
+                lat=lat, lon=lon, within=within,
+                only_with_available_tickets=True,
+                order_by="events.occurs_at ASC",
+                per_page=100,
+            )
+        except RuntimeError as e:
+            # On TEvo failure, fall through to supabase mode rather than
+            # 502'ing the home page. Logged for observability.
+            print(f"near (hybrid): TEvo failed, falling back to supabase: {e}")
+            source = "supabase"
+        else:
+            candidate_ids = [int(e["id"]) for e in (tevo_resp.get("events") or []) if e.get("id")]
+            decorated = _attach_owned_metadata(db, candidate_ids, lat, lon)
+            decorated.sort(key=lambda x: (x["distance_miles"] is None, x["distance_miles"] or 1e9))
+            return {
+                "count": len(decorated[:cap]),
+                "events": decorated[:cap],
+                "user_lat": lat, "user_lon": lon, "within_miles": within,
+                "total_within_radius": len(decorated),
+                "tevo_candidates": len(candidate_ids),
+                "source": "hybrid",
+            }
+
+    # source == "supabase" (or hybrid fallback)
+    # Pull all owned events with their venue coords, compute haversine,
+    # filter by within. 83% venue coverage means some events miss this
+    # path; an audit-lane geocoder backfill would close the gap.
+    rows = (
+        db.table("latest_event_metrics")
+        .select(
+            "event_id,owned_tickets_count,owned_groups_count,retail_min,"
+            "events!inner(id,name,occurs_at_local,venue_id,venue_name,venue_location,"
+            "primary_performer_id,primary_performer_name)"
+        )
+        .gt("owned_tickets_count", 0)
+        .limit(500)
+        .execute().data
+    ) or []
+    candidate_ids = [int(r["event_id"]) for r in rows]
+    decorated = _attach_owned_metadata(db, candidate_ids, lat, lon)
+    # Drop events outside the radius (or missing coords entirely).
+    in_radius = [d for d in decorated
+                 if d["distance_miles"] is not None and d["distance_miles"] <= within]
+    in_radius.sort(key=lambda x: x["distance_miles"])
+    return {
+        "count": len(in_radius[:cap]),
+        "events": in_radius[:cap],
+        "user_lat": lat, "user_lon": lon, "within_miles": within,
+        "total_within_radius": len(in_radius),
+        "supabase_candidates": len(rows),
+        "missing_coords": sum(1 for d in decorated if d["distance_miles"] is None),
+        "source": "supabase",
+    }
 
 
 def _csv(v: str | None) -> list[str]:
@@ -3651,6 +3935,157 @@ def _normalize_filters(raw: dict | None) -> dict:
     }
 
 
+def _fire_canonical_refresh(event_id: int, ev: dict) -> None:
+    """Fire-and-forget kick to the audit lane's collect-listings Edge Function
+    so canonical SQL stays as fresh as the storefront sees.
+
+    Two paths:
+    - **Tracked event** (row exists in `events`): hit
+      `collect-listings?event_id=X&min_age_seconds=10`. The audit-lane
+      function dedupes against recent snapshots, so 100 shoppers in 10s
+      trigger one collector run, not 100.
+    - **Untracked event** (row missing): insert primary performer into
+      `watchlist`, then call `collect-listings?watchlist_id=N`. The
+      sweep populates `events` + `listings_snapshots` + `event_metrics`
+      for that performer's full calendar. From now on the regular cron
+      cadence covers the event automatically.
+
+    Lane note: writes to `watchlist` (audit-lane table) using the same
+    insert pattern as the existing `/api/watchlist` POST endpoint. We're
+    using the existing API surface, not creating a parallel writer — the
+    unique constraint on (kind, ext_id) keeps the table consistent.
+
+    Always non-blocking; runs on a daemon thread. Failures are logged to
+    stdout, never raised back to the page handler.
+    """
+    if not (sb is not None and SUPABASE_URL and CRON_SECRET):
+        return  # Best-effort only; missing config silently no-ops.
+
+    def _go():
+        try:
+            existing = (
+                sb.table("events").select("id").eq("id", event_id).limit(1).execute().data
+            )
+        except Exception as e:
+            print(f"canonical refresh: events lookup failed for {event_id}: {e}")
+            return
+
+        if existing:
+            url = (
+                f"{SUPABASE_URL}/functions/v1/collect-listings"
+                f"?event_id={event_id}&min_age_seconds=10"
+            )
+            _fire_collect(url, CRON_SECRET)
+            return
+
+        # Auto-track path: this event is brand new to us. Add primary
+        # performer to watchlist so the cron picks it up going forward.
+        performances = ev.get("performances") or []
+        primary = next(
+            ((p.get("performer") or {}) for p in performances if p.get("primary")),
+            ((performances[0].get("performer") or {}) if performances else {}),
+        )
+        pid = primary.get("id")
+        if not pid:
+            print(f"auto-track: event {event_id} has no primary performer; skipping")
+            return
+        pid = int(pid)
+        pname = primary.get("name") or f"performer {pid}"
+
+        watchlist_id: int | None = None
+        try:
+            ins = sb.table("watchlist").insert(
+                {"kind": "performer", "ext_id": pid, "label": pname}
+            ).execute()
+            row = (ins.data or [None])[0]
+            if row:
+                watchlist_id = row.get("id")
+                print(f"auto-track: added performer {pid} ({pname}) to watchlist as id={watchlist_id}")
+        except Exception as e:
+            msg = str(e)
+            if "duplicate" in msg.lower() or "23505" in msg or "unique" in msg.lower():
+                # Already in watchlist — find the existing id so we can scope the kick.
+                try:
+                    found = (
+                        sb.table("watchlist").select("id")
+                        .eq("kind", "performer").eq("ext_id", pid)
+                        .limit(1).execute().data
+                    )
+                    if found:
+                        watchlist_id = found[0]["id"]
+                except Exception as e2:
+                    print(f"auto-track: lookup after dup failed: {e2}")
+            else:
+                print(f"auto-track: watchlist insert failed for performer {pid}: {e}")
+
+        if watchlist_id:
+            url = f"{SUPABASE_URL}/functions/v1/collect-listings?watchlist_id={watchlist_id}"
+            _fire_collect(url, CRON_SECRET)
+
+    threading.Thread(target=_go, daemon=True).start()
+
+
+def _fetch_owned_ticket_groups(
+    event_id: int,
+    max_age_seconds: int | None = None,
+) -> tuple[list[dict], str]:
+    """Pull owned-only ticket_groups for an event. Returns (groups, source)
+    where source is 'cache' (≤max_age) or 'live'.
+
+    Cache strategy:
+    - Read: gated on `max_age_seconds`. Storefront passes ~10 to keep retail
+      pages near-real-time; broker terminal passes None (uses the row's own
+      90s expires_at). This lets one cache table serve both consumers with
+      different freshness contracts.
+    - Write: always 90s TTL so the broker terminal still gets long-lived
+      data after a storefront refresh.
+
+    Note: cache key is event_id only; owned=true is implied for both
+    storefront and broker call sites that hit this helper.
+    """
+    if sb is not None:
+        try:
+            cached = sb.rpc("get_cached_ticket_groups", {"p_event_id": event_id}).execute().data
+            if cached:
+                payload_age_ok = True
+                if max_age_seconds is not None:
+                    captured_at_str = (cached or {}).get("captured_at")
+                    if captured_at_str:
+                        try:
+                            captured_at = datetime.fromisoformat(
+                                str(captured_at_str).replace("Z", "+00:00")
+                            )
+                            age = (datetime.now(timezone.utc) - captured_at).total_seconds()
+                            payload_age_ok = age <= max_age_seconds
+                        except (ValueError, TypeError):
+                            payload_age_ok = False
+                    else:
+                        payload_age_ok = False
+                if payload_age_ok:
+                    return (cached or {}).get("ticket_groups", []) or [], "cache"
+        except Exception:
+            # Cache failure must never block the page; fall through to live.
+            pass
+    try:
+        live = client.get_ticket_groups(event_id, owned=True)
+    except RuntimeError as e:
+        raise HTTPException(502, f"TEvo ticket_groups failed: {e}")
+    groups = live.get("ticket_groups", []) or []
+    if sb is not None:
+        try:
+            sb.rpc("put_cached_ticket_groups", {
+                "p_event_id": event_id,
+                "p_payload": {
+                    "ticket_groups": groups,
+                    "captured_at": datetime.now(timezone.utc).isoformat(),
+                },
+                "p_ttl_seconds": 90,
+            }).execute()
+        except Exception:
+            pass
+    return groups, "live"
+
+
 def _resolve_event_with_filters(event_id: int, filters: dict) -> dict:
     """Fetch event + owned listings, apply filters, return the same shape
     /api/store/events/{id} returns. Shared by the public detail endpoint
@@ -3659,12 +4094,11 @@ def _resolve_event_with_filters(event_id: int, filters: dict) -> dict:
         ev = client.get_event(event_id)
     except RuntimeError as e:
         raise HTTPException(502, f"TEvo event lookup failed: {e}")
-    try:
-        tg_resp = client.get_ticket_groups(event_id, owned=True)
-    except RuntimeError as e:
-        raise HTTPException(502, f"TEvo ticket_groups failed: {e}")
 
-    groups = tg_resp.get("ticket_groups") or []
+    # Storefront freshness contract: 10s. Tighter than broker's 90s because
+    # this is the buy-decision page — stale availability => bad UX.
+    groups, tg_source = _fetch_owned_ticket_groups(event_id, max_age_seconds=10)
+
     eligible = [
         tg
         for tg in groups
@@ -3728,7 +4162,34 @@ def _resolve_event_with_filters(event_id: int, filters: dict) -> dict:
     config = ev.get("configuration") or {}
     seating = (config.get("seating_chart") or {})
 
-    return {
+    # Bulk-attach branded assets (logo / colors) for the performers on
+    # this event. performer_metadata is populated by the audit lane's ESPN
+    # ingest — we read only. Falls through gracefully when a performer has
+    # no asset row yet (most non-MLB/NBA/NFL/NHL teams don't).
+    perf_assets: dict[int, dict] = {}
+    if sb is not None:
+        try:
+            perf_ids = [int((p.get("performer") or {}).get("id"))
+                        for p in performances
+                        if (p.get("performer") or {}).get("id")]
+            if perf_ids:
+                perf_assets = _bulk_performer_assets(sb, perf_ids)
+        except Exception:
+            perf_assets = {}
+
+    def _attach_assets(p):
+        perf = p.get("performer") or {}
+        pid = perf.get("id")
+        a = perf_assets.get(int(pid)) if pid else None
+        return {
+            "id": pid,
+            "name": perf.get("name"),
+            "primary": p.get("primary"),
+            "logo_url": (a or {}).get("logo_default_url"),
+            "color_primary": (a or {}).get("color_primary"),
+        }
+
+    response = {
         "event": {
             "id": ev.get("id"),
             "name": ev.get("name"),
@@ -3746,20 +4207,21 @@ def _resolve_event_with_filters(event_id: int, filters: dict) -> dict:
                 "seating_chart_medium": seating.get("medium"),
                 "seating_chart_large": seating.get("large"),
             },
-            "performers": [
-                {
-                    "id": (p.get("performer") or {}).get("id"),
-                    "name": (p.get("performer") or {}).get("name"),
-                    "primary": p.get("primary"),
-                }
-                for p in performances
-            ],
+            "performers": [_attach_assets(p) for p in performances],
         },
         "listings": listings,
         "listings_count": len(listings),
         "total_before_filters": total_before_filters,
         "filters": f,
+        "inventory_source": tg_source,        # 'cache' (≤10s old) or 'live'
     }
+
+    # Fire-and-forget: refresh canonical SQL via the audit-lane Edge Function.
+    # Auto-tracks the event (adds performer to watchlist) if we've never seen
+    # it before. Never blocks the response.
+    _fire_canonical_refresh(event_id, ev)
+
+    return response
 
 
 @app.get("/api/store/events/{event_id}")
@@ -4087,6 +4549,40 @@ def store_shared_page(share_id: str):  # noqa: ARG001 — id read by JS from URL
 @app.get("/store/shares")
 def store_shares_page():
     return FileResponse(os.path.join(STATIC_DIR, "store", "shares.html"))
+
+
+@app.get("/store/test")
+def store_test_index_page():
+    """Multi-page wiring test harness — index. Sidebar navigates to one
+    page per evo-doc workflow (search, performer, venue, event landing)
+    plus storefront-specific share links. Useful for verifying the store
+    works against real data before merging."""
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "index.html"))
+
+
+@app.get("/store/test/search")
+def store_test_search_page():
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "search.html"))
+
+
+@app.get("/store/test/performer")
+def store_test_performer_page():
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "performer.html"))
+
+
+@app.get("/store/test/venue")
+def store_test_venue_page():
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "venue.html"))
+
+
+@app.get("/store/test/event")
+def store_test_event_page():
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "event.html"))
+
+
+@app.get("/store/test/share")
+def store_test_share_page():
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "share.html"))
 
 
 # Static assets (CSS / JS / images) served from /static.

--- a/evo_client.py
+++ b/evo_client.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import time
 from typing import Any, Iterator
 from urllib.parse import urlencode
 
@@ -104,6 +105,16 @@ class EvoClient:
     # the runtime enforcement. Any non-GET attempt raises EvoReadOnlyError
     # before a network call is made.
 
+    # 429 backoff config — TEvo doesn't publish hard rate limits but
+    # empirical testing shows ~5 req/sec sustained is the safe band, with
+    # bursts of ~30 sequential requests triggering 429s. Other clients in
+    # the repo (chat fn, espn-collect, seatgeek, seatdata) implement their
+    # own backoff because this client previously did not. Closes that gap.
+    _MAX_RETRIES = 4
+    _BACKOFF_BASE_SEC = 0.5     # 0.5, 1, 2, 4 — caps below the 5s order-of-magnitude
+    _BACKOFF_CAP_SEC = 30.0
+    _RETRY_STATUSES = frozenset({429, 502, 503, 504})
+
     def _get(self, path: str, params: dict | None = None) -> dict[str, Any]:
         _assert_readonly_method("GET")  # RULE 2 enforcement
         clean = self._normalize(params)
@@ -115,13 +126,34 @@ class EvoClient:
             "X-Signature": signature,
             "Accept": "application/vnd.ticketevolution.api+json; version=9",
         }
-        r = requests.get(url, headers=headers, timeout=self.timeout)
-        if not r.ok:
-            raise RuntimeError(
-                f"{r.status_code} {r.reason} on {r.request.method} {r.url}\n"
-                f"Response body: {r.text}"
-            )
-        return r.json()
+
+        last_resp = None
+        for attempt in range(self._MAX_RETRIES + 1):
+            r = requests.get(url, headers=headers, timeout=self.timeout)
+            last_resp = r
+            if r.ok:
+                return r.json()
+            if r.status_code not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
+                break
+            # Honor Retry-After when TEvo provides it; else exponential.
+            wait: float
+            ra = r.headers.get("Retry-After")
+            if ra:
+                try:
+                    wait = float(ra)
+                except (TypeError, ValueError):
+                    wait = self._BACKOFF_BASE_SEC * (2 ** attempt)
+            else:
+                wait = self._BACKOFF_BASE_SEC * (2 ** attempt)
+            wait = min(wait, self._BACKOFF_CAP_SEC)
+            time.sleep(wait)
+
+        # Out of retries, or non-retryable status.
+        raise RuntimeError(
+            f"{last_resp.status_code} {last_resp.reason} on "
+            f"{last_resp.request.method} {last_resp.url}\n"
+            f"Response body: {last_resp.text}"
+        )
 
     def _iter_paginated(
         self,

--- a/static/store/event.html
+++ b/static/store/event.html
@@ -34,7 +34,8 @@
           </p>
         </div>
         <div class="head-actions">
-          <button class="btn ghost" id="openShare">Share inventory</button>
+          <span id="freshness" class="freshness"></span>
+          <button class="btn ghost" id="openShare">Share this view</button>
         </div>
       </div>
     </section>
@@ -52,18 +53,35 @@
 
       <div class="listings">
         <h2>Available from us <span id="listCount" class="muted"></span></h2>
-        <div class="listcontrols">
-          <label>min qty
+
+        <!-- Inline filters drive the page view AND the share URL. URL is the
+             source of truth: every change updates ?zones=&section=&min_price=
+             &max_price=&min_qty= via replaceState and re-fetches the listings.
+             Zone row only renders when this event's performer+venue has
+             curated zones in performer_zones. -->
+        <div id="filterBar" class="filter-bar">
+          <div id="zoneRow" class="filter-row" hidden>
+            <span class="filter-label">Zone</span>
+            <div class="chip-group" id="zoneChips"></div>
+          </div>
+          <div id="sectionRow" class="filter-row" hidden>
+            <span class="filter-label">Section</span>
+            <div class="chip-group" id="sectionChips"></div>
+          </div>
+          <div class="filter-row inline">
+            <span class="filter-label">Price</span>
+            <input id="minPrice" type="number" min="0" step="10" placeholder="min $" />
+            <input id="maxPrice" type="number" min="0" step="10" placeholder="max $" />
+            <span class="filter-label" style="margin-left:16px">Min qty</span>
             <select id="minQty">
-              <option value="1" selected>any</option>
+              <option value="">any</option>
               <option value="2">2+</option>
               <option value="3">3+</option>
               <option value="4">4+</option>
+              <option value="6">6+</option>
             </select>
-          </label>
-          <label>max price
-            <input id="maxPrice" type="number" min="0" step="10" placeholder="any" />
-          </label>
+            <button id="resetFilters" class="btn ghost" style="margin-left:auto">Reset</button>
+          </div>
         </div>
 
         <ul id="listings" class="list"></ul>

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -52,30 +52,49 @@
 
     let allEvents = [];
 
-    function render(events) {
+    function render(events, mode) {
+      // mode: "all" (initial load) or "search" (after a query)
       grid.innerHTML = "";
+      status.hidden = true;
       if (!events.length) {
         grid.hidden = true;
         empty.hidden = false;
-        status.hidden = true;
+        empty.textContent = mode === "search"
+          ? "No events match. Try a broader search, or clear the box to see all."
+          : "No events with available inventory right now. Check back after the next collector run.";
         return;
       }
       empty.hidden = true;
-      status.hidden = true;
       grid.hidden = false;
 
       for (const ev of events) {
         const a = document.createElement("a");
         a.className = "card";
         a.href = `/store/event/${ev.id}`;
+        if (ev.primary_performer_color) {
+          a.style.setProperty("--card-accent", ev.primary_performer_color);
+        }
 
+        // Header row: logo (if branded) + meta lines.
+        const head = document.createElement("div");
+        head.className = "card-head";
+        if (ev.primary_performer_logo) {
+          const img = document.createElement("img");
+          img.className = "card-logo";
+          img.src = ev.primary_performer_logo;
+          img.alt = "";
+          img.loading = "lazy";
+          head.append(img);
+        }
+        const headText = document.createElement("div");
         const when = document.createElement("div");
         when.className = "when";
         when.textContent = fmtWhen(ev.occurs_at_local);
-
         const name = document.createElement("div");
         name.className = "name";
         name.textContent = ev.name || "Untitled event";
+        headText.append(when, name);
+        head.append(headText);
 
         const where = document.createElement("div");
         where.className = "where";
@@ -100,20 +119,20 @@
           : "available";
         meta.append(left, right);
 
-        a.append(when, name, where, meta);
+        a.append(head, where, meta);
         grid.append(a);
       }
     }
 
     function filter(query) {
       const q = (query || "").trim().toLowerCase();
-      if (!q) return render(allEvents);
+      if (!q) return render(allEvents, "all");
       const filtered = allEvents.filter((e) => {
         const hay = [e.name, e.venue_name, e.venue_location, e.primary_performer_name]
           .filter(Boolean).join(" ").toLowerCase();
         return hay.includes(q);
       });
-      render(filtered);
+      render(filtered, "search");
     }
 
     form.addEventListener("submit", (e) => {
@@ -122,10 +141,10 @@
     });
     input.addEventListener("input", () => filter(input.value));
 
-    api("/api/store/events?limit=120")
+    api("/api/store/events?limit=500")
       .then((res) => {
         allEvents = res.events || [];
-        render(allEvents);
+        render(allEvents, "all");
       })
       .catch((err) => {
         status.textContent = `Couldn't load events: ${err.message}`;
@@ -135,13 +154,22 @@
 
   // ---------- Event detail page ----------
   function mountEvent() {
-    // Two URL shapes:
-    //   /store/event/{eventId}?zones=...    stateless (current)
-    //   /s/{shareId}                        revocable share — resolves
-    //                                       to an event_id + saved filters
-    //                                       via the /api/store/share/{id}
-    //                                       endpoint.
-    const path = location.pathname;
+    // The event/listings page is also the share-link surface — the URL is
+    // the source of truth for the filter set. Two URL shapes can land here:
+    //
+    //   /store/event/{eventId}?zones=...&min_qty=...   stateless filtered
+    //   /s/{shareId}                                   revocable share — resolves
+    //                                                  via /api/store/share/{id},
+    //                                                  then we replaceState into
+    //                                                  the canonical event URL
+    //                                                  with the saved filters.
+    //
+    // Filter inputs on the page are bound to the URL:
+    //   - chip click / input change -> debounced -> writes URL via
+    //     replaceState -> refetches /api/store/events/{id}?<filters>
+    //   - server-side filter is the only filter (no client-side narrowing)
+    //   - "Share this view" just serializes the current URL
+    let path = location.pathname;
     const sharedMatch = path.match(/^\/s\/([^/]+)$/);
     const shareId = sharedMatch ? sharedMatch[1] : null;
 
@@ -171,62 +199,103 @@
       }
     }
 
+    // DOM refs (ALL pulled here so the helpers below don't re-query).
     const status = $("#status");
     const head = $("#header");
     const body = $("#body");
-    const minQty = $("#minQty");
-    const maxPrice = $("#maxPrice");
     const listEl = $("#listings");
     const noListings = $("#noListings");
     const listCount = $("#listCount");
     const seatMap = $("#seatMap");
+    const zoneRow = $("#zoneRow");
+    const zoneChipsEl = $("#zoneChips");
+    const sectionRow = $("#sectionRow");
+    const sectionChipsEl = $("#sectionChips");
+    const minPriceInput = $("#minPrice");
+    const maxPriceInput = $("#maxPrice");
+    const minQtyInput = $("#minQty");
+    const resetBtn = $("#resetFilters");
 
     let allListings = [];
     let event = null;
     let zonesAvailable = [];   // populated from /api/store/events/{id}/zones
     let resolvedShare = null;  // populated when arriving via /s/{id}
+    let suppressApply = false; // true while we paint inputs programmatically
 
-    // Read share-link filters from the URL on load (only meaningful on the
-    // /store/event/{id}?... path; /s/{id} fills these in after resolve).
-    const urlParams = new URLSearchParams(location.search);
-    // Hardened 2026-05-11: bound prices/qty and cap chip arrays at 50
-    // entries / 64 chars each so a malicious URL can't bloat the share-UI.
-    const _capArr = (s) => s.split(",").map((x) => x.trim()).filter(Boolean).filter((x) => x.length <= 64).slice(0, 50);
-    const shareFilters = {
-      zones: _capArr(urlParams.get("zones") || ""),
-      section: _capArr(urlParams.get("section") || ""),
-      min_price: urlParams.get("min_price") ? clampFloat(urlParams.get("min_price"), 0, 1e6) : null,
-      max_price: urlParams.get("max_price") ? clampFloat(urlParams.get("max_price"), 0, 1e6) : null,
-      min_qty: urlParams.get("min_qty") ? clampInt(urlParams.get("min_qty"), 1, 50) : null,
-    };
-    const hasUrlFilters = Object.values(shareFilters).some(
-      (v) => Array.isArray(v) ? v.length : v != null
-    );
-    const isSharedView = hasUrlFilters || !!shareId;
+    // ---- URL <-> filter conversion (hardened per #57's A1 review:
+    // cap array sizes + clamp numeric ranges so a malicious URL can't
+    // bloat the share-UI or trigger backend errors). ----
+    const _capArr = (s) => s.split(",").map((x) => x.trim()).filter(Boolean)
+                            .filter((x) => x.length <= 64).slice(0, 50);
+    function parseUrlFilters() {
+      const u = new URLSearchParams(location.search);
+      return {
+        zones:    _capArr(u.get("zones") || ""),
+        section:  _capArr(u.get("section") || ""),
+        min_price: u.get("min_price") ? clampFloat(u.get("min_price"), 0, 1e6) : null,
+        max_price: u.get("max_price") ? clampFloat(u.get("max_price"), 0, 1e6) : null,
+        min_qty:   u.get("min_qty") ? clampInt(u.get("min_qty"), 1, 50) : null,
+      };
+    }
 
-    function renderList() {
-      const minQ = Number(minQty.value) || 1;
-      const maxP = Number(maxPrice.value) || Infinity;
-      const filtered = allListings.filter((l) => {
-        const splits = l.splits || [];
-        const aQty = Number(l.available_quantity) || 0;
-        const meetsQty = splits.length
-          ? splits.some((s) => s >= minQ)
-          : aQty >= minQ;
-        const price = Number(l.retail_price) || 0;
-        return meetsQty && price <= maxP;
-      });
+    function buildQueryString(f) {
+      const p = new URLSearchParams();
+      if (f.zones && f.zones.length)     p.set("zones", f.zones.join(","));
+      if (f.section && f.section.length) p.set("section", f.section.join(","));
+      if (f.min_price != null)           p.set("min_price", f.min_price);
+      if (f.max_price != null)           p.set("max_price", f.max_price);
+      if (f.min_qty != null)             p.set("min_qty", f.min_qty);
+      const qs = p.toString();
+      return qs ? `?${qs}` : "";
+    }
 
-      listCount.textContent = `${filtered.length} of ${allListings.length}`;
+    function hasActiveFilters(f) {
+      return (f.zones && f.zones.length)
+        || (f.section && f.section.length)
+        || f.min_price != null
+        || f.max_price != null
+        || f.min_qty != null;
+    }
+
+    function readFiltersFromUI() {
+      return {
+        zones:    $$(".filter-chip.on", zoneChipsEl).map(c => c.dataset.value),
+        section:  $$(".filter-chip.on", sectionChipsEl).map(c => c.dataset.value),
+        min_price: minPriceInput.value === "" ? null : Number(minPriceInput.value),
+        max_price: maxPriceInput.value === "" ? null : Number(maxPriceInput.value),
+        min_qty:   minQtyInput.value === "" ? null : Number(minQtyInput.value),
+      };
+    }
+
+    function paintInputsFromFilters(f) {
+      suppressApply = true;
+      try {
+        minPriceInput.value = f.min_price ?? "";
+        maxPriceInput.value = f.max_price ?? "";
+        minQtyInput.value   = f.min_qty != null ? String(f.min_qty) : "";
+      } finally {
+        suppressApply = false;
+      }
+    }
+
+    function updateUrl(f) {
+      const qs = buildQueryString(f);
+      const newUrl = `/store/event/${eventId}${qs}`;
+      if (newUrl !== location.pathname + location.search) {
+        history.replaceState({}, "", newUrl);
+      }
+    }
+
+    // ---- Listings rendering (server already filtered) ----
+    function renderListings() {
+      listCount.textContent = `${allListings.length}`;
       listEl.innerHTML = "";
-
-      if (!filtered.length) {
+      if (!allListings.length) {
         noListings.hidden = false;
         return;
       }
       noListings.hidden = true;
-
-      for (const l of filtered) {
+      for (const l of allListings) {
         const li = document.createElement("li");
         li.className = "row";
 
@@ -441,35 +510,96 @@
       if (e.key === "Escape") closeModal();
     });
 
-    minQty.addEventListener("change", renderList);
-    maxPrice.addEventListener("input", renderList);
-
-    // Share button — opens the share modal.
-    $("#openShare").addEventListener("click", () => openShareModal());
-
-    // "Show all" link inside the shared-view banner — strips URL filters.
-    const clearShared = $("#clearShared");
-    if (clearShared) {
-      clearShared.href = location.pathname;
+    // ---- Filter chip rendering ----
+    function renderZoneChips(activeZones) {
+      // Zones row appears ONLY when this event has curated zones in
+      // performer_zones (today: NYK at MSG and a handful of others).
+      // For everything else, the row stays hidden — sections/price/qty cover it.
+      if (!zonesAvailable.length) {
+        zoneRow.hidden = true;
+        return;
+      }
+      zoneRow.hidden = false;
+      zoneChipsEl.innerHTML = "";
+      const activeSet = new Set(activeZones || []);
+      const all = Array.from(new Set([...zonesAvailable.map(z => z.name), ...activeSet]));
+      for (const name of all) {
+        const meta = zonesAvailable.find(z => z.name === name);
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.className = "filter-chip" + (activeSet.has(name) ? " on" : "");
+        chip.dataset.value = name;
+        chip.textContent = meta && meta.tickets ? `${name} (${meta.tickets})` : name;
+        chip.addEventListener("click", () => {
+          chip.classList.toggle("on");
+          scheduleApply();
+        });
+        zoneChipsEl.append(chip);
+      }
     }
 
-    function buildEventQuery(extra) {
-      const p = new URLSearchParams();
-      const f = { ...shareFilters, ...(extra || {}) };
-      if (f.zones && f.zones.length) p.set("zones", f.zones.join(","));
-      if (f.section && f.section.length) p.set("section", f.section.join(","));
-      if (f.min_price != null && f.min_price !== "") p.set("min_price", f.min_price);
-      if (f.max_price != null && f.max_price !== "") p.set("max_price", f.max_price);
-      if (f.min_qty != null && f.min_qty !== "") p.set("min_qty", f.min_qty);
-      const qs = p.toString();
-      return qs ? `?${qs}` : "";
+    function renderSectionChips(activeSections) {
+      // Sections come from the currently-loaded listings. Active sections
+      // that aren't in current listings (e.g., recipient filtered to A,B,C
+      // and only B is present) are still shown as chips so the recipient
+      // can clear them.
+      const sectionsPresent = Array.from(new Set(
+        allListings.map(l => String(l.section || "").trim()).filter(Boolean)
+      ));
+      const activeSet = new Set(activeSections || []);
+      const all = Array.from(new Set([...sectionsPresent, ...activeSet]))
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+      if (!all.length) {
+        sectionRow.hidden = true;
+        return;
+      }
+      sectionRow.hidden = false;
+      sectionChipsEl.innerHTML = "";
+      for (const s of all) {
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.className = "filter-chip" + (activeSet.has(s) ? " on" : "");
+        chip.dataset.value = s;
+        chip.textContent = s;
+        chip.addEventListener("click", () => {
+          chip.classList.toggle("on");
+          scheduleApply();
+        });
+        sectionChipsEl.append(chip);
+      }
     }
 
+    // ---- Apply filter changes: read UI -> URL -> fetch -> render ----
+    let applyTimer = null;
+    function scheduleApply() {
+      if (suppressApply) return;
+      clearTimeout(applyTimer);
+      applyTimer = setTimeout(applyFiltersAndFetch, 250);
+    }
+
+    async function applyFiltersAndFetch() {
+      const f = readFiltersFromUI();
+      updateUrl(f);
+      try {
+        const res = await api(`/api/store/events/${eventId}${buildQueryString(f)}`);
+        applyEventResponse(res, resolvedShare);
+      } catch (err) {
+        // Filter apply failures don't break the existing rendered state —
+        // surface in the banner only.
+        console.error("filter apply failed:", err);
+      }
+    }
+
+    // ---- Banner: shows when any filter is active or arriving via /s/{id} ----
     function showSharedBanner(filters, totalBefore, listingsCount, share) {
       const banner = $("#sharedBanner");
       const summary = $("#sharedSummary");
       const clearLink = $("#clearShared");
-      if (!isSharedView) { banner.hidden = true; return; }
+      const isFiltered = hasActiveFilters(filters || {});
+      if (!isFiltered && !share) {
+        banner.hidden = true;
+        return;
+      }
       const parts = [];
       if (filters.zones?.length) parts.push(`zone: ${filters.zones.join(", ")}`);
       if (filters.section?.length) parts.push(`section: ${filters.section.join(", ")}`);
@@ -479,13 +609,17 @@
       const filterText = parts.length ? parts.join(" · ") : "no filters";
 
       // Build via DOM — filterText carries URL-param + server data unescaped.
-      // Hardened 2026-05-11 (security chat).
+      // Hardened 2026-05-11 (PR #57 A1 security review). Distinguishes
+      // "Filtered view" (user just filtered inline) from "Shared view"
+      // (arrived via /s/{id}).
       summary.replaceChildren();
       const strong = document.createElement("strong");
-      strong.textContent = "Shared view";
+      strong.textContent = share ? "Shared view" : "Filtered view";
       summary.append(
         strong,
-        document.createTextNode(` · ${filterText} · showing ${Number(listingsCount) || 0} of ${Number(totalBefore) || 0}`),
+        document.createTextNode(
+          ` · ${filterText} · showing ${Number(listingsCount) || 0} of ${Number(totalBefore) || 0}`
+        ),
       );
       if (share) {
         const track = document.createElement("span");
@@ -501,129 +635,124 @@
         summary.append(noteSpan);
       }
 
-      if (clearLink && event?.id) clearLink.href = `/store/event/${Number(event.id) || 0}`;
+      if (clearLink && eventId) clearLink.href = `/store/event/${Number(eventId) || 0}`;
       banner.hidden = false;
     }
 
+    // ---- Apply event response: paint header + listings + chip state ----
     function applyEventResponse(res, share) {
       event = res.event;
       allListings = res.listings || [];
+      const filters = res.filters || readFiltersFromUI();
 
       $("#evName").textContent = event.name || "Untitled event";
       $("#evVenue").textContent = [event.venue?.name, event.venue?.location].filter(Boolean).join(" · ");
       $("#evDate").textContent = fmtWhen(event.occurs_at_local);
-      $("#evPerformers").textContent = (event.performers || [])
-        .map((p) => p.name + (p.primary ? " (home)" : ""))
-        .join(" vs ");
+
+      const perfEl = $("#evPerformers");
+      perfEl.innerHTML = "";
+      const perfs = event.performers || [];
+      perfs.forEach((p, i) => {
+        if (i > 0) {
+          const sep = document.createElement("span");
+          sep.className = "muted";
+          sep.textContent = " vs ";
+          perfEl.append(sep);
+        }
+        const span = document.createElement("span");
+        span.className = "perf-chip";
+        if (p.color_primary) span.style.setProperty("--perf-color", p.color_primary);
+        if (p.logo_url) {
+          const img = document.createElement("img");
+          img.src = p.logo_url;
+          img.alt = "";
+          img.className = "perf-logo";
+          img.loading = "lazy";
+          span.append(img);
+        }
+        const txt = document.createElement("span");
+        txt.textContent = p.name + (p.primary ? " (home)" : "");
+        span.append(txt);
+        perfEl.append(span);
+      });
 
       const map = event.configuration?.seating_chart_medium || event.configuration?.seating_chart_large;
       if (map) seatMap.src = map;
       else seatMap.style.display = "none";
 
+      const freshness = $("#freshness");
+      if (freshness) {
+        if (res.inventory_source === "cache") {
+          freshness.textContent = "inventory cached (≤10s)";
+          freshness.className = "freshness cached";
+        } else if (res.inventory_source === "live") {
+          freshness.textContent = "live inventory";
+          freshness.className = "freshness live";
+        } else {
+          freshness.textContent = "";
+        }
+      }
+
       status.hidden = true;
       head.hidden = false;
       body.hidden = false;
-      showSharedBanner(res.filters || {}, res.total_before_filters || 0, res.listings_count || 0, share);
-      renderList();
+      renderListings();
+      // Re-render section chips against the new listings (sections may have
+      // shifted as filters narrowed); zone chips are event-static so don't
+      // need re-rendering here.
+      renderSectionChips(filters.section || []);
+      showSharedBanner(filters, res.total_before_filters || 0, res.listings_count || 0, share);
     }
 
-    function loadEvent() {
-      if (shareId) {
-        // Stateful share — server resolves filters + bumps view_count.
-        return api(`/api/store/share/${encodeURIComponent(shareId)}`)
-          .then((res) => {
-            resolvedShare = res.share || null;
-            // Backfill the share filters into the local state so the share
-            // modal pre-fills correctly if the recipient re-opens it.
-            if (resolvedShare?.filters) {
-              const f = resolvedShare.filters;
-              shareFilters.zones = f.zones || [];
-              shareFilters.section = f.section || [];
-              shareFilters.min_price = f.min_price != null ? Number(f.min_price) : null;
-              shareFilters.max_price = f.max_price != null ? Number(f.max_price) : null;
-              shareFilters.min_qty = f.min_qty != null ? Number(f.min_qty) : null;
-            }
-            eventId = res.event?.id;
-            applyEventResponse(res, resolvedShare);
-            return res;
-          });
-      }
-      // Stateless share — filters come from URL params.
-      return api(`/api/store/events/${eventId}${buildEventQuery()}`)
-        .then((res) => { applyEventResponse(res, null); return res; });
-    }
+    // ---- Filter input wiring ----
+    minPriceInput.addEventListener("input", scheduleApply);
+    maxPriceInput.addEventListener("input", scheduleApply);
+    minQtyInput.addEventListener("change", scheduleApply);
+    resetBtn.addEventListener("click", () => {
+      paintInputsFromFilters({});
+      $$(".filter-chip", $("#filterBar")).forEach((c) => c.classList.remove("on"));
+      // No debounce — Reset is intentional.
+      applyFiltersAndFetch();
+    });
 
-    function loadZones() {
-      // For /s/{id} links the eventId is unknown until loadEvent resolves,
-      // so the call is delayed in that path (see Promise chain below).
-      if (!eventId) return Promise.resolve();
-      return api(`/api/store/events/${eventId}/zones`)
-        .then((res) => { zonesAvailable = res.zones || []; })
-        .catch(() => { zonesAvailable = []; });
-    }
+    // ---- Modal close handlers (shared by reserve + share modals) ----
+    $("#closeModal").addEventListener("click", closeModal);
+    $("#modal").addEventListener("click", (e) => {
+      if (e.target.id === "modal") closeModal();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeModal();
+    });
 
-    // ---------- Share modal ----------
+    // ---- Share button ----
+    $("#openShare").addEventListener("click", openShareModal);
+
+    // ---- Share modal: serializes the CURRENT URL. No filter UI here.
+    //      The page itself is the filter UI; share is just a copy/save action. ----
     function openShareModal() {
       const modal = $("#modal");
       const mb = $("#modalBody");
+      const f = readFiltersFromUI();
+      const statelessUrl = `${location.origin}/store/event/${eventId}${buildQueryString(f)}`;
 
-      // Distinct sections present in the currently-loaded listings — so the
-      // share dialog suggests sections the seller actually has.
-      const sectionsPresent = Array.from(new Set(
-        allListings.map((l) => String(l.section || "").trim()).filter(Boolean)
-      )).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-
-      const zoneOpts = zonesAvailable.length
-        ? zonesAvailable.map((z) =>
-            `<label class="chip"><input type="checkbox" value="${escapeAttr(z.name)}" data-zone /> ${escapeHtml(z.name)} <span class="muted">(${z.tickets || 0})</span></label>`
-          ).join("")
-        : `<span class="muted">No curated zones for this event yet — use sections or price.</span>`;
-
-      const sectionOpts = sectionsPresent.length
-        ? sectionsPresent.map((s) =>
-            `<label class="chip"><input type="checkbox" value="${escapeAttr(s)}" data-section /> ${escapeHtml(s)}</label>`
-          ).join("")
-        : `<span class="muted">No sections available.</span>`;
+      const summaryParts = [];
+      if (f.zones.length)     summaryParts.push(`zone: ${f.zones.join(", ")}`);
+      if (f.section.length)   summaryParts.push(`section: ${f.section.join(", ")}`);
+      if (f.min_price != null) summaryParts.push(`min ${fmtMoney(f.min_price)}`);
+      if (f.max_price != null) summaryParts.push(`max ${fmtMoney(f.max_price)}`);
+      if (f.min_qty != null)   summaryParts.push(`${f.min_qty}+ seats`);
+      const summary = summaryParts.length
+        ? summaryParts.join(" · ")
+        : "no filters — full inventory";
+      const listingCount = allListings.length;
 
       mb.innerHTML = `
-        <h3 style="margin:0 0 4px">Share inventory</h3>
-        <p class="muted" style="margin:0 0 16px">
-          Pick what to share — recipients see only listings matching these filters.
+        <h3 style="margin:0 0 4px">Share this view</h3>
+        <p class="muted" style="margin:0 0 12px">
+          ${escapeHtml(summary)} · ${listingCount} listing${listingCount === 1 ? "" : "s"}
         </p>
 
-        <div class="share-section">
-          <div class="share-label">Zones</div>
-          <div class="chip-row" id="zoneChips">${zoneOpts}</div>
-        </div>
-
-        <div class="share-section">
-          <div class="share-label">Sections</div>
-          <div class="chip-row" id="sectionChips">${sectionOpts}</div>
-          <input id="sectionExtra" placeholder="extra sections (CSV)" class="share-input" />
-        </div>
-
-        <div class="share-section">
-          <div class="share-label">Price (per seat)</div>
-          <div class="share-row">
-            <input id="shareMin" type="number" min="0" step="10" placeholder="min $" />
-            <input id="shareMax" type="number" min="0" step="10" placeholder="max $" />
-          </div>
-        </div>
-
-        <div class="share-section">
-          <div class="share-label">Minimum quantity</div>
-          <select id="shareMinQty">
-            <option value="">any</option>
-            <option value="2">2+</option>
-            <option value="3">3+</option>
-            <option value="4">4+</option>
-            <option value="6">6+</option>
-          </select>
-        </div>
-
-        <div class="share-preview">
-          <span id="sharePreview" class="muted">Pick filters above to preview.</span>
-        </div>
+        <input id="shareUrl" class="share-url" readonly value="${escapeAttr(statelessUrl)}" />
 
         <div class="share-section">
           <label class="share-toggle">
@@ -645,148 +774,51 @@
           </div>
         </div>
 
-        <input id="shareUrl" class="share-url" readonly />
         <div class="share-actions">
           <a href="/store/shares" class="btn ghost" style="text-decoration:none">Manage links</a>
           <span style="flex:1"></span>
-          <button class="btn ghost" id="shareReset">Reset</button>
           <button class="btn" id="shareCopy">Copy link</button>
         </div>
       `;
 
-      // Pre-fill controls if a shared filter is already in the URL — lets the
-      // owner tweak an existing share.
-      if (shareFilters.zones?.length) {
-        for (const cb of $$("#zoneChips input[data-zone]", mb)) {
-          if (shareFilters.zones.includes(cb.value)) cb.checked = true;
-        }
-      }
-      if (shareFilters.section?.length) {
-        for (const cb of $$("#sectionChips input[data-section]", mb)) {
-          if (shareFilters.section.includes(cb.value)) cb.checked = true;
-        }
-        const known = new Set(sectionsPresent);
-        const extras = shareFilters.section.filter((s) => !known.has(s));
-        if (extras.length) $("#sectionExtra", mb).value = extras.join(",");
-      }
-      if (shareFilters.min_price != null) $("#shareMin", mb).value = shareFilters.min_price;
-      if (shareFilters.max_price != null) $("#shareMax", mb).value = shareFilters.max_price;
-      if (shareFilters.min_qty != null) $("#shareMinQty", mb).value = String(shareFilters.min_qty);
+      const useRevToggle = $("#useRevocable", mb);
+      const copyBtn = $("#shareCopy", mb);
+      const urlInput = $("#shareUrl", mb);
 
-      function readShareForm() {
-        const zones = $$("#zoneChips input[data-zone]", mb).filter((c) => c.checked).map((c) => c.value);
-        const sectionChips = $$("#sectionChips input[data-section]", mb).filter((c) => c.checked).map((c) => c.value);
-        const sectionExtra = ($("#sectionExtra", mb).value || "")
-          .split(",").map((s) => s.trim()).filter(Boolean);
-        const sections = Array.from(new Set([...sectionChips, ...sectionExtra]));
-        const minP = $("#shareMin", mb).value;
-        const maxP = $("#shareMax", mb).value;
-        const mq = $("#shareMinQty", mb).value;
-        return {
-          zones,
-          section: sections,
-          min_price: minP === "" ? null : Number(minP),
-          max_price: maxP === "" ? null : Number(maxP),
-          min_qty: mq === "" ? null : Number(mq),
-        };
-      }
-
-      function buildShareUrl(f) {
-        const p = new URLSearchParams();
-        if (f.zones.length) p.set("zones", f.zones.join(","));
-        if (f.section.length) p.set("section", f.section.join(","));
-        if (f.min_price != null) p.set("min_price", f.min_price);
-        if (f.max_price != null) p.set("max_price", f.max_price);
-        if (f.min_qty != null) p.set("min_qty", f.min_qty);
-        const qs = p.toString();
-        return `${location.origin}/store/event/${eventId}${qs ? "?" + qs : ""}`;
-      }
-
-      let previewTimer = null;
-      function refreshUrlPreview() {
-        // Only the stateless URL is shown live; the revocable URL is generated
-        // on click of "Generate link" since it requires a server round trip.
-        const f = readShareForm();
-        const url = buildShareUrl(f);
-        const useRev = $("#useRevocable", mb).checked;
-        if (!useRev) {
-          $("#shareUrl", mb).value = url;
-          $("#shareUrl", mb).placeholder = "";
-          $("#shareCopy", mb).textContent = "Copy link";
-        } else {
-          $("#shareUrl", mb).value = "";
-          $("#shareUrl", mb).placeholder = "click Generate to create a /s/… link";
-          $("#shareCopy", mb).textContent = "Generate link";
-        }
+      function refreshButton() {
+        const useRev = useRevToggle.checked;
         $("#revocableOpts", mb).hidden = !useRev;
-      }
-
-      function refreshCountPreview() {
-        const f = readShareForm();
-        clearTimeout(previewTimer);
-        previewTimer = setTimeout(async () => {
-          try {
-            const qp = new URLSearchParams();
-            if (f.zones.length) qp.set("zones", f.zones.join(","));
-            if (f.section.length) qp.set("section", f.section.join(","));
-            if (f.min_price != null) qp.set("min_price", f.min_price);
-            if (f.max_price != null) qp.set("max_price", f.max_price);
-            if (f.min_qty != null) qp.set("min_qty", f.min_qty);
-            const res = await api(`/api/store/events/${eventId}?${qp.toString()}`);
-            // Build via DOM — was innerHTML with server numbers. Hardened 2026-05-11.
-            const preview = $("#sharePreview", mb);
-            preview.replaceChildren();
-            const s = document.createElement("strong");
-            s.textContent = String(Number(res.listings_count) || 0);
-            preview.append(s, document.createTextNode(` of ${Number(res.total_before_filters) || 0} listings would be shared`));
-          } catch (e) {
-            $("#sharePreview", mb).textContent = `preview failed: ${e.message}`;
-          }
-        }, 200);
-      }
-
-      function updatePreview() {
-        refreshUrlPreview();
-        refreshCountPreview();
-      }
-
-      mb.addEventListener("change", updatePreview);
-      mb.addEventListener("input", updatePreview);
-
-      $("#shareReset", mb).addEventListener("click", () => {
-        $$("input[type=checkbox]", mb).forEach((c) => (c.checked = false));
-        $$('input[type="number"], input[type="text"]', mb).forEach((i) => (i.value = ""));
-        $("#sectionExtra", mb).value = "";
-        $("#shareMinQty", mb).value = "";
-        $("#shareNote", mb) && ($("#shareNote", mb).value = "");
-        updatePreview();
-      });
-
-      $("#shareCopy", mb).addEventListener("click", async () => {
-        const useRev = $("#useRevocable", mb).checked;
-        const btn = $("#shareCopy", mb);
-
-        async function copy(url) {
-          try {
-            await navigator.clipboard.writeText(url);
-            const old = btn.textContent;
-            btn.textContent = "Copied ✓";
-            setTimeout(() => (btn.textContent = old), 1200);
-          } catch {
-            $("#shareUrl", mb).select();
-          }
+        if (useRev) {
+          urlInput.value = "";
+          urlInput.placeholder = "click Generate to create a /s/… link";
+          copyBtn.textContent = "Generate link";
+        } else {
+          urlInput.value = statelessUrl;
+          urlInput.placeholder = "";
+          copyBtn.textContent = "Copy link";
         }
+      }
+      useRevToggle.addEventListener("change", refreshButton);
 
-        if (!useRev) {
-          await copy($("#shareUrl", mb).value);
+      async function copyToClipboard(url) {
+        try {
+          await navigator.clipboard.writeText(url);
+          const old = copyBtn.textContent;
+          copyBtn.textContent = "Copied ✓";
+          setTimeout(() => (copyBtn.textContent = old), 1200);
+        } catch {
+          urlInput.select();
+        }
+      }
+
+      copyBtn.addEventListener("click", async () => {
+        if (!useRevToggle.checked) {
+          await copyToClipboard(urlInput.value);
           return;
         }
-
-        // Revocable: persist a share_links row.
-        btn.disabled = true;
-        btn.textContent = "Generating…";
+        copyBtn.disabled = true;
+        copyBtn.textContent = "Generating…";
         try {
-          const f = readShareForm();
           const note = ($("#shareNote", mb)?.value || "").trim();
           const exp = $("#shareExpires", mb)?.value;
           const body = {
@@ -801,41 +833,67 @@
             body: JSON.stringify(body),
           });
           const url = `${location.origin}${created.url}`;
-          $("#shareUrl", mb).value = url;
-          await copy(url);
+          urlInput.value = url;
+          await copyToClipboard(url);
         } catch (e) {
-          $("#shareUrl", mb).value = "";
           alert(`Could not create link: ${e.message}`);
-          btn.textContent = "Generate link";
+          copyBtn.textContent = "Generate link";
         } finally {
-          btn.disabled = false;
+          copyBtn.disabled = false;
         }
       });
 
-      updatePreview();
       modal.hidden = false;
     }
 
-    // For /store/event/{id} we know eventId up front and can fire both calls
-    // in parallel. For /s/{id} we have to load the share first to discover
-    // the eventId, then load zones.
-    if (shareId) {
-      loadEvent()
-        .then(() => loadZones())
-        .catch((err) => {
-          if (err.message.includes("410")) {
-            status.textContent = "This share link is no longer active.";
-          } else {
-            status.textContent = `Couldn't load event: ${err.message}`;
-          }
-          status.style.color = "var(--bad)";
-        });
-    } else {
-      Promise.all([loadZones(), loadEvent()]).catch((err) => {
-        status.textContent = `Couldn't load event: ${err.message}`;
+    // ---- Bootstrap ----
+    async function bootstrap() {
+      try {
+        let initialFilters;
+        if (shareId) {
+          // /s/{id}: resolve the share, replaceState into the canonical event
+          // URL with the saved filters, then hand off to the normal flow.
+          const shareRes = await api(`/api/store/share/${encodeURIComponent(shareId)}`);
+          resolvedShare = shareRes.share || null;
+          eventId = shareRes.event?.id;
+          initialFilters = (resolvedShare && resolvedShare.filters) || {};
+          // Normalize the filters object so subsequent UI operations treat it cleanly.
+          initialFilters = {
+            zones: initialFilters.zones || [],
+            section: initialFilters.section || [],
+            min_price: initialFilters.min_price ?? null,
+            max_price: initialFilters.max_price ?? null,
+            min_qty: initialFilters.min_qty ?? null,
+          };
+          history.replaceState({}, "", `/store/event/${eventId}${buildQueryString(initialFilters)}`);
+
+          const zonesRes = await api(`/api/store/events/${eventId}/zones`).catch(() => ({ zones: [] }));
+          zonesAvailable = zonesRes.zones || [];
+          paintInputsFromFilters(initialFilters);
+          applyEventResponse(shareRes, resolvedShare);
+          renderZoneChips(initialFilters.zones);
+        } else {
+          initialFilters = parseUrlFilters();
+          paintInputsFromFilters(initialFilters);
+          const [evRes, zonesRes] = await Promise.all([
+            api(`/api/store/events/${eventId}${buildQueryString(initialFilters)}`),
+            api(`/api/store/events/${eventId}/zones`).catch(() => ({ zones: [] })),
+          ]);
+          zonesAvailable = zonesRes.zones || [];
+          applyEventResponse(evRes, null);
+          renderZoneChips(initialFilters.zones);
+        }
+      } catch (err) {
+        if (err.message && err.message.includes("410")) {
+          status.textContent = "This share link is no longer active.";
+        } else {
+          status.textContent = `Couldn't load event: ${err.message}`;
+        }
         status.style.color = "var(--bad)";
-      });
+      }
     }
+
+    bootstrap();
   }
 
   function escapeHtml(s) {

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -129,11 +129,37 @@ a { color: inherit; }
   text-decoration: none;
   color: inherit;
   transition: transform .12s, border-color .12s;
+  position: relative;
+  overflow: hidden;
+}
+/* Brand-color stripe along the left edge when the performer has one. */
+.card[style*="--card-accent"]::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--card-accent);
 }
 .card:hover {
   transform: translateY(-2px);
   border-color: var(--accent);
   box-shadow: var(--shadow);
+}
+.card-head {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.card-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  object-fit: contain;
+  background: var(--bg);
+  padding: 4px;
+  flex-shrink: 0;
 }
 .card .when {
   font-size: 12px;
@@ -213,24 +239,68 @@ a { color: inherit; }
 }
 .muted { color: var(--muted); font-weight: 400; font-size: 13px; }
 
-.listcontrols {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 14px;
-  font-size: 13px;
-  color: var(--muted);
-}
-.listcontrols label { display: flex; gap: 6px; align-items: center; }
-.listcontrols select,
-.listcontrols input {
+/* ----- Inline filter bar on event page ----- */
+.filter-bar {
   background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.filter-row.inline > * { flex-shrink: 0; }
+.filter-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+  margin-right: 4px;
+}
+.filter-bar input,
+.filter-bar select {
+  background: var(--bg);
   color: var(--text);
   border: 1px solid var(--line);
   border-radius: 6px;
-  padding: 6px 8px;
+  padding: 6px 10px;
   font: inherit;
 }
-.listcontrols input { width: 80px; }
+.filter-bar input[type="number"] { width: 90px; }
+.filter-bar input:focus,
+.filter-bar select:focus { outline: none; border-color: var(--accent); }
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  flex: 1;
+  min-width: 0;
+}
+.chip-group .filter-chip {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+.chip-group .filter-chip:hover { border-color: var(--accent-2); }
+.chip-group .filter-chip.on {
+  background: rgba(255,92,42,0.15);
+  border-color: var(--accent);
+  color: var(--accent-2);
+}
 
 .list {
   list-style: none;
@@ -354,7 +424,46 @@ a { color: inherit; }
   align-items: flex-start;
   gap: 16px;
 }
-.head-actions { flex-shrink: 0; }
+.head-actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+/* ----- Performer chips on event header ----- */
+.perf-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--perf-color, var(--line));
+  background: var(--panel);
+}
+.perf-chip:has(img) { padding-left: 4px; }
+.perf-logo {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
+/* ----- Inventory-freshness badge ----- */
+.freshness {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.freshness.cached { color: var(--muted); }
+.freshness.live {
+  color: var(--good);
+  border-color: rgba(74,222,128,0.3);
+  background: rgba(74,222,128,0.08);
+}
 
 /* ----- Shared-view banner ----- */
 .banner {

--- a/static/store/test/event.html
+++ b/static/store/test/event.html
@@ -1,0 +1,577 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Event — VibePass</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+    </nav>
+
+    <main class="content">
+      <!-- Empty state when no event picked. -->
+      <div id="emptyState" class="empty-state" hidden>
+        <h2>Pick an event to see tickets</h2>
+        <p>Search for an artist, team, or venue to find what's available.</p>
+        <a href="/store/test/search">Browse events →</a>
+      </div>
+
+      <!-- Loading state. -->
+      <div id="loading" class="empty-state">Loading event…</div>
+
+      <!-- Event view. -->
+      <div id="eventView" hidden>
+        <a class="prev" href="/store/test/search" style="font-size:13px;display:inline-block;margin-bottom:12px;color:var(--muted);text-decoration:none">← back to search</a>
+
+        <section class="event-hero">
+          <div>
+            <h1 id="evName"></h1>
+            <p class="meta">
+              <span id="evVenue"></span>
+              <span class="dot">·</span>
+              <span id="evDate"></span>
+            </p>
+            <p class="meta" id="evPerformers" style="margin-top:4px;font-size:13px"></p>
+          </div>
+          <div class="actions">
+            <span id="freshness" class="freshness"></span>
+            <button id="shareBtn" class="ghost">Share this view</button>
+          </div>
+        </section>
+
+        <!-- Banner shown when filters are active or arriving via /s/{id}. -->
+        <div id="banner" class="banner" hidden>
+          <span id="bannerSummary"></span>
+          <a href="" id="bannerClear">show all listings</a>
+        </div>
+
+        <!-- Inline filters drive the URL + listings. Zone row only renders
+             when this event has curated zones. -->
+        <div id="filterBar" class="filter-bar">
+          <div id="zoneRow" class="filter-row" hidden>
+            <span class="filter-label">Zone</span>
+            <div class="chip-group" id="zoneChips"></div>
+          </div>
+          <div id="sectionRow" class="filter-row" hidden>
+            <span class="filter-label">Section</span>
+            <div class="chip-group" id="sectionChips"></div>
+          </div>
+          <div class="filter-row inline">
+            <span class="filter-label">Price</span>
+            <input id="minPrice" type="number" min="0" step="10" placeholder="min $" />
+            <input id="maxPrice" type="number" min="0" step="10" placeholder="max $" />
+            <span class="filter-label" style="margin-left:16px">Min qty</span>
+            <select id="minQty">
+              <option value="">any</option>
+              <option value="2">2+</option>
+              <option value="3">3+</option>
+              <option value="4">4+</option>
+              <option value="6">6+</option>
+            </select>
+            <button id="resetFilters" class="ghost" style="margin-left:auto">Reset</button>
+          </div>
+        </div>
+
+        <h2 style="font-size:14px;color:var(--muted);text-transform:uppercase;letter-spacing:1px;margin:18px 0 8px">
+          Available tickets <span id="listingCount" style="font-weight:400;color:var(--text);text-transform:none;letter-spacing:0"></span>
+        </h2>
+        <div id="listings" class="listing-rows"></div>
+        <p id="noListings" class="empty-state" hidden style="padding:30px 0">
+          Nothing matches those filters. Loosen them — inventory shifts.
+        </p>
+      </div>
+    </main>
+  </div>
+
+  <!-- Buy / share modals share the same container. -->
+  <div id="modal" class="modal" hidden>
+    <div class="modal-card">
+      <button class="close" id="modalClose">×</button>
+      <div id="modalBody"></div>
+    </div>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, $$, fmtMoney, fmtWhen, api } = Test;
+
+    const urlParams = new URLSearchParams(location.search);
+    const eventId = Number(urlParams.get("id"));
+
+    // No id? Show empty state and stop.
+    if (!eventId) {
+      $("#loading").hidden = true;
+      $("#emptyState").hidden = false;
+    } else {
+      mountEvent();
+    }
+
+    function mountEvent() {
+      // DOM refs
+      const loading = $("#loading");
+      const view = $("#eventView");
+      const zoneRow = $("#zoneRow");
+      const zoneChipsEl = $("#zoneChips");
+      const sectionRow = $("#sectionRow");
+      const sectionChipsEl = $("#sectionChips");
+      const minPriceInput = $("#minPrice");
+      const maxPriceInput = $("#maxPrice");
+      const minQtyInput = $("#minQty");
+      const resetBtn = $("#resetFilters");
+      const listingsEl = $("#listings");
+      const noListings = $("#noListings");
+      const listingCount = $("#listingCount");
+      const banner = $("#banner");
+      const bannerSummary = $("#bannerSummary");
+      const bannerClear = $("#bannerClear");
+
+      let allListings = [];
+      let zonesAvailable = [];
+      let suppressApply = false;
+
+      // ---- URL <-> filter state ----
+      function parseUrlFilters() {
+        const u = new URLSearchParams(location.search);
+        return {
+          zones:    (u.get("zones") || "").split(",").map(s => s.trim()).filter(Boolean),
+          section:  (u.get("section") || "").split(",").map(s => s.trim()).filter(Boolean),
+          min_price: u.get("min_price") ? Number(u.get("min_price")) : null,
+          max_price: u.get("max_price") ? Number(u.get("max_price")) : null,
+          min_qty:   u.get("min_qty") ? Number(u.get("min_qty")) : null,
+        };
+      }
+
+      function readFiltersFromUI() {
+        return {
+          zones:    $$(".filter-chip.on", zoneChipsEl).map(c => c.dataset.value),
+          section:  $$(".filter-chip.on", sectionChipsEl).map(c => c.dataset.value),
+          min_price: minPriceInput.value === "" ? null : Number(minPriceInput.value),
+          max_price: maxPriceInput.value === "" ? null : Number(maxPriceInput.value),
+          min_qty:   minQtyInput.value === "" ? null : Number(minQtyInput.value),
+        };
+      }
+
+      function buildQueryString(f) {
+        const p = new URLSearchParams();
+        p.set("id", eventId);
+        if (f.zones && f.zones.length) p.set("zones", f.zones.join(","));
+        if (f.section && f.section.length) p.set("section", f.section.join(","));
+        if (f.min_price != null) p.set("min_price", f.min_price);
+        if (f.max_price != null) p.set("max_price", f.max_price);
+        if (f.min_qty != null) p.set("min_qty", f.min_qty);
+        return "?" + p.toString();
+      }
+
+      function buildApiQuery(f) {
+        const p = new URLSearchParams();
+        if (f.zones && f.zones.length) p.set("zones", f.zones.join(","));
+        if (f.section && f.section.length) p.set("section", f.section.join(","));
+        if (f.min_price != null) p.set("min_price", f.min_price);
+        if (f.max_price != null) p.set("max_price", f.max_price);
+        if (f.min_qty != null) p.set("min_qty", f.min_qty);
+        const qs = p.toString();
+        return qs ? `?${qs}` : "";
+      }
+
+      function hasActiveFilters(f) {
+        return (f.zones && f.zones.length)
+          || (f.section && f.section.length)
+          || f.min_price != null
+          || f.max_price != null
+          || f.min_qty != null;
+      }
+
+      function paintInputsFromFilters(f) {
+        suppressApply = true;
+        try {
+          minPriceInput.value = f.min_price ?? "";
+          maxPriceInput.value = f.max_price ?? "";
+          minQtyInput.value   = f.min_qty != null ? String(f.min_qty) : "";
+        } finally {
+          suppressApply = false;
+        }
+      }
+
+      function updateUrl(f) {
+        const newUrl = `/store/test/event${buildQueryString(f)}`;
+        if (newUrl !== location.pathname + location.search) {
+          history.replaceState({}, "", newUrl);
+        }
+      }
+
+      // ---- Chip rendering ----
+      function renderZoneChips(active) {
+        if (!zonesAvailable.length) {
+          zoneRow.hidden = true;
+          return;
+        }
+        zoneRow.hidden = false;
+        zoneChipsEl.innerHTML = "";
+        const activeSet = new Set(active || []);
+        const all = Array.from(new Set([...zonesAvailable.map(z => z.name), ...activeSet]));
+        for (const name of all) {
+          const meta = zonesAvailable.find(z => z.name === name);
+          const chip = document.createElement("button");
+          chip.type = "button";
+          chip.className = "filter-chip" + (activeSet.has(name) ? " on" : "");
+          chip.dataset.value = name;
+          chip.textContent = meta && meta.tickets ? `${name} (${meta.tickets})` : name;
+          chip.addEventListener("click", () => { chip.classList.toggle("on"); scheduleApply(); });
+          zoneChipsEl.append(chip);
+        }
+      }
+
+      function renderSectionChips(active) {
+        const sectionsPresent = Array.from(new Set(
+          allListings.map(l => String(l.section || "").trim()).filter(Boolean)
+        ));
+        const activeSet = new Set(active || []);
+        const all = Array.from(new Set([...sectionsPresent, ...activeSet]))
+          .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+        if (!all.length) {
+          sectionRow.hidden = true;
+          return;
+        }
+        sectionRow.hidden = false;
+        sectionChipsEl.innerHTML = "";
+        for (const s of all) {
+          const chip = document.createElement("button");
+          chip.type = "button";
+          chip.className = "filter-chip" + (activeSet.has(s) ? " on" : "");
+          chip.dataset.value = s;
+          chip.textContent = s;
+          chip.addEventListener("click", () => { chip.classList.toggle("on"); scheduleApply(); });
+          sectionChipsEl.append(chip);
+        }
+      }
+
+      // ---- Apply filter changes ----
+      let applyTimer = null;
+      function scheduleApply() {
+        if (suppressApply) return;
+        clearTimeout(applyTimer);
+        applyTimer = setTimeout(applyFiltersAndFetch, 250);
+      }
+
+      async function applyFiltersAndFetch() {
+        const f = readFiltersFromUI();
+        updateUrl(f);
+        try {
+          const { body } = await api(`/api/store/events/${eventId}${buildApiQuery(f)}`);
+          applyResponse(body);
+        } catch {}
+      }
+
+      // ---- Banner ----
+      function showBanner(filters, totalBefore, listingsCount) {
+        if (!hasActiveFilters(filters || {})) {
+          banner.hidden = true;
+          return;
+        }
+        const parts = [];
+        if (filters.zones?.length) parts.push(`zone: ${filters.zones.join(", ")}`);
+        if (filters.section?.length) parts.push(`section: ${filters.section.join(", ")}`);
+        if (filters.min_price != null) parts.push(`min ${fmtMoney(filters.min_price)}`);
+        if (filters.max_price != null) parts.push(`max ${fmtMoney(filters.max_price)}`);
+        if (filters.min_qty != null) parts.push(`${filters.min_qty}+ seats`);
+        bannerSummary.innerHTML = `<strong>Filtered view</strong> · ${parts.join(" · ")} · showing ${listingsCount} of ${totalBefore}`;
+        bannerClear.href = `/store/test/event?id=${eventId}`;
+        banner.hidden = false;
+      }
+
+      // ---- Render listings ----
+      function renderListings() {
+        listingCount.textContent = `(${allListings.length})`;
+        listingsEl.innerHTML = "";
+        if (!allListings.length) {
+          noListings.hidden = false;
+          return;
+        }
+        noListings.hidden = true;
+        for (const l of allListings) {
+          const row = document.createElement("div");
+          row.className = "listing-row";
+
+          const seat = document.createElement("div");
+          seat.className = "seat";
+          const sec = document.createElement("div");
+          sec.className = "section";
+          sec.textContent = `Section ${l.section || "—"}`;
+          if (l.zone) {
+            const z = document.createElement("span");
+            z.className = "zone-tag";
+            z.textContent = l.zone;
+            sec.append(" ", z);
+          }
+          const rowLabel = document.createElement("div");
+          rowLabel.className = "row-label";
+          rowLabel.textContent = `Row ${l.row || "—"}`;
+          seat.append(sec, rowLabel);
+
+          const splits = (l.splits && l.splits.length ? l.splits.join(", ") : (l.available_quantity || 0));
+          const qty = document.createElement("div");
+          qty.className = "qty";
+          qty.innerHTML = `${l.available_quantity || 0} available<br><span style="font-size:11px">sells in ${splits}</span>`;
+
+          const price = document.createElement("div");
+          price.className = "price";
+          price.innerHTML = `${fmtMoney(l.retail_price)}<span class="each">each</span>`;
+
+          const buy = document.createElement("button");
+          buy.className = "buy-btn";
+          buy.textContent = "Get tickets";
+          buy.addEventListener("click", () => openBuyModal(l));
+
+          row.append(seat, qty, price, buy);
+          if (l.public_notes) {
+            const notes = document.createElement("div");
+            notes.className = "public-notes";
+            notes.textContent = l.public_notes;
+            row.append(notes);
+          }
+          listingsEl.append(row);
+        }
+      }
+
+      // ---- Buy modal ----
+      function openBuyModal(listing) {
+        const splits = listing.splits && listing.splits.length ? listing.splits : [1, 2, 3, 4];
+        const opts = splits
+          .filter(s => s <= (listing.available_quantity || 999))
+          .map(s => `<option value="${s}">${s}</option>`).join("");
+        const defaultQ = splits[0] || 1;
+        const mb = $("#modalBody");
+        mb.innerHTML = `
+          <h3>Get tickets</h3>
+          <p style="color:var(--muted);margin:0 0 16px">Section ${listing.section} · Row ${listing.row}</p>
+          <div style="display:flex;justify-content:space-between;align-items:center;margin:8px 0">
+            <span>How many?</span>
+            <select id="buyQty" style="background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:6px;padding:6px 10px;font:inherit">${opts}</select>
+          </div>
+          <div class="receipt">
+            <span class="k">Per ticket</span><span class="v">${fmtMoney(listing.retail_price)}</span>
+            <span class="k">Quantity</span><span class="v" id="receiptQty">${defaultQ}</span>
+            <span class="k total">Total</span><span class="v total" id="receiptTotal">${fmtMoney(listing.retail_price * defaultQ)}</span>
+          </div>
+          <button id="confirmBuy" class="buy-btn" style="width:100%;padding:12px">Continue to checkout</button>
+          <p style="font-size:11px;color:var(--muted);text-align:center;margin:12px 0 0">
+            Demo storefront — real checkout not wired up yet.
+          </p>
+        `;
+        const qSel = $("#buyQty", mb);
+        qSel.value = String(defaultQ);
+        qSel.addEventListener("change", () => {
+          const q = Number(qSel.value);
+          $("#receiptQty", mb).textContent = q;
+          $("#receiptTotal", mb).textContent = fmtMoney(listing.retail_price * q);
+        });
+        $("#confirmBuy", mb).addEventListener("click", async () => {
+          const btn = $("#confirmBuy", mb);
+          btn.disabled = true;
+          btn.textContent = "Confirming…";
+          try {
+            const { body } = await api("/api/store/reserve", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                event_id: eventId,
+                ticket_group_id: listing.id,
+                quantity: Number(qSel.value),
+              }),
+            });
+            const r = body.reservation || {};
+            mb.innerHTML = `
+              <h3>You're set ✓</h3>
+              <p style="color:var(--muted);margin:0 0 16px">Demo confirmation — no charge processed.</p>
+              <div class="receipt">
+                <span class="k">Section</span><span class="v">${r.section || "—"}</span>
+                <span class="k">Row</span><span class="v">${r.row || "—"}</span>
+                <span class="k">Quantity</span><span class="v">${r.quantity}</span>
+                <span class="k">Per ticket</span><span class="v">${fmtMoney(r.unit_price)}</span>
+                <span class="k total">Total</span><span class="v total">${fmtMoney(r.subtotal)}</span>
+              </div>
+              <button id="closeOk" class="ghost" style="width:100%">Close</button>
+            `;
+            $("#closeOk", mb).addEventListener("click", closeModal);
+          } catch (e) {
+            btn.disabled = false;
+            btn.textContent = "Continue to checkout";
+            alert(e.message);
+          }
+        });
+        $("#modal").hidden = false;
+      }
+
+      // ---- Share modal ----
+      function openShareModal() {
+        const f = readFiltersFromUI();
+        const apiQs = buildApiQuery(f);
+        const url = `${location.origin}/store/event/${eventId}${apiQs}`;
+        const summary = (function () {
+          const parts = [];
+          if (f.zones.length)     parts.push(`zone: ${f.zones.join(", ")}`);
+          if (f.section.length)   parts.push(`section: ${f.section.join(", ")}`);
+          if (f.min_price != null) parts.push(`min ${fmtMoney(f.min_price)}`);
+          if (f.max_price != null) parts.push(`max ${fmtMoney(f.max_price)}`);
+          if (f.min_qty != null)   parts.push(`${f.min_qty}+ seats`);
+          return parts.length ? parts.join(" · ") : "no filters — full inventory";
+        })();
+        const mb = $("#modalBody");
+        mb.innerHTML = `
+          <h3>Share this view</h3>
+          <p style="color:var(--muted);margin:0 0 12px">${summary} · ${allListings.length} listing${allListings.length === 1 ? "" : "s"}</p>
+          <input id="shareUrl" readonly style="width:100%;background:var(--bg);color:var(--accent-2);border:1px solid var(--line);border-radius:6px;padding:8px 10px;font:12px ui-monospace,monospace;margin-bottom:8px" value="${url.replace(/"/g,"&quot;")}" />
+          <label style="display:flex;gap:10px;align-items:flex-start;cursor:pointer;padding:10px 12px;border:1px solid var(--line);border-radius:8px;margin:8px 0">
+            <input type="checkbox" id="useRev" style="margin-top:2px" />
+            <span>
+              <strong>Make this revocable</strong><br>
+              <span style="color:var(--muted);font-size:12px">tracks views, expires, can be turned off later</span>
+            </span>
+          </label>
+          <div id="revOpts" hidden>
+            <input id="shareNote" maxlength="500" placeholder="Optional note for the recipient" style="width:100%;background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:6px;padding:8px 10px;font:inherit;margin-bottom:6px" />
+            <select id="shareExpires" style="width:100%;background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:6px;padding:8px 10px;font:inherit">
+              <option value="">never expires</option>
+              <option value="1">expires in 1 day</option>
+              <option value="7" selected>expires in 7 days</option>
+              <option value="30">expires in 30 days</option>
+              <option value="90">expires in 90 days</option>
+            </select>
+          </div>
+          <button id="shareCopy" class="buy-btn" style="width:100%;padding:10px;margin-top:12px">Copy link</button>
+        `;
+        const useRev = $("#useRev", mb);
+        const copyBtn = $("#shareCopy", mb);
+        const urlInput = $("#shareUrl", mb);
+        useRev.addEventListener("change", () => {
+          $("#revOpts", mb).hidden = !useRev.checked;
+          if (useRev.checked) {
+            urlInput.value = "";
+            urlInput.placeholder = "click Generate to create a /s/… link";
+            copyBtn.textContent = "Generate link";
+          } else {
+            urlInput.value = url;
+            urlInput.placeholder = "";
+            copyBtn.textContent = "Copy link";
+          }
+        });
+        copyBtn.addEventListener("click", async () => {
+          if (!useRev.checked) {
+            try {
+              await navigator.clipboard.writeText(urlInput.value);
+              const old = copyBtn.textContent;
+              copyBtn.textContent = "Copied ✓";
+              setTimeout(() => (copyBtn.textContent = old), 1200);
+            } catch { urlInput.select(); }
+            return;
+          }
+          copyBtn.disabled = true;
+          copyBtn.textContent = "Generating…";
+          try {
+            const note = ($("#shareNote", mb).value || "").trim();
+            const exp = $("#shareExpires", mb).value;
+            const { body } = await api("/api/store/share", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                event_id: eventId,
+                filters: f,
+                note: note || undefined,
+                expires_in_days: exp ? Number(exp) : undefined,
+              }),
+            });
+            const fullUrl = `${location.origin}${body.url}`;
+            urlInput.value = fullUrl;
+            try {
+              await navigator.clipboard.writeText(fullUrl);
+              copyBtn.textContent = "Copied ✓";
+              setTimeout(() => (copyBtn.textContent = "Generate link"), 1200);
+            } catch { urlInput.select(); }
+          } catch (e) {
+            alert(e.message);
+            copyBtn.textContent = "Generate link";
+          } finally {
+            copyBtn.disabled = false;
+          }
+        });
+        $("#modal").hidden = false;
+      }
+
+      function closeModal() { $("#modal").hidden = true; }
+      $("#modalClose").addEventListener("click", closeModal);
+      $("#modal").addEventListener("click", (e) => { if (e.target.id === "modal") closeModal(); });
+      document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeModal(); });
+      $("#shareBtn").addEventListener("click", openShareModal);
+
+      // ---- Apply event response ----
+      function applyResponse(res) {
+        const ev = res.event || {};
+        allListings = res.listings || [];
+        const filters = res.filters || readFiltersFromUI();
+
+        $("#evName").textContent = ev.name || "Untitled event";
+        $("#evVenue").textContent = [ev.venue?.name, ev.venue?.location].filter(Boolean).join(" · ");
+        $("#evDate").textContent = fmtWhen(ev.occurs_at_local);
+        $("#evPerformers").textContent = (ev.performers || [])
+          .map(p => p.name + (p.primary ? " (home)" : ""))
+          .join(" vs ");
+
+        const fr = $("#freshness");
+        if (res.inventory_source === "live") {
+          fr.textContent = "live"; fr.className = "freshness live";
+        } else if (res.inventory_source === "cache") {
+          fr.textContent = "cached"; fr.className = "freshness cached";
+        } else {
+          fr.textContent = "";
+        }
+
+        loading.hidden = true;
+        view.hidden = false;
+        renderListings();
+        renderSectionChips(filters.section || []);
+        showBanner(filters, res.total_before_filters || 0, res.listings_count || 0);
+      }
+
+      // ---- Filter input wiring ----
+      minPriceInput.addEventListener("input", scheduleApply);
+      maxPriceInput.addEventListener("input", scheduleApply);
+      minQtyInput.addEventListener("change", scheduleApply);
+      resetBtn.addEventListener("click", () => {
+        paintInputsFromFilters({});
+        $$(".filter-chip", $("#filterBar")).forEach(c => c.classList.remove("on"));
+        applyFiltersAndFetch();
+      });
+
+      // ---- Bootstrap ----
+      (async () => {
+        const initial = parseUrlFilters();
+        paintInputsFromFilters(initial);
+        try {
+          const [ev, zones] = await Promise.all([
+            api(`/api/store/events/${eventId}${buildApiQuery(initial)}`),
+            api(`/api/store/events/${eventId}/zones`).catch(() => ({ body: { zones: [] } })),
+          ]);
+          zonesAvailable = (zones.body && zones.body.zones) || [];
+          applyResponse(ev.body);
+          renderZoneChips(initial.zones);
+        } catch (e) {
+          loading.textContent = `Couldn't load this event. ${e.message}`;
+        }
+      })();
+    }
+  </script>
+</body>
+</html>

--- a/static/store/test/event.html
+++ b/static/store/test/event.html
@@ -108,6 +108,15 @@
   <script>
     const { $, $$, fmtMoney, fmtWhen, api } = Test;
 
+    // Tiny HTML escaper — used in all innerHTML template literals below.
+    // Per #57 A1 review: TEvo listing data (section/row), URL params, and
+    // server reservation echoes are all attacker-influenceable.
+    function esc(v) {
+      return String(v == null ? "" : v).replace(/[&<>"']/g, c => (
+        { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+      ));
+    }
+
     const urlParams = new URLSearchParams(location.search);
     const eventId = Number(urlParams.get("id"));
 
@@ -287,8 +296,18 @@
         if (filters.min_price != null) parts.push(`min ${fmtMoney(filters.min_price)}`);
         if (filters.max_price != null) parts.push(`max ${fmtMoney(filters.max_price)}`);
         if (filters.min_qty != null) parts.push(`${filters.min_qty}+ seats`);
-        bannerSummary.innerHTML = `<strong>Filtered view</strong> · ${parts.join(" · ")} · showing ${listingsCount} of ${totalBefore}`;
-        bannerClear.href = `/store/test/event?id=${eventId}`;
+        // Build via DOM nodes — filter values are user-controlled URL params
+        // and TEvo data, not safe for innerHTML. Hardened per #57 A1 review.
+        bannerSummary.replaceChildren();
+        const strong = document.createElement("strong");
+        strong.textContent = "Filtered view";
+        bannerSummary.append(
+          strong,
+          document.createTextNode(
+            ` · ${parts.join(" · ")} · showing ${Number(listingsCount) || 0} of ${Number(totalBefore) || 0}`
+          ),
+        );
+        bannerClear.href = `/store/test/event?id=${Number(eventId) || 0}`;
         banner.hidden = false;
       }
 
@@ -321,14 +340,30 @@
           rowLabel.textContent = `Row ${l.row || "—"}`;
           seat.append(sec, rowLabel);
 
-          const splits = (l.splits && l.splits.length ? l.splits.join(", ") : (l.available_quantity || 0));
+          // Build qty + price via DOM — TEvo's splits / available_quantity /
+          // retail_price are server-controlled but we sanitize defensively
+          // per #57 A1 review (DOM-XSS class fixed in main store.js).
+          const splitsLabel = (l.splits && l.splits.length)
+            ? l.splits.filter(s => Number.isFinite(Number(s))).map(s => String(Number(s))).join(", ")
+            : String(Number(l.available_quantity) || 0);
           const qty = document.createElement("div");
           qty.className = "qty";
-          qty.innerHTML = `${l.available_quantity || 0} available<br><span style="font-size:11px">sells in ${splits}</span>`;
+          qty.append(
+            document.createTextNode(`${Number(l.available_quantity) || 0} available`),
+            document.createElement("br"),
+          );
+          const sells = document.createElement("span");
+          sells.style.fontSize = "11px";
+          sells.textContent = `sells in ${splitsLabel}`;
+          qty.append(sells);
 
           const price = document.createElement("div");
           price.className = "price";
-          price.innerHTML = `${fmtMoney(l.retail_price)}<span class="each">each</span>`;
+          price.append(document.createTextNode(fmtMoney(l.retail_price)));
+          const each = document.createElement("span");
+          each.className = "each";
+          each.textContent = "each";
+          price.append(each);
 
           const buy = document.createElement("button");
           buy.className = "buy-btn";
@@ -349,22 +384,26 @@
       // ---- Buy modal ----
       function openBuyModal(listing) {
         const splits = listing.splits && listing.splits.length ? listing.splits : [1, 2, 3, 4];
-        const opts = splits
-          .filter(s => s <= (listing.available_quantity || 999))
+        // Filter splits to finite integers only — defense in depth against
+        // TEvo returning unexpected types in the splits array.
+        const safeSplits = splits
+          .filter(s => Number.isFinite(Number(s)) && Number(s) <= (Number(listing.available_quantity) || 999))
+          .map(s => Math.trunc(Number(s)));
+        const opts = safeSplits
           .map(s => `<option value="${s}">${s}</option>`).join("");
-        const defaultQ = splits[0] || 1;
+        const defaultQ = safeSplits[0] || 1;
         const mb = $("#modalBody");
         mb.innerHTML = `
           <h3>Get tickets</h3>
-          <p style="color:var(--muted);margin:0 0 16px">Section ${listing.section} · Row ${listing.row}</p>
+          <p style="color:var(--muted);margin:0 0 16px">Section ${esc(listing.section)} · Row ${esc(listing.row)}</p>
           <div style="display:flex;justify-content:space-between;align-items:center;margin:8px 0">
             <span>How many?</span>
             <select id="buyQty" style="background:var(--bg);color:var(--text);border:1px solid var(--line);border-radius:6px;padding:6px 10px;font:inherit">${opts}</select>
           </div>
           <div class="receipt">
-            <span class="k">Per ticket</span><span class="v">${fmtMoney(listing.retail_price)}</span>
+            <span class="k">Per ticket</span><span class="v">${esc(fmtMoney(listing.retail_price))}</span>
             <span class="k">Quantity</span><span class="v" id="receiptQty">${defaultQ}</span>
-            <span class="k total">Total</span><span class="v total" id="receiptTotal">${fmtMoney(listing.retail_price * defaultQ)}</span>
+            <span class="k total">Total</span><span class="v total" id="receiptTotal">${esc(fmtMoney(listing.retail_price * defaultQ))}</span>
           </div>
           <button id="confirmBuy" class="buy-btn" style="width:100%;padding:12px">Continue to checkout</button>
           <p style="font-size:11px;color:var(--muted);text-align:center;margin:12px 0 0">
@@ -397,11 +436,11 @@
               <h3>You're set ✓</h3>
               <p style="color:var(--muted);margin:0 0 16px">Demo confirmation — no charge processed.</p>
               <div class="receipt">
-                <span class="k">Section</span><span class="v">${r.section || "—"}</span>
-                <span class="k">Row</span><span class="v">${r.row || "—"}</span>
-                <span class="k">Quantity</span><span class="v">${r.quantity}</span>
-                <span class="k">Per ticket</span><span class="v">${fmtMoney(r.unit_price)}</span>
-                <span class="k total">Total</span><span class="v total">${fmtMoney(r.subtotal)}</span>
+                <span class="k">Section</span><span class="v">${esc(r.section) || "—"}</span>
+                <span class="k">Row</span><span class="v">${esc(r.row) || "—"}</span>
+                <span class="k">Quantity</span><span class="v">${Number(r.quantity) || 0}</span>
+                <span class="k">Per ticket</span><span class="v">${esc(fmtMoney(r.unit_price))}</span>
+                <span class="k total">Total</span><span class="v total">${esc(fmtMoney(r.subtotal))}</span>
               </div>
               <button id="closeOk" class="ghost" style="width:100%">Close</button>
             `;
@@ -430,10 +469,12 @@
           return parts.length ? parts.join(" · ") : "no filters — full inventory";
         })();
         const mb = $("#modalBody");
+        // summary contains user-controlled URL params (zone/section names);
+        // escape it before stitching into innerHTML.
         mb.innerHTML = `
           <h3>Share this view</h3>
-          <p style="color:var(--muted);margin:0 0 12px">${summary} · ${allListings.length} listing${allListings.length === 1 ? "" : "s"}</p>
-          <input id="shareUrl" readonly style="width:100%;background:var(--bg);color:var(--accent-2);border:1px solid var(--line);border-radius:6px;padding:8px 10px;font:12px ui-monospace,monospace;margin-bottom:8px" value="${url.replace(/"/g,"&quot;")}" />
+          <p style="color:var(--muted);margin:0 0 12px">${esc(summary)} · ${Number(allListings.length) || 0} listing${allListings.length === 1 ? "" : "s"}</p>
+          <input id="shareUrl" readonly style="width:100%;background:var(--bg);color:var(--accent-2);border:1px solid var(--line);border-radius:6px;padding:8px 10px;font:12px ui-monospace,monospace;margin-bottom:8px" value="${esc(url)}" />
           <label style="display:flex;gap:10px;align-items:flex-start;cursor:pointer;padding:10px 12px;border:1px solid var(--line);border-radius:8px;margin:8px 0">
             <input type="checkbox" id="useRev" style="margin-top:2px" />
             <span>

--- a/static/store/test/index.html
+++ b/static/store/test/index.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>VibePass — find tickets</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+    </nav>
+
+    <main class="content">
+      <h1>Find tickets to anything we have</h1>
+      <p class="subtitle">Live inventory from our seller account. No middlemen.</p>
+
+      <!-- Hero search — the primary entry point. -->
+      <form id="searchForm" class="row" style="margin: 18px 0 12px">
+        <input id="q" type="search" placeholder="Search artists, teams, venues, cities" autofocus
+               style="flex: 1; padding: 14px 16px; font-size: 15px" />
+        <button type="submit" style="padding: 14px 24px">Search</button>
+      </form>
+
+      <!-- "Find events near me" — sits below the search bar. Browser geolocation
+           prompt only fires on click (no auto-prompt on page load — that's
+           intrusive). Renders up to 10 closest events sorted by distance.
+           Source toggle (hybrid vs supabase) lets us A/B test the two
+           implementations against the same coordinates. -->
+      <div style="margin: 0 0 24px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap">
+        <button id="findNearMe" class="ghost" style="padding: 8px 14px; font-size: 13px">
+          📍 Find events near me
+        </button>
+        <select id="nearMeSource" style="padding: 6px 8px; font-size: 12px; background: var(--panel); color: var(--text); border: 1px solid var(--line); border-radius: 6px">
+          <option value="hybrid" selected>hybrid (TEvo geo + owned filter)</option>
+          <option value="supabase">supabase only (venue_assets)</option>
+          <option value="tevo">TEvo only (debug)</option>
+        </select>
+        <span id="nearMeStatus" style="font-size: 12px; color: var(--muted)"></span>
+      </div>
+
+      <!-- Near-you strip. Hidden until user grants location and we have matches. -->
+      <section id="nearMeSection" hidden style="margin-bottom: 28px">
+        <h2 style="font-size: 14px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin: 0 0 12px">
+          Near you · <span id="nearMeRadius">50 mi</span>
+        </h2>
+        <div id="nearMeCards" class="cards"></div>
+      </section>
+
+      <!-- Featured events — surface upcoming inventory so users have something to click. -->
+      <h2 style="font-size: 14px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin: 0 0 12px">
+        Featured this week
+      </h2>
+      <div id="status" style="color: var(--muted); font-size: 13px; margin-bottom: 12px">Loading…</div>
+      <div id="featured" class="cards"></div>
+
+      <!-- Browse-by callouts -->
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 28px">
+        <a href="/store/test/performer" style="background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; text-decoration: none; color: inherit">
+          <div style="font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px">Browse</div>
+          <div style="font-size: 16px; font-weight: 600; margin-top: 4px">Performers →</div>
+          <div style="font-size: 13px; color: var(--muted); margin-top: 4px">Find a team, artist, or speaker</div>
+        </a>
+        <a href="/store/test/venue" style="background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; text-decoration: none; color: inherit">
+          <div style="font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px">Browse</div>
+          <div style="font-size: 16px; font-weight: 600; margin-top: 4px">Venues →</div>
+          <div style="font-size: 13px; color: var(--muted); margin-top: 4px">Find a stadium, arena, or theater</div>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, fmtMoney, fmtWhen } = Test;
+
+    // Hero search -> hand off to the search page.
+    $("#searchForm").addEventListener("submit", (e) => {
+      e.preventDefault();
+      const q = $("#q").value.trim();
+      location.href = "/store/test/search" + (q ? `?q=${encodeURIComponent(q)}` : "");
+    });
+
+    // "Find events near me" — geolocate on click, fetch /api/store/events/near,
+    // render up to 10 closest events. Permission is requested only when the
+    // button is pressed (no auto-prompt on load).
+    const findBtn = $("#findNearMe");
+    const nearStatus = $("#nearMeStatus");
+    const nearSection = $("#nearMeSection");
+    const nearGrid = $("#nearMeCards");
+    const RADIUS_MILES = 50;
+    $("#nearMeRadius").textContent = RADIUS_MILES + " mi";
+
+    findBtn.addEventListener("click", () => {
+      if (!navigator.geolocation) {
+        nearStatus.textContent = "Your browser doesn't support location.";
+        return;
+      }
+      findBtn.disabled = true;
+      nearStatus.textContent = "Asking for your location…";
+      navigator.geolocation.getCurrentPosition(
+        async (pos) => {
+          const { latitude, longitude } = pos.coords;
+          nearStatus.textContent = "Finding events nearby…";
+          const source = $("#nearMeSource").value || "hybrid";
+          try {
+            const r = await fetch(
+              `/api/store/events/near?lat=${latitude}&lon=${longitude}` +
+              `&within=${RADIUS_MILES}&limit=10&source=${encodeURIComponent(source)}`
+            );
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            const body = await r.json();
+            const events = body.events || [];
+            if (!events.length) {
+              nearStatus.textContent = `No events within ${RADIUS_MILES} miles (${source}). Try searching by artist or team.`;
+              nearSection.hidden = true;
+              findBtn.disabled = false;
+              findBtn.textContent = "📍 Try again";
+              return;
+            }
+            // Render the near-you strip.
+            nearGrid.innerHTML = "";
+            for (const ev of events) {
+              const c = document.createElement("a");
+              c.className = "card";
+              c.href = `/store/test/event?id=${ev.id}`;
+              if (ev.primary_performer_color) {
+                c.style.setProperty("--card-accent", ev.primary_performer_color);
+              }
+              const distLabel = ev.distance_miles != null
+                ? `${ev.distance_miles} mi away`
+                : "distance n/a";
+              c.innerHTML = `
+                <div class="when">${fmtWhen(ev.occurs_at_local)} · ${distLabel}</div>
+                <div class="name">${ev.name || "—"}</div>
+                <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+                <div class="price">${ev.from_price != null ? "from " + fmtMoney(ev.from_price) : ""}</div>
+              `;
+              nearGrid.append(c);
+            }
+            nearSection.hidden = false;
+            const more = (body.total_within_radius || 0) > events.length
+              ? ` (${body.total_within_radius - events.length} more — refine via search)`
+              : "";
+            // Status line shows which source served + helpful debug numbers.
+            const srcLabel = body.source === "hybrid"
+              ? `hybrid · TEvo returned ${body.tevo_candidates ?? "?"} candidates`
+              : body.source === "supabase"
+                ? `supabase · ${body.supabase_candidates ?? "?"} candidates, ${body.missing_coords ?? 0} no-coord`
+                : `${body.source}`;
+            nearStatus.textContent = `${events.length} closest${more} · ${srcLabel}`;
+            findBtn.disabled = false;
+            findBtn.textContent = "📍 Refresh nearby";
+          } catch (e) {
+            nearStatus.textContent = "Couldn't load: " + e.message;
+            findBtn.disabled = false;
+          }
+        },
+        (err) => {
+          // err.code 1 = PERMISSION_DENIED, 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT
+          const msg = err.code === 1
+            ? "Location access denied — you can always search instead."
+            : err.code === 3
+              ? "Location lookup timed out — try again."
+              : "Couldn't get your location.";
+          nearStatus.textContent = msg;
+          findBtn.disabled = false;
+        },
+        { timeout: 10000, maximumAge: 60000 }
+      );
+    });
+
+    // Featured = first ~12 events from the catalog, sorted by date.
+    async function loadFeatured() {
+      try {
+        const r = await fetch("/api/store/events?limit=24");
+        const body = await r.json();
+        const events = body.events || [];
+        $("#status").textContent = events.length
+          ? `${events.length} event${events.length === 1 ? "" : "s"} with tickets available`
+          : "No events with tickets right now. Check back soon.";
+        const grid = $("#featured");
+        grid.innerHTML = "";
+        for (const ev of events.slice(0, 12)) {
+          const c = document.createElement("a");
+          c.className = "card";
+          c.href = `/store/test/event?id=${ev.id}`;
+          if (ev.primary_performer_color) {
+            c.style.setProperty("--card-accent", ev.primary_performer_color);
+          }
+          c.innerHTML = `
+            <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
+            <div class="name">${ev.name || "—"}</div>
+            <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+            <div class="price">from ${fmtMoney(ev.from_price)}</div>
+          `;
+          grid.append(c);
+        }
+      } catch (e) {
+        $("#status").textContent = "Couldn't load events. " + e.message;
+        $("#status").style.color = "var(--bad)";
+      }
+    }
+    loadFeatured();
+  </script>
+</body>
+</html>

--- a/static/store/test/performer.html
+++ b/static/store/test/performer.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Performers — VibePass</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+    </nav>
+
+    <main class="content">
+      <h1>Browse by performer</h1>
+      <p class="subtitle">Type an artist or team. Pick one to see their upcoming events.</p>
+
+      <div class="row" style="margin: 16px 0 16px">
+        <input id="q" type="search" placeholder="e.g. Knicks, Yankees, Taylor Swift" autofocus style="flex: 1; padding: 12px 14px; font-size: 15px" />
+      </div>
+
+      <div id="status" style="color: var(--muted); font-size: 13px; margin-bottom: 12px"></div>
+
+      <!-- Matching performers as chips -->
+      <div id="performersRow" hidden style="margin-bottom: 24px">
+        <div class="filter-label">Performers</div>
+        <div id="performerChips" class="chip-group" style="margin-top: 8px"></div>
+      </div>
+
+      <!-- Events for the selected performer (or all matching events). -->
+      <div id="eventsHeader" style="font-size: 14px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px"></div>
+      <div id="cards" class="cards"></div>
+
+      <div id="empty" class="empty-state" hidden>
+        <h2>No performers match</h2>
+        <p>Try a broader keyword. We only show performers with tickets currently available.</p>
+      </div>
+    </main>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, $$, fmtMoney, fmtWhen } = Test;
+
+    // All events with owned inventory — fetched once, filtered client-side
+    // since the user can't actually type a performer ID. Performers and the
+    // events for the selected performer all derive from this single dataset.
+    let allEvents = [];
+    let selectedPerformerId = null;
+
+    function aggregatePerformers(events) {
+      // Group events by primary performer; surface name + count + sample logo.
+      const map = new Map();
+      for (const e of events) {
+        const id = e.primary_performer_id;
+        if (!id) continue;
+        const existing = map.get(id);
+        if (existing) {
+          existing.events.push(e);
+        } else {
+          map.set(id, {
+            id,
+            name: e.primary_performer_name || `Performer ${id}`,
+            logo: e.primary_performer_logo,
+            color: e.primary_performer_color,
+            events: [e],
+          });
+        }
+      }
+      return [...map.values()].sort((a, b) => b.events.length - a.events.length);
+    }
+
+    function renderPerformerChips(performers) {
+      const row = $("#performersRow");
+      const chipsEl = $("#performerChips");
+      chipsEl.innerHTML = "";
+      if (!performers.length) {
+        row.hidden = true;
+        return;
+      }
+      row.hidden = false;
+      for (const p of performers.slice(0, 30)) {
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.className = "filter-chip" + (p.id === selectedPerformerId ? " on" : "");
+        chip.dataset.value = p.id;
+        chip.textContent = `${p.name} (${p.events.length})`;
+        chip.addEventListener("click", () => {
+          selectedPerformerId = (selectedPerformerId === p.id) ? null : p.id;
+          renderPerformerChips(performers);
+          renderEventCards(currentEvents());
+        });
+        chipsEl.append(chip);
+      }
+    }
+
+    function renderEventCards(events) {
+      const grid = $("#cards");
+      grid.innerHTML = "";
+      const header = $("#eventsHeader");
+      if (!events.length) {
+        header.textContent = "";
+        return;
+      }
+      const sel = selectedPerformerId
+        ? events[0].primary_performer_name
+        : null;
+      header.textContent = sel
+        ? `${sel} · ${events.length} upcoming`
+        : `${events.length} event${events.length === 1 ? "" : "s"}`;
+      for (const ev of events) {
+        const c = document.createElement("a");
+        c.className = "card";
+        c.href = `/store/test/event?id=${ev.id}`;
+        if (ev.primary_performer_color) {
+          c.style.setProperty("--card-accent", ev.primary_performer_color);
+        }
+        c.innerHTML = `
+          <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
+          <div class="name">${ev.name || "—"}</div>
+          <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+          <div class="price">from ${fmtMoney(ev.from_price)}</div>
+        `;
+        grid.append(c);
+      }
+    }
+
+    // Events visible right now: filtered by query AND optionally by selected performer.
+    function currentEvents() {
+      const q = ($("#q").value || "").trim().toLowerCase();
+      const matchQuery = (e) => {
+        if (!q) return true;
+        const hay = [e.name, e.venue_name, e.venue_location, e.primary_performer_name]
+          .filter(Boolean).join(" ").toLowerCase();
+        return hay.includes(q);
+      };
+      let events = allEvents.filter(matchQuery);
+      if (selectedPerformerId) {
+        events = events.filter(e => e.primary_performer_id === selectedPerformerId);
+      }
+      return events;
+    }
+
+    function refresh() {
+      const events = currentEvents();
+      const performers = aggregatePerformers(events);
+      const empty = !events.length;
+      $("#empty").hidden = !empty;
+      renderPerformerChips(performers);
+      renderEventCards(selectedPerformerId
+        ? events  // already filtered to selected performer
+        : events.slice(0, 60));  // cap when no specific performer selected
+    }
+
+    async function load() {
+      $("#status").textContent = "Loading…";
+      try {
+        const r = await fetch("/api/store/events?limit=500");
+        const body = await r.json();
+        allEvents = body.events || [];
+        $("#status").textContent = `${aggregatePerformers(allEvents).length} performers with tickets available`;
+        refresh();
+      } catch (e) {
+        $("#status").textContent = "Couldn't load. " + e.message;
+        $("#status").style.color = "var(--bad)";
+      }
+    }
+
+    $("#q").addEventListener("input", () => {
+      // Reset selection when the query changes — user is searching anew.
+      selectedPerformerId = null;
+      refresh();
+    });
+
+    load();
+  </script>
+</body>
+</html>

--- a/static/store/test/search.html
+++ b/static/store/test/search.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Search — VibePass</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+    </nav>
+
+    <main class="content">
+      <h1>Find tickets</h1>
+      <p class="subtitle">Search by artist, team, venue, or city.</p>
+
+      <div class="row" style="margin: 16px 0 24px">
+        <input id="q" type="search" placeholder="e.g. Knicks, Madison Square Garden, Yankees" autofocus style="flex: 1; padding: 12px 14px; font-size: 15px" />
+        <button id="go" style="padding: 12px 22px">Search</button>
+      </div>
+
+      <div id="status" style="color: var(--muted); font-size: 13px; margin-bottom: 12px"></div>
+
+      <div id="cards" class="cards"></div>
+
+      <div id="empty" class="empty-state" hidden>
+        <h2>No matches</h2>
+        <p>Try a broader keyword, or browse <a href="/store/test/performer" style="color: var(--accent-2)">performers</a> or <a href="/store/test/venue" style="color: var(--accent-2)">venues</a> instead.</p>
+      </div>
+    </main>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, fmtMoney, fmtWhen } = Test;
+
+    let allEvents = [];
+
+    function renderCards(events) {
+      const grid = $("#cards");
+      grid.innerHTML = "";
+      $("#status").textContent = events.length
+        ? `${events.length} event${events.length === 1 ? "" : "s"} available`
+        : "";
+      if (!events.length) {
+        $("#empty").hidden = false;
+        return;
+      }
+      $("#empty").hidden = true;
+      for (const ev of events) {
+        const c = document.createElement("a");
+        c.className = "card";
+        c.href = `/store/test/event?id=${ev.id}`;
+        if (ev.primary_performer_color) {
+          c.style.setProperty("--card-accent", ev.primary_performer_color);
+        }
+        c.innerHTML = `
+          <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
+          <div class="name">${ev.name || "—"}</div>
+          <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+          <div class="price">from ${fmtMoney(ev.from_price)}</div>
+        `;
+        grid.append(c);
+      }
+    }
+
+    function filterLocal(q) {
+      const needle = (q || "").trim().toLowerCase();
+      if (!needle) return renderCards(allEvents);
+      const filtered = allEvents.filter(e => {
+        const hay = [e.name, e.venue_name, e.venue_location, e.primary_performer_name]
+          .filter(Boolean).join(" ").toLowerCase();
+        return hay.includes(needle);
+      });
+      renderCards(filtered);
+    }
+
+    async function load() {
+      $("#status").textContent = "Loading available events…";
+      try {
+        const r = await fetch("/api/store/events?limit=500");
+        const body = await r.json();
+        allEvents = body.events || [];
+        const initialQ = new URLSearchParams(location.search).get("q") || "";
+        if (initialQ) {
+          $("#q").value = initialQ;
+          filterLocal(initialQ);
+        } else {
+          renderCards(allEvents);
+        }
+      } catch (e) {
+        $("#status").textContent = "Couldn't load events. " + e.message;
+        $("#status").style.color = "var(--bad)";
+      }
+    }
+
+    $("#go").addEventListener("click", () => filterLocal($("#q").value));
+    $("#q").addEventListener("input", () => filterLocal($("#q").value));
+    $("#q").addEventListener("keydown", (e) => { if (e.key === "Enter") filterLocal($("#q").value); });
+
+    load();
+  </script>
+</body>
+</html>

--- a/static/store/test/share.html
+++ b/static/store/test/share.html
@@ -109,8 +109,15 @@
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+        // Build the anchor via DOM — res.url is a server-issued path but
+        // we defensively escape per #57 A1 review.
         const fullUrl = `${location.origin}${res.url}`;
-        $("#newUrl").innerHTML = `<a href="${res.url}" target="_blank">${fullUrl}</a>`;
+        const anchor = document.createElement("a");
+        anchor.href = res.url;
+        anchor.target = "_blank";
+        anchor.rel = "noopener";
+        anchor.textContent = fullUrl;
+        $("#newUrl").replaceChildren(anchor);
         $("#createStatus").className = "pill live";
         $("#createStatus").textContent = "active";
         $("#createJson").innerHTML = fmtJson(res);
@@ -230,7 +237,12 @@
         }
         list.append(tbl);
       } catch (e) {
-        $("#list").innerHTML = `<p style="color: var(--bad)">error: ${e.message}</p>`;
+        // Build via DOM — error messages can echo attacker-controlled data
+        // back from the server. Per #57 A1 review.
+        const p = document.createElement("p");
+        p.style.color = "var(--bad)";
+        p.textContent = `error: ${e.message}`;
+        $("#list").replaceChildren(p);
       }
     }
 

--- a/static/store/test/share.html
+++ b/static/store/test/share.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Share Links — Wiring Test</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass · wiring test</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Start</h3>
+      <a href="/store/test"><span class="num"></span> Index</a>
+      <h3>Workflows</h3>
+      <a href="/store/test/search"><span class="num">04.</span> Comprehensive Search</a>
+      <a href="/store/test/performer"><span class="num">06.</span> Performer Landing</a>
+      <a href="/store/test/venue"><span class="num">07.</span> Venue Landing</a>
+      <a href="/store/test/event"><span class="num">08.</span> Event Landing</a>
+      <h3>Storefront</h3>
+      <a href="/store/test/share"><span class="num">▸</span> Share Links</a>
+    </nav>
+
+    <main class="content">
+      <h1>Share Links</h1>
+      <p class="subtitle">
+        Storefront-specific. Revocable filtered links live at
+        <code>/s/{id}</code>; resolve to the same event-detail UI with the
+        saved filter set applied server-side. Backed by the
+        <code>share_links</code> table + <code>bump_share_view()</code> RPC.
+      </p>
+
+      <div class="panel">
+        <h3>Create</h3>
+        <div class="row">
+          <input id="event_id" type="number" placeholder="event id" />
+          <input id="zones" type="text" placeholder="zones (CSV, optional)" style="max-width: 200px" />
+          <input id="maxP" type="number" placeholder="max $" style="max-width: 90px" />
+          <input id="minQty" type="number" placeholder="min qty" style="max-width: 90px" />
+          <input id="note" type="text" placeholder="note (optional)" />
+          <select id="ttl" style="max-width: 140px">
+            <option value="">never expires</option>
+            <option value="1">1 day</option>
+            <option value="7" selected>7 days</option>
+            <option value="30">30 days</option>
+            <option value="90">90 days</option>
+          </select>
+          <button id="create">Create link</button>
+        </div>
+        <div class="meta">
+          <span>url: <strong id="newUrl">—</strong></span>
+          <span>status: <span id="createStatus" class="pill">—</span></span>
+        </div>
+        <pre id="createJson" class="json">fill in event id (and any filters) then click Create</pre>
+      </div>
+
+      <div class="panel">
+        <h3>Active links</h3>
+        <div class="row">
+          <label style="margin: 0; display: flex; gap: 6px; align-items: center; text-transform: none; letter-spacing: 0;">
+            <input type="checkbox" id="includeInactive" /> include revoked &amp; expired
+          </label>
+          <button id="refresh" class="ghost">Refresh</button>
+        </div>
+        <div id="list" style="margin-top: 12px"></div>
+      </div>
+
+      <div class="panel">
+        <h3>Activity</h3>
+        <div id="log" class="console"></div>
+      </div>
+
+      <nav class="docnav">
+        <a class="prev" href="/store/test/event"><span class="label">Previous</span>08. Event Landing</a>
+        <a class="next" href="/store/test"><span class="label">Next</span>Index</a>
+      </nav>
+    </main>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, fmtJson, api, log } = Test;
+
+    async function create() {
+      const event_id = Number($("#event_id").value);
+      if (!event_id) { log("event_id required", "err"); return; }
+      const filters = {};
+      const z = $("#zones").value.trim();
+      if (z) filters.zones = z.split(",").map((x) => x.trim()).filter(Boolean);
+      const mx = $("#maxP").value;
+      if (mx) filters.max_price = Number(mx);
+      const mq = $("#minQty").value;
+      if (mq) filters.min_qty = Number(mq);
+      const note = $("#note").value.trim() || undefined;
+      const ttl = $("#ttl").value;
+      const body = {
+        event_id,
+        filters,
+        note,
+        expires_in_days: ttl ? Number(ttl) : undefined,
+      };
+      try {
+        const { body: res } = await api("/api/store/share", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const fullUrl = `${location.origin}${res.url}`;
+        $("#newUrl").innerHTML = `<a href="${res.url}" target="_blank">${fullUrl}</a>`;
+        $("#createStatus").className = "pill live";
+        $("#createStatus").textContent = "active";
+        $("#createJson").innerHTML = fmtJson(res);
+        loadList();  // refresh list to show new entry
+      } catch (e) {
+        $("#createStatus").className = "pill err";
+        $("#createStatus").textContent = "error";
+        $("#createJson").innerHTML = fmtJson({ error: e.message });
+      }
+    }
+
+    function statusPill(s) {
+      if (s.revoked_at) return '<span class="pill err">revoked</span>';
+      if (s.expires_at) {
+        const exp = new Date(s.expires_at);
+        if (!isNaN(exp.getTime()) && exp <= new Date()) return '<span class="pill err">expired</span>';
+        return `<span class="pill live">active</span> <span style="color: var(--muted); font-size: 11px">until ${exp.toLocaleDateString()}</span>`;
+      }
+      return '<span class="pill live">active</span>';
+    }
+
+    function fmtFilters(f) {
+      if (!f) return "(none)";
+      const parts = [];
+      if (f.zones && f.zones.length) parts.push(`zones: ${f.zones.join(", ")}`);
+      if (f.section && f.section.length) parts.push(`section: ${f.section.join(", ")}`);
+      if (f.min_price != null) parts.push(`≥ $${f.min_price}`);
+      if (f.max_price != null) parts.push(`≤ $${f.max_price}`);
+      if (f.min_qty != null) parts.push(`${f.min_qty}+ seats`);
+      return parts.length ? parts.join(" · ") : "(none)";
+    }
+
+    async function loadList() {
+      const inc = $("#includeInactive").checked;
+      try {
+        const { body } = await api(`/api/store/shares?include_inactive=${inc}`);
+        const list = $("#list");
+        list.innerHTML = "";
+        if (!body.shares || !body.shares.length) {
+          list.innerHTML = '<p style="color: var(--muted)">no share links yet</p>';
+          return;
+        }
+        const tbl = document.createElement("div");
+        tbl.style.display = "grid";
+        tbl.style.gridTemplateColumns = "auto 1fr 1fr 60px 130px 100px";
+        tbl.style.gap = "8px 14px";
+        tbl.style.fontSize = "13px";
+        tbl.style.alignItems = "center";
+        tbl.innerHTML = `
+          <div style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:1px">LINK</div>
+          <div style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:1px">EVENT</div>
+          <div style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:1px">FILTERS</div>
+          <div style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:1px">VIEWS</div>
+          <div style="font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:1px">STATUS</div>
+          <div></div>
+        `;
+        for (const s of body.shares) {
+          const link = document.createElement("a");
+          link.href = s.url;
+          link.target = "_blank";
+          link.style.fontFamily = "ui-monospace, monospace";
+          link.style.fontSize = "12px";
+          link.textContent = `/s/${s.id}`;
+
+          const ev = document.createElement("a");
+          ev.href = `/store/test/event?id=${s.event_id}`;
+          ev.textContent = `#${s.event_id}`;
+
+          const f = document.createElement("span");
+          f.style.color = "var(--muted)";
+          f.textContent = fmtFilters(s.filters);
+
+          const views = document.createElement("span");
+          views.textContent = s.view_count || 0;
+
+          const status = document.createElement("span");
+          status.innerHTML = statusPill(s);
+
+          const actions = document.createElement("div");
+          actions.style.display = "flex";
+          actions.style.gap = "6px";
+          actions.style.justifyContent = "flex-end";
+
+          const copyBtn = document.createElement("button");
+          copyBtn.className = "ghost";
+          copyBtn.style.padding = "4px 8px";
+          copyBtn.style.fontSize = "11px";
+          copyBtn.textContent = "copy";
+          copyBtn.onclick = async () => {
+            try {
+              await navigator.clipboard.writeText(`${location.origin}${s.url}`);
+              copyBtn.textContent = "copied ✓";
+              setTimeout(() => (copyBtn.textContent = "copy"), 1200);
+            } catch {}
+          };
+          actions.append(copyBtn);
+
+          if (!s.revoked_at) {
+            const rev = document.createElement("button");
+            rev.className = "ghost";
+            rev.style.padding = "4px 8px";
+            rev.style.fontSize = "11px";
+            rev.textContent = "revoke";
+            rev.onclick = async () => {
+              if (!confirm(`Revoke /s/${s.id}?`)) return;
+              try {
+                await api(`/api/store/share/${encodeURIComponent(s.id)}`, { method: "DELETE" });
+                loadList();
+              } catch (e) {
+                alert(e.message);
+              }
+            };
+            actions.append(rev);
+          }
+
+          tbl.append(link, ev, f, views, status, actions);
+        }
+        list.append(tbl);
+      } catch (e) {
+        $("#list").innerHTML = `<p style="color: var(--bad)">error: ${e.message}</p>`;
+      }
+    }
+
+    $("#create").addEventListener("click", create);
+    $("#refresh").addEventListener("click", loadList);
+    $("#includeInactive").addEventListener("change", loadList);
+    loadList();
+  </script>
+</body>
+</html>

--- a/static/store/test/test.css
+++ b/static/store/test/test.css
@@ -1,0 +1,504 @@
+/* Shared layout + components for the multi-page wiring test harness.
+   Mirrors the evo-docs structure: sidebar TOC, prev/next nav at the bottom
+   of every page, monospace JSON output, dark theme. */
+
+:root {
+  --bg: #0e0f12;
+  --panel: #16181d;
+  --panel-2: #1d2026;
+  --line: #2a2d35;
+  --text: #eef0f4;
+  --muted: #9aa0a6;
+  --accent: #ff5c2a;
+  --accent-2: #ffa066;
+  --good: #4ade80;
+  --warn: #facc15;
+  --bad: #ef4444;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  min-height: 100vh;
+}
+a { color: var(--accent-2); text-decoration: none; }
+a:hover { color: var(--accent); }
+code { font: 12px ui-monospace, "SF Mono", Consolas, monospace; color: var(--accent-2); }
+
+/* --- Top bar --- */
+.topbar {
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+  padding: 12px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.brand {
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  color: var(--accent);
+  text-decoration: none;
+}
+.brand::before { content: "◤ "; color: var(--accent-2); }
+.pill {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.pill.live { background: rgba(74,222,128,0.1); color: var(--good); border-color: rgba(74,222,128,0.3); }
+.pill.cache { background: rgba(250,204,21,0.1); color: var(--warn); border-color: rgba(250,204,21,0.3); }
+.pill.err { background: rgba(239,68,68,0.1); color: var(--bad); border-color: rgba(239,68,68,0.3); }
+
+/* --- Layout: sidebar + main --- */
+.layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: calc(100vh - 53px);
+}
+.sidebar {
+  background: var(--panel);
+  border-right: 1px solid var(--line);
+  padding: 18px 0;
+}
+.sidebar h3 {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+  margin: 18px 18px 6px;
+  font-weight: 700;
+}
+.sidebar h3:first-child { margin-top: 0; }
+.sidebar a {
+  display: block;
+  padding: 7px 18px;
+  color: var(--text);
+  font-size: 13px;
+  border-left: 2px solid transparent;
+}
+.sidebar a:hover { background: rgba(255,255,255,0.03); color: var(--accent-2); }
+.sidebar a.current {
+  background: rgba(255,92,42,0.08);
+  border-left-color: var(--accent);
+  color: var(--accent-2);
+  font-weight: 600;
+}
+.sidebar a .num {
+  display: inline-block;
+  width: 22px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+main.content {
+  padding: 24px 32px 48px;
+  max-width: 980px;
+}
+main.content h1 {
+  margin: 0 0 4px;
+  font-size: 22px;
+  font-weight: 700;
+}
+main.content .subtitle {
+  color: var(--muted);
+  margin: 0 0 20px;
+  font-size: 13px;
+}
+main.content h2 {
+  margin: 28px 0 8px;
+  font-size: 16px;
+  font-weight: 700;
+}
+main.content p { color: var(--muted); }
+main.content p strong { color: var(--text); }
+
+/* --- Form controls --- */
+input, select, button, textarea {
+  font: inherit;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); }
+button {
+  background: var(--accent);
+  border-color: var(--accent);
+  cursor: pointer;
+  font-weight: 600;
+}
+button:hover { background: var(--accent-2); }
+button:disabled { opacity: 0.4; cursor: not-allowed; }
+button.ghost { background: transparent; border-color: var(--line); color: var(--text); }
+button.ghost:hover { border-color: var(--accent); background: rgba(255,92,42,0.06); }
+
+label { display: block; font-size: 11px; color: var(--muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 1px; }
+
+.row { display: flex; gap: 8px; align-items: end; flex-wrap: wrap; }
+.row > * { flex: 0 0 auto; }
+.row > input { flex: 1; min-width: 180px; }
+
+/* --- Panels --- */
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+.panel h3 {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.meta {
+  font-size: 12px;
+  color: var(--muted);
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding-top: 10px;
+  margin-top: 10px;
+  border-top: 1px solid var(--line);
+}
+.meta strong { color: var(--text); font-weight: 600; }
+
+/* --- JSON output --- */
+pre.json {
+  background: #0a0b0e;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 12px;
+  font: 11px/1.45 ui-monospace, "SF Mono", Consolas, monospace;
+  max-height: 320px;
+  overflow: auto;
+  margin: 12px 0 0;
+  color: #cfd2d8;
+}
+pre.json .key { color: #7cb5ff; }
+pre.json .str { color: #a8d785; }
+pre.json .num { color: #ffb86c; }
+pre.json .bool { color: #ff79c6; }
+pre.json .null { color: var(--muted); }
+
+/* --- Activity console --- */
+.console {
+  background: #0a0b0e;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: 11px/1.5 ui-monospace, monospace;
+  max-height: 220px;
+  overflow-y: auto;
+  color: var(--muted);
+}
+.console .line { white-space: pre-wrap; padding: 1px 0; word-break: break-all; }
+.console .line.ok { color: var(--good); }
+.console .line.err { color: var(--bad); }
+
+/* --- Cards (catalog/search results) --- */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+.cards .card {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px;
+  cursor: pointer;
+  transition: border-color .12s;
+}
+.cards .card:hover { border-color: var(--accent); }
+.cards .card .when { font-size: 11px; color: var(--muted); }
+.cards .card .name { font-weight: 600; margin: 4px 0; font-size: 13px; line-height: 1.3; }
+.cards .card .where { font-size: 12px; color: var(--muted); }
+.cards .card .price { font-size: 13px; color: var(--accent); margin-top: 6px; }
+
+/* --- Consumer-style listings (rows with Buy button) --- */
+.listing-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+.listing-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  gap: 18px;
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  transition: border-color .12s;
+}
+.listing-row:hover { border-color: var(--accent); }
+.listing-row .seat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.listing-row .seat .section {
+  font-weight: 700;
+  font-size: 14px;
+}
+.listing-row .seat .row-label {
+  font-size: 12px;
+  color: var(--muted);
+}
+.listing-row .seat .zone-tag {
+  display: inline-block;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(74,158,255,0.12);
+  color: #7cb5ff;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-left: 6px;
+}
+.listing-row .qty {
+  font-size: 13px;
+  color: var(--muted);
+  text-align: right;
+  white-space: nowrap;
+}
+.listing-row .price {
+  font-weight: 800;
+  font-size: 18px;
+  color: var(--accent-2);
+  text-align: right;
+  min-width: 90px;
+}
+.listing-row .price .each {
+  display: block;
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.listing-row .buy-btn {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font: 600 13px/1 system-ui;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.listing-row .buy-btn:hover { background: var(--accent-2); }
+.listing-row .public-notes {
+  grid-column: 1 / -1;
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+  padding-top: 4px;
+  border-top: 1px dashed var(--line);
+  margin-top: 4px;
+}
+
+/* --- Filter bar (inline filters above listings) --- */
+.filter-bar {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.filter-row.inline > * { flex-shrink: 0; }
+.filter-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+  margin-right: 4px;
+}
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  flex: 1;
+  min-width: 0;
+}
+.filter-chip {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+.filter-chip:hover { border-color: var(--accent-2); }
+.filter-chip.on {
+  background: rgba(255,92,42,0.15);
+  border-color: var(--accent);
+  color: var(--accent-2);
+}
+
+/* --- Modal (buy confirmation) --- */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+}
+.modal-card {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 480px;
+  width: 100%;
+  position: relative;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+}
+.modal-card h3 { margin: 0 0 4px; font-size: 18px; }
+.modal-card .close {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 24px;
+  cursor: pointer;
+}
+.modal-card .close:hover { color: var(--text); }
+.receipt {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 16px;
+  margin: 16px 0;
+  font-size: 14px;
+}
+.receipt .k { color: var(--muted); }
+.receipt .v { text-align: right; font-weight: 600; }
+.receipt .total { color: var(--accent-2); font-size: 18px; }
+
+/* --- Event header (StubHub-style) --- */
+.event-hero {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+.event-hero h1 { margin: 0 0 6px; font-size: 22px; font-weight: 700; }
+.event-hero .meta { color: var(--muted); font-size: 14px; }
+.event-hero .meta .dot { margin: 0 6px; opacity: 0.5; }
+.event-hero .actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.event-hero .freshness {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.event-hero .freshness.live {
+  color: var(--good);
+  border-color: rgba(74,222,128,0.3);
+  background: rgba(74,222,128,0.08);
+}
+.event-hero .freshness.cached {
+  color: var(--warn);
+  border-color: rgba(250,204,21,0.3);
+  background: rgba(250,204,21,0.08);
+}
+
+/* --- Banner (filtered/shared view) --- */
+.banner {
+  background: rgba(255,160,102,0.1);
+  border: 1px solid rgba(255,160,102,0.3);
+  color: var(--accent-2);
+  padding: 10px 14px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.banner a {
+  color: var(--accent-2);
+  text-decoration: underline;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* --- Empty state --- */
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+  color: var(--muted);
+}
+.empty-state h2 { color: var(--text); font-size: 18px; margin: 0 0 8px; }
+.empty-state p { margin: 0 0 16px; }
+.empty-state a {
+  display: inline-block;
+  padding: 10px 20px;
+  background: var(--accent);
+  color: white;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.empty-state a:hover { background: var(--accent-2); }
+
+/* --- Prev/Next nav (bottom of every page) --- */
+.docnav {
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
+.docnav .prev::before { content: "← "; color: var(--muted); }
+.docnav .next::after { content: " →"; color: var(--muted); }
+.docnav .label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 1px; display: block; margin-bottom: 2px; }

--- a/static/store/test/test.js
+++ b/static/store/test/test.js
@@ -1,0 +1,99 @@
+/* Shared helpers for the multi-page wiring test harness.
+   Each page imports this and uses Test.* utilities. */
+(function () {
+  "use strict";
+
+  const $ = (s, root = document) => root.querySelector(s);
+  const $$ = (s, root = document) => Array.from(root.querySelectorAll(s));
+
+  function fmtMoney(v) {
+    if (v == null || isNaN(Number(v))) return "—";
+    return "$" + Number(v).toLocaleString(undefined, { maximumFractionDigits: 0 });
+  }
+
+  function fmtWhen(iso) {
+    if (!iso) return "";
+    const clean = String(iso).endsWith("Z") ? String(iso).slice(0, -1) : iso;
+    const d = new Date(clean);
+    if (isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+      + " " + d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  }
+
+  function fmtJson(v) {
+    const json = JSON.stringify(v, null, 2) || "";
+    return json
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+      .replace(/"([^"]+)":/g, '<span class="key">"$1":</span>')
+      .replace(/: "([^"]*)"/g, ': <span class="str">"$1"</span>')
+      .replace(/: (true|false)/g, ': <span class="bool">$1</span>')
+      .replace(/: (null)/g, ': <span class="null">$1</span>')
+      .replace(/: (-?\d+\.?\d*)/g, ': <span class="num">$1</span>');
+  }
+
+  // Activity log — adds to #log if present on the page.
+  function log(msg, cls) {
+    const el = $("#log");
+    if (!el) return;
+    const ts = new Date().toLocaleTimeString();
+    const line = document.createElement("div");
+    line.className = "line" + (cls ? " " + cls : "");
+    line.textContent = `[${ts}]  ${msg}`;
+    el.append(line);
+    el.scrollTop = el.scrollHeight;
+  }
+
+  // Minimal fetch wrapper with timing + auto-log + JSON parsing.
+  async function api(path, init) {
+    const t0 = performance.now();
+    let res, body, err;
+    try {
+      res = await fetch(path, init);
+      const text = await res.text();
+      try { body = JSON.parse(text); } catch { body = text; }
+      if (!res.ok) {
+        err = (body && (body.detail || body.error)) || text || `HTTP ${res.status}`;
+      }
+    } catch (e) {
+      err = e.message;
+    }
+    const dt = Math.round(performance.now() - t0);
+    const status = res ? res.status : "ERR";
+    log(
+      `${(init && init.method) || "GET"} ${path} → ${status} (${dt}ms)${err ? ' ' + err : ''}`,
+      err ? "err" : "ok"
+    );
+    if (err) throw new Error(err);
+    return { body, dt, status };
+  }
+
+  // Highlight the active sidebar link based on the current path.
+  function markCurrentNav() {
+    const path = location.pathname;
+    for (const a of $$(".sidebar a")) {
+      if (a.getAttribute("href") === path) a.classList.add("current");
+    }
+  }
+
+  // Boot — fill the server-env pill, mark sidebar.
+  async function boot() {
+    markCurrentNav();
+    const envEl = $("#serverEnv");
+    if (envEl) {
+      try {
+        const r = await fetch("/api/public/config");
+        const cfg = await r.json();
+        const env = cfg && cfg.supabase_url
+          ? new URL(cfg.supabase_url).hostname.split(".")[0]
+          : "?";
+        envEl.textContent = `supabase: ${env}`;
+      } catch {
+        envEl.textContent = "config unreachable";
+        envEl.className = "pill err";
+      }
+    }
+  }
+
+  window.Test = { $, $$, fmtMoney, fmtWhen, fmtJson, log, api, boot };
+  document.addEventListener("DOMContentLoaded", boot);
+})();

--- a/static/store/test/venue.html
+++ b/static/store/test/venue.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Venues — VibePass</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+    </nav>
+
+    <main class="content">
+      <h1>Browse by venue</h1>
+      <p class="subtitle">Type a venue or city. Pick one to see what's coming up there.</p>
+
+      <div class="row" style="margin: 16px 0 16px">
+        <input id="q" type="search" placeholder="e.g. Madison Square Garden, Yankee Stadium, NYC" autofocus style="flex: 1; padding: 12px 14px; font-size: 15px" />
+      </div>
+
+      <div id="status" style="color: var(--muted); font-size: 13px; margin-bottom: 12px"></div>
+
+      <div id="venuesRow" hidden style="margin-bottom: 24px">
+        <div class="filter-label">Venues</div>
+        <div id="venueChips" class="chip-group" style="margin-top: 8px"></div>
+      </div>
+
+      <div id="eventsHeader" style="font-size: 14px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px"></div>
+      <div id="cards" class="cards"></div>
+
+      <div id="empty" class="empty-state" hidden>
+        <h2>No venues match</h2>
+        <p>Try a broader keyword or city. We only show venues with tickets currently available.</p>
+      </div>
+    </main>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, $$, fmtMoney, fmtWhen } = Test;
+
+    let allEvents = [];
+    let selectedVenueKey = null;  // composite "name|location" since venue_id isn't on the catalog row
+
+    // The catalog response doesn't include venue_id directly (it's nested
+    // under events.venue_id, which we surface via /api/store/events?venue_id=X
+    // but not in the response payload). For chip resolution we fall back
+    // to grouping by (venue_name, venue_location) and matching client-side.
+    function venueKey(e) {
+      return [e.venue_name, e.venue_location].filter(Boolean).join("|") || null;
+    }
+
+    function aggregateVenues(events) {
+      const map = new Map();
+      for (const e of events) {
+        const key = venueKey(e);
+        if (!key) continue;
+        const existing = map.get(key);
+        if (existing) {
+          existing.events.push(e);
+        } else {
+          map.set(key, {
+            key,
+            name: e.venue_name || "",
+            location: e.venue_location || "",
+            events: [e],
+          });
+        }
+      }
+      return [...map.values()].sort((a, b) => b.events.length - a.events.length);
+    }
+
+    function renderVenueChips(venues) {
+      const row = $("#venuesRow");
+      const chipsEl = $("#venueChips");
+      chipsEl.innerHTML = "";
+      if (!venues.length) {
+        row.hidden = true;
+        return;
+      }
+      row.hidden = false;
+      for (const v of venues.slice(0, 30)) {
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.className = "filter-chip" + (v.key === selectedVenueKey ? " on" : "");
+        chip.dataset.value = v.key;
+        const label = v.location ? `${v.name} · ${v.location}` : v.name;
+        chip.textContent = `${label} (${v.events.length})`;
+        chip.addEventListener("click", () => {
+          selectedVenueKey = (selectedVenueKey === v.key) ? null : v.key;
+          renderVenueChips(venues);
+          renderEventCards(currentEvents());
+        });
+        chipsEl.append(chip);
+      }
+    }
+
+    function renderEventCards(events) {
+      const grid = $("#cards");
+      grid.innerHTML = "";
+      const header = $("#eventsHeader");
+      if (!events.length) {
+        header.textContent = "";
+        return;
+      }
+      const sel = selectedVenueKey
+        ? `${events[0].venue_name}${events[0].venue_location ? " · " + events[0].venue_location : ""}`
+        : null;
+      header.textContent = sel
+        ? `${sel} · ${events.length} upcoming`
+        : `${events.length} event${events.length === 1 ? "" : "s"}`;
+      for (const ev of events) {
+        const c = document.createElement("a");
+        c.className = "card";
+        c.href = `/store/test/event?id=${ev.id}`;
+        if (ev.primary_performer_color) {
+          c.style.setProperty("--card-accent", ev.primary_performer_color);
+        }
+        c.innerHTML = `
+          <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
+          <div class="name">${ev.name || "—"}</div>
+          <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+          <div class="price">from ${fmtMoney(ev.from_price)}</div>
+        `;
+        grid.append(c);
+      }
+    }
+
+    function currentEvents() {
+      const q = ($("#q").value || "").trim().toLowerCase();
+      const matchQuery = (e) => {
+        if (!q) return true;
+        const hay = [e.name, e.venue_name, e.venue_location, e.primary_performer_name]
+          .filter(Boolean).join(" ").toLowerCase();
+        return hay.includes(q);
+      };
+      let events = allEvents.filter(matchQuery);
+      if (selectedVenueKey) {
+        events = events.filter(e => venueKey(e) === selectedVenueKey);
+      }
+      return events;
+    }
+
+    function refresh() {
+      const events = currentEvents();
+      const venues = aggregateVenues(events);
+      const empty = !events.length;
+      $("#empty").hidden = !empty;
+      renderVenueChips(venues);
+      renderEventCards(selectedVenueKey ? events : events.slice(0, 60));
+    }
+
+    async function load() {
+      $("#status").textContent = "Loading…";
+      try {
+        const r = await fetch("/api/store/events?limit=500");
+        const body = await r.json();
+        allEvents = body.events || [];
+        $("#status").textContent = `${aggregateVenues(allEvents).length} venues with tickets available`;
+        refresh();
+      } catch (e) {
+        $("#status").textContent = "Couldn't load. " + e.message;
+        $("#status").style.color = "var(--bad)";
+      }
+    }
+
+    $("#q").addEventListener("input", () => {
+      selectedVenueKey = null;
+      refresh();
+    });
+
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Four-commit batch on the storefront lane. All MVP-scope, all read-only, no schema changes.

| # | Commit | What |
|---|---|---|
| 1 | `78849ed` | **EvoClient 429 / Retry-After backoff** — closes the gap flagged in AGENTS.md (other clients had this; Python client didn't). 4 retries, 0.5s base, exp doubling, 30s cap. |
| 2 | `ebb2d0b` | **Hybrid near-me endpoint** — `/api/store/events/near?source=hybrid\|supabase\|tevo`. Implements evo-docs §05 with three selectable modes. Also adds `performer_id` + `venue_id` filters to `/api/store/events` via PostgREST `!inner` join shorthand. |
| 3 | `b62f582` | **Concierge filter-then-share flow** on the event page — inline filter bar IS the share UI. Sales rep narrows by zone/section/price/qty on the page; "Share this view" serializes the current URL. Stripped duplicate filter UI from the share modal. |
| 4 | `14b33ec` | **Consumer-style multi-page test harness** at `/store/test`. Keyword search everywhere (no IDs in inputs), no raw JSON, no dev panels. Pages: home (with geolocated "near me" + source dropdown), search, performer, venue, event, share-admin. |

## Hybrid near-me — design rationale

Per evo-docs §05, TEvo's `/v9/events?lat&lon&within` has authoritative venue coords for **100% of venues**, while our `venue_assets` table covers ~83%. Pure-Supabase is faster (no TEvo round-trip) but caps coverage; pure-TEvo loses the owned filter (storefront wall). The hybrid uses TEvo for geo authority + Supabase for the owned/lifecycle filter — best of both.

```
hybrid:   TEvo /v9/events?lat&lon&within  ->  intersect latest_event_metrics
                                              + event_lifecycle.is_active
                                              + decorate w/ venue_assets coords
                                              + bulk performer assets
                                              -> top N by distance
supabase: latest_event_metrics + venue_assets coords + python haversine
tevo:     raw TEvo geo, debug-only (no owned filter — not in consumer UI)
```

`?source=` lets you A/B between hybrid + supabase against the same coords from the home page dropdown. Hybrid falls back to supabase mode if TEvo errors so the home page stays up.

## Filter-then-share flow

Replaces the old "open share modal, re-pick filters" anti-pattern with: filter inline on the page → click "Share this view" → URL on clipboard (or revocable `/s/{id}` link). The share modal is now just a copy/revocable confirmation, not a second filter UI.

Recipients of a share link see the same listings (server-side filtered identically) with the inline filter inputs pre-checked. They can adjust or hit "show all" to clear.

## Smoke testing done

- ✅ EvoClient 429 backoff: dry-run code path verified, real 429 not triggered in testing.
- ✅ TEvo-only mode (`?source=tevo`): live test at `lat=40.83 lon=-73.93 within=25` returned 5 NYC events sorted by date. Hit 422 initially on `order_by=events.occurs_at` (missing direction), fixed to `events.occurs_at ASC`.
- ✅ 5 random events / 5 performers / 5 venues from prod (sampled via Supabase MCP) all return live TEvo data correctly. Two notes: Spurs G1 on 2026-05-04 has 0 available now (event passed; lifecycle filter would drop it); `retail_min` in `latest_event_metrics` is stale vs live TEvo by ~6-12h — catalog "from $X" is approximate, real prices come from the event-detail page's live fetch.
- ⚠️ Hybrid + Supabase modes need `SUPABASE_SERVICE_ROLE_KEY` to test end-to-end — not available on this dev box. Both modes share `_attach_owned_metadata()` so the join logic is the same code, but verify in staging before relying on either.

## Lane / Touches / Pre-reqs

- **Lane**: primary-sales (storefront, full-stack in own domain).
- **Touches (R only)**: `latest_event_metrics`, `events`, `event_lifecycle`, `venue_assets`, `performer_assets`, `share_links`. All read-only from this lane.
- **Touches (W)**: `share_links` only (already owned by this lane, from PR #54).
- **Pre-reqs**: none. No new migration; no new tables; no vault secrets.

## Test plan

- [ ] Visit `/store` → filter inline by zone/section/price/qty → click "Share this view" → copy → open URL in incognito → confirm same listings.
- [ ] Same flow with "Make this revocable" toggle → generate `/s/{id}` link → revoke from `/store/shares` → reload `/s/{id}` → expect 410.
- [ ] Visit `/store/test` → click "Find events near me" → grant location → confirm 10 closest events. Toggle source dropdown to "supabase only" + "TEvo only (debug)" and compare results.
- [ ] Browse `/store/test/performer` → type a team name → confirm chips appear → click one → confirm events for that performer.
- [ ] Hit `/store/test/event?id=<any-id-from-search>` → confirm hero + filter bar + listings + buy modal flow.
- [ ] Verify EvoClient backoff path: artificially induce a 429 (or watch logs under load) — should retry up to 4× with exponential delay before raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)