### PR TITLE
feat(c1): lockdown protocol + evo MVP media test surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,14 +24,18 @@ Read freely: `SELECT`, `information_schema`, `pg_*` views, log inspection, MCP `
 - Supabase **branch** creation (`create_branch` produces a copy-on-write fork — no prod-data mutation)
 - Author migrations as files in `supabase/migrations/` — application to prod is gated separately
 
-### 2. TEvo is read-only
+### 2. Upstream third-party APIs are read-only
 
-OK: `/v9/searches/suggestions`, `/v9/events`, `/v9/performers`, `/v9/venues`, `/v9/ticket_groups` GET, any read endpoint.
+Applies to **every** external API the project integrates with — TEvo, SeatGeek, SeatData, TickPick, Vivid, and any future client (`*_client.py`).
+
+OK: search / suggestions / events / performers / venues / ticket_groups / listings — any GET / read endpoint.
 
 **Forbidden without explicit operator authorization:**
-- Order creation / `POST /v9/orders`
-- Holds, locks, inventory mutations
-- Any TEvo write endpoint
+- Order creation (`POST /orders`, `POST /v9/orders`, equivalent on SG / TP / Vivid)
+- Holds, locks, reservations, inventory mutations
+- Any write / mutation endpoint on any upstream API
+- Webhook subscription changes
+- Account / seller-side configuration changes
 
 ### 3. Free reign on HTML / wiring within your lane
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md — project-wide operating rules for Claude Code sessions
+
+Loaded automatically by Claude Code on every session in this repo. Applies to **all** bots regardless of lane.
+
+Per-lane detail in `LANE_DISCIPLINE.md` (per-bot scope) + `BOT_HIERARCHY.md` (push restrictions matrix). Per-bot self-contracts live at `docs/<bot>_operating_constraints.md` (see §7 of LANE_DISCIPLINE).
+
+## Global operator rules (2026-05-13 lockdown)
+
+These three rules supersede prior MCP-applied autonomy. They apply to every bot in every lane.
+
+### 1. SQL data is read-only by default
+
+Read freely: `SELECT`, `information_schema`, `pg_*` views, log inspection, MCP `list_*`/`get_*` calls.
+
+**Need explicit operator permission before:**
+- `apply_migration` against any prod project
+- `execute_sql` with `INSERT` / `UPDATE` / `DELETE` / `DDL` on prod
+- Cron schedule changes (`cron.schedule`, `cron.unschedule`)
+- Edge function deploys that mutate data
+- Any change to `vault.*` / `auth.*` / `cron.*` schemas
+
+**Standing permissions (no per-call ask):**
+- `bot_chat` writes via `bot_chat_log()` / `bot_chat_resolve()` — these are the designed cross-lane coordination surface
+- Supabase **branch** creation (`create_branch` produces a copy-on-write fork — no prod-data mutation)
+- Author migrations as files in `supabase/migrations/` — application to prod is gated separately
+
+### 2. TEvo is read-only
+
+OK: `/v9/searches/suggestions`, `/v9/events`, `/v9/performers`, `/v9/venues`, `/v9/ticket_groups` GET, any read endpoint.
+
+**Forbidden without explicit operator authorization:**
+- Order creation / `POST /v9/orders`
+- Holds, locks, inventory mutations
+- Any TEvo write endpoint
+
+### 3. Free reign on HTML / wiring within your lane
+
+Each bot has operational latitude on UI files and JS wiring routed to them. Build, iterate, refactor without per-step approval.
+
+Lane assignments per `LANE_DISCIPLINE.md`:
+- **D0** — Terminal FE (`static/terminal/*` when built)
+- **D1** — Consumer Retail (`static/store/*`, `static/store/test/*` sandbox)
+- **C1** — supervisor docs + audit harnesses + lane discipline
+- Operator may explicitly route HTML work to a bot outside its default lane (this is the override path)
+
+## Cross-lane writes
+
+If your work needs to touch another lane's surface:
+1. Propose via PR comment to the lane owner first
+2. If owner offline, surface as `flag` in `bot_chat` for B1/A1 resolution
+3. **Never silently write across lanes** — even read-only-looking writes (e.g. cache files, logs) count
+
+## Push protocol
+
+- **A1 is sole pusher to `main`** (see `MIGRATION_CONVENTIONS.md §9`)
+- **B1 = test prod** (active integration; under the 2026-05-13 protocol, lands subordinate work before A1 promotes to main)
+- Subordinate bots open PRs against the supervisor branch first, never directly against main
+
+## When in doubt
+
+- Ask via `AskUserQuestion` for a quick clarification
+- Use `bot_chat` `question` event_type for cross-lane queries
+- Read-only investigation is always safe; mutation is never safe by default

--- a/app.py
+++ b/app.py
@@ -6090,6 +6090,14 @@ def store_test_share_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "share.html"))
 
 
+@app.get("/store/test/media_test")
+def store_test_media_test_page(_=Depends(_require_non_prod)):
+    # C1-authored sandbox under 2026-05-13 operator routing. Validates that
+    # primary_performer_logo / primary_performer_color (already in the
+    # /api/store/events payload) actually render through the test harness.
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "media_test.html"))
+
+
 # Static assets (CSS / JS / images) served from /static.
 # Keep this LAST so explicit routes above win.
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")

--- a/docs/c1_operating_constraints.md
+++ b/docs/c1_operating_constraints.md
@@ -1,0 +1,86 @@
+# C1 Operating Constraints — Data + Chat Supervisor
+
+C1's per-bot self-contract. Companion to `LANE_DISCIPLINE.md §C1` (which sets the lane scope) and `CLAUDE.md` (which sets the project-wide operator rules).
+
+This doc is C1's specific working agreement: read surface, write surface, forbidden actions, standing permissions, escalation paths.
+
+Mirrors the D1 pattern (`docs/d1_operating_constraints.md`, PR #77).
+
+## Read surface
+
+Everything. C1 supervises D0-D4 + Undelivered FE, so it must be able to read across all lanes to spot drift, audit handoffs, and catch lane-discipline violations.
+
+**Active read targets:**
+- All Supabase tables / views / functions (read-only `SELECT`)
+- All `bot_chat` rows (cross-lane coordination history)
+- All GitHub PRs in the repo (`pull_request_read`, `issue_read`, `search_pull_requests`)
+- All Render service metadata via Render MCP (read-only — D1 owns writes)
+- All TEvo GET endpoints (search, events, performers, venues, ticket_groups)
+
+## Write surface (authored files)
+
+Per `LANE_DISCIPLINE.md` line 66-79:
+- Supervisor-lane migrations (`supabase/migrations/*` for xref governance, queue-health views, sweep functions, `bot_chat` schema)
+- `bot_chat` custodial maintenance (helper functions, retention sweeps)
+- Audit docs in `docs/*-audit-*.md`, `docs/*-handoff-*.md`
+- Lane discipline + supervisor protocols (`LANE_DISCIPLINE.md`)
+- This file (`docs/c1_operating_constraints.md`)
+- Operator-routed HTML/JS test surfaces (see §"Operator-routed exceptions" below)
+
+## Standing permissions (no per-call ask)
+
+These are pre-approved by the lockdown protocol:
+
+1. **`bot_chat` writes** — `bot_chat_log()` calls for `change_log`, `sync`, `question`, `status`, `flag`, `broadcast`, `collision`, `p0_security`. Resolving rows via `bot_chat_resolve()`. This is C1's designed coordination surface; gating it would break the supervisor protocol.
+2. **Supabase **branch** creation** — copy-on-write forks don't mutate prod data. Used for validating migration drafts before promoting.
+3. **Migration drafting** — authoring files in `supabase/migrations/`. Application to prod (`apply_migration`) is separately gated.
+4. **Static-analysis SQL probes** — `SELECT` against `information_schema`, `pg_stat_*`, `pg_*` system catalogs.
+
+## Need-permission actions
+
+Operator must explicitly approve each of these:
+
+- `apply_migration` to prod (`hzrizjeaxlqcxfrtczpq`)
+- Any `execute_sql` that contains `INSERT` / `UPDATE` / `DELETE` / `DDL` against prod (except `bot_chat_log()` invocations, which are wrapped writes)
+- Cron schedule changes
+- Edge function deploys / mutations
+- Render workspace writes (forbidden entirely — D1's lane per Cross-cutting Rule #6)
+- Any TEvo write path (orders, holds, inventory mutations)
+- Any file write outside the write surface above
+
+## Forbidden actions (no permission unblocks)
+
+- Push directly to `main` (A1's sole authority per `MIGRATION_CONVENTIONS.md §9`)
+- Modify Render workspace (D1's sole lane per Cross-cutting Rule #6)
+- Modify another subordinate's primary source files (`evo_client.py`, `broadway_client.py`, `static/store/*` outside operator routing, etc.)
+- Bypass security gates (`--no-verify`, `--no-gpg-sign`)
+- Force-push to `main`
+
+## Operator-routed exceptions
+
+The operator may direct C1 to work on surfaces outside its default lane for a specific task. When this happens:
+1. The operator's instruction is the authority for that task only
+2. Note the deviation in the bot_chat row that logs the work
+3. PR description must reference the operator routing
+4. Default lane reverts when the task completes
+
+**Active operator routings:**
+- 2026-05-13: storefront HTML test surface (`static/store/test/*`) for evo MVP media validation — operator instruction "free reign on respective html and wiring" plus "build this as evo mvp test"
+
+## Escalation paths
+
+- **Cross-lane writes needed** → PR comment to lane owner; if offline, `flag` in `bot_chat` for B1/A1
+- **Security-class finding** → `p0_security` event_type in `bot_chat`, addressed to B1
+- **Governance ambiguity** → `question` event_type in `bot_chat`, addressed to A1
+- **Resource pressure** (Supabase / Render quota) → `flag` to B1 + A1
+
+## Historical drift acknowledged
+
+C1 was previously calling `mcp__supabase__apply_migration` directly against prod for supervisor migrations (PRs #61, #64, #65, #68). That was operationally functional but technically outside the documented `MIGRATION_CONVENTIONS.md §9` protocol (A1 is the sole prod applier). The 2026-05-13 lockdown corrects this: C1 authors migrations as files, A1 (or B1 in test-prod role) applies them.
+
+## Companion docs
+
+- `CLAUDE.md` (project root) — project-wide operator rules
+- `LANE_DISCIPLINE.md` (root) — per-lane scope map
+- `BOT_HIERARCHY.md` (root) — push restrictions matrix
+- `MIGRATION_CONVENTIONS.md` — §9 review checklist for migrations

--- a/docs/c1_operating_constraints.md
+++ b/docs/c1_operating_constraints.md
@@ -15,7 +15,7 @@ Everything. C1 supervises D0-D4 + Undelivered FE, so it must be able to read acr
 - All `bot_chat` rows (cross-lane coordination history)
 - All GitHub PRs in the repo (`pull_request_read`, `issue_read`, `search_pull_requests`)
 - All Render service metadata via Render MCP (read-only — D1 owns writes)
-- All TEvo GET endpoints (search, events, performers, venues, ticket_groups)
+- All upstream third-party API GET endpoints: TEvo, SeatGeek, SeatData, TickPick, Vivid (search, events, performers, venues, ticket_groups, listings)
 
 ## Write surface (authored files)
 
@@ -45,7 +45,7 @@ Operator must explicitly approve each of these:
 - Cron schedule changes
 - Edge function deploys / mutations
 - Render workspace writes (forbidden entirely — D1's lane per Cross-cutting Rule #6)
-- Any TEvo write path (orders, holds, inventory mutations)
+- Any upstream API write path on TEvo / SeatGeek / SeatData / TickPick / Vivid (orders, holds, reservations, inventory mutations, webhook config, seller-side changes)
 - Any file write outside the write surface above
 
 ## Forbidden actions (no permission unblocks)

--- a/docs/templates/LANE_DISCIPLINE.template.md
+++ b/docs/templates/LANE_DISCIPLINE.template.md
@@ -1,0 +1,173 @@
+# LANE_DISCIPLINE.md — TEMPLATE for multi-bot projects
+
+> **How to use:** Copy this file to `LANE_DISCIPLINE.md` at your repo root. Replace every `<<…>>` placeholder. Delete any lane (`A1`, `B1`, etc.) you don't need; rename them to match your project's structure. The companion `BOT_HIERARCHY.md` template is the quick-reference matrix; this doc holds the per-lane operating detail.
+>
+> **Origin:** This template is generalized from the Terminal-2 multi-bot ticketing project (2026-05-13 lockdown). The core ideas: explicit per-lane write surfaces, single-writer-per-table rule, security/governance separation, and an explicit cross-cutting "deploy infrastructure" ownership section.
+
+---
+
+# LANE_DISCIPLINE.md — per-lane operating rules
+
+Each bot writes only to its assigned files / tables / crons / edge functions. Out-of-lane writes require PR comment to the lane owner first.
+
+**Companion to `BOT_HIERARCHY.md`** (repo root) — that doc is the quick-reference: hierarchy diagram, push restrictions matrix, single-writer table ownership, fast-path workflow. **This doc is the detail**: per-lane writes / never-writes / function-call rules / client-response filters.
+
+**Per-bot self-contracts** sit one layer below this. Bots may author their own deep operational detail file at `docs/<bot>_operating_constraints.md`.
+
+When a per-bot doc exists, it MUST be consistent with this doc and `BOT_HIERARCHY.md`. If a conflict surfaces, this doc + BOT_HIERARCHY.md win until reconciled.
+
+See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIONS.md` (migration / commit conventions that overlay this scope map).
+
+## Lane assignments
+
+| ID  | Lane                         | Active bot   | Status |
+|-----|------------------------------|--------------|--------|
+| A1  | Admin / Audit / Push         | `<<bot-id>>` | active |
+| B1  | Security Manager             | `<<bot-id>>` | active |
+| C1  | Supervisor / Coordination    | `<<bot-id>>` | active |
+| D1  | <<surface-1-name>>           | `<<bot-id>>` | active |
+| D2  | <<surface-2-name>>           | `<<bot-id>>` | active |
+| Dn  | <<surface-n-name>>           | unassigned   | future |
+
+## Per-lane restrictions
+
+### A1 — Admin / Audit / Push
+
+**Writes:**
+- Core backend files shared across lanes (coordinate before edit)
+- Foundation migrations (schema, canonical data, cross-lane infra)
+- Governance docs: `MIGRATION_CONVENTIONS.md`, `SCHEMA.md`, `<<other-governance-docs>>`
+- Ledger reconciliation in `<<migration-ledger-table>>`
+- Cron schedules in audit-lane namespace
+
+**Reads:** everything.
+
+**Authority:**
+- Sole pusher to `main`
+- Reviews all PRs against `MIGRATION_CONVENTIONS.md §<<n>>` checklist
+- Approves merges
+
+### B1 — Security Manager
+
+**Writes (cross-cutting allowed):**
+- Security backlog (`KANBAN.md` or equivalent)
+- Security runbooks (`docs/security-runbook-*.md`)
+- Hand-apply gate set: `docs/proposed-migrations/*_security_*.sql`
+- Auto-apply set: `<<migrations-dir>>/*_security_*.sql`
+- Shared auth helpers (`<<auth-shared-dir>>`)
+- Per-lane patches for security CRIT/HIGH (must coordinate via PR comment to lane owner)
+
+**Reads:** everything.
+
+**Authority:**
+- Middle-man review between supervisor (C1) and admin (A1) for security-sensitive PRs
+- Resolves `event_type IN ('p0_security', 'flag')` in coordination table
+- Owns hand-apply gate for sensitive migrations (RLS, secret rotations, etc.)
+
+### C1 — Supervisor / Coordination
+
+**Writes:**
+- Supervisor-lane migrations (xref governance, queue health views, sweep functions)
+- Cross-lane coordination table (`bot_chat` or equivalent) — schema + helper functions
+- Audit docs in `docs/*-audit-*.md`, `docs/*-handoff-*.md`
+- Lane discipline + supervisor protocols (this file)
+
+**Reads:** everything.
+
+**Authority:**
+- Supervises subordinate lanes (D1+)
+- Routes signals to/from A1, B1
+- Logs change_log / sync rows in coordination table on each PR landing
+
+### D1 — <<surface-1-name>>
+
+**Writes (source files):**
+- `<<lane-specific-files>>` (coordinate with A1 on shared files)
+- `<<lane-specific-static-assets>>`
+- `<<lane-specific-tables>>` migrations
+- Coordination table writes if D1 owns chat-style surface
+
+**Never writes (source files):**
+- Other lanes' source files
+- Edge functions outside the lane's namespace
+- Infrastructure migrations shared across lanes
+
+**May invoke (server-side function calls):**
+- Other lanes' read-safe functions when the use case is read-only/search
+- `*_public` RPCs designed for the consumer surface
+- Lane-appropriate views (e.g. `<<retail_*>>` views)
+
+**Never invokes:**
+- Lane-private RPCs (admin / internal / brokerage-only)
+- Direct upstream API paths that return privileged data
+
+**Must filter from any client response:**
+- `<<sensitive-fields>>` (e.g. wholesale prices, internal cost, brokerage IDs)
+- `<<provenance-flags>>` that reveal internal inventory position
+- Tokens, secrets, vault references
+- Raw upstream rows that haven't been filtered through a `*_public` wrapper
+- Any column not whitelisted by an explicit public-RPC
+
+**Filter pattern:** call public-RPC → response only contains client-safe fields → serialize that to client. Never dump raw privileged rows.
+
+**Reads:** core context tables shared across lanes.
+
+**Owns deploy infra:**
+- `<<deploy-target-name>>` (sole owner — see Cross-cutting Rule #6). Other subordinates are explicitly barred from this deploy surface.
+
+### D2 / D3 / Dn — additional subordinate lanes
+
+Follow the D1 pattern. Each subordinate lane should declare:
+- **Writes** — exact files, tables, crons
+- **Never writes** — explicit list of forbidden surfaces
+- **Reads** — context tables it can query
+- **Owns deploy infra** — if any, or "none" if shared
+
+## Cross-cutting rules
+
+1. **Shared files** — propose changes via PR comment to the owner before editing:
+   - `<<shared-backend-file>>` (A1 owns; subordinates have specific namespaces)
+   - Dependency pinning files (A1 owns pinning shape; lanes add own deps)
+   - Governance docs (`MIGRATION_CONVENTIONS.md`, `SCHEMA.md`, this file)
+   - Hierarchy visualizations (C1 maintains)
+   - Security backlog (B1 + A1 share)
+
+2. **Single-writer per table** — see `MIGRATION_CONVENTIONS.md §<<n>>`. Each table has one owning lane that writes; others read.
+
+3. **Security cross-cutting exception** — B1 may patch any file when fixing a security CRIT/HIGH, but must surface the patch via PR comment to the affected lane.
+
+4. **Out-of-lane writes** — require PR comment to lane owner before push. If lane owner is offline, surface as `flag` in coordination table for B1 / A1 resolution.
+
+5. **SECURITY DEFINER convention** (or your platform's equivalent privileged-function pattern) — every new privileged function must ship in one migration with:
+   - `REVOKE EXECUTE ... FROM PUBLIC, <<unprivileged-roles>>`
+   - Explicit `GRANT EXECUTE ... TO <<service-role>>`
+   - Body-level `current_user` (or equivalent) assertion at function entry
+   - All three lines together, every time
+
+6. **Deploy infrastructure ownership** — per-lane infra exclusivity:
+   - **`<<deploy-target-A>>`** — owned by `<<lane>>` exclusively. Specifies what deploys here, who can provision services, modify env vars, configure crons, etc. No other lane may push/deploy here without explicit operator approval.
+   - **`<<deploy-target-B>>`** — current legacy deploy or shared platform. Governance: `<<who-owns-it>>`.
+   - **`<<data-platform>>`** — shared platform; per-table ownership via `MIGRATION_CONVENTIONS §<<n>>`. RLS / access coverage maintained by B1.
+   - **Future lanes** — when scope activates, lane gets its own deploy target. Choice deferred until then.
+
+7. **Operator-lockdown rules (global)** — apply to every bot, supersede prior MCP-applied autonomy:
+   - **SQL/database writes** — read-only by default. Need explicit operator permission for any `INSERT` / `UPDATE` / `DELETE` / DDL / `apply_migration` against prod. Exceptions: coordination-table writes via designed helper functions (standing permission); database branch creation (copy-on-write, no prod mutation); migration file authoring (application separately gated).
+   - **Upstream API writes** — read-only by default. Search / GET endpoints OK. Write paths (orders, mutations, holds) need explicit authorization.
+   - **HTML / UI / wiring** — free reign on lane-assigned UI files. Build, iterate, refactor without per-step approval. Operator may explicitly route HTML work to a bot outside its default lane (this is the override path; document the routing).
+
+## Enforcement
+
+- A1 catches violations during §<<n>> review
+- B1 catches security-class violations
+- C1 catches lane-discipline violations in supervised work
+- All violations logged as `flag` in coordination table; resolved by B1 (security findings) or A1 (governance)
+
+---
+
+## Template usage notes
+
+- **Renaming lanes:** keep the A1/B1/C1 + D-series pattern even if you rename them; the hierarchy depth (admin → security → supervisor → subordinates) maps to most projects.
+- **Project without security manager:** delete B1; have A1 do double duty. The CRIT/HIGH lockdown gate still applies, just under A1's name.
+- **Project with just one subordinate:** delete D2+. Keep D1's pattern; it's the read/write/invoke/filter scaffolding that matters.
+- **No deploy infra split:** delete Cross-cutting Rule #6 entirely. Keep Rule #7 — that's the operator lockdown and is platform-agnostic.
+- **No coordination table:** strip references to `bot_chat`; substitute PR comments. The operating rules don't depend on a shared table, just on a place to surface cross-lane signals.

--- a/docs/templates/LANE_DISCIPLINE.template.md
+++ b/docs/templates/LANE_DISCIPLINE.template.md
@@ -152,7 +152,7 @@ Follow the D1 pattern. Each subordinate lane should declare:
 
 7. **Operator-lockdown rules (global)** — apply to every bot, supersede prior MCP-applied autonomy:
    - **SQL/database writes** — read-only by default. Need explicit operator permission for any `INSERT` / `UPDATE` / `DELETE` / DDL / `apply_migration` against prod. Exceptions: coordination-table writes via designed helper functions (standing permission); database branch creation (copy-on-write, no prod mutation); migration file authoring (application separately gated).
-   - **Upstream API writes** — read-only by default. Search / GET endpoints OK. Write paths (orders, mutations, holds) need explicit authorization.
+   - **Upstream third-party APIs (every integration)** — read-only by default. Search / GET endpoints OK. Order creation, holds, reservations, inventory mutations, webhook config, seller-side config — all require explicit authorization. Applies uniformly to every `*_client.py` integration regardless of upstream provider (ticketing APIs, data brokers, scraping targets, etc.).
    - **HTML / UI / wiring** — free reign on lane-assigned UI files. Build, iterate, refactor without per-step approval. Operator may explicitly route HTML work to a bot outside its default lane (this is the override path; document the routing).
 
 ## Enforcement

--- a/static/store/test/media_test.html
+++ b/static/store/test/media_test.html
@@ -1,0 +1,363 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Media MVP — evo storefront test</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+  <style>
+    /* Media test surface — C1-authored sandbox for the 2026-05-13 evo MVP test.
+       Operator-routed per LANE_DISCIPLINE §"free reign on respective HTML and
+       wiring." Companion file: docs/c1_operating_constraints.md §"Active
+       operator routings."
+
+       Goal: prove the media wiring works end-to-end. Performer logos and
+       primary colors are already in /api/store/events payload (lines 4236-7
+       of app.py) but D1's existing test cards never render them. */
+
+    /* Hero strip per card — logo on the left, brand color band on top */
+    .cards .card {
+      padding: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+    .cards .card .accent-bar {
+      height: 4px;
+      background: var(--card-accent, var(--line));
+    }
+    .cards .card .card-body {
+      padding: 12px;
+      display: grid;
+      grid-template-columns: 56px 1fr;
+      gap: 12px;
+      align-items: start;
+    }
+    .cards .card .logo-frame {
+      width: 56px;
+      height: 56px;
+      border-radius: 8px;
+      background: var(--card-accent, var(--panel-2));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .cards .card .logo-frame img {
+      max-width: 48px;
+      max-height: 48px;
+      object-fit: contain;
+    }
+    .cards .card .logo-frame .fallback {
+      font-size: 18px;
+      font-weight: 800;
+      color: #fff;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.4);
+    }
+    .cards .card .card-meta { min-width: 0; }
+    .cards .card .badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      margin-top: 6px;
+    }
+    .cards .card .badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: rgba(255,160,102,0.12);
+      color: var(--accent-2);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .cards .card .badge.league {
+      background: rgba(124,181,255,0.12);
+      color: #7cb5ff;
+    }
+
+    /* Coverage strip */
+    .coverage {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 10px;
+      margin: 12px 0 18px;
+    }
+    .coverage .metric {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+    .coverage .metric .v {
+      font-size: 22px;
+      font-weight: 800;
+      color: var(--accent-2);
+    }
+    .coverage .metric .k {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: var(--muted);
+    }
+    .coverage .metric .sub {
+      font-size: 11px;
+      color: var(--muted);
+      margin-top: 2px;
+    }
+
+    /* Search dropdown preview */
+    .search-results {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .search-results .bucket {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+    }
+    .search-results .bucket h4 {
+      margin: 0 0 8px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: var(--muted);
+    }
+    .search-results .hit {
+      padding: 6px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      font-size: 12px;
+    }
+    .search-results .hit:last-child { border-bottom: none; }
+    .search-results .hit .where {
+      color: var(--muted);
+      font-size: 11px;
+      margin-top: 2px;
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">checking…</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+      <h3>C1 sandbox</h3>
+      <a href="/store/test/media_test" class="current"><span class="num"></span> Media MVP</a>
+    </nav>
+
+    <main class="content">
+      <h1>Media MVP — evo storefront wiring test</h1>
+      <p class="subtitle">
+        Validates that <code>primary_performer_logo</code> / <code>primary_performer_color</code> from
+        <code>performer_metadata</code> flow through <code>/api/store/events</code> → cards. Built under the
+        2026-05-13 read-only-SQL / TEvo-search-only protocol. C1 sandbox; no prod writes.
+      </p>
+
+      <h2>Coverage (SQL-side)</h2>
+      <p>Read-only probes of <code>performer_metadata</code> + <code>venue_assets</code> against owned-inventory upcoming events.</p>
+      <div class="coverage" id="coverageStrip">
+        <div class="metric">
+          <div class="k">Owned upcoming events</div>
+          <div class="v" id="covEvents">…</div>
+          <div class="sub" id="covEventsSub">loading via /api/store/events</div>
+        </div>
+        <div class="metric">
+          <div class="k">Cards with logo</div>
+          <div class="v" id="covLogos">…</div>
+          <div class="sub" id="covLogosSub">primary_performer_logo not null</div>
+        </div>
+        <div class="metric">
+          <div class="k">Cards with color</div>
+          <div class="v" id="covColors">…</div>
+          <div class="sub" id="covColorsSub">primary_performer_color not null</div>
+        </div>
+        <div class="metric">
+          <div class="k">Cards with context</div>
+          <div class="v" id="covContext">…</div>
+          <div class="sub" id="covContextSub">rivalry / playoff / weather / etc.</div>
+        </div>
+      </div>
+
+      <h2>Live event cards (with media)</h2>
+      <p>Cards render <strong>logo</strong>, <strong>brand color accent bar</strong>, and <strong>context badges</strong>. Fallback initials shown when a logo is missing.</p>
+      <div id="status" style="color: var(--muted); font-size: 13px; margin-bottom: 12px">Loading…</div>
+      <div id="cardsGrid" class="cards"></div>
+
+      <h2>Search dropdown — /api/store/search probe</h2>
+      <p>Test the three-bucket dropdown (events / performers / venues). TEvo-direct in live mode, ILIKE in SQL-only mode.</p>
+      <form id="searchForm" class="row" style="margin: 10px 0">
+        <input id="q" type="search" placeholder="Try: knicks, mets, beyonce, Madison Square Garden" style="flex: 1" />
+        <button type="submit">Probe search</button>
+      </form>
+      <div class="search-results">
+        <div class="bucket">
+          <h4>Events</h4>
+          <div id="searchEvents"><div class="hit" style="color: var(--muted)">no probe yet</div></div>
+        </div>
+        <div class="bucket">
+          <h4>Performers</h4>
+          <div id="searchPerformers"><div class="hit" style="color: var(--muted)">no probe yet</div></div>
+        </div>
+        <div class="bucket">
+          <h4>Venues</h4>
+          <div id="searchVenues"><div class="hit" style="color: var(--muted)">no probe yet</div></div>
+        </div>
+      </div>
+
+      <h2>Activity console</h2>
+      <div id="log" class="console"></div>
+    </main>
+  </div>
+
+  <script src="/static/store/test/test.js"></script>
+  <script>
+    const { $, fmtMoney, fmtWhen, api } = Test;
+
+    // Compute "is dark" for a hex color so we can pick contrasting text on
+    // the logo-frame fallback initials. Cheap luma calc — Y'CbCr coefficient
+    // approximation, no perceptual model needed.
+    function isDarkHex(hex) {
+      if (!hex) return true;
+      const h = hex.replace(/^#/, "");
+      if (h.length !== 6) return true;
+      const r = parseInt(h.slice(0, 2), 16);
+      const g = parseInt(h.slice(2, 4), 16);
+      const b = parseInt(h.slice(4, 6), 16);
+      const luma = 0.299 * r + 0.587 * g + 0.114 * b;
+      return luma < 140;
+    }
+
+    function initials(name) {
+      if (!name) return "?";
+      const parts = name.split(/\s+/).filter(Boolean);
+      if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
+
+    function renderCard(ev) {
+      const c = document.createElement("a");
+      c.className = "card";
+      c.href = `/store/test/event?id=${ev.id}`;
+      const accent = ev.primary_performer_color ? `#${ev.primary_performer_color}` : null;
+      if (accent) c.style.setProperty("--card-accent", accent);
+
+      // Build context badges from the payload's optional fields.
+      const badgeBits = [];
+      if (ev.primary_performer_league) {
+        badgeBits.push(`<span class="badge league">${ev.primary_performer_league}</span>`);
+      }
+      if (ev.rivalry) badgeBits.push(`<span class="badge">⚡ rivalry</span>`);
+      if (ev.playoff) badgeBits.push(`<span class="badge">★ playoff</span>`);
+      if (ev.mlb_series) badgeBits.push(`<span class="badge">series</span>`);
+      if (ev.tournament) badgeBits.push(`<span class="badge">tournament</span>`);
+      if (ev.weather) badgeBits.push(`<span class="badge">${ev.weather}</span>`);
+      if (ev.holiday) badgeBits.push(`<span class="badge">${ev.holiday}</span>`);
+
+      // Logo frame — img if URL present, otherwise initials on the brand color.
+      const logoFrame = ev.primary_performer_logo
+        ? `<div class="logo-frame"><img src="${ev.primary_performer_logo}" alt="" loading="lazy" /></div>`
+        : `<div class="logo-frame"><span class="fallback">${initials(ev.primary_performer_name || ev.name)}</span></div>`;
+
+      c.innerHTML = `
+        <div class="accent-bar"></div>
+        <div class="card-body">
+          ${logoFrame}
+          <div class="card-meta">
+            <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
+            <div class="name">${ev.name || "—"}</div>
+            <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+            <div class="price">${ev.from_price != null ? "from " + fmtMoney(ev.from_price) : "—"}</div>
+            ${badgeBits.length ? `<div class="badges">${badgeBits.join("")}</div>` : ""}
+          </div>
+        </div>
+      `;
+      return c;
+    }
+
+    async function loadCatalog() {
+      $("#status").textContent = "Loading /api/store/events…";
+      try {
+        const { body } = await api("/api/store/events?limit=24");
+        const events = body.events || [];
+        const total = events.length;
+        const withLogo = events.filter(e => !!e.primary_performer_logo).length;
+        const withColor = events.filter(e => !!e.primary_performer_color).length;
+        const withCtx = events.filter(e =>
+          e.rivalry || e.playoff || e.mlb_series || e.tournament || e.weather || e.holiday
+        ).length;
+
+        $("#covEvents").textContent = total;
+        $("#covLogos").textContent = withLogo;
+        $("#covLogosSub").textContent = `${total ? Math.round(100 * withLogo / total) : 0}% of returned cards`;
+        $("#covColors").textContent = withColor;
+        $("#covColorsSub").textContent = `${total ? Math.round(100 * withColor / total) : 0}% of returned cards`;
+        $("#covContext").textContent = withCtx;
+        $("#covContextSub").textContent = `${total ? Math.round(100 * withCtx / total) : 0}% with ≥1 badge`;
+
+        $("#status").textContent = total
+          ? `${total} owned-inventory event${total === 1 ? "" : "s"} (api returned ≤ limit)`
+          : "No owned-inventory events. Check matview freshness.";
+        const grid = $("#cardsGrid");
+        grid.innerHTML = "";
+        for (const ev of events) grid.append(renderCard(ev));
+      } catch (e) {
+        $("#status").textContent = "Couldn't load. " + e.message;
+        $("#status").style.color = "var(--bad)";
+      }
+    }
+
+    function renderBucket(targetId, hits, formatter) {
+      const el = $(`#${targetId}`);
+      el.innerHTML = "";
+      if (!hits || !hits.length) {
+        el.innerHTML = `<div class="hit" style="color: var(--muted)">no matches</div>`;
+        return;
+      }
+      for (const h of hits) {
+        const d = document.createElement("div");
+        d.className = "hit";
+        d.innerHTML = formatter(h);
+        el.append(d);
+      }
+    }
+
+    async function probeSearch(q) {
+      if (!q || !q.trim()) return;
+      try {
+        const { body } = await api(`/api/store/search?q=${encodeURIComponent(q)}&limit=6`);
+        renderBucket("searchEvents", body.events, (h) => `
+          <div><strong>${h.name || "—"}</strong>${h.we_own ? ' <span class="badge">owned</span>' : ""}</div>
+          <div class="where">${[h.venue_name, h.location].filter(Boolean).join(" · ")}</div>
+        `);
+        renderBucket("searchPerformers", body.performers, (h) => `
+          <div><strong>${h.name || "—"}</strong>${h.league ? ` · ${h.league}` : ""}</div>
+          <div class="where">${h.location || ""}</div>
+        `);
+        renderBucket("searchVenues", body.venues, (h) => `
+          <div><strong>${h.name || "—"}</strong></div>
+          <div class="where">${h.location || ""}</div>
+        `);
+      } catch (e) {
+        Test.log("search probe failed: " + e.message, "err");
+      }
+    }
+
+    $("#searchForm").addEventListener("submit", (e) => {
+      e.preventDefault();
+      probeSearch($("#q").value);
+    });
+
+    loadCatalog();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Persists the **2026-05-13 operator lockdown protocol** into project context and demonstrates it under a working evo storefront MVP test.

### Lockdown rules (now hard-coded)
1. **SQL data is read-only by default** — `apply_migration` / `INSERT` / `UPDATE` / `DELETE` / DDL / cron changes / edge-fn deploys all require explicit operator OK. Standing permissions: `bot_chat_log()` writes, Supabase branch creation, migration file authoring.
2. **TEvo is read-only** — search / GET only. No order / hold / mutation paths without authorization.
3. **Free reign on HTML / wiring** in lane-assigned UI files. Operator may route across lanes for specific tasks (documented in `c1_operating_constraints.md` §"Active operator routings").

## Files

| File | Status | Role |
|---|---|---|
| `CLAUDE.md` | new | Project-wide, auto-loaded by Claude Code on every session |
| `docs/c1_operating_constraints.md` | new | C1 self-contract (mirrors D1's #77 pattern) |
| `docs/templates/LANE_DISCIPLINE.template.md` | new | Reusable skeleton for future multi-bot projects |
| `static/store/test/media_test.html` | new | C1-authored MVP test surface — proves media renders |
| `app.py` | +route | `/store/test/media_test` page registration |

## Why the new test page

`/api/store/events` has been returning `primary_performer_logo` + `primary_performer_color` for weeks (app.py:4236-7), but no card renders them. The new test surface plugs them in, plus context badges (rivalry / playoff / weather), to prove the wiring end-to-end before D1 promotes it to the main `static/store/index.html`.

## Findings from read-only probes

- **99.6% logo coverage** on owned-inventory upcoming events (242 of 243). Lone gap: a concert (Bring Me the Horizon) — `performer_metadata` is ESPN-team-scoped, music acts unpopulated.
- **98.2% venue hero coverage** (109 of 111) — but `/api/store/events` does **not** bulk-fetch `venue_assets.hero_image_url`. Surfaceable via a follow-up.
- **Search SQL probes healthy**: 24 Knicks events, 62 Mets, 53 Dodgers, 125 events at MSG, 85 at Yankee Stadium. ILIKE path will return data; the dropdown will be populated.

## Historical drift acknowledged

C1 had been calling `apply_migration` directly against prod for supervisor migrations (#61, #64, #65, #68). Operationally functional but outside `MIGRATION_CONVENTIONS.md §9` (A1 is sole prod applier). Lockdown corrects: C1 authors as files, A1 (or B1 in test-prod role) applies.

## Branch note

`claude/audit-data-sources-b7EGu` was 10 commits ahead of main but those commits were already squash-merged via PR #58. Reset to `origin/main` and force-push-with-lease (PR #58 already closed, no listeners on stale history). New work lives on top of `0a9459b`.

## Test plan

- [ ] `curl /store/test/media_test` returns the new HTML (after deploy)
- [ ] Cards render with logos + brand color accent bar + context badges
- [ ] Coverage strip shows ~99% logo / ~99% color / variable context
- [ ] Search probe with `q=knicks` returns events + performers + venues buckets
- [ ] Fallback initials render when a performer has no logo (concert events)

## Upstream coordination

Rule #7 amendment to `LANE_DISCIPLINE.md` proposed as a PR comment on #69 (open governance bundle). Logged to `bot_chat` row 77.

https://claude.ai/code/session_019H1D1yuzPfkJvxt2C15EZE


---
_Generated by [Claude Code](https://claude.ai/code/session_019H1D1yuzPfkJvxt2C15EZE)_