### PR TITLE
feat(infra): Render MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "render": {
+      "type": "http",
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${RENDER_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds project-level Render MCP server config.

**Config:**
- `.mcp.json` (committed) — references `${RENDER_API_KEY}`
- `.env` (gitignored already) — holds the actual key

**Activation:** restart Claude Code session. MCP tools `mcp__render__*` will surface after reload.

**Once live:**
- `list_workspaces` / `set_workspace` for routing
- `list_services` for deploy baseline
- A1 can manage Render services directly (web services, static sites, cron jobs, Postgres, Key Value)
- Closes one of B1's deferred items from #57 (Railway→Render migration prep)

**API key scope:** broadly scoped per Render docs — grants access to all workspaces the operator account sees. Only destructive op MCP supports is modifying existing service env vars. Operator should rotate the bootstrap key after MCP verification.

**Limitations:**
- Cannot delete services, modify scaling, IP allowlists, image-backed services
- Cannot trigger deploys (use dashboard or REST API for that)
- env-var modifications on existing services are the one destructive op exposed

https://claude.ai/code/session_019H1D1yuzPfkJvxt2C15EZE

---
_Generated by [Claude Code](https://claude.ai/code/session_019H1D1yuzPfkJvxt2C15EZE)_