### PR TITLE
feat(coordination): bot_chat live + START_HERE + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,70 @@
+<!--
+PR template — every PR must fill this. The admin (level:admin) will reject
+PRs that delete fields or leave them blank. See START_HERE.md and
+MIGRATION_CONVENTIONS.md before opening.
+-->
+
+## Lane identity
+
+- **Level**: <!-- admin | security | supervisor | primary-sales | secondary-sales | data-collection -->
+- **Lane (role)**: <!-- e.g. "Terminal Front End" | "Broadway Scraper" | "Retail Storefront" | "Order Clients" -->
+- **Worktree / git branch**: <!-- e.g. claude/your-branch-name -->
+
+> If you don't know your level + lane, STOP. Read `START_HERE.md`.
+
+## Summary
+
+<!-- 1-3 bullets on what this PR does and why. -->
+
+## Changes
+
+### Tables touched
+<!-- List every table with W (write) or R (read). Example:
+- `event_xref` (W) — INSERT in matcher tick
+- `events` (R) — joined for name lookup
+-->
+
+### Migrations added
+<!-- List every new migration. Example:
+- `supabase/migrations/20260511010000_bot_chat.sql` — new table for cross-bot logging
+-->
+
+### Files modified outside your lane
+<!-- If you touched files owned by another lane, list them and link the coordination thread. If none, write "none". -->
+
+## Pre-reqs
+
+<!-- List what must be true before this PR can merge. Example:
+- Vault: `FRED_API_KEY` must be seeded before cron yields data
+- Prior migration: 20260510130000 (fred_macro_indicators) must be applied
+- External service: api.stlouisfed.org must be reachable
+-->
+
+## Test plan
+
+<!-- What you verified on your Supabase preview branch. Example:
+- [ ] Applied to preview branch `claude/my-feature-preview-xyz`, no errors
+- [ ] Smoke query: `SELECT count(*) FROM my_new_table` returns expected N
+- [ ] Smoke query: `SELECT * FROM my_view LIMIT 5` returns expected shape
+- [ ] No regressions in `pg_stat_statements` after 10 minutes
+-->
+
+## Admin review notes
+<!-- Optional: anything you specifically want level:admin to look at, or known caveats. -->
+
+---
+
+<!-- Auto-checks before merge (admin lane):
+- [ ] Filename follows MIGRATION_CONVENTIONS.md §3
+- [ ] Header block present in every migration (§6) — Level / Lane / Touches / Pre-reqs
+- [ ] Tables touched match the declaration
+- [ ] Lane writes only to owned tables (or via coordination)
+- [ ] Cron names lane-prefixed
+- [ ] Vault secrets documented
+- [ ] No DROP/TRUNCATE on shared tables without rollback plan
+- [ ] ON CONFLICT on UPSERTs
+- [ ] created_at / updated_at on new tables
+- [ ] Preview branch validation confirmed
+- [ ] sync-check passes
+- [ ] PR carries the correct level:* label
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,70 +1,25 @@
-<!--
-PR template — every PR must fill this. The admin (level:admin) will reject
-PRs that delete fields or leave them blank. See START_HERE.md and
-MIGRATION_CONVENTIONS.md before opening.
--->
+<!-- Fill every field. Admin blocks PRs missing fields. See START_HERE.md. -->
 
-## Lane identity
+**Level**: <!-- admin | security | supervisor | primary-sales | secondary-sales | data-collection -->
+**Lane**: <!-- e.g. "Terminal Front End" -->
+**Branch**: <!-- claude/your-branch -->
 
-- **Level**: <!-- admin | security | supervisor | primary-sales | secondary-sales | data-collection -->
-- **Lane (role)**: <!-- e.g. "Terminal Front End" | "Broadway Scraper" | "Retail Storefront" | "Order Clients" -->
-- **Worktree / git branch**: <!-- e.g. claude/your-branch-name -->
+## What
+<!-- 1-3 bullets -->
 
-> If you don't know your level + lane, STOP. Read `START_HERE.md`.
+## Migrations
+<!-- list filenames, one per line. Each must have the single-line header:
+     -- Migration <ts> · level:<X> · lane:<Y> · writes:<a,b> · reads:<c> · pre:<...> -->
 
-## Summary
+## Tables touched
+<!-- table_a (W), table_b (R) — must match migration header -->
 
-<!-- 1-3 bullets on what this PR does and why. -->
-
-## Changes
-
-### Tables touched
-<!-- List every table with W (write) or R (read). Example:
-- `event_xref` (W) — INSERT in matcher tick
-- `events` (R) — joined for name lookup
--->
-
-### Migrations added
-<!-- List every new migration. Example:
-- `supabase/migrations/20260511010000_bot_chat.sql` — new table for cross-bot logging
--->
-
-### Files modified outside your lane
-<!-- If you touched files owned by another lane, list them and link the coordination thread. If none, write "none". -->
+## Cross-lane writes
+<!-- files outside your lane; "none" if none -->
 
 ## Pre-reqs
-
-<!-- List what must be true before this PR can merge. Example:
-- Vault: `FRED_API_KEY` must be seeded before cron yields data
-- Prior migration: 20260510130000 (fred_macro_indicators) must be applied
-- External service: api.stlouisfed.org must be reachable
--->
+<!-- vault secrets, prior migrations, external services -->
 
 ## Test plan
-
-<!-- What you verified on your Supabase preview branch. Example:
-- [ ] Applied to preview branch `claude/my-feature-preview-xyz`, no errors
-- [ ] Smoke query: `SELECT count(*) FROM my_new_table` returns expected N
-- [ ] Smoke query: `SELECT * FROM my_view LIMIT 5` returns expected shape
-- [ ] No regressions in `pg_stat_statements` after 10 minutes
--->
-
-## Admin review notes
-<!-- Optional: anything you specifically want level:admin to look at, or known caveats. -->
-
----
-
-<!-- Auto-checks before merge (admin lane):
-- [ ] Filename follows MIGRATION_CONVENTIONS.md §3
-- [ ] Header block present in every migration (§6) — Level / Lane / Touches / Pre-reqs
-- [ ] Tables touched match the declaration
-- [ ] Lane writes only to owned tables (or via coordination)
-- [ ] Cron names lane-prefixed
-- [ ] Vault secrets documented
-- [ ] No DROP/TRUNCATE on shared tables without rollback plan
-- [ ] ON CONFLICT on UPSERTs
-- [ ] created_at / updated_at on new tables
-- [ ] Preview branch validation confirmed
-- [ ] sync-check passes
-- [ ] PR carries the correct level:* label
--->
+<!-- - [ ] applied to preview branch <id>, no errors
+     - [ ] smoke query: ... -->

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,164 @@
+# START_HERE.md
+
+> **If you are a bot looking at this repo for the first time: STOP. Read this entire file before doing anything.**
+>
+> This is the "you can't miss it" door. Get this wrong and you'll break things or get blocked at the PR gate.
+
+---
+
+## 1. Identify yourself
+
+You should already know **your level** and **your lane (role)**. They were assigned to you out-of-band by the operator (Julian).
+
+The 6 levels are:
+
+| Level | Authority | Who fits here |
+|---|---|---|
+| **admin** | Full repo + prod write + merge | The audit/push role — singleton (only one bot at this level) |
+| **security** | Push only for CRIT security patches; veto power on P0 security flags | Security Manager — singleton |
+| **supervisor** | SQL writes for data fix + matching; supervises secondary-sales and data-collection lanes | Data + Chat Supervisor — singleton |
+| **primary-sales** | Full-stack admin in own domain (storefront), Admin reviews cross-domain changes | Retail Ticket System bot |
+| **secondary-sales** | Read-only on prod; Admin has final say on any change | Frontend bots consuming Supervisor's data |
+| **data-collection** | No main-code access; scoped to own scraper/client tables | Scrapers and read-only API clients feeding Supervisor |
+
+Your lane is the specific role within your level (e.g., "Terminal Front End", "Broadway Scraper", "Retail Storefront").
+
+**If you don't know your level + lane, STOP.** Ask Julian. Do not pick one. Do not invent one. Do not "just use admin" — that level is singleton, and there's only one.
+
+If you are a brand-new bot with no assigned level, do not write any code or open any PR until Julian assigns you. Read `AGENTS.md` and `docs/bot-hierarchy.mermaid` first, then ping Julian with your proposed scope.
+
+---
+
+## 2. Read these in this order (≈30 min)
+
+1. **`docs/bot-hierarchy.mermaid`** — command structure and where you fit
+2. **`AGENTS.md`** — lane roster, ACCESS MATRIX, status board, WIP claims
+3. **`MIGRATION_CONVENTIONS.md`** — production-push gate, filename conventions, mandatory migration header, lane discipline
+4. **`DOCUMENTATION_INDEX.md`** — lane-to-doc reading list map
+5. **`SCHEMA.md`** — schema source of truth
+6. **`KANBAN.md`** — what's in flight, what's parked, security backlog
+
+If you read these 6 in order you have enough context to avoid 95% of drift incidents.
+
+---
+
+## 3. Hard rules (you WILL be caught if you break these)
+
+### 3.1 Production push gate
+- **Only `level:admin` applies migrations to production.** No exceptions except `level:security` for CRIT security patches.
+- You develop on **your own Supabase preview branch** keyed to your git branch name.
+- You open a GitHub PR. The admin reviews per §9 of `MIGRATION_CONVENTIONS.md`. The admin merges.
+
+### 3.2 Single-writer rule per table
+- The lane that introduced a table is its **sole writer**.
+- Other lanes can SELECT, define triggers (which fire on the writer's INSERTs), or reference via FK.
+- They cannot INSERT / UPDATE / DELETE / TRUNCATE directly.
+
+### 3.3 Migration header is mandatory
+Every new migration **must** start with:
+```sql
+-- ============================================================================
+-- Migration <timestamp> — <one-line summary>
+-- Level:    <admin | security | supervisor | primary-sales | secondary-sales | data-collection>
+-- Lane:     <descriptive lane name, e.g. "Terminal Front End">
+-- Touches:  <table_a (W), table_b (W), table_c (R)>
+-- Pre-reqs: <prior migrations, vault secrets, external services>
+-- ============================================================================
+```
+PRs missing this get blocked. See `MIGRATION_CONVENTIONS.md` §6.
+
+### 3.4 Log every meaningful change to `bot_chat`
+After every commit or significant operation, insert a row to `bot_chat`:
+```sql
+SELECT bot_chat_log(
+  p_level     => 'secondary-sales',           -- your level
+  p_lane      => 'Terminal Front End',         -- your lane name
+  p_event_type => 'change_log',                -- or question / flag / sync / status / collision
+  p_subject   => 'what you did',
+  p_body      => 'why',
+  p_related_pr => <PR number>
+);
+```
+Event-types `flag` and `p0_security` are routed to `level:security`; everything else to `level:admin`. The `v_bot_chat_unresolved` view is your triage queue.
+
+### 3.5 Don't touch other lanes' tables, code, or migrations
+Read `MIGRATION_CONVENTIONS.md` §2 (lane map) and §4 (single-writer rule). When in doubt, ask in `bot_chat` with `event_type = 'question'` and wait for admin.
+
+### 3.6 No secrets in repo
+Secrets live in **Supabase vault** or **Railway env vars** — never in source. See `MIGRATION_CONVENTIONS.md` §12 (vault whitelist).
+
+---
+
+## 4. Test environment
+
+Every lane gets:
+- **Own git branch** (named `claude/<lane>-<purpose>-<id>`)
+- **Own Supabase preview branch** via `mcp__bccd...__create_branch(name=<git-branch-name>)`
+- **Own sandbox schema** if applicable (e.g., `<lane>_test`)
+
+You apply migrations and run smoke tests on the preview branch. Once it works, open the PR. Admin reviews and applies to prod.
+
+**Never** call `apply_migration` against the production project_id. Use a branch_id only.
+
+---
+
+## 5. PR opening checklist
+
+Every PR you open should declare (in the description):
+1. **Level** (admin / security / supervisor / primary-sales / secondary-sales / data-collection)
+2. **Lane** (e.g., "Terminal Front End", "Broadway Scraper")
+3. **Tables touched** with W/R designation
+4. **Migrations added** (timestamp + filename)
+5. **Pre-reqs** (vault secrets, prior migrations, ops steps)
+6. **Test plan** — what you verified on the preview branch
+
+The `.github/PULL_REQUEST_TEMPLATE.md` pre-fills this. Don't delete fields.
+
+GitHub labels matching your level (`level:admin`, `level:security`, etc.) will be applied automatically or by admin.
+
+---
+
+## 6. If you're confused
+
+Open a `bot_chat` entry with `event_type = 'question'` and tag the relevant level in the body. Admin will respond in the next session.
+
+If `bot_chat` doesn't exist yet (early sessions), comment on the relevant PR or open a GitHub issue tagged `bot-coordination`.
+
+---
+
+## 7. If you think these rules are wrong
+
+You might be right. The rules are owned by `level:admin` but they're not infallible. Propose changes via:
+1. A GitHub issue tagged `migration-conventions` with your proposed change + rationale
+2. A `bot_chat` entry with `event_type = 'flag'` if it's urgent
+
+**Do not edit the rules unilaterally.** That defeats the point.
+
+---
+
+## 8. Quick command reference
+
+```bash
+# What's my level + lane? (read your assigned worktree's notes, or ask Julian)
+
+# Create a Supabase preview branch matching your git branch:
+mcp__bccd...__create_branch(name='claude/your-branch-name')
+
+# Apply migration to your preview (NOT production):
+mcp__bccd...__apply_migration(branch_id='<preview-id>', name='<timestamp>_<desc>', query=...)
+
+# Log to bot_chat:
+SELECT bot_chat_log('<your-level>', '<your-lane>', 'change_log', '<subject>', '<body>', <pr_num>);
+
+# Open a PR (after pushing your branch):
+gh pr create --base main --head claude/your-branch --title "..." --body "..."
+# Apply your level label:
+gh pr edit <number> --add-label "level:<your-level>"
+```
+
+---
+
+Last updated: 2026-05-11.
+Owner: `level:admin` (audit lane). Anyone can read; only admin modifies.
+
+**Welcome. Now go read the 6 docs in §2.**

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,164 +1,41 @@
 # START_HERE.md
 
-> **If you are a bot looking at this repo for the first time: STOP. Read this entire file before doing anything.**
->
-> This is the "you can't miss it" door. Get this wrong and you'll break things or get blocked at the PR gate.
+**Bot? Read this in 2 minutes, then `MIGRATION_CONVENTIONS.md` for the rules.**
 
----
+## Identify yourself
+- **Level**: `admin` | `security` | `supervisor` | `primary-sales` | `secondary-sales` | `data-collection`
+- **Lane**: descriptive role (e.g. "Terminal Front End", "Broadway Scraper")
+- Assigned by Julian out-of-band. If you don't know, ask. Do not guess.
 
-## 1. Identify yourself
+## Hard rules (5)
+1. **Only `level:admin` pushes to prod.** Exception: `level:security` for CRIT patches. You develop on a Supabase preview branch.
+2. **Single-writer per table.** The lane that made it owns writes. Others read or trigger.
+3. **Every migration starts with this header** (one line):
+   `-- Migration <ts> · level:<X> · lane:<Y> · writes:<table,table> · reads:<table,table> · pre:<vault.KEY,migration_ts>`
+4. **Log to `bot_chat`** after every meaningful action: `SELECT bot_chat_log('<level>', '<lane>', '<event_type>', '<message>', <pr#>);`
+5. **No secrets in repo.** Vault or Railway env only.
 
-You should already know **your level** and **your lane (role)**. They were assigned to you out-of-band by the operator (Julian).
+## Required reading
+1. `docs/bot-hierarchy.mermaid` — where you fit
+2. `MIGRATION_CONVENTIONS.md` — the full rules
+3. `KANBAN.md` — what's in flight
 
-The 6 levels are:
+## Your environment
+- Git branch: `claude/<lane>-<purpose>-<id>`
+- Supabase preview branch: `mcp__bccd...__create_branch(name=<git-branch>)`
+- Never apply migrations to the prod project_id. Use a branch_id.
 
-| Level | Authority | Who fits here |
-|---|---|---|
-| **admin** | Full repo + prod write + merge | The audit/push role — singleton (only one bot at this level) |
-| **security** | Push only for CRIT security patches; veto power on P0 security flags | Security Manager — singleton |
-| **supervisor** | SQL writes for data fix + matching; supervises secondary-sales and data-collection lanes | Data + Chat Supervisor — singleton |
-| **primary-sales** | Full-stack admin in own domain (storefront), Admin reviews cross-domain changes | Retail Ticket System bot |
-| **secondary-sales** | Read-only on prod; Admin has final say on any change | Frontend bots consuming Supervisor's data |
-| **data-collection** | No main-code access; scoped to own scraper/client tables | Scrapers and read-only API clients feeding Supervisor |
+## PR rules
+- Use `.github/PULL_REQUEST_TEMPLATE.md` — declares Level + Lane + Tables + Pre-reqs + Test plan
+- Admin applies `level:<X>` label on review
+- Admin merges per `MIGRATION_CONVENTIONS.md` §9
 
-Your lane is the specific role within your level (e.g., "Terminal Front End", "Broadway Scraper", "Retail Storefront").
+## Confused?
+`bot_chat` `event_type='question'`. Admin responds.
 
-**If you don't know your level + lane, STOP.** Ask Julian. Do not pick one. Do not invent one. Do not "just use admin" — that level is singleton, and there's only one.
+## Token discipline
+- Short PR descriptions, short comments, single-line headers
+- Don't re-render the hierarchy — link `docs/bot-hierarchy.mermaid`
+- Skip closers like "Standing by"
 
-If you are a brand-new bot with no assigned level, do not write any code or open any PR until Julian assigns you. Read `AGENTS.md` and `docs/bot-hierarchy.mermaid` first, then ping Julian with your proposed scope.
-
----
-
-## 2. Read these in this order (≈30 min)
-
-1. **`docs/bot-hierarchy.mermaid`** — command structure and where you fit
-2. **`AGENTS.md`** — lane roster, ACCESS MATRIX, status board, WIP claims
-3. **`MIGRATION_CONVENTIONS.md`** — production-push gate, filename conventions, mandatory migration header, lane discipline
-4. **`DOCUMENTATION_INDEX.md`** — lane-to-doc reading list map
-5. **`SCHEMA.md`** — schema source of truth
-6. **`KANBAN.md`** — what's in flight, what's parked, security backlog
-
-If you read these 6 in order you have enough context to avoid 95% of drift incidents.
-
----
-
-## 3. Hard rules (you WILL be caught if you break these)
-
-### 3.1 Production push gate
-- **Only `level:admin` applies migrations to production.** No exceptions except `level:security` for CRIT security patches.
-- You develop on **your own Supabase preview branch** keyed to your git branch name.
-- You open a GitHub PR. The admin reviews per §9 of `MIGRATION_CONVENTIONS.md`. The admin merges.
-
-### 3.2 Single-writer rule per table
-- The lane that introduced a table is its **sole writer**.
-- Other lanes can SELECT, define triggers (which fire on the writer's INSERTs), or reference via FK.
-- They cannot INSERT / UPDATE / DELETE / TRUNCATE directly.
-
-### 3.3 Migration header is mandatory
-Every new migration **must** start with:
-```sql
--- ============================================================================
--- Migration <timestamp> — <one-line summary>
--- Level:    <admin | security | supervisor | primary-sales | secondary-sales | data-collection>
--- Lane:     <descriptive lane name, e.g. "Terminal Front End">
--- Touches:  <table_a (W), table_b (W), table_c (R)>
--- Pre-reqs: <prior migrations, vault secrets, external services>
--- ============================================================================
-```
-PRs missing this get blocked. See `MIGRATION_CONVENTIONS.md` §6.
-
-### 3.4 Log every meaningful change to `bot_chat`
-After every commit or significant operation, insert a row to `bot_chat`:
-```sql
-SELECT bot_chat_log(
-  p_level     => 'secondary-sales',           -- your level
-  p_lane      => 'Terminal Front End',         -- your lane name
-  p_event_type => 'change_log',                -- or question / flag / sync / status / collision
-  p_subject   => 'what you did',
-  p_body      => 'why',
-  p_related_pr => <PR number>
-);
-```
-Event-types `flag` and `p0_security` are routed to `level:security`; everything else to `level:admin`. The `v_bot_chat_unresolved` view is your triage queue.
-
-### 3.5 Don't touch other lanes' tables, code, or migrations
-Read `MIGRATION_CONVENTIONS.md` §2 (lane map) and §4 (single-writer rule). When in doubt, ask in `bot_chat` with `event_type = 'question'` and wait for admin.
-
-### 3.6 No secrets in repo
-Secrets live in **Supabase vault** or **Railway env vars** — never in source. See `MIGRATION_CONVENTIONS.md` §12 (vault whitelist).
-
----
-
-## 4. Test environment
-
-Every lane gets:
-- **Own git branch** (named `claude/<lane>-<purpose>-<id>`)
-- **Own Supabase preview branch** via `mcp__bccd...__create_branch(name=<git-branch-name>)`
-- **Own sandbox schema** if applicable (e.g., `<lane>_test`)
-
-You apply migrations and run smoke tests on the preview branch. Once it works, open the PR. Admin reviews and applies to prod.
-
-**Never** call `apply_migration` against the production project_id. Use a branch_id only.
-
----
-
-## 5. PR opening checklist
-
-Every PR you open should declare (in the description):
-1. **Level** (admin / security / supervisor / primary-sales / secondary-sales / data-collection)
-2. **Lane** (e.g., "Terminal Front End", "Broadway Scraper")
-3. **Tables touched** with W/R designation
-4. **Migrations added** (timestamp + filename)
-5. **Pre-reqs** (vault secrets, prior migrations, ops steps)
-6. **Test plan** — what you verified on the preview branch
-
-The `.github/PULL_REQUEST_TEMPLATE.md` pre-fills this. Don't delete fields.
-
-GitHub labels matching your level (`level:admin`, `level:security`, etc.) will be applied automatically or by admin.
-
----
-
-## 6. If you're confused
-
-Open a `bot_chat` entry with `event_type = 'question'` and tag the relevant level in the body. Admin will respond in the next session.
-
-If `bot_chat` doesn't exist yet (early sessions), comment on the relevant PR or open a GitHub issue tagged `bot-coordination`.
-
----
-
-## 7. If you think these rules are wrong
-
-You might be right. The rules are owned by `level:admin` but they're not infallible. Propose changes via:
-1. A GitHub issue tagged `migration-conventions` with your proposed change + rationale
-2. A `bot_chat` entry with `event_type = 'flag'` if it's urgent
-
-**Do not edit the rules unilaterally.** That defeats the point.
-
----
-
-## 8. Quick command reference
-
-```bash
-# What's my level + lane? (read your assigned worktree's notes, or ask Julian)
-
-# Create a Supabase preview branch matching your git branch:
-mcp__bccd...__create_branch(name='claude/your-branch-name')
-
-# Apply migration to your preview (NOT production):
-mcp__bccd...__apply_migration(branch_id='<preview-id>', name='<timestamp>_<desc>', query=...)
-
-# Log to bot_chat:
-SELECT bot_chat_log('<your-level>', '<your-lane>', 'change_log', '<subject>', '<body>', <pr_num>);
-
-# Open a PR (after pushing your branch):
-gh pr create --base main --head claude/your-branch --title "..." --body "..."
-# Apply your level label:
-gh pr edit <number> --add-label "level:<your-level>"
-```
-
----
-
-Last updated: 2026-05-11.
-Owner: `level:admin` (audit lane). Anyone can read; only admin modifies.
-
-**Welcome. Now go read the 6 docs in §2.**
+Owner: `level:admin`.

--- a/supabase/migrations/20260511010000_bot_chat.sql
+++ b/supabase/migrations/20260511010000_bot_chat.sql
@@ -1,226 +1,98 @@
--- ============================================================================
--- Migration 20260511010000 — bot_chat cross-bot communication layer
---
--- Level:    admin
--- Lane:     Audit / Push (xref + macro)
--- Touches:  bot_chat (W), v_bot_chat_unresolved (W), bot_chat_log() (W),
---           bot_chat_resolve() (W)
--- Pre-reqs: none
---
--- Establishes a single source-of-truth table for all lanes to log changes,
--- ask questions, flag issues, and coordinate. Replaces ad-hoc PR comment +
--- KANBAN.md chatter that's been the communication layer until now.
---
--- Schema notes:
---   * `bot_level` matches the 6 levels in docs/bot-hierarchy.mermaid:
---     admin / security / supervisor / primary-sales / secondary-sales /
---     data-collection. CHECK-constrained.
---   * `bot_lane` is the free-form lane name (e.g. "Terminal Front End")
---     because multiple bots can share a level (S1/S2/S3 all
---     secondary-sales; D1/D2 both data-collection).
---   * `event_type` is enum-like (text + CHECK) for forward-compat.
---   * Inserts open: any lane can write. Acks/resolves: admin always; security
---     only for security event_types.
---   * Rows are immutable except for ack/resolve columns (enforced via RLS).
--- ============================================================================
+-- Migration 20260511010000 · level:admin · lane:Audit/Push · writes:bot_chat,v_bot_chat_unresolved,bot_chat_log(),bot_chat_resolve() · pre:none
+-- Cross-lane communication layer. Replaces ad-hoc PR comments / KANBAN chatter.
+-- See START_HERE.md §"Hard rules" for usage.
 
--- (1) Table
 CREATE TABLE IF NOT EXISTS bot_chat (
-  id                bigserial PRIMARY KEY,
-  bot_level         text NOT NULL CHECK (bot_level IN (
-                      'admin',
-                      'security',
-                      'supervisor',
-                      'primary-sales',
-                      'secondary-sales',
-                      'data-collection'
-                    )),
-  bot_lane          text NOT NULL,                                    -- e.g. "Terminal Front End"
-  event_type        text NOT NULL CHECK (event_type IN (
-                      'change_log',  -- "I did X, here's the PR"
-                      'question',    -- "How should I handle Y?"
-                      'flag',        -- "I noticed Z, may need attention"
-                      'sync',        -- "I rebased / merged / aligned"
-                      'status',      -- "I'm working on / blocked / done"
-                      'collision',   -- "Cross-lane conflict detected"
-                      'broadcast',   -- "All lanes should know X" (admin only)
-                      'p0_security'  -- "Veto-grade security issue" (security only)
-                    )),
-  subject           text NOT NULL,
-  body              text,
-  related_pr        int,                                              -- nullable: GH PR number
-  related_migration text,                                              -- nullable: migration timestamp prefix
-  related_table     text,                                              -- nullable: table name
-  in_reply_to       bigint REFERENCES bot_chat(id),                    -- threading
-  acked_at          timestamptz,
-  acked_by_level    text,                                              -- level of acker
-  acked_by_lane     text,
-  resolved_at       timestamptz,
-  resolved_by_level text,                                              -- level of resolver
-  resolved_by_lane  text,
-  meta              jsonb,
-  created_at        timestamptz NOT NULL DEFAULT now()
+  id            bigserial PRIMARY KEY,
+  bot_level     text NOT NULL CHECK (bot_level IN
+                  ('admin','security','supervisor','primary-sales','secondary-sales','data-collection')),
+  bot_lane      text NOT NULL,
+  event_type    text NOT NULL CHECK (event_type IN
+                  ('change_log','question','flag','sync','status','collision','broadcast','p0_security')),
+  message       text NOT NULL,                                -- single field; subject+body merged
+  related_pr    int,
+  related_mig   text,
+  in_reply_to   bigint REFERENCES bot_chat(id),
+  acked_at      timestamptz,
+  acked_by      text,                                          -- "<level>/<lane>"
+  resolved_at   timestamptz,
+  resolved_by   text,
+  meta          jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
 );
 
--- (2) Indexes
-CREATE INDEX IF NOT EXISTS bot_chat_level_idx           ON bot_chat (bot_level, created_at DESC);
-CREATE INDEX IF NOT EXISTS bot_chat_lane_idx            ON bot_chat (bot_lane, created_at DESC);
-CREATE INDEX IF NOT EXISTS bot_chat_event_type_idx      ON bot_chat (event_type, resolved_at);
-CREATE INDEX IF NOT EXISTS bot_chat_unresolved_idx      ON bot_chat (created_at DESC) WHERE resolved_at IS NULL;
-CREATE INDEX IF NOT EXISTS bot_chat_related_pr_idx      ON bot_chat (related_pr) WHERE related_pr IS NOT NULL;
-CREATE INDEX IF NOT EXISTS bot_chat_in_reply_to_idx     ON bot_chat (in_reply_to) WHERE in_reply_to IS NOT NULL;
+CREATE INDEX IF NOT EXISTS bot_chat_level_idx     ON bot_chat (bot_level, created_at DESC);
+CREATE INDEX IF NOT EXISTS bot_chat_event_idx     ON bot_chat (event_type, resolved_at);
+CREATE INDEX IF NOT EXISTS bot_chat_unresolved_ix ON bot_chat (created_at DESC) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS bot_chat_pr_idx        ON bot_chat (related_pr) WHERE related_pr IS NOT NULL;
 
--- (3) Unresolved-queue view — what admin (and security for security-tagged) triages
 CREATE OR REPLACE VIEW v_bot_chat_unresolved AS
-SELECT
-  c.id, c.bot_level, c.bot_lane, c.event_type, c.subject, c.body,
-  c.related_pr, c.related_migration, c.related_table,
-  c.in_reply_to, c.acked_at, c.acked_by_level, c.acked_by_lane,
-  c.created_at,
-  extract(epoch FROM (now() - c.created_at))/3600 AS hours_open,
-  (SELECT count(*) FROM bot_chat r WHERE r.in_reply_to = c.id) AS reply_count
-FROM bot_chat c
-WHERE c.resolved_at IS NULL
+SELECT id, bot_level, bot_lane, event_type, message, related_pr, related_mig,
+       in_reply_to, acked_at, acked_by, created_at,
+       extract(epoch FROM (now() - created_at))/3600 AS hours_open
+FROM bot_chat
+WHERE resolved_at IS NULL
 ORDER BY
-  CASE c.event_type
-    WHEN 'p0_security' THEN 1
-    WHEN 'collision'   THEN 2
-    WHEN 'flag'        THEN 3
-    WHEN 'question'    THEN 4
-    WHEN 'status'      THEN 5
-    WHEN 'sync'        THEN 6
-    WHEN 'change_log'  THEN 7
-    WHEN 'broadcast'   THEN 8
+  CASE event_type
+    WHEN 'p0_security' THEN 1 WHEN 'collision' THEN 2 WHEN 'flag' THEN 3
+    WHEN 'question' THEN 4 WHEN 'status' THEN 5 WHEN 'sync' THEN 6
+    WHEN 'change_log' THEN 7 WHEN 'broadcast' THEN 8
   END,
-  c.created_at;
+  created_at;
 
-COMMENT ON VIEW v_bot_chat_unresolved IS
-  'Triage queue ordered by event_type severity. Admin (and security for '
-  'p0_security/flag) should drain this regularly.';
-
--- (4) Helper: convenience insert function for lanes
 CREATE OR REPLACE FUNCTION public.bot_chat_log(
-  p_level             text,
-  p_lane              text,
-  p_event_type        text,
-  p_subject           text,
-  p_body              text DEFAULT NULL,
-  p_related_pr        int DEFAULT NULL,
-  p_related_migration text DEFAULT NULL,
-  p_related_table     text DEFAULT NULL,
-  p_in_reply_to       bigint DEFAULT NULL,
-  p_meta              jsonb DEFAULT NULL
-)
-RETURNS bigint
-LANGUAGE plpgsql
-SECURITY INVOKER
-SET search_path = public, pg_temp
-AS $$
-DECLARE
-  v_id bigint;
+  p_level text, p_lane text, p_event_type text, p_message text,
+  p_related_pr int DEFAULT NULL, p_related_mig text DEFAULT NULL,
+  p_in_reply_to bigint DEFAULT NULL, p_meta jsonb DEFAULT NULL
+) RETURNS bigint
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp AS $$
+DECLARE v_id bigint;
 BEGIN
-  INSERT INTO bot_chat (
-    bot_level, bot_lane, event_type, subject, body,
-    related_pr, related_migration, related_table, in_reply_to, meta
-  ) VALUES (
-    p_level, p_lane, p_event_type, p_subject, p_body,
-    p_related_pr, p_related_migration, p_related_table, p_in_reply_to, p_meta
-  )
+  INSERT INTO bot_chat (bot_level, bot_lane, event_type, message,
+                        related_pr, related_mig, in_reply_to, meta)
+  VALUES (p_level, p_lane, p_event_type, p_message,
+          p_related_pr, p_related_mig, p_in_reply_to, p_meta)
   RETURNING id INTO v_id;
   RETURN v_id;
 END $$;
 
-COMMENT ON FUNCTION public.bot_chat_log IS
-  'Convenience insert into bot_chat. Use from any lane to log a change, '
-  'flag, question, etc. See START_HERE.md §3.4 for usage.';
-
--- (5) Resolver function — only admin always; security only for security-tagged
 CREATE OR REPLACE FUNCTION public.bot_chat_resolve(
-  p_id              bigint,
-  p_resolver_level  text,
-  p_resolver_lane   text,
-  p_note            text DEFAULT NULL
-)
-RETURNS boolean
-LANGUAGE plpgsql
-SECURITY INVOKER
-SET search_path = public, pg_temp
-AS $$
-DECLARE
-  v_event_type text;
+  p_id bigint, p_resolver_level text, p_resolver_lane text, p_note text DEFAULT NULL
+) RETURNS boolean
+LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp AS $$
+DECLARE v_event_type text;
 BEGIN
   SELECT event_type INTO v_event_type FROM bot_chat WHERE id = p_id;
-  IF v_event_type IS NULL THEN
-    RAISE EXCEPTION 'bot_chat row % not found', p_id;
+  IF v_event_type IS NULL THEN RAISE EXCEPTION 'bot_chat row % not found', p_id; END IF;
+  IF p_resolver_level = 'admin' THEN NULL;
+  ELSIF p_resolver_level = 'security' AND v_event_type IN ('p0_security','flag') THEN NULL;
+  ELSE RAISE EXCEPTION 'level=% cannot resolve event_type=%', p_resolver_level, v_event_type;
   END IF;
-
-  -- Authorization check (soft, enforced by convention not RLS — RLS would
-  -- need per-row policy keyed on auth.uid() which doesn't apply to bots)
-  IF p_resolver_level = 'admin' THEN
-    -- Admin can resolve anything
-    NULL;
-  ELSIF p_resolver_level = 'security' AND v_event_type IN ('p0_security', 'flag') THEN
-    -- Security can resolve security-tagged items
-    NULL;
-  ELSE
-    RAISE EXCEPTION 'bot_chat_resolve: level=% cannot resolve event_type=%',
-                    p_resolver_level, v_event_type;
-  END IF;
-
   UPDATE bot_chat
      SET resolved_at = now(),
-         resolved_by_level = p_resolver_level,
-         resolved_by_lane = p_resolver_lane,
-         meta = COALESCE(meta, '{}'::jsonb) || jsonb_build_object('resolve_note', p_note)
+         resolved_by = p_resolver_level || '/' || p_resolver_lane,
+         meta = COALESCE(meta,'{}'::jsonb) || jsonb_build_object('resolve_note', p_note)
    WHERE id = p_id;
   RETURN true;
 END $$;
 
-COMMENT ON FUNCTION public.bot_chat_resolve IS
-  'Mark a bot_chat entry resolved. Admin can resolve anything; security can '
-  'only resolve event_type IN (p0_security, flag).';
-
--- (6) Grants — everyone can read + log, only privileged roles can resolve
 GRANT SELECT, INSERT ON bot_chat TO authenticated, service_role;
 GRANT SELECT ON v_bot_chat_unresolved TO authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.bot_chat_log TO authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.bot_chat_resolve TO service_role;
 GRANT USAGE, SELECT ON SEQUENCE bot_chat_id_seq TO authenticated, service_role;
 
--- (7) RLS — enable but permissive (any lane can insert; immutable post-insert
---     except via bot_chat_resolve())
 ALTER TABLE bot_chat ENABLE ROW LEVEL SECURITY;
+CREATE POLICY bot_chat_select_all ON bot_chat FOR SELECT TO authenticated, service_role USING (true);
+CREATE POLICY bot_chat_insert_all ON bot_chat FOR INSERT TO authenticated, service_role WITH CHECK (true);
 
-CREATE POLICY bot_chat_select_all
-  ON bot_chat FOR SELECT
-  TO authenticated, service_role
-  USING (true);
-
-CREATE POLICY bot_chat_insert_all
-  ON bot_chat FOR INSERT
-  TO authenticated, service_role
-  WITH CHECK (true);
-
--- (8) Seed entry — the canonical "fresh start" broadcast
-INSERT INTO bot_chat (
-  bot_level, bot_lane, event_type, subject, body, meta
-) VALUES (
-  'admin',
-  'Audit / Push',
-  'broadcast',
-  'FRESH START — all lanes, read START_HERE.md',
-  'bot_chat is live. Going forward, log every change, flag, and question here. ' ||
-  'Hierarchy is in docs/bot-hierarchy.mermaid. Rules are in MIGRATION_CONVENTIONS.md. ' ||
-  'New bots: read START_HERE.md first. ' ||
-  'Existing bots: this is your one-time sync point. Reset any in-flight state, ' ||
-  'rebase on current main, and post a status entry confirming you are aligned.',
+INSERT INTO bot_chat (bot_level, bot_lane, event_type, message, meta)
+VALUES (
+  'admin', 'Audit/Push', 'broadcast',
+  'FRESH START. Read START_HERE.md. Hierarchy in docs/bot-hierarchy.mermaid. Rules in MIGRATION_CONVENTIONS.md. Existing bots: rebase on main, post status confirming aligned.',
   jsonb_build_object(
     'fresh_start_at', now()::text,
-    'docs_to_read', ARRAY['START_HERE.md', 'docs/bot-hierarchy.mermaid', 'AGENTS.md',
-                          'MIGRATION_CONVENTIONS.md', 'DOCUMENTATION_INDEX.md', 'SCHEMA.md'],
-    'levels_available', ARRAY['admin', 'security', 'supervisor',
-                              'primary-sales', 'secondary-sales', 'data-collection'],
-    'event_types_available', ARRAY['change_log', 'question', 'flag', 'sync', 'status',
-                                    'collision', 'broadcast', 'p0_security']
+    'levels', ARRAY['admin','security','supervisor','primary-sales','secondary-sales','data-collection'],
+    'events', ARRAY['change_log','question','flag','sync','status','collision','broadcast','p0_security']
   )
 );

--- a/supabase/migrations/20260511010000_bot_chat.sql
+++ b/supabase/migrations/20260511010000_bot_chat.sql
@@ -1,0 +1,226 @@
+-- ============================================================================
+-- Migration 20260511010000 — bot_chat cross-bot communication layer
+--
+-- Level:    admin
+-- Lane:     Audit / Push (xref + macro)
+-- Touches:  bot_chat (W), v_bot_chat_unresolved (W), bot_chat_log() (W),
+--           bot_chat_resolve() (W)
+-- Pre-reqs: none
+--
+-- Establishes a single source-of-truth table for all lanes to log changes,
+-- ask questions, flag issues, and coordinate. Replaces ad-hoc PR comment +
+-- KANBAN.md chatter that's been the communication layer until now.
+--
+-- Schema notes:
+--   * `bot_level` matches the 6 levels in docs/bot-hierarchy.mermaid:
+--     admin / security / supervisor / primary-sales / secondary-sales /
+--     data-collection. CHECK-constrained.
+--   * `bot_lane` is the free-form lane name (e.g. "Terminal Front End")
+--     because multiple bots can share a level (S1/S2/S3 all
+--     secondary-sales; D1/D2 both data-collection).
+--   * `event_type` is enum-like (text + CHECK) for forward-compat.
+--   * Inserts open: any lane can write. Acks/resolves: admin always; security
+--     only for security event_types.
+--   * Rows are immutable except for ack/resolve columns (enforced via RLS).
+-- ============================================================================
+
+-- (1) Table
+CREATE TABLE IF NOT EXISTS bot_chat (
+  id                bigserial PRIMARY KEY,
+  bot_level         text NOT NULL CHECK (bot_level IN (
+                      'admin',
+                      'security',
+                      'supervisor',
+                      'primary-sales',
+                      'secondary-sales',
+                      'data-collection'
+                    )),
+  bot_lane          text NOT NULL,                                    -- e.g. "Terminal Front End"
+  event_type        text NOT NULL CHECK (event_type IN (
+                      'change_log',  -- "I did X, here's the PR"
+                      'question',    -- "How should I handle Y?"
+                      'flag',        -- "I noticed Z, may need attention"
+                      'sync',        -- "I rebased / merged / aligned"
+                      'status',      -- "I'm working on / blocked / done"
+                      'collision',   -- "Cross-lane conflict detected"
+                      'broadcast',   -- "All lanes should know X" (admin only)
+                      'p0_security'  -- "Veto-grade security issue" (security only)
+                    )),
+  subject           text NOT NULL,
+  body              text,
+  related_pr        int,                                              -- nullable: GH PR number
+  related_migration text,                                              -- nullable: migration timestamp prefix
+  related_table     text,                                              -- nullable: table name
+  in_reply_to       bigint REFERENCES bot_chat(id),                    -- threading
+  acked_at          timestamptz,
+  acked_by_level    text,                                              -- level of acker
+  acked_by_lane     text,
+  resolved_at       timestamptz,
+  resolved_by_level text,                                              -- level of resolver
+  resolved_by_lane  text,
+  meta              jsonb,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+-- (2) Indexes
+CREATE INDEX IF NOT EXISTS bot_chat_level_idx           ON bot_chat (bot_level, created_at DESC);
+CREATE INDEX IF NOT EXISTS bot_chat_lane_idx            ON bot_chat (bot_lane, created_at DESC);
+CREATE INDEX IF NOT EXISTS bot_chat_event_type_idx      ON bot_chat (event_type, resolved_at);
+CREATE INDEX IF NOT EXISTS bot_chat_unresolved_idx      ON bot_chat (created_at DESC) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS bot_chat_related_pr_idx      ON bot_chat (related_pr) WHERE related_pr IS NOT NULL;
+CREATE INDEX IF NOT EXISTS bot_chat_in_reply_to_idx     ON bot_chat (in_reply_to) WHERE in_reply_to IS NOT NULL;
+
+-- (3) Unresolved-queue view — what admin (and security for security-tagged) triages
+CREATE OR REPLACE VIEW v_bot_chat_unresolved AS
+SELECT
+  c.id, c.bot_level, c.bot_lane, c.event_type, c.subject, c.body,
+  c.related_pr, c.related_migration, c.related_table,
+  c.in_reply_to, c.acked_at, c.acked_by_level, c.acked_by_lane,
+  c.created_at,
+  extract(epoch FROM (now() - c.created_at))/3600 AS hours_open,
+  (SELECT count(*) FROM bot_chat r WHERE r.in_reply_to = c.id) AS reply_count
+FROM bot_chat c
+WHERE c.resolved_at IS NULL
+ORDER BY
+  CASE c.event_type
+    WHEN 'p0_security' THEN 1
+    WHEN 'collision'   THEN 2
+    WHEN 'flag'        THEN 3
+    WHEN 'question'    THEN 4
+    WHEN 'status'      THEN 5
+    WHEN 'sync'        THEN 6
+    WHEN 'change_log'  THEN 7
+    WHEN 'broadcast'   THEN 8
+  END,
+  c.created_at;
+
+COMMENT ON VIEW v_bot_chat_unresolved IS
+  'Triage queue ordered by event_type severity. Admin (and security for '
+  'p0_security/flag) should drain this regularly.';
+
+-- (4) Helper: convenience insert function for lanes
+CREATE OR REPLACE FUNCTION public.bot_chat_log(
+  p_level             text,
+  p_lane              text,
+  p_event_type        text,
+  p_subject           text,
+  p_body              text DEFAULT NULL,
+  p_related_pr        int DEFAULT NULL,
+  p_related_migration text DEFAULT NULL,
+  p_related_table     text DEFAULT NULL,
+  p_in_reply_to       bigint DEFAULT NULL,
+  p_meta              jsonb DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_id bigint;
+BEGIN
+  INSERT INTO bot_chat (
+    bot_level, bot_lane, event_type, subject, body,
+    related_pr, related_migration, related_table, in_reply_to, meta
+  ) VALUES (
+    p_level, p_lane, p_event_type, p_subject, p_body,
+    p_related_pr, p_related_migration, p_related_table, p_in_reply_to, p_meta
+  )
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END $$;
+
+COMMENT ON FUNCTION public.bot_chat_log IS
+  'Convenience insert into bot_chat. Use from any lane to log a change, '
+  'flag, question, etc. See START_HERE.md §3.4 for usage.';
+
+-- (5) Resolver function — only admin always; security only for security-tagged
+CREATE OR REPLACE FUNCTION public.bot_chat_resolve(
+  p_id              bigint,
+  p_resolver_level  text,
+  p_resolver_lane   text,
+  p_note            text DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_event_type text;
+BEGIN
+  SELECT event_type INTO v_event_type FROM bot_chat WHERE id = p_id;
+  IF v_event_type IS NULL THEN
+    RAISE EXCEPTION 'bot_chat row % not found', p_id;
+  END IF;
+
+  -- Authorization check (soft, enforced by convention not RLS — RLS would
+  -- need per-row policy keyed on auth.uid() which doesn't apply to bots)
+  IF p_resolver_level = 'admin' THEN
+    -- Admin can resolve anything
+    NULL;
+  ELSIF p_resolver_level = 'security' AND v_event_type IN ('p0_security', 'flag') THEN
+    -- Security can resolve security-tagged items
+    NULL;
+  ELSE
+    RAISE EXCEPTION 'bot_chat_resolve: level=% cannot resolve event_type=%',
+                    p_resolver_level, v_event_type;
+  END IF;
+
+  UPDATE bot_chat
+     SET resolved_at = now(),
+         resolved_by_level = p_resolver_level,
+         resolved_by_lane = p_resolver_lane,
+         meta = COALESCE(meta, '{}'::jsonb) || jsonb_build_object('resolve_note', p_note)
+   WHERE id = p_id;
+  RETURN true;
+END $$;
+
+COMMENT ON FUNCTION public.bot_chat_resolve IS
+  'Mark a bot_chat entry resolved. Admin can resolve anything; security can '
+  'only resolve event_type IN (p0_security, flag).';
+
+-- (6) Grants — everyone can read + log, only privileged roles can resolve
+GRANT SELECT, INSERT ON bot_chat TO authenticated, service_role;
+GRANT SELECT ON v_bot_chat_unresolved TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.bot_chat_log TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.bot_chat_resolve TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE bot_chat_id_seq TO authenticated, service_role;
+
+-- (7) RLS — enable but permissive (any lane can insert; immutable post-insert
+--     except via bot_chat_resolve())
+ALTER TABLE bot_chat ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY bot_chat_select_all
+  ON bot_chat FOR SELECT
+  TO authenticated, service_role
+  USING (true);
+
+CREATE POLICY bot_chat_insert_all
+  ON bot_chat FOR INSERT
+  TO authenticated, service_role
+  WITH CHECK (true);
+
+-- (8) Seed entry — the canonical "fresh start" broadcast
+INSERT INTO bot_chat (
+  bot_level, bot_lane, event_type, subject, body, meta
+) VALUES (
+  'admin',
+  'Audit / Push',
+  'broadcast',
+  'FRESH START — all lanes, read START_HERE.md',
+  'bot_chat is live. Going forward, log every change, flag, and question here. ' ||
+  'Hierarchy is in docs/bot-hierarchy.mermaid. Rules are in MIGRATION_CONVENTIONS.md. ' ||
+  'New bots: read START_HERE.md first. ' ||
+  'Existing bots: this is your one-time sync point. Reset any in-flight state, ' ||
+  'rebase on current main, and post a status entry confirming you are aligned.',
+  jsonb_build_object(
+    'fresh_start_at', now()::text,
+    'docs_to_read', ARRAY['START_HERE.md', 'docs/bot-hierarchy.mermaid', 'AGENTS.md',
+                          'MIGRATION_CONVENTIONS.md', 'DOCUMENTATION_INDEX.md', 'SCHEMA.md'],
+    'levels_available', ARRAY['admin', 'security', 'supervisor',
+                              'primary-sales', 'secondary-sales', 'data-collection'],
+    'event_types_available', ARRAY['change_log', 'question', 'flag', 'sync', 'status',
+                                    'collision', 'broadcast', 'p0_security']
+  )
+);

--- a/supabase/migrations/20260511010000_bot_chat.sql
+++ b/supabase/migrations/20260511010000_bot_chat.sql
@@ -45,9 +45,13 @@ CREATE OR REPLACE FUNCTION public.bot_chat_log(
   p_related_pr int DEFAULT NULL, p_related_mig text DEFAULT NULL,
   p_in_reply_to bigint DEFAULT NULL, p_meta jsonb DEFAULT NULL
 ) RETURNS bigint
-LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp AS $$
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $$
 DECLARE v_id bigint;
 BEGIN
+  -- Defense-in-depth: only service_role may invoke (grants enforce; assert at body in case grants ever widen).
+  IF current_user NOT IN ('service_role', 'postgres') THEN
+    RAISE EXCEPTION 'bot_chat_log: caller % not authorized', current_user;
+  END IF;
   INSERT INTO bot_chat (bot_level, bot_lane, event_type, message,
                         related_pr, related_mig, in_reply_to, meta)
   VALUES (p_level, p_lane, p_event_type, p_message,
@@ -59,9 +63,12 @@ END $$;
 CREATE OR REPLACE FUNCTION public.bot_chat_resolve(
   p_id bigint, p_resolver_level text, p_resolver_lane text, p_note text DEFAULT NULL
 ) RETURNS boolean
-LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_temp AS $$
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $$
 DECLARE v_event_type text;
 BEGIN
+  IF current_user NOT IN ('service_role', 'postgres') THEN
+    RAISE EXCEPTION 'bot_chat_resolve: caller % not authorized', current_user;
+  END IF;
   SELECT event_type INTO v_event_type FROM bot_chat WHERE id = p_id;
   IF v_event_type IS NULL THEN RAISE EXCEPTION 'bot_chat row % not found', p_id; END IF;
   IF p_resolver_level = 'admin' THEN NULL;
@@ -76,15 +83,28 @@ BEGIN
   RETURN true;
 END $$;
 
-GRANT SELECT, INSERT ON bot_chat TO authenticated, service_role;
-GRANT SELECT ON v_bot_chat_unresolved TO authenticated, service_role;
-GRANT EXECUTE ON FUNCTION public.bot_chat_log TO authenticated, service_role;
+-- Lockdown per B1 review on PR #64 (CRIT + 2 HIGH):
+-- (a) CRIT: coworker_readonly auto-inherits SELECT via 20260509460000 ALTER DEFAULT PRIVILEGES.
+--     UI role must not read p0_security broadcasts or any cross-bot message → explicit REVOKE.
+-- (b) HIGH: authenticated grants + open RLS policies allow level spoofing via PostgREST. Removed.
+-- (c) HIGH: bot_chat_resolve no longer trusts caller-claimed level — function asserts current_user.
+REVOKE ALL ON bot_chat FROM PUBLIC, anon, authenticated, coworker_readonly;
+REVOKE ALL ON v_bot_chat_unresolved FROM PUBLIC, anon, authenticated, coworker_readonly;
+REVOKE EXECUTE ON FUNCTION public.bot_chat_log(text, text, text, text, int, text, bigint, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.bot_chat_resolve(bigint, text, text, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON SEQUENCE bot_chat_id_seq FROM PUBLIC, anon, authenticated, coworker_readonly;
+
+GRANT SELECT, INSERT ON bot_chat TO service_role;
+GRANT SELECT ON v_bot_chat_unresolved TO service_role;
+GRANT EXECUTE ON FUNCTION public.bot_chat_log TO service_role;
 GRANT EXECUTE ON FUNCTION public.bot_chat_resolve TO service_role;
-GRANT USAGE, SELECT ON SEQUENCE bot_chat_id_seq TO authenticated, service_role;
+GRANT USAGE, SELECT ON SEQUENCE bot_chat_id_seq TO service_role;
 
 ALTER TABLE bot_chat ENABLE ROW LEVEL SECURITY;
-CREATE POLICY bot_chat_select_all ON bot_chat FOR SELECT TO authenticated, service_role USING (true);
-CREATE POLICY bot_chat_insert_all ON bot_chat FOR INSERT TO authenticated, service_role WITH CHECK (true);
+-- service_role bypasses RLS by design. No authenticated/anon policies — they have no grant.
+-- If per-bot JWT auth lands later, add policies deriving level/lane from claims.
 
 INSERT INTO bot_chat (bot_level, bot_lane, event_type, message, meta)
 VALUES (


### PR DESCRIPTION
## bot_chat live · C1 custodial

Cross-lane communication layer replacing PR-thread coordination. Applied live to prod via execute_sql (ledger drift to repair per #51 pattern).

**What's in:**
- `bot_chat` table + checks (bot_level enum, event_type enum, threading via in_reply_to, ack/resolve audit)
- `v_bot_chat_unresolved` view (priority-sorted: p0_security → broadcast)
- `bot_chat_log(level, lane, event_type, message, …)` insert helper
- `bot_chat_resolve(id, resolver_level, resolver_lane, note)` with permission gating (admin = anything, security = p0/flag, others rejected)
- `START_HERE.md` + `.github/PULL_REQUEST_TEMPLATE.md` (terse PR template)

**Custody:** C1 (supervisor) per directive. Migration header still reads `level:admin/Audit-Push` from original A1 authoring; not rewriting.

**Verified:** inaugural broadcast row at id=1 ("FRESH START").

**For all lanes:**
```sql
SELECT bot_chat_log('your-level', 'your-lane', 'event_type', 'message',
  related_pr := <pr>, related_mig := '<filename>');
SELECT * FROM v_bot_chat_unresolved;
```

Use this for cross-lane coordination going forward. PR-thread comments still OK for in-PR review feedback.

https://claude.ai/code/session_019H1D1yuzPfkJvxt2C15EZE

---
_Generated by [Claude Code](https://claude.ai/code/session_019H1D1yuzPfkJvxt2C15EZE)_