### PR TITLE
chore(admin): stop reddit cron pipeline (P0 resource pressure)

### DIFF
--- a/supabase/migrations/20260513002000_stop_reddit_crons.sql
+++ b/supabase/migrations/20260513002000_stop_reddit_crons.sql
@@ -1,0 +1,38 @@
+-- Migration 20260513002000 · level:admin · lane:Audit/Push · writes:cron(unschedule reddit_queue_30min,reddit_process_30min,reddit_pending_sweep_daily) · reads:- · pre:20260513001000
+-- P0 resource-pressure response 2026-05-12: Supabase performance advisor
+-- flagged the project as "exhausting multiple resources." Reddit pipeline
+-- (PR 20260509410000) has no active use case yet — operator directive 22:50 EDT:
+-- "stop reddit pulls, no use case yet."
+--
+-- This migration unschedules the 3 reddit crons:
+--   * reddit_queue_30min          (jobid 75, schedule */30)
+--   * reddit_process_30min        (jobid 76, schedule 5-59/30)
+--   * reddit_pending_sweep_daily  (jobid 77, schedule 40 3 * * *)
+--
+-- Function definitions (reddit_queue, reddit_process, reddit_pending_sweep)
+-- are PRESERVED — only the schedules drop. Reactivation requires re-running
+-- the cron.schedule() calls from 20260509410000 (or a successor migration).
+--
+-- Why: 18s mean per reddit_queue call × ~48 calls/day = ~14 minutes of DB
+-- time/day spent on data nobody reads. Net wins:
+--   * Drops jobid 75 from the expensive-query top-15 (1.5% of total)
+--   * Frees pg_cron worker slots (was occasionally blocking other refreshes)
+--   * Removes Reddit API call traffic (no quota, but unnecessary)
+--
+-- Tables retained, no data wiped — historical reddit_signals rows are still
+-- queryable, just no new pulls. If reactivation is needed, see
+-- 20260509410000_betting_odds_and_reddit_signals.sql lines 475-492 for the
+-- original schedule blocks.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'reddit_queue_30min') THEN
+    PERFORM cron.unschedule('reddit_queue_30min');
+  END IF;
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'reddit_process_30min') THEN
+    PERFORM cron.unschedule('reddit_process_30min');
+  END IF;
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'reddit_pending_sweep_daily') THEN
+    PERFORM cron.unschedule('reddit_pending_sweep_daily');
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Supabase performance advisor flagged the project as **"exhausting multiple resources"** on 2026-05-12.
- `reddit_queue()` measured at **18s mean × ~48 calls/day = ~14 minutes of DB time/day** on data with no active consumer.
- **Operator directive** (22:50 EDT): _"stop reddit pulls, no use case yet."_
- Unschedules the 3 reddit crons. Function definitions and `reddit_signals` table retained — clean reactivation path preserved.

## What's dropped
| jobid | jobname | schedule |
|---|---|---|
| 75 | `reddit_queue_30min` | `*/30 * * * *` |
| 76 | `reddit_process_30min` | `5-59/30 * * * *` |
| 77 | `reddit_pending_sweep_daily` | `40 3 * * *` |

## What's preserved
- `reddit_queue()`, `reddit_process()`, `reddit_pending_sweep()` functions (no DROP)
- `reddit_signals` / `performer_reddit_pulse` tables and historical data
- Reactivation path: re-run the `cron.schedule()` blocks from `20260509410000_betting_odds_and_reddit_signals.sql` (lines 475–492) or write a successor migration.

## Already applied to prod
Migration was executed via MCP **before** this PR landed (P0 mitigation). The migration file in this PR is the **idempotent codification** for repo reproducibility — uses `IF EXISTS` guards so it's a no-op on re-apply against current prod state.

## Test plan
- [x] All 3 jobs gone from `cron.job` (verified post-apply: `SELECT * FROM cron.job WHERE jobname ILIKE 'reddit%'` returns empty)
- [x] Functions still exist (no callers will break)
- [x] Idempotent under re-apply (`IF EXISTS` guards)

## Related advisor lines from the alert (next owners to ping via bot_chat)
- `master_cascade_2min()` — 11s mean × 1,020 calls (15.5%) — top orchestrator
- `v_dashboard_writes_24h` refresh every 60s at 5.3s mean (8.8% of clock time)
- `backfill_stale_zone_metrics()` — 60s mean × 175 calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)