### PR TITLE
feat(store): MVP catalog — TEvo-direct /api/store/events

### DIFF
--- a/app.py
+++ b/app.py
@@ -5237,38 +5237,18 @@ def _resolve_event_with_filters(event_id: int, filters: dict, include_inactive: 
     is unchanged. inventory_source reflects 'snapshot' + adds
     snapshot_age_seconds so the demo banner can show staleness honestly.
 
-    Lifecycle gate: events flagged `is_active=false` by event_lifecycle
-    (ghost_eliminated, cancelled, postponed, completed) 404 by default —
-    same policy as the catalog, applied to direct hits and share-link
-    resolution. Set include_inactive=true to bypass for admin/debug paths.
+    MVP prod checkpoint (2026-05-13): the SQL `event_lifecycle` gate was
+    removed. Rationale: the catalog now filters by office_id at TEvo, so
+    only events our office has inventory for ever surface. The gate was
+    a defensive measure against ghost playoff rows + cancelled-but-still-
+    listed games; with office_id, those edge cases are rare AND the
+    broker terminal is the right place to manage stale listings, not the
+    public detail page. Lifting the gate also fixes a real inconsistency
+    where catalog showed a TBD playoff game (TEvo had inventory) but
+    detail 404'd (audit SQL had marked it 'completed' when the series
+    ended without that game). Set include_inactive=true is now a no-op
+    kept for callsite compatibility.
     """
-    # Bail early on inactive events so we don't show ghost/cancelled inventory
-    # to the public. event_lifecycle is the audit lane's canonical truth on
-    # whether an event is still "alive" — TEvo keeps returning ghost rows
-    # with stale prices long after a team is eliminated. Catalog already
-    # filters this; doing it here closes the direct-URL bypass.
-    if not include_inactive and sb is not None:
-        try:
-            lc = (
-                sb.table("event_lifecycle")
-                .select("status,is_active")
-                .eq("event_id", event_id)
-                .limit(1)
-                .execute()
-            ).data or []
-            if lc and lc[0].get("is_active") is False:
-                status = lc[0].get("status") or "inactive"
-                raise HTTPException(
-                    404,
-                    f"event {event_id} is {status}; not shown by default",
-                )
-        except HTTPException:
-            raise
-        except Exception:
-            # event_lifecycle view missing in some envs; better to fall
-            # through than to 500 the storefront.
-            pass
-
     snapshot_captured_at: str | None = None
     if STOREFRONT_SQL_ONLY:
         ev = _fetch_event_from_db(event_id)

--- a/app.py
+++ b/app.py
@@ -4002,40 +4002,94 @@ def _ticket_group_to_listing(tg: dict) -> dict:
 
 @app.get("/api/store/_probe_owned")
 def store_probe_owned():
-    """TEMP probe: try several owned-only filter syntaxes against TEvo
-    /v9/events and report which ones server-side filter to we-own only.
-    Removed once we've picked the winner."""
+    """TEMP probe v2: hunt for an owned-only enumeration path."""
     if client is None:
         raise HTTPException(503, "TEvo client not configured")
     today_iso = datetime.now(timezone.utc).date().isoformat()
-    variants = [
-        ("baseline", {}),
-        ("owned_by_office=true", {"owned_by_office": True}),
-        ("owned=true", {"owned": True}),
-        ("only_with_owned_tickets=true", {"only_with_owned_tickets": True}),
-    ]
-    report = {}
-    for label, extra in variants:
+    report: dict = {}
+
+    # ---- Probe A: extract our office_id from /v9/orders ----
+    office_id: int | None = None
+    seller_office: dict | None = None
+    try:
+        orders_resp = client.list_orders(per_page=3)
+        orders = orders_resp.get("orders") or []
+        if orders:
+            first = orders[0]
+            seller_office = first.get("seller") or {}
+            office_id = (seller_office or {}).get("id")
+            report["A_orders_probe"] = {
+                "ok": True, "total_orders": orders_resp.get("total_entries"),
+                "first_order_keys": sorted(first.keys()),
+                "seller_office": seller_office,
+                "extracted_office_id": office_id,
+            }
+        else:
+            report["A_orders_probe"] = {"ok": True, "orders": "none returned"}
+    except Exception as e:
+        report["A_orders_probe"] = {"ok": False, "error": str(e)}
+
+    # ---- Probe B: /v9/events?office_id=X if we found one ----
+    if office_id:
         try:
             resp = client.list_events(
-                occurs_at_gte=today_iso,
-                only_with_available_tickets=True,
-                order_by="events.occurs_at ASC",
-                per_page=50,
-                page=1,
-                **extra,
+                occurs_at_gte=today_iso, only_with_available_tickets=True,
+                order_by="events.occurs_at ASC", per_page=50, page=1,
+                **{"office_id": office_id},
             )
-            events = resp.get("events", []) or []
-            we_own = sum(1 for e in events if e.get("owned_by_office"))
-            report[label] = {
-                "ok": True,
-                "total_entries": resp.get("total_entries"),
-                "events_returned": len(events),
+            evs = resp.get("events", []) or []
+            we_own = sum(1 for e in evs if e.get("owned_by_office"))
+            report["B_events_office_id"] = {
+                "ok": True, "total_entries": resp.get("total_entries"),
+                "returned": len(evs),
                 "we_own_count": we_own,
-                "we_own_pct": (round(we_own / len(events) * 100, 1) if events else None),
+                "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
             }
-        except RuntimeError as e:
-            report[label] = {"ok": False, "error": str(e)}
+        except Exception as e:
+            report["B_events_office_id"] = {"ok": False, "error": str(e)}
+    else:
+        report["B_events_office_id"] = {"skipped": "no office_id found"}
+
+    # ---- Probe C: /v9/ticket_groups?owned=true (no event_id) ----
+    try:
+        # Use _get directly since list_ticket_groups requires event_id.
+        resp = client._get("/v9/ticket_groups", {"owned": True, "per_page": 50})
+        tgs = resp.get("ticket_groups") or []
+        # Pull event_ids from the response if present
+        event_ids = set()
+        for tg in tgs[:20]:
+            ev = (tg.get("event") or {})
+            if ev.get("id"):
+                event_ids.add(ev["id"])
+        report["C_ticket_groups_no_event_id"] = {
+            "ok": True,
+            "total_entries": resp.get("total_entries"),
+            "returned_groups": len(tgs),
+            "distinct_events_in_first_20": len(event_ids),
+            "sample_event_ids": sorted(event_ids)[:5],
+            "first_tg_keys": sorted(tgs[0].keys()) if tgs else None,
+        }
+    except Exception as e:
+        report["C_ticket_groups_no_event_id"] = {"ok": False, "error": str(e)}
+
+    # ---- Probe D: /v9/events?owned_by_office.eq=true ----
+    try:
+        resp = client.list_events(
+            occurs_at_gte=today_iso, only_with_available_tickets=True,
+            order_by="events.occurs_at ASC", per_page=50, page=1,
+            **{"owned_by_office.eq": "true"},
+        )
+        evs = resp.get("events", []) or []
+        we_own = sum(1 for e in evs if e.get("owned_by_office"))
+        report["D_events_owned_by_office_eq"] = {
+            "ok": True, "total_entries": resp.get("total_entries"),
+            "returned": len(evs),
+            "we_own_count": we_own,
+            "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
+        }
+    except Exception as e:
+        report["D_events_owned_by_office_eq"] = {"ok": False, "error": str(e)}
+
     return report
 
 

--- a/app.py
+++ b/app.py
@@ -4000,97 +4000,12 @@ def _ticket_group_to_listing(tg: dict) -> dict:
     }
 
 
-@app.get("/api/store/_probe_owned")
-def store_probe_owned():
-    """TEMP probe v2: hunt for an owned-only enumeration path."""
-    if client is None:
-        raise HTTPException(503, "TEvo client not configured")
-    today_iso = datetime.now(timezone.utc).date().isoformat()
-    report: dict = {}
-
-    # ---- Probe A: extract our office_id from /v9/orders ----
-    office_id: int | None = None
-    seller_office: dict | None = None
-    try:
-        orders_resp = client.list_orders(per_page=3)
-        orders = orders_resp.get("orders") or []
-        if orders:
-            first = orders[0]
-            seller_office = first.get("seller") or {}
-            office_id = (seller_office or {}).get("id")
-            report["A_orders_probe"] = {
-                "ok": True, "total_orders": orders_resp.get("total_entries"),
-                "first_order_keys": sorted(first.keys()),
-                "seller_office": seller_office,
-                "extracted_office_id": office_id,
-            }
-        else:
-            report["A_orders_probe"] = {"ok": True, "orders": "none returned"}
-    except Exception as e:
-        report["A_orders_probe"] = {"ok": False, "error": str(e)}
-
-    # ---- Probe B: /v9/events?office_id=X if we found one ----
-    if office_id:
-        try:
-            resp = client.list_events(
-                occurs_at_gte=today_iso, only_with_available_tickets=True,
-                order_by="events.occurs_at ASC", per_page=50, page=1,
-                **{"office_id": office_id},
-            )
-            evs = resp.get("events", []) or []
-            we_own = sum(1 for e in evs if e.get("owned_by_office"))
-            report["B_events_office_id"] = {
-                "ok": True, "total_entries": resp.get("total_entries"),
-                "returned": len(evs),
-                "we_own_count": we_own,
-                "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
-            }
-        except Exception as e:
-            report["B_events_office_id"] = {"ok": False, "error": str(e)}
-    else:
-        report["B_events_office_id"] = {"skipped": "no office_id found"}
-
-    # ---- Probe C: /v9/ticket_groups?owned=true (no event_id) ----
-    try:
-        # Use _get directly since list_ticket_groups requires event_id.
-        resp = client._get("/v9/ticket_groups", {"owned": True, "per_page": 50})
-        tgs = resp.get("ticket_groups") or []
-        # Pull event_ids from the response if present
-        event_ids = set()
-        for tg in tgs[:20]:
-            ev = (tg.get("event") or {})
-            if ev.get("id"):
-                event_ids.add(ev["id"])
-        report["C_ticket_groups_no_event_id"] = {
-            "ok": True,
-            "total_entries": resp.get("total_entries"),
-            "returned_groups": len(tgs),
-            "distinct_events_in_first_20": len(event_ids),
-            "sample_event_ids": sorted(event_ids)[:5],
-            "first_tg_keys": sorted(tgs[0].keys()) if tgs else None,
-        }
-    except Exception as e:
-        report["C_ticket_groups_no_event_id"] = {"ok": False, "error": str(e)}
-
-    # ---- Probe D: /v9/events?owned_by_office.eq=true ----
-    try:
-        resp = client.list_events(
-            occurs_at_gte=today_iso, only_with_available_tickets=True,
-            order_by="events.occurs_at ASC", per_page=50, page=1,
-            **{"owned_by_office.eq": "true"},
-        )
-        evs = resp.get("events", []) or []
-        we_own = sum(1 for e in evs if e.get("owned_by_office"))
-        report["D_events_owned_by_office_eq"] = {
-            "ok": True, "total_entries": resp.get("total_entries"),
-            "returned": len(evs),
-            "we_own_count": we_own,
-            "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
-        }
-    except Exception as e:
-        report["D_events_owned_by_office_eq"] = {"ok": False, "error": str(e)}
-
-    return report
+# Our TEvo brokerage's office id. Resolved via probe `/v9/orders` (probe v2,
+# 2026-05-13): brokerage=S4K Entertainment (id 1768), office=Office 3
+# (id 42029, NYC). Filter /v9/events with office_id=this to get only events
+# our office has inventory for (server-side filter, 100% we_own match).
+# Override via TEVO_OFFICE_ID env var if the brokerage adds offices later.
+TEVO_OFFICE_ID = int(os.environ.get("TEVO_OFFICE_ID", "42029"))
 
 
 @app.get("/api/store/events")
@@ -4102,26 +4017,27 @@ def store_events(
     offset: int = 0,
     include_inactive: bool = False,
 ):
-    """Catalog: upcoming events from TEvo /v9/events (MVP pass-through).
+    """Catalog: upcoming events our brokerage office has inventory for.
 
-    Pulls directly from the TEvo API — no Supabase joins. Cards carry
-    raw TEvo metadata: id, name, venue, occurs_at_local, primary performer.
-    The Supabase enrichment layer (we_own flag, from_price, performer logos
-    / brand colors, rivalry / MLB-series / tournament / weather / holiday
-    / playoff badges) is intentionally OMITTED in this build — the front
-    end null-checks every enrichment key so cards still render cleanly.
+    Pulled directly from TEvo /v9/events with office_id=TEVO_OFFICE_ID,
+    which is TEvo's native server-side filter for "events MY office has
+    listings on". 100% we_own — there is no "browse market" fallthrough.
 
-    Ownership and pricing are revealed on the detail page
-    (/api/store/events/:id), which hits /v9/ticket_groups?owned=true.
+    Performer media (logos + brand colors) is bulk-enriched from Supabase
+    performer_metadata. That's the only Supabase touch on this route —
+    the events themselves come from TEvo. Rest of the prior badge
+    enrichments (rivalry / MLB-series / tournament / weather / holiday /
+    playoff) stay nullable for now; they get re-layered after the prod
+    checkpoint.
 
     Pagination: TEvo caps per_page at 100; this handler pages through
     enough TEvo pages to fill the requested `limit` (max 500 → up to
-    5 TEvo calls, ~1-2s warm).
+    5 TEvo calls).
 
     Args mirror the prior shape so the front-end + share-link routes
     don't need to change. `include_inactive` is kept as a no-op for
-    callsite compatibility (TEvo's only_with_available_tickets already
-    drops most stale events; CANCELLED markers are filtered by name).
+    callsite compatibility (CANCELLED markers are still filtered by
+    name string in case TEvo leaks them through the office filter).
     """
     if client is None:
         # SQL-only demo mode boots without TEvo. MVP catalog requires it.
@@ -4138,11 +4054,10 @@ def store_events(
     raw_events: list[dict] = []
     try:
         for p in range(start_page, start_page + pages_needed):
-            # order_by uses the same syntax as the broker /api/events route
-            # ("table.column DIRECTION"). The simpler "occurs_at asc" form
-            # is rejected by TEvo with a non-2xx that bubbles back as
-            # "no response" because of the __bool__ quirk in evo_client's
-            # warning logger. Stick with the verified pattern.
+            # office_id=TEVO_OFFICE_ID filters TEvo to ONLY events our office
+            # has inventory for. Verified 100% we_own match in probe v2.
+            # `office_id` goes through evo_client.list_events's **extra
+            # kwarg so it reaches the request as-is.
             resp = client.list_events(
                 q=q or None,
                 performer_id=performer_id,
@@ -4152,6 +4067,7 @@ def store_events(
                 order_by="events.occurs_at ASC",
                 per_page=per_page,
                 page=p,
+                **{"office_id": TEVO_OFFICE_ID},
             )
             batch = resp.get("events", []) or []
             if not batch:
@@ -4172,6 +4088,29 @@ def store_events(
         if "CANCELLED" not in (e.get("name") or "").upper()
     ]
     raw_events = raw_events[:cap]
+
+    # ---- Bulk-fetch performer media from Supabase performer_metadata ----
+    # Single SQL roundtrip pulls logo + color for every performer that
+    # appears on the catalog page. The TEvo /v9/events response only
+    # carries performer id + name — logos and ESPN team data live in our
+    # SQL enrichment table (populated by the crawl-venues-and-performers
+    # collector). This is the only Supabase touch on the catalog.
+    perf_ids: set[int] = set()
+    for ev in raw_events:
+        for perf in (ev.get("performances") or []):
+            pid = (perf.get("performer") or {}).get("id")
+            if pid:
+                perf_ids.add(int(pid))
+    perf_assets: dict[int, dict] = {}
+    if perf_ids:
+        try:
+            db = require_sb()
+            perf_assets = _bulk_performer_assets(db, list(perf_ids))
+        except Exception as e:
+            # Don't break the catalog if performer_metadata is unavailable;
+            # cards just render without logos/colors.
+            print(f"performer_metadata bulk-fetch failed: {e}")
+            perf_assets = {}
 
     out: list[dict] = []
     for ev in raw_events:
@@ -4197,9 +4136,14 @@ def store_events(
 
         # owned_by_office is TEvo's native we-own signal — true when our
         # token's brokerage office has inventory listed for this event.
-        # Removes the need for a per-event /v9/ticket_groups probe on
-        # the catalog render.
+        # With office_id filter applied to /v9/events, this is always
+        # true; kept on the response shape for forward-compat.
         we_own = bool(ev.get("owned_by_office"))
+
+        # Performer media: logo + brand color from Supabase performer_metadata.
+        # Falls back to None on either side if the performer isn't seeded.
+        perf_id = performer.get("id")
+        assets = perf_assets.get(int(perf_id)) if perf_id else None
 
         out.append({
             "id": ev.get("id"),
@@ -4210,27 +4154,25 @@ def store_events(
             "venue_name": venue.get("name"),
             "venue_location": venue_loc,
             "primary_performer_name": performer.get("name"),
-            "primary_performer_id": performer.get("id"),
+            "primary_performer_id": perf_id,
+            "primary_performer_logo": (assets or {}).get("logo_default_url"),
+            "primary_performer_color": (assets or {}).get("color_primary"),
+            "primary_performer_league": (assets or {}).get("espn_league"),
             # available_count is deprecated for authoritative pricing but
             # is fine as a "tickets available" indicator on cards (the
             # detail page uses /v9/events/:id/stats for exact numbers).
             "available_count": ev.get("available_count"),
-            # we_own straight from TEvo. owned_tickets_count and
-            # from_price still need a per-event call so stay null on
-            # the catalog payload; revealed on click-through.
             "we_own": we_own,
             "tbd": bool(ev.get("tbd")),
             "popularity_score": ev.get("popularity_score"),
-            # Enrichment keys held nullable so the front-end's
-            # `if (ev.rivalry) {...}` checks stay valid. Reintroduced
-            # once raw TEvo flow is verified end-to-end.
-            "primary_performer_logo": None,
-            "primary_performer_color": None,
-            "primary_performer_league": None,
+            # from_price + owned_tickets_count still need a per-event call
+            # so stay null on the catalog payload; revealed on click-through.
             "from_price": None,
             "owned_tickets_count": None,
             "owned_groups_count": None,
             "captured_at": None,
+            # Other badge enrichments (rivalry / series / weather / holiday
+            # / playoff) — re-layer in a follow-up after the prod checkpoint.
             "rivalry": None,
             "mlb_series": None,
             "tournament": None,

--- a/app.py
+++ b/app.py
@@ -4080,16 +4080,6 @@ def store_events(
     ]
     raw_events = raw_events[:cap]
 
-    # TEMPORARY DEBUG (remove once mapping is confirmed): log keys of the
-    # first raw TEvo event so we can see whether performers nest under
-    # 'performers', 'primary_performer', 'performances', etc.
-    if raw_events:
-        first = raw_events[0]
-        print(f"[mvp-debug] /v9/events item keys: {sorted(first.keys())}")
-        perf_field = first.get("performers")
-        print(f"[mvp-debug] performers raw: {perf_field!r}")
-        print(f"[mvp-debug] primary_performer raw: {first.get('primary_performer')!r}")
-
     out: list[dict] = []
     for ev in raw_events:
         venue = ev.get("venue") or {}
@@ -4102,11 +4092,21 @@ def store_events(
             state = venue.get("state") or ""
             venue_loc = f"{city}, {state}".strip(", ") or None
 
-        performers = ev.get("performers") or []
-        primary = (
-            next((p for p in performers if p.get("primary")), None)
-            or (performers[0] if performers else {})
+        # /v9/events list response uses `performances`, NOT `performers`
+        # (that's the /v9/events/:id show shape). Each performance nests
+        # a `performer: {id, name}` object plus a `primary` boolean.
+        performances = ev.get("performances") or []
+        primary_perf = (
+            next((p for p in performances if p.get("primary")), None)
+            or (performances[0] if performances else {})
         )
+        performer = (primary_perf or {}).get("performer") or {}
+
+        # owned_by_office is TEvo's native we-own signal — true when our
+        # token's brokerage office has inventory listed for this event.
+        # Removes the need for a per-event /v9/ticket_groups probe on
+        # the catalog render.
+        we_own = bool(ev.get("owned_by_office"))
 
         out.append({
             "id": ev.get("id"),
@@ -4116,8 +4116,18 @@ def store_events(
             "occurs_at_local": ev.get("occurs_at_local") or ev.get("occurs_at"),
             "venue_name": venue.get("name"),
             "venue_location": venue_loc,
-            "primary_performer_name": (primary or {}).get("name"),
-            "primary_performer_id": (primary or {}).get("id"),
+            "primary_performer_name": performer.get("name"),
+            "primary_performer_id": performer.get("id"),
+            # available_count is deprecated for authoritative pricing but
+            # is fine as a "tickets available" indicator on cards (the
+            # detail page uses /v9/events/:id/stats for exact numbers).
+            "available_count": ev.get("available_count"),
+            # we_own straight from TEvo. owned_tickets_count and
+            # from_price still need a per-event call so stay null on
+            # the catalog payload; revealed on click-through.
+            "we_own": we_own,
+            "tbd": bool(ev.get("tbd")),
+            "popularity_score": ev.get("popularity_score"),
             # Enrichment keys held nullable so the front-end's
             # `if (ev.rivalry) {...}` checks stay valid. Reintroduced
             # once raw TEvo flow is verified end-to-end.

--- a/app.py
+++ b/app.py
@@ -4000,6 +4000,45 @@ def _ticket_group_to_listing(tg: dict) -> dict:
     }
 
 
+@app.get("/api/store/_probe_owned")
+def store_probe_owned():
+    """TEMP probe: try several owned-only filter syntaxes against TEvo
+    /v9/events and report which ones server-side filter to we-own only.
+    Removed once we've picked the winner."""
+    if client is None:
+        raise HTTPException(503, "TEvo client not configured")
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    variants = [
+        ("baseline", {}),
+        ("owned_by_office=true", {"owned_by_office": True}),
+        ("owned=true", {"owned": True}),
+        ("only_with_owned_tickets=true", {"only_with_owned_tickets": True}),
+    ]
+    report = {}
+    for label, extra in variants:
+        try:
+            resp = client.list_events(
+                occurs_at_gte=today_iso,
+                only_with_available_tickets=True,
+                order_by="events.occurs_at ASC",
+                per_page=50,
+                page=1,
+                **extra,
+            )
+            events = resp.get("events", []) or []
+            we_own = sum(1 for e in events if e.get("owned_by_office"))
+            report[label] = {
+                "ok": True,
+                "total_entries": resp.get("total_entries"),
+                "events_returned": len(events),
+                "we_own_count": we_own,
+                "we_own_pct": (round(we_own / len(events) * 100, 1) if events else None),
+            }
+        except RuntimeError as e:
+            report[label] = {"ok": False, "error": str(e)}
+    return report
+
+
 @app.get("/api/store/events")
 def store_events(
     q: str | None = None,

--- a/app.py
+++ b/app.py
@@ -4009,183 +4009,118 @@ def store_events(
     offset: int = 0,
     include_inactive: bool = False,
 ):
-    """Catalog: events for which we have owned inventory in TEvo.
+    """Catalog: upcoming events from TEvo /v9/events (MVP pass-through).
 
-    Driven by Supabase `latest_event_metrics` (collector populates
-    owned_tickets_count via /v9/ticket_groups?owned=true on every run).
+    Pulls directly from the TEvo API — no Supabase joins. Cards carry
+    raw TEvo metadata: id, name, venue, occurs_at_local, primary performer.
+    The Supabase enrichment layer (we_own flag, from_price, performer logos
+    / brand colors, rivalry / MLB-series / tournament / weather / holiday
+    / playoff badges) is intentionally OMITTED in this build — the front
+    end null-checks every enrichment key so cards still render cleanly.
 
-    Wiring:
-    - Filtered by `event_lifecycle.is_active` so ghosts / completed /
-      postponed events are dropped (set include_inactive=true to bypass).
-    - Performer assets (logos / brand colors) bulk-fetched from
-      performer_metadata so cards can render branding without N+1.
-    - Search is in-Python over the already-narrowed result set; cheap
-      because the DB query already caps at limit×2 candidate rows.
+    Ownership and pricing are revealed on the detail page
+    (/api/store/events/:id), which hits /v9/ticket_groups?owned=true.
+
+    Pagination: TEvo caps per_page at 100; this handler pages through
+    enough TEvo pages to fill the requested `limit` (max 500 → up to
+    5 TEvo calls, ~1-2s warm).
+
+    Args mirror the prior shape so the front-end + share-link routes
+    don't need to change. `include_inactive` is kept as a no-op for
+    callsite compatibility (TEvo's only_with_available_tickets already
+    drops most stale events; CANCELLED markers are filtered by name).
     """
-    db = require_sb()
-    # Cap raised from 200 -> 500 so consumer search pages can cover the full
-    # owned-inventory set in one fetch. Prod has ~270 events with owned
-    # tickets at any given time; capping at 200 was leaving ~25% invisible
-    # to anyone searching by performer name on the storefront. Pagination
-    # is the next step if the catalog grows past ~500.
+    if client is None:
+        # SQL-only demo mode boots without TEvo. MVP catalog requires it.
+        raise HTTPException(503, "TEvo client not configured")
+
     cap = min(max(limit, 1), 500)
+    # offset → TEvo page index. TEvo paginates 1-based.
+    per_page = min(cap, 100)
+    start_page = (max(offset, 0) // per_page) + 1
+    pages_needed = (cap + per_page - 1) // per_page
 
-    # Pull a wider candidate set so we can post-filter by lifecycle + search
-    # and still serve a full page.
-    candidate_limit = min(cap * 2, 1000) if not include_inactive else cap
+    today_iso = datetime.now(timezone.utc).date().isoformat()
 
-    # Events-first two-query merge (was `events!inner(...)` embedding,
-    # which PostgREST PGRST200s on view→table FK after cache rebuilds).
-    #
-    # Always start from `events` filtered to upcoming so we don't waste
-    # candidate slots on yesterday's games. Step 1: pull `events` ordered
-    # by occurs_at_local (with optional performer/venue filter). Step 2:
-    # join `latest_event_metrics` for owned-only. Step 3: merge in Python.
-    #
-    # Over-pull events by 3x so we have headroom after the owned filter
-    # narrows the set. include_inactive=true skips the upcoming filter
-    # (debug / admin only).
-    evs_q = db.table("events").select(
-        "id,name,occurs_at_local,venue_id,venue_name,venue_location,"
-        "primary_performer_id,primary_performer_name"
-    )
-    if not include_inactive:
-        # "Today or later" — local-time strings sort correctly here.
-        evs_q = evs_q.gte("occurs_at_local", datetime.now(timezone.utc).date().isoformat())
-    if performer_id is not None:
-        evs_q = evs_q.eq("primary_performer_id", int(performer_id))
-    if venue_id is not None:
-        evs_q = evs_q.eq("venue_id", int(venue_id))
-    evs_q = evs_q.order("occurs_at_local", desc=False).limit(candidate_limit * 3)
-    events_rows = (evs_q.execute().data) or []
-    if not events_rows:
-        return {"count": 0, "events": [], "limit": cap, "offset": offset}
-    events_by_id = {int(e["id"]): e for e in events_rows if e.get("id")}
-    event_ids = list(events_by_id.keys())
+    raw_events: list[dict] = []
+    try:
+        for p in range(start_page, start_page + pages_needed):
+            resp = client.list_events(
+                q=q or None,
+                performer_id=performer_id,
+                venue_id=venue_id,
+                occurs_at_gte=today_iso,
+                only_with_available_tickets=True,
+                order_by="occurs_at asc",
+                per_page=per_page,
+                page=p,
+            )
+            batch = resp.get("events", []) or []
+            if not batch:
+                break
+            raw_events.extend(batch)
+            if len(raw_events) >= cap:
+                break
+            # Stop early if we've hit the total.
+            total = int(resp.get("total_entries") or 0)
+            if total and len(raw_events) >= total:
+                break
+    except RuntimeError as e:
+        raise HTTPException(502, f"TEvo events fetch failed: {e}")
 
-    # Owned-only metrics for those event ids.
-    metrics_rows = (
-        db.table("latest_event_metrics")
-        .select("event_id,owned_tickets_count,owned_groups_count,owned_median_retail,"
-                "tickets_count,retail_min,captured_at")
-        .gt("owned_tickets_count", 0)
-        .in_("event_id", event_ids)
-        .limit(candidate_limit)
-        .offset(max(offset, 0))
-        .execute().data
-    ) or []
-    if not metrics_rows:
-        return {"count": 0, "events": [], "limit": cap, "offset": offset}
-
-    # Merge into the row shape downstream code expects (the old !inner
-    # response: each row has a nested `events` dict).
-    rows = [{**m, "events": events_by_id.get(int(m["event_id"]))} for m in metrics_rows]
-    rows = [r for r in rows if r.get("events")]
-    # Event-list sort hierarchy (per 2026-05-12 directive):
-    #   1. date  asc   — soonest event first
-    #   2. time  asc   — earliest start within a day first
-    #   3. qty   desc  — more owned tickets ranks higher
-    #   4. listings desc — more distinct listings ranks higher
-    #   5. getin desc  — higher cheapest-price (= "premium first") ranks higher
-    #
-    # occurs_at_local is text in YYYY-MM-DDTHH:MM:SS+TZ form; lexicographic
-    # ascending comparison naturally gives correct date+time order. Desc
-    # numeric columns are negated to fit a single ascending tuple sort.
-    def _catalog_sort_key(r):
-        ev = r.get("events") or {}
-        occurs = ev.get("occurs_at_local") or "9999-12-31T23:59:59"
-        qty = -(int(r.get("owned_tickets_count") or 0))
-        listings = -(int(r.get("owned_groups_count") or 0))
-        rmin = r.get("retail_min")
-        try:
-            price = -float(rmin) if rmin is not None else 0.0
-        except (TypeError, ValueError):
-            price = 0.0
-        return (occurs, qty, listings, price)
-    rows.sort(key=_catalog_sort_key)
-
-    # Drop ghosts / completed / postponed unless caller opts in. Same
-    # pattern as broker_movers — small id-set, single roundtrip to the
-    # event_lifecycle view (over derive_event_lifecycle()).
-    if rows and not include_inactive:
-        ev_ids = [(r.get("events") or {}).get("id") for r in rows]
-        ev_ids = [e for e in ev_ids if e]
-        if ev_ids:
-            try:
-                lc_rows = (
-                    db.table("event_lifecycle")
-                    .select("event_id,status,is_active")
-                    .in_("event_id", ev_ids)
-                    .execute()
-                ).data or []
-                inactive = {r["event_id"] for r in lc_rows if not r.get("is_active")}
-                if inactive:
-                    rows = [r for r in rows
-                            if (r.get("events") or {}).get("id") not in inactive]
-            except Exception:
-                # event_lifecycle view missing in some envs; better to show
-                # everything than 500 the storefront.
-                pass
-
-    # Bulk-fetch performer assets so card branding doesn't N+1.
-    perf_ids = [(r.get("events") or {}).get("primary_performer_id") for r in rows]
-    perf_ids = [int(p) for p in perf_ids if p]
-    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
-
-    # Bulk-fetch rivalry / MLB-series / tournament context per event. Three
-    # cheap view reads → flat lookup map keyed by event_id. Each card may
-    # render zero, one, or several badges.
-    ev_ids_for_ctx = [int(e["id"]) for e in (r.get("events") or {} for r in rows) if e.get("id")]
-    ctx_by_id = _bulk_event_context(db, ev_ids_for_ctx) if ev_ids_for_ctx else {}
+    # TEvo bakes CANCELLED markers into the event name string.
+    raw_events = [
+        e for e in raw_events
+        if "CANCELLED" not in (e.get("name") or "").upper()
+    ]
+    raw_events = raw_events[:cap]
 
     out: list[dict] = []
-    needle = (q or "").strip().lower()
-    for r in rows:
-        ev = r.get("events") or {}
-        if not ev:
-            continue
-        if needle:
-            hay = " ".join(
-                str(x or "") for x in (
-                    ev.get("name"),
-                    ev.get("venue_name"),
-                    ev.get("venue_location"),
-                    ev.get("primary_performer_name"),
-                )
-            ).lower()
-            if needle not in hay:
-                continue
-        a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
-        ctx = ctx_by_id.get(int(ev.get("id") or 0)) or {}
+    for ev in raw_events:
+        venue = ev.get("venue") or {}
+        # TEvo venue shape: {id, name, slug, location, time_zone,
+        #   city, state, country, ...}. `location` is "City, ST" string
+        #   on most events; fall back to city/state if absent.
+        venue_loc = venue.get("location")
+        if not venue_loc:
+            city = venue.get("city") or ""
+            state = venue.get("state") or ""
+            venue_loc = f"{city}, {state}".strip(", ") or None
+
+        performers = ev.get("performers") or []
+        primary = (
+            next((p for p in performers if p.get("primary")), None)
+            or (performers[0] if performers else {})
+        )
+
         out.append({
             "id": ev.get("id"),
             "name": ev.get("name"),
-            "occurs_at_local": ev.get("occurs_at_local"),
-            "venue_name": ev.get("venue_name"),
-            "venue_location": ev.get("venue_location"),
-            "primary_performer_name": ev.get("primary_performer_name"),
-            "primary_performer_id": ev.get("primary_performer_id"),
-            "primary_performer_logo": (a or {}).get("logo_default_url"),
-            "primary_performer_color": (a or {}).get("color_primary"),
-            # League gates the MLB "Series" tab on the catalog. Clients
-            # use this to decide whether to render the tabbed UI when the
-            # user is filtered to one performer.
-            "primary_performer_league": (a or {}).get("espn_league"),
-            "from_price": r.get("retail_min"),
-            "owned_tickets_count": r.get("owned_tickets_count"),
-            "owned_groups_count": r.get("owned_groups_count"),
-            "captured_at": r.get("captured_at"),
-            # Optional context badges — keys are always present so the client
-            # can do `if (ev.rivalry) render(...)` without ?-chaining.
-            "rivalry": ctx.get("rivalry"),
-            "mlb_series": ctx.get("mlb_series"),
-            "tournament": ctx.get("tournament"),
-            "weather": ctx.get("weather"),
-            "holiday": ctx.get("holiday"),
-            "playoff": ctx.get("playoff"),
+            # occurs_at_local has the real local offset; occurs_at is the
+            # misleading "Z"-suffixed local time. Prefer _local.
+            "occurs_at_local": ev.get("occurs_at_local") or ev.get("occurs_at"),
+            "venue_name": venue.get("name"),
+            "venue_location": venue_loc,
+            "primary_performer_name": (primary or {}).get("name"),
+            "primary_performer_id": (primary or {}).get("id"),
+            # Enrichment keys held nullable so the front-end's
+            # `if (ev.rivalry) {...}` checks stay valid. Reintroduced
+            # once raw TEvo flow is verified end-to-end.
+            "primary_performer_logo": None,
+            "primary_performer_color": None,
+            "primary_performer_league": None,
+            "from_price": None,
+            "owned_tickets_count": None,
+            "owned_groups_count": None,
+            "captured_at": None,
+            "rivalry": None,
+            "mlb_series": None,
+            "tournament": None,
+            "weather": None,
+            "holiday": None,
+            "playoff": None,
         })
-        if len(out) >= cap:
-            break
+
     return {"count": len(out), "events": out, "limit": cap, "offset": offset}
 
 

--- a/app.py
+++ b/app.py
@@ -4045,13 +4045,18 @@ def store_events(
     raw_events: list[dict] = []
     try:
         for p in range(start_page, start_page + pages_needed):
+            # order_by uses the same syntax as the broker /api/events route
+            # ("table.column DIRECTION"). The simpler "occurs_at asc" form
+            # is rejected by TEvo with a non-2xx that bubbles back as
+            # "no response" because of the __bool__ quirk in evo_client's
+            # warning logger. Stick with the verified pattern.
             resp = client.list_events(
                 q=q or None,
                 performer_id=performer_id,
                 venue_id=venue_id,
                 occurs_at_gte=today_iso,
                 only_with_available_tickets=True,
-                order_by="occurs_at asc",
+                order_by="events.occurs_at ASC",
                 per_page=per_page,
                 page=p,
             )

--- a/app.py
+++ b/app.py
@@ -4080,6 +4080,16 @@ def store_events(
     ]
     raw_events = raw_events[:cap]
 
+    # TEMPORARY DEBUG (remove once mapping is confirmed): log keys of the
+    # first raw TEvo event so we can see whether performers nest under
+    # 'performers', 'primary_performer', 'performances', etc.
+    if raw_events:
+        first = raw_events[0]
+        print(f"[mvp-debug] /v9/events item keys: {sorted(first.keys())}")
+        perf_field = first.get("performers")
+        print(f"[mvp-debug] performers raw: {perf_field!r}")
+        print(f"[mvp-debug] primary_performer raw: {first.get('primary_performer')!r}")
+
     out: list[dict] = []
     for ev in raw_events:
         venue = ev.get("venue") or {}

--- a/docs/d1_pending_merge_back.md
+++ b/docs/d1_pending_merge_back.md
@@ -1,0 +1,88 @@
+# D1 — Pending merge-back work
+
+Filed 2026-05-13 alongside PR #79 (MVP catalog TEvo-direct). Render is being repointed to `claude/d1-mvp-tevo-direct` for MVP review. Work captured here is parked on **other branches** and needs to come back when MVP shape is locked.
+
+## PR #76 — Sprint 1.5 UX batch (parked)
+
+Branch: `claude/store-sql-only-demo-mode`
+Commit: `a8f44d2` — `ux(store): Sprint 1.5 polish — 7 audit findings landed`
+Deploy status when parked: `update_failed` (deploy `dep-d81tu7ek1jcs73eml4n0`, 2026-05-13 02:35 UTC).
+
+### What's in the commit
+
+7 UX fixes from the static audit. Net diff: +167 / -18 across `static/store/store.js` and `static/store/style.css`. No Python touched, no `app.py` overlap with PR #79.
+
+| # | Where | Fix |
+|---|---|---|
+| 1 | `store.js:401-404` + `index.html:53` | Catalog load error: replaces stuck red text with inline **Retry** button. `loadCatalog()` factored out so Retry re-fires `/api/store/events` without page reload. |
+| 2 | `store.js:447-455` + `style.css:add suggest-status.error` | Search dropdown error tone: `.suggest-status.error` variant uses `--bad` color + ⚠ glyph so "Search unavailable" is visually distinct from "Searching…". |
+| 3 | `store.js:1432-1433` + event.html | Missing seating chart: hide `<img>` + inject `.map-placeholder` div so 2-col event-body grid keeps its left column footprint. Without this, listings reflowed into the empty space at the 760px breakpoint. |
+| 4 | `event.html:115` + `store.js:906-985` | Parking tab `aria-label="Parking, N listings"` so screen readers announce the count. `.listing-tab[aria-disabled="true"]` rule added defensively. |
+| 5 | `store.js:1245-1251` | Filter apply failure: `applyFiltersAndFetch`'s catch now surfaces inline `.filter-error` pill in the filter bar (was silent `console.error`). Pill auto-clears on next successful apply. |
+| 6 | `style.css:1125-1134` + `event.html:73-78` | Parking tab count: `white-space: nowrap` + `font-size: 10px` so "Parking 12" doesn't wrap on narrow viewports. |
+| 8 | `index.html:15` + `event.html:15` + `style.css` | Under 760px, hide the "MVP · browse only · no real purchases" text and show just "MVP" via `font-size: 0` + `::before { content: "MVP" }` pattern. Topbar stays uncrowded on mobile without changing desktop copy. |
+
+Audit item #7 (Reserve button `:disabled`) was **skipped during the original commit** — audit had misidentified scope; the global `.btn:disabled` rule at `style.css:562` already covered row buttons.
+
+### Why the deploy failed
+
+`render.yaml:32` sets `healthCheckPath: /`. The storefront landing page route is heavier than `/healthz` (90KB JS + CSS). On Render free-tier cold-start dyno, the healthcheck on `/` timed out before the server settled. Build succeeded, server detected port 10000, but Render flagged `update_failed` after 18 minutes of retries. The previous successful deploy (`268cae3`) stayed live, so the user-facing site was never down — it just didn't pick up the Sprint 1.5 fixes.
+
+### Recommended re-merge sequence
+
+1. Merge PR #79 (MVP catalog) to `main` after operator review.
+2. Cherry-pick `a8f44d2` (Sprint 1.5) onto a new branch off `main`. No conflicts expected — `app.py` vs JS/CSS, fully orthogonal.
+3. **Before triggering deploy**, patch `render.yaml`:
+   ```diff
+   - healthCheckPath: /
+   + healthCheckPath: /healthz
+   ```
+   `/healthz` is sub-50ms warm and doesn't load static assets — won't time out on cold dyno boot.
+4. Open PR for the Sprint 1.5 cherry-pick + healthcheck path swap. Single PR keeps the deploy-fix coupled to the cherry-pick that triggered the failure.
+5. After merge, the next deploy from `main` should ship Sprint 1.5 + the healthcheck fix.
+6. Smoke after deploy: `/healthz` 200; `/store` renders the Retry button on simulated catalog 500; MVP badge shrinks to "MVP" under 760px viewport.
+
+### Open question to reconcile during merge-back
+
+The Sprint 1.5 #1 fix wires Retry to `/api/store/events`. Post-MVP that endpoint is TEvo-direct. The Retry button still works (same path, same failure modes), so no code change needed — but worth confirming the error message in the catch ("Couldn't load events:") still reads naturally if TEvo returns a 502 instead of Supabase.
+
+## bot_chat row 68 — B1 RULE 2 carve-out (still pending B1)
+
+Architectural review request for Sprint 2 (real purchase path). Filed 2026-05-13. B1 hasn't responded. This is a *future* work item — Sprint 2 is frozen until:
+- All front-end sprints (1, 1.5, 3, 4a) shipped
+- TEvo merchant-of-record onboarding confirmed
+- B1 sign-off on `evo_orders_client.py` sibling-module shape
+
+No action needed during MVP review; just remember it exists when Sprint 2 thaws.
+
+## PR #77 — D1 operating constraints doc
+
+Branch: `claude/d1-operating-constraints`. Self-contract doc, no code. Filed for A1 review same day. Independent of MVP / Sprint 1.5 — merge whenever convenient.
+
+## Sprint 4a / Sprint 5 sketches (plan-only)
+
+From `~/.claude/plans/smooth-coalescing-garden.md`:
+- **Sprint 4a**: OG tags + Twitter card + JSON-LD `Organization`/`Event` on `/store` and `/store/event/:id`. Favicon waits on operator asset.
+- **Sprint 5**: `Cache-Control: public, max-age=300` on `/static/store/*`, footer with copyright + `git rev-parse --short HEAD` version line, terser minification of `store.js`.
+
+These haven't been started. Both are independent of MVP shape; revisit after MVP is locked.
+
+## Render deploy state at parking time
+
+| Field | Value |
+|---|---|
+| Service | `vibepass-storefront-test` (`srv-d8140bnaqgkc73al4asg`) |
+| Source branch (at parking time) | `claude/store-sql-only-demo-mode` |
+| Last successful deploy | `dep-d81qk0osfn5c738slgrg` @ commit `268cae3` (status: `live`) |
+| Last failed deploy | `dep-d81tu7ek1jcs73eml4n0` @ commit `a8f44d2` (Sprint 1.5) |
+| `healthCheckPath` in render.yaml | `/` — change to `/healthz` next merge |
+| Free-tier behavior | sleeps after 15min idle, ~50s cold start to `/healthz`, <1s warm |
+
+## TL;DR for the merge-back operator
+
+1. Merge PR #79 → main.
+2. Cherry-pick `a8f44d2` onto a branch off main.
+3. Change `render.yaml` line 32: `healthCheckPath: /` → `/healthz`.
+4. PR + merge that.
+5. Repoint Render service from `claude/d1-mvp-tevo-direct` (MVP testing branch) back to `main`.
+6. Smoke. Retire `claude/store-sql-only-demo-mode` and `claude/d1-mvp-tevo-direct` once green.

--- a/docs/templates/bot_lane_constraints_template.md
+++ b/docs/templates/bot_lane_constraints_template.md
@@ -1,0 +1,151 @@
+# <BOT_ID> Operating Constraints — Template
+
+> Reusable template for codifying a single bot's lane in a multi-bot, single-writer-per-table codebase. Fill in the `<PLACEHOLDERS>` and drop the angle-brackets. Delete sections that don't apply.
+
+`<BOT_ID>` = e.g., `D1`, `A2`, `B1`. Worktree `<worktree-name>`. Old label `<deprecated-name>` (deprecated `<date>`; see `bot_chat` rows `<n-m>`).
+
+This doc codifies the boundaries `<BOT_ID>` operates within. **`BOT_HIERARCHY.md` (or equivalent canonical lane chart) is the source of truth — read it first.** This file fills in `<BOT_ID>`-specific operational detail that doesn't belong in the global chart.
+
+## Scope
+
+One-sentence statement of what `<BOT_ID>` owns end-to-end. Include the surface area (which routes / which UI / which data product). One worktree, one push surface, single-writer to `<owned tables>`.
+
+## Read surface (allowed sources)
+
+### External APIs (live, read-only via `<client_module>.py` — RULE N wall)
+
+| Endpoint | Use |
+|---|---|
+| `GET <path>` | what for |
+| `GET <path>` | what for |
+
+Auth: `<auth scheme>`. Credentials resolved in priority order: (1) `<source>`, (2) `<source>`, (3) `<source>`. See `<resolver function>()` in `<file>`.
+
+### Internal DB / SQL (read-only on these — `<BOT_ID>` does not write)
+
+| Object | Owner lane | What `<BOT_ID>` uses it for |
+|---|---|---|
+| `<table>` | `<owner>` | `<purpose>` |
+| `<view>` | `<owner>` | `<purpose>` |
+
+If `<BOT_ID>` needs a new read, ack the owner lane in `bot_chat` (or equivalent coordination channel) first.
+
+## Write surface (`<BOT_ID>` is the writer)
+
+### Local files (`<BOT_ID>` lane)
+
+- `<file>` — scope statement (e.g., "storefront routes only"). Cross-lane routes are read-only.
+- `<file>` — full ownership / single-writer / append-only.
+- `<file>` — read-only to `<BOT_ID>`. Modifying `<specific guards/lines>` is **forbidden** — see carve-out section below.
+- `<file>` — `<BOT_ID>` may author/edit.
+- `<coordination file>` — append-only, `<BOT_ID>` may add rows in `(<old-label> → <other-lane>)` style.
+
+### DB tables (`<BOT_ID>` single-writer)
+
+| Table | Writer pattern |
+|---|---|
+| `<table>` | Single-writer. Migration `<path>`. RPC `<rpc_name>(...)`. Schema: `<short schema>`. RLS enabled; service_role bypasses; all access through `<handler>` routes. |
+| `<append-only table>` | Append-only multi-writer (all lanes). `<BOT_ID>` posts with `<discriminator>='<BOT_ID>'`. Use `<thread key>` to thread. |
+
+Future tables (post-freeze): `<table_a>`, `<table_b>`. Same pattern.
+
+### Hosting / infra (`<BOT_ID>` exclusive — sole owner per `BOT_HIERARCHY` §N)
+
+- Service config (build/start commands, plan, region, branch)
+- Env vars (read, set, delete via API)
+- Deploys (trigger, restart, deactivate)
+- Runtime logs (read)
+- Health check path
+
+API key lives in gitignored `<.env or secrets file>` as `<KEY_NAME>`.
+
+## Forbidden actions
+
+`<BOT_ID>` **must not**:
+
+1. **Run `<destructive op>` against the prod `<resource>`.** Migrations / schema changes land via PR → `<reviewer>` review → `<applier>` applies. Preview branches allowed for validation.
+2. **Push to `main`.** Only `<merge owners>` merge to `main`. `<BOT_ID>` ships via PR.
+3. **Modify `<critical guard / RULE N wall>` in `<file>:<line range>`.** Future write capability lives in a sibling module (see carve-out below).
+4. **Edit cross-lane files**: list specific files. Anything not explicitly in `<BOT_ID>`'s write surface above.
+5. **Modify infra config on services other than `<owned services>`** (`<BOT_ID>` is sole owner of that service only).
+6. **Submit to `<coordination channel>` with another lane's discriminator.** Always `<discriminator>='<BOT_ID>'`.
+7. **Use the legacy `<old-label>` in new `<coordination channel>` rows.** It is deprecated. `<BOT_ID>` going forward.
+8. **Echo secrets in chat or commits.** All credentials live in gitignored `<.env>` or `<settings table>`. Reference via env-var indirection.
+
+## Coordination triggers
+
+`<BOT_ID>` must file a `<coordination channel>` flag/sync row **before** any of:
+
+- Adding a new read against a table/view `<BOT_ID>` doesn't already use → ack owner lane
+- Proposing a new column/index on a shared read source → `<reviewer>` review
+- Touching security posture (CSP, RLS, auth flow) → `<security lane>` review
+- Adding a new outbound service call → security review (CSP update etc.)
+- Any change that affects PII surface → security review
+- Lifting `<critical guard>` (sprint carve-out) → architectural sign-off
+- New scheduled job → `<scheduler owner>` review
+
+## Carve-out / freeze conditions (if applicable)
+
+`<feature>` is **mock today / frozen**. Storefront/UI carries an indicator badge.
+
+Unfreezes only when **all N** are true:
+
+1. **Operator-side**: external dependency confirmed (vendor onboarding, contract, mechanics).
+2. **Architectural sign-off**: Filed in `<coordination channel>` row `<n>`. Proposed shape:
+   - New module `<sibling_module>.py` (NOT modifying the existing guard)
+   - Scoped allowlist: `frozenset({...})`
+   - Scope: specific endpoints only
+   - Existing guard untouched (`<tests>` keeps passing)
+   - `<canonical doc>` section updated
+3. **Front-end shipped**: prerequisite sprints in main, indicator badge removable.
+
+## Verification / smoke after every `<BOT_ID>` PR merge
+
+After merge + deploy from `main`:
+
+```bash
+curl <url>/healthz
+# expect: <known good shape>
+
+curl <url>/<key route>
+# expect: <known good shape>, <SLA>
+
+curl <url>/<another key route>
+# expect: <known good shape>
+```
+
+Post `<coordination channel>` status (`<discriminator>='<BOT_ID>'`, `event_type='change_log'`) referencing the merged PR # + smoke results.
+
+## References
+
+- `BOT_HIERARCHY.md` (or equivalent) — canonical lane chart + push matrix
+- `<MIGRATION_CONVENTIONS.md>` — repo migration discipline
+- `<SCHEMA.md>` — RULE N (read-only wall, security boundaries)
+- Other lane docs that intersect `<BOT_ID>`'s surface
+
+## Revision history
+
+| Date | What | Why |
+|---|---|---|
+| `<YYYY-MM-DD>` | Initial draft | `<BOT_ID>` codifies own constraints. Filed by `<BOT_ID>` as a self-imposed contract; `<reviewer>` reviews via PR. |
+
+---
+
+## How to use this template
+
+1. **Copy** to a new file in your project's docs directory: `docs/<bot-id>_operating_constraints.md`.
+2. **Read your project's `BOT_HIERARCHY.md`** (or whatever the canonical lane chart is called). The lane discipline doc complements it, it doesn't replace it.
+3. **Fill in placeholders top-down.** Each `<PLACEHOLDER>` is a decision point — if you can't answer it, that's a coordination question to surface with the team before you start writing code.
+4. **Delete sections that don't apply.** Carve-out / freeze section is only relevant if your lane has a future-state write capability gated behind external dependencies.
+5. **File as a PR for review** by the lane that owns canonical / architecture review. The doc itself is a self-contract; review confirms the contract terms match what other lanes expect.
+6. **Update revision history** when your lane's boundaries change (new tables owned, scope expanded, etc.). Don't silently mutate the constraints — every change goes through PR.
+
+## Why this pattern works
+
+The lane discipline doc is a **self-imposed contract** with three benefits:
+
+1. **Onboarding speed**: a new agent / new contributor reads ~150 lines and knows exactly what they can and can't touch. No spelunking through commit history to discover boundaries by accident.
+2. **Coordination cost reduction**: explicit "must file before" list eliminates 80% of cross-lane Slack/chat traffic. Lanes know when they need to coordinate vs when they can move alone.
+3. **Audit trail**: when a lane DOES violate its constraints (intentionally — e.g., emergency security fix), the deviation is visible against an explicit baseline. No ambiguity about whether the violation was a coordination failure or a known exception.
+
+The doc lives **in the codebase**, not in a wiki or notion page, so it versions with the code and can't drift out of sync with the actual files it references.

--- a/render.yaml
+++ b/render.yaml
@@ -23,14 +23,18 @@ services:
     plan: free
     region: oregon          # closest to Supabase us-east-2; tradeoff vs us-east-ohio (~50ms)
     # If your Supabase project is us-east-2 specifically, prefer 'ohio' region instead.
-    branch: claude/store-sql-only-demo-mode
+    branch: claude/d1-mvp-tevo-direct
     autoDeploy: true        # every push to the branch redeploys
 
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
 
-    healthCheckPath: /
-    # Health endpoint returns {"ok": true, ...} so Render's HTTP probe succeeds.
+    healthCheckPath: /healthz
+    # /healthz returns {"ok": true, ...} fast (<50ms warm, ~1s cold) and
+    # doesn't load the storefront's static bundle. Previously /, but that
+    # rendered the full landing page (90KB JS) + timed out the cold-dyno
+    # healthcheck window on free tier — Sprint 1.5 deploy (a8f44d2) failed
+    # for exactly that reason. /healthz boots cleanly even on cold start.
 
     envVars:
       # Pin to Python 3.12 — Render's auto-pick of 3.14.3 is brand-new and


### PR DESCRIPTION
## Status: PROD CHECKPOINT — 2026-05-13 (tag `d1-mvp-prod-checkpoint-2026-05-13`)

Storefront live at https://vibepass-storefront-test.onrender.com pulling 100% from TEvo's `office_id=42029` filter (S4K Entertainment "Office 3"). 5/5 catalog → detail samples green. Checkout still gated.

## Summary

- `/api/store/events`: TEvo `/v9/events?office_id=TEVO_OFFICE_ID` (env-override of default 42029). 100% we_own server-side. Performer media (logo, brand color, ESPN league) re-plugged via Supabase `performer_metadata` bulk-fetch — single SQL roundtrip, no N+1.
- `/api/store/events/{id}`: lifecycle 404 gate removed — catalog and detail now agree. Trust TEvo + office_id as source of truth for "live and ours".
- Probe endpoint removed.

## Smoke matrix (warm dyno)

| Route | HTTP | Latency | Notes |
|---|---|---|---|
| `/healthz` | 200 | 0.3s | `evo_creds_source=supabase.settings`, smoke pass |
| `/api/store/events?limit=5` | 200 | 1.2s | 100% we_own=true |
| `/api/store/events?limit=500` | 200 | 12.2s | 500/500 we_own, 245/500 with logos |
| `/api/store/events?performer_id=16303` | 200 | 1.0s | 8 Knicks playoff games |
| `/api/store/events?q=mets` | 200 | 0.7s | TEvo q= passthrough |
| `/api/store/search?q=knicks` | 200 | 0.8s | TEvo live |
| `/api/store/events/3342335` (TBD playoff) | 200 | 3.2s | 125 listings, was 404 pre-fix |
| `/api/store/events/3161083` (concert) | 200 | 3.2s | 65 listings |
| `/api/store/events/3336644` (NHL playoff) | 200 | 3.6s | 303 listings |
| `/api/store/events/3221983` (MLS) | 200 | 2.9s | 2 listings |
| `/api/store/events/3282925` (WNBA) | 200 | 4.0s | 401 listings |
| `/store` HTML | 200 | 0.4s | MVP badge + CSP wired |
| `/store/event/{id}` HTML | 200 | 0.2s | |
| `/s/{share_id}` HTML | 200 | 0.2s | |
| `/api/store/share/{bogus}` | 404 | 0.3s | Clean error |
| `/api/store/_probe_owned` | 404 | — | Pruned ✓ |

## Brokerage probe results (reference)

- Office id: **42029** ("Office 3", NYC)
- Brokerage id: **1768** ("S4K Entertainment", abbreviation "S4K")
- Total /v9/events with office_id=42029: **2,700**
- Total /v9/orders processed lifetime: **5,610**

## What's plugged in

- Live TEvo catalog with we_own = 100% (`office_id` server-side filter)
- Performer logos + brand colors (Supabase `performer_metadata` bulk-fetch)
- Share link create / resolve / revoke / list routes (D1 single-writer to `share_links`)
- Event detail with live `/v9/ticket_groups?owned=true`
- /healthz with TEvo + Supabase smoke
- CSP headers, MVP badge, share link share dialog

## What's still null on cards (deferred — re-layer post-checkpoint)

- `from_price` (needs per-event `/v9/events/:id/stats`)
- `owned_tickets_count`, `owned_groups_count` (same)
- `rivalry`, `mlb_series`, `tournament`, `weather`, `holiday`, `playoff` (Supabase enrichment views)
- `captured_at` (no longer relevant; live data)

Front-end null-checks every key — cards render cleanly without them ("available" fallback text instead of tix counts).

## Known gaps (out of scope this PR)

- `/api/store/movers`: returns `count=0` (PostgREST `or_()` ilike filter not matching NYC venues). Separate fix.
- Checkout flow: `/api/store/reserve` still mock. Sprint 2 freeze until B1 RULE 2 carve-out + TEvo merchant-of-record onboarding.

## Branch state

5 + 7 + 1 = 13 commits ahead of main:
- `e396646` MVP catalog rewrite
- `6ad999e` Sprint 1.5 + healthcheck merge-back notes
- `22e6926` render.yaml sync (branch + healthCheckPath)
- `a3afd03` order_by syntax fix
- `2256296` debug-shape print
- `231b986` performances + owned_by_office mapping
- `dd2f631` probe v1
- `d7c2a5c` lane discipline template
- `eef3432` merge main (operator-driven, brought SYNC_PROTOCOL + RESOURCES_BIBLE)
- `9c115b4` probe v2 (orders + ticket_groups + office_id variants)
- `2e5461b` office_id filter + media re-plug + probe removed
- `7913c20` **TAG d1-mvp-prod-checkpoint-2026-05-13** — lifecycle gate lifted

## Re-merge path

Notes still apply from `docs/d1_pending_merge_back.md` (commit `6ad999e`):
1. Merge this PR (#79) to main once eyeballed
2. Cherry-pick `a8f44d2` (Sprint 1.5 UX, from `claude/store-sql-only-demo-mode`) onto a fresh branch off post-merged main
3. Verify `render.yaml`'s `healthCheckPath: /healthz` is preserved
4. Repoint Render back to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)