### PR TITLE
fix(evo_client): correct Response truthiness in error logger (flagged by D1)

### DIFF
--- a/evo_client.py
+++ b/evo_client.py
@@ -156,18 +156,29 @@ class EvoClient:
         # intermediate-proxy info. Pattern matches seatgeek_client.py:495
         # (B1 SEC-MED SW-1, security chat 2026-05-10).
         # Log full detail server-side; only generic status reaches caller.
+        #
+        # Truthiness note: `requests.Response.__bool__` returns `self.ok`
+        # (`status_code < 400`), so `if last_resp` is FALSE for the exact
+        # case we want to log — a non-2xx response. Use `is not None` to
+        # distinguish "no response object at all" (connection failure) from
+        # "response object that happens to be non-2xx". Flagged by D1 in
+        # the 2026-05-13 MVP-deploy debugging session.
         import logging
-        logging.getLogger(__name__).warning(
-            "TEvo API non-2xx response: %s %s on %s %s — body: %s",
-            last_resp.status_code if last_resp else "no-resp",
-            last_resp.reason if last_resp else "",
-            last_resp.request.method if last_resp else "",
-            last_resp.url if last_resp else "",
-            (last_resp.text[:500] if last_resp else "")
-        )
-        raise RuntimeError(
-            f"TEvo API returned {last_resp.status_code if last_resp else 'no response'}"
-        )
+        if last_resp is not None:
+            logging.getLogger(__name__).warning(
+                "TEvo API non-2xx response: %s %s on %s %s — body: %s",
+                last_resp.status_code,
+                last_resp.reason,
+                last_resp.request.method,
+                last_resp.url,
+                last_resp.text[:500],
+            )
+            raise RuntimeError(f"TEvo API returned {last_resp.status_code}")
+        else:
+            logging.getLogger(__name__).warning(
+                "TEvo API call failed with no response (connection/timeout/DNS)"
+            )
+            raise RuntimeError("TEvo API returned no response")
 
     def _iter_paginated(
         self,


### PR DESCRIPTION
## Summary

D1 flagged this during the 2026-05-13 MVP-deploy debugging session: `requests.Response.__bool__` returns `self.ok` (`status_code < 400`), so the `if last_resp` checks in `evo_client.py:160-170` evaluated to **False for the exact case we wanted to log** — a non-2xx response.

### Before

Non-2xx Response from TEvo:

```
log:   "TEvo API non-2xx response: no-resp  on   — body: "
raise: RuntimeError("TEvo API returned no response")
```

→ Looks like a connection failure. Real upstream status code + body hidden.

### After

Same situation, fixed truthiness check:

```
log:   "TEvo API non-2xx response: 422 Unprocessable Entity on GET https://api.ticketevolution.com/v9/events?... — body: {\"errors\":[...]}"
raise: RuntimeError("TEvo API returned 422")
```

Split into two clean branches:
- `last_resp is not None` → log full status/reason/method/url + 500-char body, raise with real status code
- `last_resp is None` (no response at all — connection/DNS/timeout) → log generic, raise generic

### Why D1 hit this

D1's MVP deploy ran into a TEvo rejection on `/v9/events` (likely a malformed `order_by`). The current logger said "no response" and "no-resp" — so D1 had to guess the actual cause was wrong `order_by` (correct fix shipped as `a3afd03` on D1's branch). With this fix landed, future similar failures surface the actual upstream error immediately.

## Lane

`evo_client.py` is A1+D2-owned per `LANE_DISCIPLINE.md`. This is a logging/observability fix in the shared retry block — not a RULE 2 surface change. D1 correctly didn't edit the file directly and flagged for A1 instead.

## Security check

- ✅ Still no URL or body in the raised exception (only status code) — preserves SW-1 hardening from PR #57
- ✅ No credentials in any log path (X-Token / X-Signature in headers, not URL)
- ✅ `last_resp.text[:500]` slice cap unchanged
- ✅ Same shape as `seatgeek_client.py:495` post-#57

## Test plan

- [ ] CI green
- [ ] D1 redeploys after merge; next non-2xx TEvo response logs actual status + body server-side
- [ ] Existing connection-failure path (no response) still shows "TEvo API returned no response"

https://claude.ai/code/session_01N2AB5FXu6TkTMGe3W2jxqG

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2AB5FXu6TkTMGe3W2jxqG)_