### PR TITLE
fix(security): REVOKE EXECUTE FROM PUBLIC on PR #66 SECURITY DEFINER fns

### DIFF
--- a/supabase/migrations/20260513000000_security_lock_pr66_definer_fns.sql
+++ b/supabase/migrations/20260513000000_security_lock_pr66_definer_fns.sql
@@ -1,0 +1,32 @@
+-- Migration 20260513000000 · level:admin · lane:Audit/Push · writes:revokes+grants(sweep_duplicate_listings,sweep_terminal_event_listings,match_listings_to_sg_tick) · pre:20260512240000
+
+-- A1 security review of PR #66: three SECURITY DEFINER functions shipped
+-- without explicit REVOKE FROM PUBLIC. Postgres grants EXECUTE to PUBLIC by
+-- default on CREATE FUNCTION; combined with SECURITY DEFINER, an anon caller
+-- can hit /rest/v1/rpc/<fn> via PostgREST and:
+--   * sweep_duplicate_listings(p_max_events := <huge>) — mass DELETE on listings_snapshots
+--   * sweep_terminal_event_listings(p_max_events := <huge>) — same
+--   * match_listings_to_sg_tick() — pollute listing_xref with bogus matches
+--
+-- Pattern inconsistent with PR #64/#65 which REVOKE + assert current_user at
+-- the function body. This migration brings #66's functions in line: REVOKE
+-- from PUBLIC/anon/authenticated; explicit GRANT to service_role only.
+-- Cron jobs run as the cron-owner (service_role/postgres) so they're
+-- unaffected.
+--
+-- Follow-up (separate PR): re-CREATE the 3 functions with `IF current_user
+-- NOT IN ('service_role', 'postgres') THEN RAISE EXCEPTION` defense-in-depth
+-- per the pattern A1 established in 20260512200000 and C1 adopted in #64.
+-- The grant model is the primary gate; the body assertion is belt-and-
+-- suspenders for the day someone widens a grant by mistake.
+
+REVOKE EXECUTE ON FUNCTION public.sweep_duplicate_listings(int)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sweep_terminal_event_listings(int)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.match_listings_to_sg_tick()
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.sweep_duplicate_listings(int) TO service_role;
+GRANT EXECUTE ON FUNCTION public.sweep_terminal_event_listings(int) TO service_role;
+GRANT EXECUTE ON FUNCTION public.match_listings_to_sg_tick() TO service_role;


### PR DESCRIPTION
## Summary

A1 retroactive audit of PR #66 (`3da96ec`) caught 3 SECURITY DEFINER functions shipped without `REVOKE EXECUTE FROM PUBLIC`. Postgres grants EXECUTE to PUBLIC on `CREATE FUNCTION` by default; combined with `SECURITY DEFINER`, that means anon can invoke them via PostgREST `/rest/v1/rpc/<fn>`:

| Function | Worst case if anon-callable |
|---|---|
| `sweep_duplicate_listings(int)` | Mass DELETE on `listings_snapshots` (passes attacker-supplied `p_max_events`) |
| `sweep_terminal_event_listings(int)` | Same |
| `match_listings_to_sg_tick()` | Pollute `listing_xref` with bogus matches |

Pattern inconsistent with the post-#57 grant-model established by PR #64 (`bot_chat_log` / `bot_chat_resolve`) and PR #65 (`sweep_expired_pg_net_pending`), which both REVOKE + assert `current_user`.

## Fix

`REVOKE EXECUTE FROM PUBLIC, anon, authenticated` + explicit `GRANT EXECUTE TO service_role` on all 3 functions. Cron jobs run as `service_role`/`postgres`, so the scheduled sweeps are unaffected.

## Follow-up (separate PR)

Re-CREATE the 3 functions with `IF current_user NOT IN ('service_role', 'postgres') THEN RAISE EXCEPTION` defense-in-depth at the body, matching the pattern in `20260511010000_bot_chat.sql` and `20260512200000_c1_pg_net_retention_sweep.sql`. The grant model is the primary gate; the body assertion catches the day someone widens a grant by mistake.

## Test plan

- [ ] CI green
- [ ] Operator verifies `\df+ sweep_duplicate_listings` shows only `service_role` after apply
- [ ] Cron `sweep_duplicate_listings_hourly` continues to tick after apply (visible in `cron.job_run_details`)
- [ ] `POST /rest/v1/rpc/sweep_duplicate_listings` with anon key returns 401/403 (was: silently dropped rows)

https://claude.ai/code/session_01N2AB5FXu6TkTMGe3W2jxqG

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2AB5FXu6TkTMGe3W2jxqG)_