### PR TITLE
docs(admin): bot-hierarchy chart + evo-store next-steps

### DIFF
--- a/BOT_HIERARCHY.md
+++ b/BOT_HIERARCHY.md
@@ -1,0 +1,152 @@
+# BOT_HIERARCHY.md
+
+**Quick-reference chart for who-does-what and who-can-push-where. Updated 2026-05-13.**
+
+If the chart in this doc disagrees with `docs/bot-hierarchy.mermaid` or `DOCUMENTATION_INDEX.md` — this doc wins (DOCUMENTATION_INDEX was last refreshed 2026-05-10 with the old `code/canonical/broadway/storefront` naming and is partially stale; the lane reassignments in `bot_chat` rows 50-58 superseded it).
+
+---
+
+## 1. Hierarchy at a glance
+
+```
+                     ┌──────────────────────────────┐
+                     │            A1                │  admin
+                     │  Audit / Push (Admin)        │  sole prod pusher
+                     └──────────────┬───────────────┘
+                                    │ delegates security audits to
+                                    ▼
+                     ┌──────────────────────────────┐
+                     │            B1                │  security
+                     │  Security Manager            │  prod push only for CRIT patches
+                     └──────────────┬───────────────┘
+                                    │ oversees data + sales lanes via
+                                    ▼
+                     ┌──────────────────────────────┐
+                     │            C1                │  supervisor
+                     │  Canonical (Data + Chat)     │  preview branches only
+                     └──┬──────┬──────┬──────┬──────┘
+                        │      │      │      │
+       ┌────────────────┘      │      │      └─────────────────┐
+       ▼                       ▼      ▼                        ▼
+  ┌────────┐            ┌─────────┐ ┌─────────┐         ┌────────────┐
+  │  D0    │            │   D1    │ │   D2    │         │     D4     │
+  │ Term FE│            │ Consumer│ │  Order  │         │ Ticketing  │
+  │ (RO    │            │  Retail │ │ Clients │         │ infra      │
+  │  ref)  │            │  + Rndr │ │         │         │ UNASSIGNED │
+  └────────┘            └─────────┘ └────┬────┘         └────────────┘
+                                         │
+                                         │ sub
+                                         ▼
+                                    ┌─────────┐
+                                    │   D3    │
+                                    │Broadway │
+                                    │Scraper  │
+                                    └─────────┘
+```
+
+All D-tier lanes use `bot_level = data-collection` in `bot_chat`. The hierarchy ranks
+the sub-relationships within that level.
+
+---
+
+## 2. Lane roster (current state)
+
+| Lane | Identity / role | Worktree branch | bot_level | Status |
+|---|---|---|---|---|
+| **A1** | Audit / Push (Admin) | `mystifying-lederberg-ea407b` | `admin` | ACTIVE |
+| **B1** | Security Manager | `review-supabase-access-v8Dtl` | `security` | ACTIVE (SECURITY BACKLOG drain) |
+| **C1** | Canonical (Data + Chat supervisor) | `audit-datasets-schemas-auoc3` | `supervisor` | ACTIVE (PR #51 phase 13) |
+| **D0** | Terminal FE / read-only reference + prediction guide | `audit-datasets-schemas-auoc3` (reassigned) | `data-collection` | ACTIVE |
+| **D1** | Consumer Retail (storefront + search + share-links) | `eloquent-chatterjee-aaedf0` | `data-collection` | ACTIVE (PR #54 merged) |
+| **D2** | Order Clients (seatdata + evo + sg + tickpick + vivid ORDERS, no listings) | `review-unified-order-suite-FA0qA` | `data-collection` | ACTIVE (PR #56) |
+| **D3** | Broadway Scraper (sub of D2) | `broadway-scraper-eChQ6` | `data-collection` | ACTIVE (PR #52) |
+| **D4** | Our ticketing infra (AR codes, custom ticketing) | — | — | UNASSIGNED |
+
+---
+
+## 3. Push restrictions matrix
+
+| | Prod DB (Supabase main project) | Prod git (`main` branch) | Render workspace | Edge functions | Vault / secrets |
+|---|---|---|---|---|---|
+| **A1** | ✅ via MCP | ✅ merge any PR | ✅ (until D1 takes over) | ✅ deploy | ✅ rotate/set |
+| **B1** | ✅ **CRIT security only** | ✅ for sec PRs | ❌ | ✅ for sec | ✅ |
+| **C1** | ❌ preview only; A1 applies | ❌ A1 merges | ❌ | ❌ A1 deploys | ❌ |
+| **D0** | ❌ preview only | ❌ A1 merges | ❌ | ❌ | ❌ |
+| **D1** | ❌ preview only | ❌ A1 merges | ✅ **sole owner** | ❌ A1 deploys | ❌ |
+| **D2** | ❌ preview only | ❌ A1 merges | ❌ | ❌ | ❌ |
+| **D3** | ❌ preview only | ❌ A1 merges | ❌ | ❌ | ❌ |
+
+**Two hard rules surface from this:**
+- **Only A1 pushes prod DB and merges to `main`.** B1 is the exception for CRIT security only.
+- **Only D1 touches Render.** D0/D2/D3/D4 may NOT push to Render, provision services there, modify env vars, or configure crons in the Render workspace.
+
+---
+
+## 4. Single-writer table ownership (writes)
+
+Single-writer rule: the lane that created a table owns its writes. Others can read or call write-RPCs.
+
+| Lane | Tables they write (illustrative — not exhaustive) |
+|---|---|
+| **A1** | `event_xref`, `*_xref`, performance crons, audit views, sweep functions (`sweep_old_listings`, `sweep_duplicate_listings`, etc.), `latest_event_metrics` matview, FRED macro tables |
+| **B1** | `pg_policies` (via migrations), `secrets`-related, RLS configs |
+| **C1** | `events`, `*_canonical`, `*_resolved` sidecars (e.g. `seatgeek_orders_resolved`), `bot_chat`, dashboard matviews, `seatgeek_event_xref` (canonical authority — D2's sidecar is the canonical write path, not parallel writes on `seatgeek_orders.tevo_event_id`) |
+| **D0** | (read-only reference) |
+| **D1** | `share_links`, storefront `app.py` (no DB tables directly) |
+| **D2** | `evo_orders`, `evo_order_items`, `seatgeek_orders` (raw), `tickpick_orders`, `vivid_orders`, `seatdata_sales_snapshots`. **Sidecar pattern**: D2 writes to `*_orders` raw, C1 resolves into `*_resolved` sidecar. D2 will NOT add parallel `tevo_event_id` write paths — sidecar is canonical (2026-05-12 decision). |
+| **D3** | `broadway_*` tables |
+
+When in doubt, post a `question` in `bot_chat` and A1 / C1 will adjudicate.
+
+---
+
+## 5. Code-review + push workflow (the fast path)
+
+For any change a lane wants in prod:
+
+1. **Branch** — `claude/<lane>-<purpose>-<id>`, off `main`.
+2. **Migration header** (required, one line, see `MIGRATION_CONVENTIONS.md` §3):
+   `-- Migration <ts> · level:<X> · lane:<Y> · writes:<...> · reads:<...> · pre:<...>`
+3. **PR** — use `.github/PULL_REQUEST_TEMPLATE.md` (declares Level + Lane + Tables + Pre-reqs + Test plan).
+4. **Apply to preview branch** via MCP, never to the main project_id.
+5. **bot_chat log** — `change_log` event with PR# linked.
+6. **Hand to A1 for review + push** — A1 reviews, applies migration to prod via MCP, merges PR, posts close-out `change_log`.
+
+Critical security patches: B1 may apply directly with `event_type='p0_security'` and a post-mortem in the same `bot_chat` row.
+
+---
+
+## 6. SECURITY DEFINER function convention (PR #67/#68 — adopted 2026-05-13)
+
+Every SECURITY DEFINER function ships in **one migration** with three lines together, every time:
+
+```sql
+CREATE OR REPLACE FUNCTION public.my_function(...)
+RETURNS ... LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$ BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'my_function: caller % not authorized', current_user;
+  END IF;
+  -- function body
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.my_function(...) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.my_function(...) TO service_role;
+```
+
+Belt-and-suspenders: grant gate (primary) + body assertion (defense-in-depth). To be folded into `MIGRATION_CONVENTIONS.md` §6/§12 next pass.
+
+---
+
+## 7. Quick links
+
+- `MIGRATION_CONVENTIONS.md` — the full rules (13 sections, the canonical reference)
+- `START_HERE.md` — 2-min bootstrap, hard rules
+- `DOCUMENTATION_INDEX.md` — full doc map (note: 2026-05-10 vintage, partial drift on lane names)
+- `docs/bot-hierarchy.mermaid` — visual diagram (refreshed 2026-05-13)
+- `bot_chat` rows 50-58 — lane-assignment broadcasts that established this hierarchy
+- `bot_chat` row 57 — INFRA OWNERSHIP RULE (D1 Render-exclusive)
+- `bot_chat` row 64 — sidecar-canonical decision (D2 will not add parallel writes)
+
+Owner: A1. Update when a lane assignment changes or a new bot is rostered.

--- a/docs/bot-hierarchy.mermaid
+++ b/docs/bot-hierarchy.mermaid
@@ -1,93 +1,68 @@
 %% bot-hierarchy.mermaid — Terminal-2 bot command structure
 %%
+%% Refreshed 2026-05-13. See BOT_HIERARCHY.md for the canonical chart;
+%% this file is the visual companion (kept current with the same data).
+%%
 %% ====================================================================
-%% IN-FLIGHT HANDOFF — A1 -> B1 · 2026-05-10 · "security chat" session
+%% Current lane roster (bot_chat rows 50-58, 2026-05-12)
 %% ====================================================================
 %%
-%% Security audit completed by A1 (Primary/Audit/Push Bot). 16 findings
-%% filed under "SECURITY BACKLOG" in KANBAN.md on branch
-%% claude/review-supabase-access-v8Dtl (PR #57, draft).
+%%   A1 - Audit / Push (Admin)              admin           prod pusher
+%%   B1 - Security Manager                  security        CRIT-only prod
+%%   C1 - Canonical (Data + Chat super)     supervisor      preview only
+%%   D0 - Terminal FE (RO reference)        data-collection
+%%   D1 - Consumer Retail + Render owner    data-collection
+%%   D2 - Order Clients (orders, no list.)  data-collection
+%%   D3 - Broadway Scraper (sub of D2)      data-collection
+%%   D4 - Ticketing infra (AR codes)        UNASSIGNED
 %%
-%% Passing UP to B1 (Security Manager Bot) for triage + delegation —
-%% B1 is the chart's chartered security role; S1->B1 audit-feed already
-%% exists, so this is in-protocol.
+%% Two hard rules surface from this hierarchy:
+%%   1) Only A1 pushes prod DB / merges to main. B1 for CRIT security only.
+%%   2) Render workspace is D1-exclusive. D0/D2/D3/D4 may NOT push to Render.
 %%
-%% B1's delegation map (which executing bot owns each entry):
-%%
-%%   SEC-CRIT: Rotate leaked CRON_SECRET + redact         -> A1
-%%   SEC-CRIT: Rotate coworker_readonly password          -> A1
-%%   SEC-CRIT: Auth on /api/store/share* POST/DEL/list    -> P1
-%%   SEC-CRIT: Fix fail-open CRON_SECRET (app + edge)     -> A1 + C1
-%%   SEC-CRIT: DOM-XSS in static/store/store.js           -> P1
-%%   SEC-HIGH: SET search_path on 3 DEFINER funcs         -> A1
-%%   SEC-HIGH: RLS coverage audit (~120 tables)           -> A1 (B1 signs off)
-%%   SEC-HIGH: Verify Supabase network restrictions       -> A1
-%%   SEC-HIGH: chat edge fn CORS + rate-limit             -> C1
-%%   SEC-HIGH: Move anon JWT out of cron migrations       -> A1
-%%   SEC-HIGH: Replace AUTH_DISABLED kill-switch          -> A1
-%%   SEC-HIGH: Auth-gate 5 unauth'd edge fns              -> C1
-%%   SEC-MED:  CSP + CORS middleware                      -> A1 + P1
-%%   SEC-MED:  Constant-time secret compare               -> A1 + C1
-%%   SEC-MED:  Rate limit /api/store/*                    -> A1 + P1
-%%   SEC-MED:  Bound numeric params in store.js           -> P1
-%%   SEC-LOW:  SRI + clickjacking on retail HTML          -> P1
-%%   SEC-LOW:  Document get_app_secret whitelist          -> B1
-%%
-%% Recommended order: rotate CRON_SECRET first — unblocks safe deploys
-%% for the rest of the backlog (several follow-up fixes need the env in
-%% place first).
-%%
-%% NOT recipients of any entry: S1, S2, S3, D1, D2 — no findings landed
-%% in their surfaces.
-%%
-%% Carrier: PR #57 (https://github.com/JulianS4K/Terminal-2/pull/57)
+%% Sidecar canonical: D2 will NOT add parallel tevo_event_id write paths.
+%% C1 owns *_resolved sidecars. Operator decision 2026-05-12, bot_chat #64.
 %% ====================================================================
 
 graph TD
     subgraph CONTROL[Command & Control]
-        A1[Primary/Audit/Push Bot<br/>Admin<br/>handoff sent -> B1 via PR #57]
-        B1[Security Manager Bot<br/>Manager<br/>INBOX: SECURITY BACKLOG · 16 entries]
-        C1[Data + Chat Bot<br/>Supervisor]
-
+        A1[A1<br/>Audit / Push - Admin<br/>sole prod pusher]
+        B1[B1<br/>Security Manager<br/>CRIT-only prod push]
+        C1[C1<br/>Canonical / Data + Chat<br/>supervisor - preview only]
         A1 --> B1
         B1 --> C1
     end
 
-    subgraph PRIMARY[Primary Sales Environment]
-        P1[Retail Ticket System Bot<br/>Front & Back - Admin]
+    subgraph DATA[Data-Collection Lanes - under C1]
+        D0[D0<br/>Terminal FE<br/>RO reference + prediction]
+        D1[D1<br/>Consumer Retail<br/>SOLE Render owner]
+        D2[D2<br/>Order Clients<br/>orders only - no listings]
+        D3[D3<br/>Broadway Scraper<br/>sub of D2]
+        D4[D4<br/>Our Ticketing Infra<br/>UNASSIGNED]
+        D2 --> D3
     end
 
-    subgraph SECONDARY[Secondary Sales Environment]
-        S1[Terminal Front End Bot<br/>Design & Implementation<br/>audit-datasets-schemas-auoc3]
-        S2[Retail Search Evo Front End Bot<br/>Design & Implementation]
-        S3[Undelivered Front End Bot<br/>Design & Implementation<br/>assigned: review-unified-order-suite-FA0qA / PR #56]
-    end
+    C1 --> D0
+    C1 --> D1
+    C1 --> D2
+    C1 --> D4
 
-    subgraph DATA[Data Collection]
-        D1[Broadway Scraper Bot<br/>Data Scraping]
-        D2[TickPick + Vivid Order Clients<br/>Read-only API Pulls<br/>RULE 2 bucket: Evo / SG / TP / VIV]
-    end
+    A1 -.->|reviews + pushes<br/>all prod changes| C1
+    A1 -.->|reviews + pushes| B1
 
-    C1 --> PRIMARY
-    C1 --> SECONDARY
-    C1 --> DATA
+    D1 -.->|Render workspace<br/>EXCLUSIVE| D1RNDR((Render))
+    D2 -.->|writes raw orders;<br/>C1 resolves to<br/>*_resolved sidecar| C1
 
-    D1 -.->|feeds data| S1
-    D2 -.->|unfulfilled / pending<br/>shipment orders| S3
-    A1 -.->|event_xref writes<br/>cascade via S1's<br/>drift triggers| S1
-    S1 -.->|audit views<br/>drift reports| B1
-    A1 ==>|2026-05-10 security audit<br/>16 backlog entries<br/>PR #57| B1
-
-    classDef adminClass fill:#ff6b6b,stroke:#c92a2a,color:#fff,stroke-width:3px
-    classDef managerClass fill:#4c6ef5,stroke:#364fc7,color:#fff,stroke-width:3px
-    classDef supervisorClass fill:#51cf66,stroke:#2f9e44,color:#fff,stroke-width:3px
-    classDef primaryClass fill:#ff8787,stroke:#fa5252,color:#fff,stroke-width:2px
-    classDef secondaryClass fill:#ffd43b,stroke:#fab005,color:#000,stroke-width:2px
-    classDef dataClass fill:#74c0fc,stroke:#339af0,color:#000,stroke-width:2px
+    classDef adminClass     fill:#ff6b6b,stroke:#c92a2a,color:#fff,stroke-width:3px
+    classDef securityClass  fill:#4c6ef5,stroke:#364fc7,color:#fff,stroke-width:3px
+    classDef supervClass    fill:#51cf66,stroke:#2f9e44,color:#fff,stroke-width:3px
+    classDef dataClass      fill:#74c0fc,stroke:#339af0,color:#000,stroke-width:2px
+    classDef unassignedCl   fill:#dee2e6,stroke:#868e96,color:#000,stroke-width:1px,stroke-dasharray: 5 5
+    classDef extClass       fill:#fff3bf,stroke:#fab005,color:#000,stroke-width:2px
 
     class A1 adminClass
-    class B1 managerClass
-    class C1 supervisorClass
-    class P1 primaryClass
-    class S1,S2,S3 secondaryClass
-    class D1,D2 dataClass
+    class B1 securityClass
+    class C1 supervClass
+    class D0,D1,D2,D3 dataClass
+    class D4 unassignedCl
+    class D1RNDR extClass

--- a/docs/evo_store_next_steps.md
+++ b/docs/evo_store_next_steps.md
@@ -1,0 +1,138 @@
+# Evo Store — Next Steps to Live
+
+**Owner: D1 (Consumer Retail). Render workspace exclusive.**
+**Date: 2026-05-13. State after PR #71 (latest_event_metrics matview) + PR #72 (reddit stop).**
+
+This is the green-light list for getting the storefront from "data flowing, catalog blocked" to "fully live." Items are ordered by what unblocks what.
+
+---
+
+## What's already done (don't redo)
+
+| ✅ | Item | Evidence |
+|---|---|---|
+| ✅ | `STOREFRONT_SQL_ONLY=false` on Render | env var set, verified via `/api/store/events/3346000 inventory_source=live` |
+| ✅ | TEvo live path proven end-to-end | bot_chat row 60 — `/api/store/search?q=knicks source=live` 11s, listings_count=190 matches direct TEvo |
+| ✅ | EVO_API_TOKEN + secrets in Render env | both EVO_API sets confirmed in 2026-05-12 sweep |
+| ✅ | CORS_ALLOWED_ORIGINS set | confirmed in 2026-05-12 sweep |
+| ✅ | `latest_event_metrics` view fixed (was 50s, blocking `/api/store/events`) | **PR #71** — now matview, warm query 272ms |
+| ✅ | `evo_client.py` security hardening (URL/body redact from RuntimeError) | PR #66 |
+
+---
+
+## What's still blocking (do these in order)
+
+### 1. Deploy branch sync — most urgent
+
+The Render service `vibepass-storefront-test` is wired to deploy from the branch `claude/store-sql-only-demo-mode`. As of last check that branch is **9928 lines behind `main`** — it doesn't have:
+- The `evo_client.py` security patch (PR #66)
+- The `latest_event_metrics` matview (PR #71 — without it, catalog will time out)
+- The reddit-stop migration (PR #72, low-impact for retail but cleanup)
+- All of B1's RLS/security migrations
+
+**Two options** (D1 picks):
+
+**Option A: merge `main` → `claude/store-sql-only-demo-mode`** (preserves the demo-mode branch name, no Render reconfig needed):
+```bash
+git fetch origin
+git checkout claude/store-sql-only-demo-mode
+git merge origin/main
+# resolve any conflicts (likely none — app.py paths don't conflict)
+git push origin claude/store-sql-only-demo-mode
+# Render will auto-deploy
+```
+
+**Option B: repoint Render at `main`** (cleaner long-term, no more dual-branch maintenance):
+- In Render UI for service `srv-d8140bnaqgkc73al4asg` (vibepass-storefront-test):
+  Settings → Branch → change `claude/store-sql-only-demo-mode` → `main` → Save.
+- Trigger a manual deploy from `main`.
+
+Recommend **Option B** — eliminates the drift risk going forward. A1 will not enforce; D1's call.
+
+### 2. JWT key format
+
+`/api/public/config` was returning valid keys but `Invoke-RestMethod` against `/rest/v1/events?select=count` returned `"message":"Invalid API key"` for BOTH the legacy `anon` and `service_role` JWTs (`eyJ...` format). Both keys match the values shown in the Supabase Settings sidebar — so this is not a copy/paste error.
+
+**Hypothesis**: the project's JWT signing secret was rotated between when those legacy JWTs were issued and now. Supabase now expects the new key format.
+
+**Action for D1**:
+1. In Supabase Dashboard → Project Settings → API → grab the **publishable key** (`sb_publishable_...`) and the **secret key** (`sb_secret_...`). These are the post-rotation format.
+2. Update Render env vars:
+   - `SUPABASE_ANON_KEY` → set to the `sb_publishable_...` value
+   - `SUPABASE_SERVICE_ROLE_KEY` → set to the `sb_secret_...` value
+3. Update the local `.env` (D1's worktree) and `app.py`'s `SUPABASE_KEY` constant reference to match the new env-var names if the code uses literal `eyJ` prefix anywhere (it shouldn't — check `app.py:102`).
+4. Trigger Render redeploy.
+
+A1 verified the old `eyJ` legacy JWTs no longer pass `/rest/v1` calls in PowerShell sweep 2026-05-12. The keys themselves were copied correctly; they're just no longer valid.
+
+### 3. Re-verify catalog endpoint
+
+Once #1 and #2 land:
+
+```powershell
+# Health check
+Invoke-RestMethod "https://vibepass-storefront-test.onrender.com/healthz"
+# Expect: { ok: true, ... }
+
+# Catalog (this was the broken endpoint — fixed by PR #71)
+Invoke-RestMethod "https://vibepass-storefront-test.onrender.com/api/store/events?limit=3"
+# Expect: 200 in <2s, array of 3 events with inventory_source=live
+
+# Detail
+Invoke-RestMethod "https://vibepass-storefront-test.onrender.com/api/store/events/3346000"
+# Expect: inventory_source=live, listings_count > 0
+```
+
+Acceptance: all three return 200, catalog returns in <2s end-to-end (matview query is 272ms; the rest is network + TEvo enrichment).
+
+### 4. Google Auth (deferred)
+
+`ALLOWED_EMAIL_DOMAIN` is set but Google Auth was never plugged in. Storefront currently runs without login gate.
+
+**For initial live launch**: that's fine — the storefront is read-only (search + browse + share-link), no auth needed for general public.
+
+**For "logged-in users get a different view"** features (your watch lists, saved searches, etc.): D1 + A1 will wire Google OAuth in a follow-up. Pre-reqs:
+- Decide whether to use Supabase Auth (Google provider) or roll Flask-side OAuth.
+- Add `GOOGLE_OAUTH_CLIENT_ID` + `GOOGLE_OAUTH_CLIENT_SECRET` to Render env vars (and Supabase vault for cron access).
+- Add `/auth/google/callback` route in `app.py`.
+
+Track this as a separate task; not a blocker for retail go-live.
+
+---
+
+## Reference — Render service details
+
+| Field | Value |
+|---|---|
+| Service ID | `srv-d8140bnaqgkc73al4asg` |
+| Service name | `vibepass-storefront-test` |
+| Current branch | `claude/store-sql-only-demo-mode` (9928 lines behind main as of 2026-05-13) |
+| Recommended branch | `main` (eliminates drift) |
+| Autodeploy | `true` |
+| Render MCP server | `.mcp.json` + `.env` landed in PR #70 — D1 has access |
+
+---
+
+## Reference — Endpoints already proven working in live mode
+
+From bot_chat row 60 (2026-05-12 22:03 UTC):
+
+- `GET /healthz` → 200
+- `GET /api/store/search?q=knicks` → `source=live`, 11s (TEvo enrichment time, not query time)
+- `GET /api/store/events/3346000` → `inventory_source=live`, `listings_count=190` (matches direct TEvo)
+
+Only `/api/store/events` (catalog list) was broken — now fixed via PR #71.
+
+---
+
+## bot_chat thread
+
+- Row 50-58 — C1 lane assignments + Render-exclusive rule
+- Row 59-60 — D1 ack + status (live mode confirmed)
+- Row 61 — D1 escalation (latest_event_metrics slow)
+- Row 63 — A1 reply: matview shipped PR #71
+- Row 64 — A1 broadcast: reddit stop, sidecar canonical, strict matcher unblock, LEM matview
+
+D1: post a `change_log` after step #1 (deploy branch sync) and step #3 (catalog re-verify) lands. Link this doc.
+
+A1: keep PR review/push gate. Will apply any storefront-blocking migrations same-day if D1 flags them.


### PR DESCRIPTION
## Summary
Two reference docs to make code-review + push workflow faster, plus the green-light list to get the evo storefront fully live.

## Files

### `BOT_HIERARCHY.md` (new, repo root)
Quick-reference chart for who-can-push-where:
- Current lane roster (A1/B1/C1/D0-D4) — supersedes `DOCUMENTATION_INDEX.md` (2026-05-10, partial drift)
- Push restrictions matrix (prod DB / git main / Render / edge fns / vault)
- Single-writer table ownership map
- SECURITY DEFINER function convention from PR #67/#68 (REVOKE + GRANT + body-assert pattern)
- Fast-path PR workflow

### `docs/bot-hierarchy.mermaid` (refreshed)
Previous version still showed old `code/canonical/broadway/storefront` naming and was missing the D1 Render-exclusive + D2 sidecar-canonical rules. Now in sync with `bot_chat` rows 50-58 (C1's lane assignments).

### `docs/evo_store_next_steps.md` (new)
D1's green-light list to get storefront from "data flowing, catalog blocked" → fully live:
1. **Deploy branch sync** — Render service is 9928 lines behind main; recommend repointing to `main` directly.
2. **JWT key format** — legacy `eyJ...` JWTs now reject. Switch to `sb_secret_*`/`sb_publishable_*`.
3. **Re-verify catalog** — `/api/store/events?limit=3` should now return 200 in <2s (PR #71 matview fix).
4. **Google Auth** — deferred (storefront is read-only, no auth gate needed for v1 live).

## Test plan
- [x] Hierarchy in `BOT_HIERARCHY.md` matches `bot_chat` rows 50-58 lane assignments
- [x] Push restrictions match operator's 2026-05-12 decisions (A1 prod-only, B1 CRIT-only, D1 Render-exclusive)
- [x] Mermaid renders cleanly (validated locally)
- [x] `DOCUMENTATION_INDEX.md` left untouched (separate task to refresh it)
- [ ] D1 reads `evo_store_next_steps.md` and ack's via bot_chat before next storefront push

🤖 Generated with [Claude Code](https://claude.com/claude-code)