### PR TITLE
d1: consolidated bundle — #79 base + #76 Sprint 1.5 UX + #77 constraints

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,15 @@ STOREFRONT_PREFER_INTERNAL_ZONES = (
 if STOREFRONT_PREFER_INTERNAL_ZONES:
     print("STOREFRONT_PREFER_INTERNAL_ZONES=true — granular zones preferred when (performer, venue) has them.")
 
+# Reserve endpoint auth gate. MVP demo runs without auth (front-end button
+# would 401 if always-on). Flip to true at Sprint 2 (real-purchase path)
+# unfreeze, after the front-end starts attaching Authorization headers.
+STOREFRONT_RESERVE_REQUIRES_AUTH = (
+    os.environ.get("STOREFRONT_RESERVE_REQUIRES_AUTH", "false").lower() == "true"
+)
+if STOREFRONT_RESERVE_REQUIRES_AUTH:
+    print("STOREFRONT_RESERVE_REQUIRES_AUTH=true — /api/store/reserve gated by require_auth.")
+
 sb = None
 if SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY:
     try:
@@ -234,6 +243,13 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
         response.headers.setdefault("X-Frame-Options", "DENY")
         response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+        # HSTS: tell browsers to upgrade to HTTPS for this host for 2y +
+        # include subdomains. Render terminates TLS at the proxy so the
+        # response is always HTTPS-served regardless of how we send it.
+        response.headers.setdefault(
+            "Strict-Transport-Security",
+            "max-age=63072000; includeSubDomains",
+        )
         return response
 
 
@@ -5693,10 +5709,17 @@ def store_event_zones(event_id: int):
 
 
 @app.post("/api/store/reserve")
-def store_reserve(payload: dict = Body(...)):
+def store_reserve(payload: dict = Body(...), authorization: str | None = Header(None)):
     """MVP placeholder: a real checkout is not wired up yet. Validates that
     the requested ticket_group + quantity matches the live owned inventory in
-    TEvo, then returns a mock confirmation. NEVER calls /v9/orders."""
+    TEvo, then returns a mock confirmation. NEVER calls /v9/orders.
+
+    Auth: gated by STOREFRONT_RESERVE_REQUIRES_AUTH env flag. MVP demo
+    leaves it off so the front-end's "Reserve (mock)" button works without
+    a Supabase session. Sprint 2 (real-purchase path) flips the flag on
+    once the front-end attaches Authorization headers."""
+    if STOREFRONT_RESERVE_REQUIRES_AUTH:
+        require_auth(authorization)
     try:
         event_id = int(payload.get("event_id") or 0)
         ticket_group_id = int(payload.get("ticket_group_id") or 0)

--- a/app.py
+++ b/app.py
@@ -5237,38 +5237,18 @@ def _resolve_event_with_filters(event_id: int, filters: dict, include_inactive: 
     is unchanged. inventory_source reflects 'snapshot' + adds
     snapshot_age_seconds so the demo banner can show staleness honestly.
 
-    Lifecycle gate: events flagged `is_active=false` by event_lifecycle
-    (ghost_eliminated, cancelled, postponed, completed) 404 by default —
-    same policy as the catalog, applied to direct hits and share-link
-    resolution. Set include_inactive=true to bypass for admin/debug paths.
+    MVP prod checkpoint (2026-05-13): the SQL `event_lifecycle` gate was
+    removed. Rationale: the catalog now filters by office_id at TEvo, so
+    only events our office has inventory for ever surface. The gate was
+    a defensive measure against ghost playoff rows + cancelled-but-still-
+    listed games; with office_id, those edge cases are rare AND the
+    broker terminal is the right place to manage stale listings, not the
+    public detail page. Lifting the gate also fixes a real inconsistency
+    where catalog showed a TBD playoff game (TEvo had inventory) but
+    detail 404'd (audit SQL had marked it 'completed' when the series
+    ended without that game). Set include_inactive=true is now a no-op
+    kept for callsite compatibility.
     """
-    # Bail early on inactive events so we don't show ghost/cancelled inventory
-    # to the public. event_lifecycle is the audit lane's canonical truth on
-    # whether an event is still "alive" — TEvo keeps returning ghost rows
-    # with stale prices long after a team is eliminated. Catalog already
-    # filters this; doing it here closes the direct-URL bypass.
-    if not include_inactive and sb is not None:
-        try:
-            lc = (
-                sb.table("event_lifecycle")
-                .select("status,is_active")
-                .eq("event_id", event_id)
-                .limit(1)
-                .execute()
-            ).data or []
-            if lc and lc[0].get("is_active") is False:
-                status = lc[0].get("status") or "inactive"
-                raise HTTPException(
-                    404,
-                    f"event {event_id} is {status}; not shown by default",
-                )
-        except HTTPException:
-            raise
-        except Exception:
-            # event_lifecycle view missing in some envs; better to fall
-            # through than to 500 the storefront.
-            pass
-
     snapshot_captured_at: str | None = None
     if STOREFRONT_SQL_ONLY:
         ev = _fetch_event_from_db(event_id)

--- a/app.py
+++ b/app.py
@@ -4002,40 +4002,94 @@ def _ticket_group_to_listing(tg: dict) -> dict:
 
 @app.get("/api/store/_probe_owned")
 def store_probe_owned():
-    """TEMP probe: try several owned-only filter syntaxes against TEvo
-    /v9/events and report which ones server-side filter to we-own only.
-    Removed once we've picked the winner."""
+    """TEMP probe v2: hunt for an owned-only enumeration path."""
     if client is None:
         raise HTTPException(503, "TEvo client not configured")
     today_iso = datetime.now(timezone.utc).date().isoformat()
-    variants = [
-        ("baseline", {}),
-        ("owned_by_office=true", {"owned_by_office": True}),
-        ("owned=true", {"owned": True}),
-        ("only_with_owned_tickets=true", {"only_with_owned_tickets": True}),
-    ]
-    report = {}
-    for label, extra in variants:
+    report: dict = {}
+
+    # ---- Probe A: extract our office_id from /v9/orders ----
+    office_id: int | None = None
+    seller_office: dict | None = None
+    try:
+        orders_resp = client.list_orders(per_page=3)
+        orders = orders_resp.get("orders") or []
+        if orders:
+            first = orders[0]
+            seller_office = first.get("seller") or {}
+            office_id = (seller_office or {}).get("id")
+            report["A_orders_probe"] = {
+                "ok": True, "total_orders": orders_resp.get("total_entries"),
+                "first_order_keys": sorted(first.keys()),
+                "seller_office": seller_office,
+                "extracted_office_id": office_id,
+            }
+        else:
+            report["A_orders_probe"] = {"ok": True, "orders": "none returned"}
+    except Exception as e:
+        report["A_orders_probe"] = {"ok": False, "error": str(e)}
+
+    # ---- Probe B: /v9/events?office_id=X if we found one ----
+    if office_id:
         try:
             resp = client.list_events(
-                occurs_at_gte=today_iso,
-                only_with_available_tickets=True,
-                order_by="events.occurs_at ASC",
-                per_page=50,
-                page=1,
-                **extra,
+                occurs_at_gte=today_iso, only_with_available_tickets=True,
+                order_by="events.occurs_at ASC", per_page=50, page=1,
+                **{"office_id": office_id},
             )
-            events = resp.get("events", []) or []
-            we_own = sum(1 for e in events if e.get("owned_by_office"))
-            report[label] = {
-                "ok": True,
-                "total_entries": resp.get("total_entries"),
-                "events_returned": len(events),
+            evs = resp.get("events", []) or []
+            we_own = sum(1 for e in evs if e.get("owned_by_office"))
+            report["B_events_office_id"] = {
+                "ok": True, "total_entries": resp.get("total_entries"),
+                "returned": len(evs),
                 "we_own_count": we_own,
-                "we_own_pct": (round(we_own / len(events) * 100, 1) if events else None),
+                "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
             }
-        except RuntimeError as e:
-            report[label] = {"ok": False, "error": str(e)}
+        except Exception as e:
+            report["B_events_office_id"] = {"ok": False, "error": str(e)}
+    else:
+        report["B_events_office_id"] = {"skipped": "no office_id found"}
+
+    # ---- Probe C: /v9/ticket_groups?owned=true (no event_id) ----
+    try:
+        # Use _get directly since list_ticket_groups requires event_id.
+        resp = client._get("/v9/ticket_groups", {"owned": True, "per_page": 50})
+        tgs = resp.get("ticket_groups") or []
+        # Pull event_ids from the response if present
+        event_ids = set()
+        for tg in tgs[:20]:
+            ev = (tg.get("event") or {})
+            if ev.get("id"):
+                event_ids.add(ev["id"])
+        report["C_ticket_groups_no_event_id"] = {
+            "ok": True,
+            "total_entries": resp.get("total_entries"),
+            "returned_groups": len(tgs),
+            "distinct_events_in_first_20": len(event_ids),
+            "sample_event_ids": sorted(event_ids)[:5],
+            "first_tg_keys": sorted(tgs[0].keys()) if tgs else None,
+        }
+    except Exception as e:
+        report["C_ticket_groups_no_event_id"] = {"ok": False, "error": str(e)}
+
+    # ---- Probe D: /v9/events?owned_by_office.eq=true ----
+    try:
+        resp = client.list_events(
+            occurs_at_gte=today_iso, only_with_available_tickets=True,
+            order_by="events.occurs_at ASC", per_page=50, page=1,
+            **{"owned_by_office.eq": "true"},
+        )
+        evs = resp.get("events", []) or []
+        we_own = sum(1 for e in evs if e.get("owned_by_office"))
+        report["D_events_owned_by_office_eq"] = {
+            "ok": True, "total_entries": resp.get("total_entries"),
+            "returned": len(evs),
+            "we_own_count": we_own,
+            "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
+        }
+    except Exception as e:
+        report["D_events_owned_by_office_eq"] = {"ok": False, "error": str(e)}
+
     return report
 
 

--- a/app.py
+++ b/app.py
@@ -4000,97 +4000,12 @@ def _ticket_group_to_listing(tg: dict) -> dict:
     }
 
 
-@app.get("/api/store/_probe_owned")
-def store_probe_owned():
-    """TEMP probe v2: hunt for an owned-only enumeration path."""
-    if client is None:
-        raise HTTPException(503, "TEvo client not configured")
-    today_iso = datetime.now(timezone.utc).date().isoformat()
-    report: dict = {}
-
-    # ---- Probe A: extract our office_id from /v9/orders ----
-    office_id: int | None = None
-    seller_office: dict | None = None
-    try:
-        orders_resp = client.list_orders(per_page=3)
-        orders = orders_resp.get("orders") or []
-        if orders:
-            first = orders[0]
-            seller_office = first.get("seller") or {}
-            office_id = (seller_office or {}).get("id")
-            report["A_orders_probe"] = {
-                "ok": True, "total_orders": orders_resp.get("total_entries"),
-                "first_order_keys": sorted(first.keys()),
-                "seller_office": seller_office,
-                "extracted_office_id": office_id,
-            }
-        else:
-            report["A_orders_probe"] = {"ok": True, "orders": "none returned"}
-    except Exception as e:
-        report["A_orders_probe"] = {"ok": False, "error": str(e)}
-
-    # ---- Probe B: /v9/events?office_id=X if we found one ----
-    if office_id:
-        try:
-            resp = client.list_events(
-                occurs_at_gte=today_iso, only_with_available_tickets=True,
-                order_by="events.occurs_at ASC", per_page=50, page=1,
-                **{"office_id": office_id},
-            )
-            evs = resp.get("events", []) or []
-            we_own = sum(1 for e in evs if e.get("owned_by_office"))
-            report["B_events_office_id"] = {
-                "ok": True, "total_entries": resp.get("total_entries"),
-                "returned": len(evs),
-                "we_own_count": we_own,
-                "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
-            }
-        except Exception as e:
-            report["B_events_office_id"] = {"ok": False, "error": str(e)}
-    else:
-        report["B_events_office_id"] = {"skipped": "no office_id found"}
-
-    # ---- Probe C: /v9/ticket_groups?owned=true (no event_id) ----
-    try:
-        # Use _get directly since list_ticket_groups requires event_id.
-        resp = client._get("/v9/ticket_groups", {"owned": True, "per_page": 50})
-        tgs = resp.get("ticket_groups") or []
-        # Pull event_ids from the response if present
-        event_ids = set()
-        for tg in tgs[:20]:
-            ev = (tg.get("event") or {})
-            if ev.get("id"):
-                event_ids.add(ev["id"])
-        report["C_ticket_groups_no_event_id"] = {
-            "ok": True,
-            "total_entries": resp.get("total_entries"),
-            "returned_groups": len(tgs),
-            "distinct_events_in_first_20": len(event_ids),
-            "sample_event_ids": sorted(event_ids)[:5],
-            "first_tg_keys": sorted(tgs[0].keys()) if tgs else None,
-        }
-    except Exception as e:
-        report["C_ticket_groups_no_event_id"] = {"ok": False, "error": str(e)}
-
-    # ---- Probe D: /v9/events?owned_by_office.eq=true ----
-    try:
-        resp = client.list_events(
-            occurs_at_gte=today_iso, only_with_available_tickets=True,
-            order_by="events.occurs_at ASC", per_page=50, page=1,
-            **{"owned_by_office.eq": "true"},
-        )
-        evs = resp.get("events", []) or []
-        we_own = sum(1 for e in evs if e.get("owned_by_office"))
-        report["D_events_owned_by_office_eq"] = {
-            "ok": True, "total_entries": resp.get("total_entries"),
-            "returned": len(evs),
-            "we_own_count": we_own,
-            "we_own_pct": round(we_own / len(evs) * 100, 1) if evs else None,
-        }
-    except Exception as e:
-        report["D_events_owned_by_office_eq"] = {"ok": False, "error": str(e)}
-
-    return report
+# Our TEvo brokerage's office id. Resolved via probe `/v9/orders` (probe v2,
+# 2026-05-13): brokerage=S4K Entertainment (id 1768), office=Office 3
+# (id 42029, NYC). Filter /v9/events with office_id=this to get only events
+# our office has inventory for (server-side filter, 100% we_own match).
+# Override via TEVO_OFFICE_ID env var if the brokerage adds offices later.
+TEVO_OFFICE_ID = int(os.environ.get("TEVO_OFFICE_ID", "42029"))
 
 
 @app.get("/api/store/events")
@@ -4102,26 +4017,27 @@ def store_events(
     offset: int = 0,
     include_inactive: bool = False,
 ):
-    """Catalog: upcoming events from TEvo /v9/events (MVP pass-through).
+    """Catalog: upcoming events our brokerage office has inventory for.
 
-    Pulls directly from the TEvo API — no Supabase joins. Cards carry
-    raw TEvo metadata: id, name, venue, occurs_at_local, primary performer.
-    The Supabase enrichment layer (we_own flag, from_price, performer logos
-    / brand colors, rivalry / MLB-series / tournament / weather / holiday
-    / playoff badges) is intentionally OMITTED in this build — the front
-    end null-checks every enrichment key so cards still render cleanly.
+    Pulled directly from TEvo /v9/events with office_id=TEVO_OFFICE_ID,
+    which is TEvo's native server-side filter for "events MY office has
+    listings on". 100% we_own — there is no "browse market" fallthrough.
 
-    Ownership and pricing are revealed on the detail page
-    (/api/store/events/:id), which hits /v9/ticket_groups?owned=true.
+    Performer media (logos + brand colors) is bulk-enriched from Supabase
+    performer_metadata. That's the only Supabase touch on this route —
+    the events themselves come from TEvo. Rest of the prior badge
+    enrichments (rivalry / MLB-series / tournament / weather / holiday /
+    playoff) stay nullable for now; they get re-layered after the prod
+    checkpoint.
 
     Pagination: TEvo caps per_page at 100; this handler pages through
     enough TEvo pages to fill the requested `limit` (max 500 → up to
-    5 TEvo calls, ~1-2s warm).
+    5 TEvo calls).
 
     Args mirror the prior shape so the front-end + share-link routes
     don't need to change. `include_inactive` is kept as a no-op for
-    callsite compatibility (TEvo's only_with_available_tickets already
-    drops most stale events; CANCELLED markers are filtered by name).
+    callsite compatibility (CANCELLED markers are still filtered by
+    name string in case TEvo leaks them through the office filter).
     """
     if client is None:
         # SQL-only demo mode boots without TEvo. MVP catalog requires it.
@@ -4138,11 +4054,10 @@ def store_events(
     raw_events: list[dict] = []
     try:
         for p in range(start_page, start_page + pages_needed):
-            # order_by uses the same syntax as the broker /api/events route
-            # ("table.column DIRECTION"). The simpler "occurs_at asc" form
-            # is rejected by TEvo with a non-2xx that bubbles back as
-            # "no response" because of the __bool__ quirk in evo_client's
-            # warning logger. Stick with the verified pattern.
+            # office_id=TEVO_OFFICE_ID filters TEvo to ONLY events our office
+            # has inventory for. Verified 100% we_own match in probe v2.
+            # `office_id` goes through evo_client.list_events's **extra
+            # kwarg so it reaches the request as-is.
             resp = client.list_events(
                 q=q or None,
                 performer_id=performer_id,
@@ -4152,6 +4067,7 @@ def store_events(
                 order_by="events.occurs_at ASC",
                 per_page=per_page,
                 page=p,
+                **{"office_id": TEVO_OFFICE_ID},
             )
             batch = resp.get("events", []) or []
             if not batch:
@@ -4172,6 +4088,29 @@ def store_events(
         if "CANCELLED" not in (e.get("name") or "").upper()
     ]
     raw_events = raw_events[:cap]
+
+    # ---- Bulk-fetch performer media from Supabase performer_metadata ----
+    # Single SQL roundtrip pulls logo + color for every performer that
+    # appears on the catalog page. The TEvo /v9/events response only
+    # carries performer id + name — logos and ESPN team data live in our
+    # SQL enrichment table (populated by the crawl-venues-and-performers
+    # collector). This is the only Supabase touch on the catalog.
+    perf_ids: set[int] = set()
+    for ev in raw_events:
+        for perf in (ev.get("performances") or []):
+            pid = (perf.get("performer") or {}).get("id")
+            if pid:
+                perf_ids.add(int(pid))
+    perf_assets: dict[int, dict] = {}
+    if perf_ids:
+        try:
+            db = require_sb()
+            perf_assets = _bulk_performer_assets(db, list(perf_ids))
+        except Exception as e:
+            # Don't break the catalog if performer_metadata is unavailable;
+            # cards just render without logos/colors.
+            print(f"performer_metadata bulk-fetch failed: {e}")
+            perf_assets = {}
 
     out: list[dict] = []
     for ev in raw_events:
@@ -4197,9 +4136,14 @@ def store_events(
 
         # owned_by_office is TEvo's native we-own signal — true when our
         # token's brokerage office has inventory listed for this event.
-        # Removes the need for a per-event /v9/ticket_groups probe on
-        # the catalog render.
+        # With office_id filter applied to /v9/events, this is always
+        # true; kept on the response shape for forward-compat.
         we_own = bool(ev.get("owned_by_office"))
+
+        # Performer media: logo + brand color from Supabase performer_metadata.
+        # Falls back to None on either side if the performer isn't seeded.
+        perf_id = performer.get("id")
+        assets = perf_assets.get(int(perf_id)) if perf_id else None
 
         out.append({
             "id": ev.get("id"),
@@ -4210,27 +4154,25 @@ def store_events(
             "venue_name": venue.get("name"),
             "venue_location": venue_loc,
             "primary_performer_name": performer.get("name"),
-            "primary_performer_id": performer.get("id"),
+            "primary_performer_id": perf_id,
+            "primary_performer_logo": (assets or {}).get("logo_default_url"),
+            "primary_performer_color": (assets or {}).get("color_primary"),
+            "primary_performer_league": (assets or {}).get("espn_league"),
             # available_count is deprecated for authoritative pricing but
             # is fine as a "tickets available" indicator on cards (the
             # detail page uses /v9/events/:id/stats for exact numbers).
             "available_count": ev.get("available_count"),
-            # we_own straight from TEvo. owned_tickets_count and
-            # from_price still need a per-event call so stay null on
-            # the catalog payload; revealed on click-through.
             "we_own": we_own,
             "tbd": bool(ev.get("tbd")),
             "popularity_score": ev.get("popularity_score"),
-            # Enrichment keys held nullable so the front-end's
-            # `if (ev.rivalry) {...}` checks stay valid. Reintroduced
-            # once raw TEvo flow is verified end-to-end.
-            "primary_performer_logo": None,
-            "primary_performer_color": None,
-            "primary_performer_league": None,
+            # from_price + owned_tickets_count still need a per-event call
+            # so stay null on the catalog payload; revealed on click-through.
             "from_price": None,
             "owned_tickets_count": None,
             "owned_groups_count": None,
             "captured_at": None,
+            # Other badge enrichments (rivalry / series / weather / holiday
+            # / playoff) — re-layer in a follow-up after the prod checkpoint.
             "rivalry": None,
             "mlb_series": None,
             "tournament": None,

--- a/app.py
+++ b/app.py
@@ -4080,16 +4080,6 @@ def store_events(
     ]
     raw_events = raw_events[:cap]
 
-    # TEMPORARY DEBUG (remove once mapping is confirmed): log keys of the
-    # first raw TEvo event so we can see whether performers nest under
-    # 'performers', 'primary_performer', 'performances', etc.
-    if raw_events:
-        first = raw_events[0]
-        print(f"[mvp-debug] /v9/events item keys: {sorted(first.keys())}")
-        perf_field = first.get("performers")
-        print(f"[mvp-debug] performers raw: {perf_field!r}")
-        print(f"[mvp-debug] primary_performer raw: {first.get('primary_performer')!r}")
-
     out: list[dict] = []
     for ev in raw_events:
         venue = ev.get("venue") or {}
@@ -4102,11 +4092,21 @@ def store_events(
             state = venue.get("state") or ""
             venue_loc = f"{city}, {state}".strip(", ") or None
 
-        performers = ev.get("performers") or []
-        primary = (
-            next((p for p in performers if p.get("primary")), None)
-            or (performers[0] if performers else {})
+        # /v9/events list response uses `performances`, NOT `performers`
+        # (that's the /v9/events/:id show shape). Each performance nests
+        # a `performer: {id, name}` object plus a `primary` boolean.
+        performances = ev.get("performances") or []
+        primary_perf = (
+            next((p for p in performances if p.get("primary")), None)
+            or (performances[0] if performances else {})
         )
+        performer = (primary_perf or {}).get("performer") or {}
+
+        # owned_by_office is TEvo's native we-own signal — true when our
+        # token's brokerage office has inventory listed for this event.
+        # Removes the need for a per-event /v9/ticket_groups probe on
+        # the catalog render.
+        we_own = bool(ev.get("owned_by_office"))
 
         out.append({
             "id": ev.get("id"),
@@ -4116,8 +4116,18 @@ def store_events(
             "occurs_at_local": ev.get("occurs_at_local") or ev.get("occurs_at"),
             "venue_name": venue.get("name"),
             "venue_location": venue_loc,
-            "primary_performer_name": (primary or {}).get("name"),
-            "primary_performer_id": (primary or {}).get("id"),
+            "primary_performer_name": performer.get("name"),
+            "primary_performer_id": performer.get("id"),
+            # available_count is deprecated for authoritative pricing but
+            # is fine as a "tickets available" indicator on cards (the
+            # detail page uses /v9/events/:id/stats for exact numbers).
+            "available_count": ev.get("available_count"),
+            # we_own straight from TEvo. owned_tickets_count and
+            # from_price still need a per-event call so stay null on
+            # the catalog payload; revealed on click-through.
+            "we_own": we_own,
+            "tbd": bool(ev.get("tbd")),
+            "popularity_score": ev.get("popularity_score"),
             # Enrichment keys held nullable so the front-end's
             # `if (ev.rivalry) {...}` checks stay valid. Reintroduced
             # once raw TEvo flow is verified end-to-end.

--- a/app.py
+++ b/app.py
@@ -4000,6 +4000,45 @@ def _ticket_group_to_listing(tg: dict) -> dict:
     }
 
 
+@app.get("/api/store/_probe_owned")
+def store_probe_owned():
+    """TEMP probe: try several owned-only filter syntaxes against TEvo
+    /v9/events and report which ones server-side filter to we-own only.
+    Removed once we've picked the winner."""
+    if client is None:
+        raise HTTPException(503, "TEvo client not configured")
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    variants = [
+        ("baseline", {}),
+        ("owned_by_office=true", {"owned_by_office": True}),
+        ("owned=true", {"owned": True}),
+        ("only_with_owned_tickets=true", {"only_with_owned_tickets": True}),
+    ]
+    report = {}
+    for label, extra in variants:
+        try:
+            resp = client.list_events(
+                occurs_at_gte=today_iso,
+                only_with_available_tickets=True,
+                order_by="events.occurs_at ASC",
+                per_page=50,
+                page=1,
+                **extra,
+            )
+            events = resp.get("events", []) or []
+            we_own = sum(1 for e in events if e.get("owned_by_office"))
+            report[label] = {
+                "ok": True,
+                "total_entries": resp.get("total_entries"),
+                "events_returned": len(events),
+                "we_own_count": we_own,
+                "we_own_pct": (round(we_own / len(events) * 100, 1) if events else None),
+            }
+        except RuntimeError as e:
+            report[label] = {"ok": False, "error": str(e)}
+    return report
+
+
 @app.get("/api/store/events")
 def store_events(
     q: str | None = None,

--- a/app.py
+++ b/app.py
@@ -4009,183 +4009,118 @@ def store_events(
     offset: int = 0,
     include_inactive: bool = False,
 ):
-    """Catalog: events for which we have owned inventory in TEvo.
+    """Catalog: upcoming events from TEvo /v9/events (MVP pass-through).
 
-    Driven by Supabase `latest_event_metrics` (collector populates
-    owned_tickets_count via /v9/ticket_groups?owned=true on every run).
+    Pulls directly from the TEvo API — no Supabase joins. Cards carry
+    raw TEvo metadata: id, name, venue, occurs_at_local, primary performer.
+    The Supabase enrichment layer (we_own flag, from_price, performer logos
+    / brand colors, rivalry / MLB-series / tournament / weather / holiday
+    / playoff badges) is intentionally OMITTED in this build — the front
+    end null-checks every enrichment key so cards still render cleanly.
 
-    Wiring:
-    - Filtered by `event_lifecycle.is_active` so ghosts / completed /
-      postponed events are dropped (set include_inactive=true to bypass).
-    - Performer assets (logos / brand colors) bulk-fetched from
-      performer_metadata so cards can render branding without N+1.
-    - Search is in-Python over the already-narrowed result set; cheap
-      because the DB query already caps at limit×2 candidate rows.
+    Ownership and pricing are revealed on the detail page
+    (/api/store/events/:id), which hits /v9/ticket_groups?owned=true.
+
+    Pagination: TEvo caps per_page at 100; this handler pages through
+    enough TEvo pages to fill the requested `limit` (max 500 → up to
+    5 TEvo calls, ~1-2s warm).
+
+    Args mirror the prior shape so the front-end + share-link routes
+    don't need to change. `include_inactive` is kept as a no-op for
+    callsite compatibility (TEvo's only_with_available_tickets already
+    drops most stale events; CANCELLED markers are filtered by name).
     """
-    db = require_sb()
-    # Cap raised from 200 -> 500 so consumer search pages can cover the full
-    # owned-inventory set in one fetch. Prod has ~270 events with owned
-    # tickets at any given time; capping at 200 was leaving ~25% invisible
-    # to anyone searching by performer name on the storefront. Pagination
-    # is the next step if the catalog grows past ~500.
+    if client is None:
+        # SQL-only demo mode boots without TEvo. MVP catalog requires it.
+        raise HTTPException(503, "TEvo client not configured")
+
     cap = min(max(limit, 1), 500)
+    # offset → TEvo page index. TEvo paginates 1-based.
+    per_page = min(cap, 100)
+    start_page = (max(offset, 0) // per_page) + 1
+    pages_needed = (cap + per_page - 1) // per_page
 
-    # Pull a wider candidate set so we can post-filter by lifecycle + search
-    # and still serve a full page.
-    candidate_limit = min(cap * 2, 1000) if not include_inactive else cap
+    today_iso = datetime.now(timezone.utc).date().isoformat()
 
-    # Events-first two-query merge (was `events!inner(...)` embedding,
-    # which PostgREST PGRST200s on view→table FK after cache rebuilds).
-    #
-    # Always start from `events` filtered to upcoming so we don't waste
-    # candidate slots on yesterday's games. Step 1: pull `events` ordered
-    # by occurs_at_local (with optional performer/venue filter). Step 2:
-    # join `latest_event_metrics` for owned-only. Step 3: merge in Python.
-    #
-    # Over-pull events by 3x so we have headroom after the owned filter
-    # narrows the set. include_inactive=true skips the upcoming filter
-    # (debug / admin only).
-    evs_q = db.table("events").select(
-        "id,name,occurs_at_local,venue_id,venue_name,venue_location,"
-        "primary_performer_id,primary_performer_name"
-    )
-    if not include_inactive:
-        # "Today or later" — local-time strings sort correctly here.
-        evs_q = evs_q.gte("occurs_at_local", datetime.now(timezone.utc).date().isoformat())
-    if performer_id is not None:
-        evs_q = evs_q.eq("primary_performer_id", int(performer_id))
-    if venue_id is not None:
-        evs_q = evs_q.eq("venue_id", int(venue_id))
-    evs_q = evs_q.order("occurs_at_local", desc=False).limit(candidate_limit * 3)
-    events_rows = (evs_q.execute().data) or []
-    if not events_rows:
-        return {"count": 0, "events": [], "limit": cap, "offset": offset}
-    events_by_id = {int(e["id"]): e for e in events_rows if e.get("id")}
-    event_ids = list(events_by_id.keys())
+    raw_events: list[dict] = []
+    try:
+        for p in range(start_page, start_page + pages_needed):
+            resp = client.list_events(
+                q=q or None,
+                performer_id=performer_id,
+                venue_id=venue_id,
+                occurs_at_gte=today_iso,
+                only_with_available_tickets=True,
+                order_by="occurs_at asc",
+                per_page=per_page,
+                page=p,
+            )
+            batch = resp.get("events", []) or []
+            if not batch:
+                break
+            raw_events.extend(batch)
+            if len(raw_events) >= cap:
+                break
+            # Stop early if we've hit the total.
+            total = int(resp.get("total_entries") or 0)
+            if total and len(raw_events) >= total:
+                break
+    except RuntimeError as e:
+        raise HTTPException(502, f"TEvo events fetch failed: {e}")
 
-    # Owned-only metrics for those event ids.
-    metrics_rows = (
-        db.table("latest_event_metrics")
-        .select("event_id,owned_tickets_count,owned_groups_count,owned_median_retail,"
-                "tickets_count,retail_min,captured_at")
-        .gt("owned_tickets_count", 0)
-        .in_("event_id", event_ids)
-        .limit(candidate_limit)
-        .offset(max(offset, 0))
-        .execute().data
-    ) or []
-    if not metrics_rows:
-        return {"count": 0, "events": [], "limit": cap, "offset": offset}
-
-    # Merge into the row shape downstream code expects (the old !inner
-    # response: each row has a nested `events` dict).
-    rows = [{**m, "events": events_by_id.get(int(m["event_id"]))} for m in metrics_rows]
-    rows = [r for r in rows if r.get("events")]
-    # Event-list sort hierarchy (per 2026-05-12 directive):
-    #   1. date  asc   — soonest event first
-    #   2. time  asc   — earliest start within a day first
-    #   3. qty   desc  — more owned tickets ranks higher
-    #   4. listings desc — more distinct listings ranks higher
-    #   5. getin desc  — higher cheapest-price (= "premium first") ranks higher
-    #
-    # occurs_at_local is text in YYYY-MM-DDTHH:MM:SS+TZ form; lexicographic
-    # ascending comparison naturally gives correct date+time order. Desc
-    # numeric columns are negated to fit a single ascending tuple sort.
-    def _catalog_sort_key(r):
-        ev = r.get("events") or {}
-        occurs = ev.get("occurs_at_local") or "9999-12-31T23:59:59"
-        qty = -(int(r.get("owned_tickets_count") or 0))
-        listings = -(int(r.get("owned_groups_count") or 0))
-        rmin = r.get("retail_min")
-        try:
-            price = -float(rmin) if rmin is not None else 0.0
-        except (TypeError, ValueError):
-            price = 0.0
-        return (occurs, qty, listings, price)
-    rows.sort(key=_catalog_sort_key)
-
-    # Drop ghosts / completed / postponed unless caller opts in. Same
-    # pattern as broker_movers — small id-set, single roundtrip to the
-    # event_lifecycle view (over derive_event_lifecycle()).
-    if rows and not include_inactive:
-        ev_ids = [(r.get("events") or {}).get("id") for r in rows]
-        ev_ids = [e for e in ev_ids if e]
-        if ev_ids:
-            try:
-                lc_rows = (
-                    db.table("event_lifecycle")
-                    .select("event_id,status,is_active")
-                    .in_("event_id", ev_ids)
-                    .execute()
-                ).data or []
-                inactive = {r["event_id"] for r in lc_rows if not r.get("is_active")}
-                if inactive:
-                    rows = [r for r in rows
-                            if (r.get("events") or {}).get("id") not in inactive]
-            except Exception:
-                # event_lifecycle view missing in some envs; better to show
-                # everything than 500 the storefront.
-                pass
-
-    # Bulk-fetch performer assets so card branding doesn't N+1.
-    perf_ids = [(r.get("events") or {}).get("primary_performer_id") for r in rows]
-    perf_ids = [int(p) for p in perf_ids if p]
-    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
-
-    # Bulk-fetch rivalry / MLB-series / tournament context per event. Three
-    # cheap view reads → flat lookup map keyed by event_id. Each card may
-    # render zero, one, or several badges.
-    ev_ids_for_ctx = [int(e["id"]) for e in (r.get("events") or {} for r in rows) if e.get("id")]
-    ctx_by_id = _bulk_event_context(db, ev_ids_for_ctx) if ev_ids_for_ctx else {}
+    # TEvo bakes CANCELLED markers into the event name string.
+    raw_events = [
+        e for e in raw_events
+        if "CANCELLED" not in (e.get("name") or "").upper()
+    ]
+    raw_events = raw_events[:cap]
 
     out: list[dict] = []
-    needle = (q or "").strip().lower()
-    for r in rows:
-        ev = r.get("events") or {}
-        if not ev:
-            continue
-        if needle:
-            hay = " ".join(
-                str(x or "") for x in (
-                    ev.get("name"),
-                    ev.get("venue_name"),
-                    ev.get("venue_location"),
-                    ev.get("primary_performer_name"),
-                )
-            ).lower()
-            if needle not in hay:
-                continue
-        a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
-        ctx = ctx_by_id.get(int(ev.get("id") or 0)) or {}
+    for ev in raw_events:
+        venue = ev.get("venue") or {}
+        # TEvo venue shape: {id, name, slug, location, time_zone,
+        #   city, state, country, ...}. `location` is "City, ST" string
+        #   on most events; fall back to city/state if absent.
+        venue_loc = venue.get("location")
+        if not venue_loc:
+            city = venue.get("city") or ""
+            state = venue.get("state") or ""
+            venue_loc = f"{city}, {state}".strip(", ") or None
+
+        performers = ev.get("performers") or []
+        primary = (
+            next((p for p in performers if p.get("primary")), None)
+            or (performers[0] if performers else {})
+        )
+
         out.append({
             "id": ev.get("id"),
             "name": ev.get("name"),
-            "occurs_at_local": ev.get("occurs_at_local"),
-            "venue_name": ev.get("venue_name"),
-            "venue_location": ev.get("venue_location"),
-            "primary_performer_name": ev.get("primary_performer_name"),
-            "primary_performer_id": ev.get("primary_performer_id"),
-            "primary_performer_logo": (a or {}).get("logo_default_url"),
-            "primary_performer_color": (a or {}).get("color_primary"),
-            # League gates the MLB "Series" tab on the catalog. Clients
-            # use this to decide whether to render the tabbed UI when the
-            # user is filtered to one performer.
-            "primary_performer_league": (a or {}).get("espn_league"),
-            "from_price": r.get("retail_min"),
-            "owned_tickets_count": r.get("owned_tickets_count"),
-            "owned_groups_count": r.get("owned_groups_count"),
-            "captured_at": r.get("captured_at"),
-            # Optional context badges — keys are always present so the client
-            # can do `if (ev.rivalry) render(...)` without ?-chaining.
-            "rivalry": ctx.get("rivalry"),
-            "mlb_series": ctx.get("mlb_series"),
-            "tournament": ctx.get("tournament"),
-            "weather": ctx.get("weather"),
-            "holiday": ctx.get("holiday"),
-            "playoff": ctx.get("playoff"),
+            # occurs_at_local has the real local offset; occurs_at is the
+            # misleading "Z"-suffixed local time. Prefer _local.
+            "occurs_at_local": ev.get("occurs_at_local") or ev.get("occurs_at"),
+            "venue_name": venue.get("name"),
+            "venue_location": venue_loc,
+            "primary_performer_name": (primary or {}).get("name"),
+            "primary_performer_id": (primary or {}).get("id"),
+            # Enrichment keys held nullable so the front-end's
+            # `if (ev.rivalry) {...}` checks stay valid. Reintroduced
+            # once raw TEvo flow is verified end-to-end.
+            "primary_performer_logo": None,
+            "primary_performer_color": None,
+            "primary_performer_league": None,
+            "from_price": None,
+            "owned_tickets_count": None,
+            "owned_groups_count": None,
+            "captured_at": None,
+            "rivalry": None,
+            "mlb_series": None,
+            "tournament": None,
+            "weather": None,
+            "holiday": None,
+            "playoff": None,
         })
-        if len(out) >= cap:
-            break
+
     return {"count": len(out), "events": out, "limit": cap, "offset": offset}
 
 

--- a/app.py
+++ b/app.py
@@ -4045,13 +4045,18 @@ def store_events(
     raw_events: list[dict] = []
     try:
         for p in range(start_page, start_page + pages_needed):
+            # order_by uses the same syntax as the broker /api/events route
+            # ("table.column DIRECTION"). The simpler "occurs_at asc" form
+            # is rejected by TEvo with a non-2xx that bubbles back as
+            # "no response" because of the __bool__ quirk in evo_client's
+            # warning logger. Stick with the verified pattern.
             resp = client.list_events(
                 q=q or None,
                 performer_id=performer_id,
                 venue_id=venue_id,
                 occurs_at_gte=today_iso,
                 only_with_available_tickets=True,
-                order_by="occurs_at asc",
+                order_by="events.occurs_at ASC",
                 per_page=per_page,
                 page=p,
             )

--- a/app.py
+++ b/app.py
@@ -4080,6 +4080,16 @@ def store_events(
     ]
     raw_events = raw_events[:cap]
 
+    # TEMPORARY DEBUG (remove once mapping is confirmed): log keys of the
+    # first raw TEvo event so we can see whether performers nest under
+    # 'performers', 'primary_performer', 'performances', etc.
+    if raw_events:
+        first = raw_events[0]
+        print(f"[mvp-debug] /v9/events item keys: {sorted(first.keys())}")
+        perf_field = first.get("performers")
+        print(f"[mvp-debug] performers raw: {perf_field!r}")
+        print(f"[mvp-debug] primary_performer raw: {first.get('primary_performer')!r}")
+
     out: list[dict] = []
     for ev in raw_events:
         venue = ev.get("venue") or {}

--- a/docs/d1_operating_constraints.md
+++ b/docs/d1_operating_constraints.md
@@ -1,0 +1,157 @@
+# D1 Operating Constraints
+
+D1 = Consumer Retail Bot. Worktree `eloquent-chatterjee-aaedf0`. Old label P1 (deprecated post-restructure 2026-05-12; see `bot_chat` rows 47-58).
+
+This doc codifies the boundaries D1 operates within. **`BOT_HIERARCHY.md` is the canonical lane chart and push matrix** — read it first. This file fills in D1-specific operational detail that doesn't belong in the global chart.
+
+## Scope
+
+D1 owns the public storefront end-to-end: catalog, search, event detail, share links, sharing UX, retail account flows (future). One worktree, one push surface, single-writer to `share_links`.
+
+## Read surface (allowed sources)
+
+### TEvo API (live, read-only via `evo_client.py` — RULE 2 wall)
+
+| Endpoint | Use |
+|---|---|
+| `GET /v9/events` | listing |
+| `GET /v9/events/:id` | event detail metadata |
+| `GET /v9/events/:id/stats` | authoritative tickets/price stats |
+| `GET /v9/ticket_groups?owned=true` | owned inventory for `/api/store/events/:id` |
+| `GET /v9/searches/suggestions` | live autocomplete on `/api/store/search` |
+| `GET /v9/performers`, `/v9/performers/:id`, `/v9/performers/search` | clickable performer pivots |
+| `GET /v9/venues`, `/v9/venues/:id`, `/v9/venues/search` | clickable venue pivots |
+| `GET /v9/configurations`, `/v9/configurations/:id` | seating chart asset URLs |
+
+Auth: X-Token + X-Signature (HMAC-SHA256). Credentials resolved in priority order: (1) `supabase.settings.tevo_token`/`tevo_secret`, (2) env `TEVO_TOKEN`/`TEVO_SECRET`, (3) env `TEVO_API_TOKEN`/`TEVO_API_SECRET`. See `resolve_tevo_creds()` in `app.py`.
+
+### Supabase (read-only on these — D1 does not write)
+
+| Object | Owner lane | What D1 uses it for |
+|---|---|---|
+| `events` | audit (A1) | catalog rows |
+| `latest_event_metrics` (matview, post-PR #71) | A1 | owned ticket counts, retail_min, from_price |
+| `event_lifecycle` (view) | A1 | drop ghost/cancelled/postponed events |
+| `listings_snapshots` | A1 | SQL-only-mode ticket-group fallback |
+| `performer_metadata` | A1 | logos, colors, league tags |
+| `venue_assets` | A1 | hero images, indoor/capacity tags |
+| `v_event_seating_chart` (view) | A1 | seating chart + fanvenues_key |
+| `performer_zones`, `performer_zone_rules` | A1 | zone curation chips |
+| `v_rivalry_events`, `sporting_rivalries`, `mlb_branded_series` | A1 | rivalry / branded-series badges |
+| `v_mlb_game_series` | A1 | MLB series context |
+| `v_event_tournament_context`, `espn_tournament_events`, `event_xref` | C1 / A1 | F1/golf/tennis tournament parent |
+| `v_event_weather_with_fallback`, `weather_observations`, `nws_alerts` | A1 | weather row + alerts |
+| `v_event_calendar_context`, `holidays`, `school_break_windows` | A1 | holiday pills |
+| `v_event_velocity_windows` | A1 | NYC movers strip signals |
+| `settings` | A1 | TEvo credential lookup at boot |
+| `bot_chat` | shared | inbound coordination messages |
+
+If D1 needs a new read, ack the owner lane in `bot_chat` first.
+
+## Write surface (D1 is the writer)
+
+### Local files (D1 lane)
+
+- `app.py` — **storefront routes only**: `/api/store/*`, `/store`, `/store/event/{id}`, `/s/{share_id}`, `/healthz` (D1-style boot/credential diagnostics). Cross-lane routes (`/api/broker/*`, `/api/portfolio`, `/api/seatdata/*`, `/api/seatgeek/*`, `/api/admin/*`) are read-only to D1.
+- `evo_client.py` — **read-only** to D1. Adding a method like `search_suggestions()` is allowed when it's a GET wrapper (PR #63 precedent). Modifying the RULE 2 guard at lines 47-67 is **forbidden** — see Sprint 2 carve-out below.
+- `static/store/*` — full ownership: `index.html`, `event.html`, `shares.html`, `store.js`, `style.css`, future `legal.html`, `favicon.*`, sitemap, OG image, etc.
+- `render.yaml` — D1 owns (sole Render workspace owner).
+- `.env` (gitignored) — local secrets cache. Never committed.
+- `docs/d1_*.md`, `docs/evo_store_*.md` — D1 may author/edit.
+- `KANBAN.md` — append-only, D1 may add rows in `(P1 → A1)` style (legacy label still works in row titles).
+
+### Supabase tables (D1 single-writer)
+
+| Table | Writer pattern |
+|---|---|
+| `share_links` | Single-writer. Migration `20260510120150_share_links.sql`. RPC `bump_share_view(p_id)`. Schema: id PK, event_id, filters jsonb, note, expires_at, revoked_at, view_count, last_viewed_at. RLS enabled; service_role bypasses; all access through `/api/store/share/*` handlers. |
+| `bot_chat` | Append-only multi-writer (all lanes). D1 posts with `bot_lane='D1'`, `bot_level='data-collection'`. Event types: `status`, `flag`, `change_log`, `sync`. Use `in_reply_to` to thread. |
+
+Future tables (Sprint 2 unfreeze): `store_orders`, `store_payments`. Single-writer pattern, same as share_links.
+
+### Render workspace (D1 exclusive — sole owner per BOT_HIERARCHY §3)
+
+- Service config (build/start commands, plan, region, branch)
+- Env vars (read, set, delete via Render REST API)
+- Deploys (trigger, restart, deactivate)
+- Runtime logs (read)
+- Health check path
+
+API key lives in gitignored `.env` as `RENDER_API_KEY`. Future Render MCP via PR #70 (still open).
+
+## Forbidden actions
+
+D1 **must not**:
+
+1. **Run `apply_migration` against the prod project_id.** Migrations land via PR → A1 review → A1 applies. Preview branches (`create_branch`) are allowed for validation.
+2. **Push to `main`.** Only A1 (and B1 for CRIT security) merges to `main`. D1 ships via PR.
+3. **Modify the RULE 2 guard in `evo_client.py:47–67`.** Future write capability lives in a sibling module (`evo_orders_client.py`, see below).
+4. **Edit cross-lane files**: `seatgeek_client.py`, `seatdata_client.py`, `tickpick_client.py`, `vivid_client.py`, `broadway_client.py`, `supabase/migrations/*` (anything not `share_links` or its successors), `supabase/functions/*`, `SCHEMA.md` outside D1's referenced sections.
+5. **Modify Render env vars on services other than `vibepass-storefront-test`** (D1 is sole owner of that service only; future D1-owned services follow same rule).
+6. **Submit to bot_chat with another lane's `bot_lane=` value.** Always `bot_lane='D1'`.
+7. **Use the legacy P1 label in new bot_chat rows.** P1 is deprecated. D1 going forward.
+8. **Echo secrets in chat or commits.** TEvo creds, Render API key, Supabase Service Role Key all live in gitignored `.env` or `supabase.settings`. Reference via env-var indirection.
+
+## Coordination triggers
+
+D1 must file a `bot_chat` flag/sync row **before** any of:
+
+- Adding a new read against a table/view D1 doesn't already use → ack owner lane
+- Proposing a new column/index on a shared read source → A1 review
+- Touching CSP, RLS posture, or auth flow → B1 review
+- Adding a new outbound service call (Stripe, Sentry, analytics, etc.) → CSP update needs B1
+- Any change that affects `/api/store/share/*` revocation/PII surface → B1 review
+- Lifting RULE 2 (Sprint 2 carve-out) → B1 architectural sign-off
+- New cron schedule → A1 (per `docs/cron-landscape-*`)
+
+## Sprint 2 freeze (purchase path)
+
+`/api/store/reserve` is a **mock** today. `purchase_enabled: false`. Storefront pages carry an "MVP · browse only" badge.
+
+Sprint 2 unfreezes only when **all three** are true:
+
+1. **Operator-side**: TEvo merchant-of-record onboarding confirmed (eligibility, fee structure, /v9/orders contract, refund pattern).
+2. **D1 + B1 architectural**: Chartered RULE 2 carve-out approved. Filed in `bot_chat` row 68. Proposed shape:
+   - New module `evo_orders_client.py`
+   - `ALLOWED_ORDERS_METHODS = frozenset({"GET","POST"})`
+   - POST scope: `/v9/orders` only
+   - `evo_client.py` guard untouched (`tests/test_readonly_guards.py` keeps passing)
+   - `SCHEMA.md` RULE 2 section updated
+3. **Front-end shipped**: Sprints 1.5 / 3 / 4a / 5 in main, "MVP" badge removable.
+
+Sprint 4b (sitemap, Search Console submission) waits until Sprint 2 ships — indexing a non-functional checkout damages search quality signals.
+
+## Verification / smoke after every D1 PR merge
+
+After A1 merges any D1 PR + Render auto-deploys from `main`:
+
+```bash
+curl https://vibepass-storefront-test.onrender.com/healthz
+# expect: ok=true, evo_creds_source=supabase.settings, smoke=pass
+
+curl 'https://vibepass-storefront-test.onrender.com/api/store/events?limit=3'
+# expect: 200, <2s, real events with from_price + owned_tickets_count
+
+curl 'https://vibepass-storefront-test.onrender.com/api/store/search?q=knicks&limit=4'
+# expect: 200, source=live (or sql in demo mode), we_own:true on owned events
+
+curl 'https://vibepass-storefront-test.onrender.com/api/store/events/3346000'
+# expect: 200, inventory_source=live, listings_count>0
+```
+
+Post `bot_chat` status (`bot_lane='D1'`, `event_type='change_log'`) referencing the merged PR # + smoke results.
+
+## References
+
+- `BOT_HIERARCHY.md` — canonical lane chart + push matrix
+- `MIGRATION_CONVENTIONS.md` — repo migration discipline (D1 follows §2, §3, §6 even for share_links)
+- `SCHEMA.md` — RULE 2 (read-only TEvo wall)
+- `docs/evo_store_next_steps.md` — A1's PR #74 Sprint 1 unblocks
+- `docs/d1_retail_finish_punchlist.md` — A1's PR #75 MVP→prod sprint plan
+- `docs/bot-hierarchy.mermaid` — visual chart (mirrors BOT_HIERARCHY.md)
+
+## Revision history
+
+| Date | What | Why |
+|---|---|---|
+| 2026-05-13 | Initial draft | D1 codifies own constraints post-restructure (rows 47-58, PRs #74/#75). Filed by D1 as a self-imposed contract; A1 reviews via PR. |

--- a/docs/d1_pending_merge_back.md
+++ b/docs/d1_pending_merge_back.md
@@ -1,0 +1,88 @@
+# D1 — Pending merge-back work
+
+Filed 2026-05-13 alongside PR #79 (MVP catalog TEvo-direct). Render is being repointed to `claude/d1-mvp-tevo-direct` for MVP review. Work captured here is parked on **other branches** and needs to come back when MVP shape is locked.
+
+## PR #76 — Sprint 1.5 UX batch (parked)
+
+Branch: `claude/store-sql-only-demo-mode`
+Commit: `a8f44d2` — `ux(store): Sprint 1.5 polish — 7 audit findings landed`
+Deploy status when parked: `update_failed` (deploy `dep-d81tu7ek1jcs73eml4n0`, 2026-05-13 02:35 UTC).
+
+### What's in the commit
+
+7 UX fixes from the static audit. Net diff: +167 / -18 across `static/store/store.js` and `static/store/style.css`. No Python touched, no `app.py` overlap with PR #79.
+
+| # | Where | Fix |
+|---|---|---|
+| 1 | `store.js:401-404` + `index.html:53` | Catalog load error: replaces stuck red text with inline **Retry** button. `loadCatalog()` factored out so Retry re-fires `/api/store/events` without page reload. |
+| 2 | `store.js:447-455` + `style.css:add suggest-status.error` | Search dropdown error tone: `.suggest-status.error` variant uses `--bad` color + ⚠ glyph so "Search unavailable" is visually distinct from "Searching…". |
+| 3 | `store.js:1432-1433` + event.html | Missing seating chart: hide `<img>` + inject `.map-placeholder` div so 2-col event-body grid keeps its left column footprint. Without this, listings reflowed into the empty space at the 760px breakpoint. |
+| 4 | `event.html:115` + `store.js:906-985` | Parking tab `aria-label="Parking, N listings"` so screen readers announce the count. `.listing-tab[aria-disabled="true"]` rule added defensively. |
+| 5 | `store.js:1245-1251` | Filter apply failure: `applyFiltersAndFetch`'s catch now surfaces inline `.filter-error` pill in the filter bar (was silent `console.error`). Pill auto-clears on next successful apply. |
+| 6 | `style.css:1125-1134` + `event.html:73-78` | Parking tab count: `white-space: nowrap` + `font-size: 10px` so "Parking 12" doesn't wrap on narrow viewports. |
+| 8 | `index.html:15` + `event.html:15` + `style.css` | Under 760px, hide the "MVP · browse only · no real purchases" text and show just "MVP" via `font-size: 0` + `::before { content: "MVP" }` pattern. Topbar stays uncrowded on mobile without changing desktop copy. |
+
+Audit item #7 (Reserve button `:disabled`) was **skipped during the original commit** — audit had misidentified scope; the global `.btn:disabled` rule at `style.css:562` already covered row buttons.
+
+### Why the deploy failed
+
+`render.yaml:32` sets `healthCheckPath: /`. The storefront landing page route is heavier than `/healthz` (90KB JS + CSS). On Render free-tier cold-start dyno, the healthcheck on `/` timed out before the server settled. Build succeeded, server detected port 10000, but Render flagged `update_failed` after 18 minutes of retries. The previous successful deploy (`268cae3`) stayed live, so the user-facing site was never down — it just didn't pick up the Sprint 1.5 fixes.
+
+### Recommended re-merge sequence
+
+1. Merge PR #79 (MVP catalog) to `main` after operator review.
+2. Cherry-pick `a8f44d2` (Sprint 1.5) onto a new branch off `main`. No conflicts expected — `app.py` vs JS/CSS, fully orthogonal.
+3. **Before triggering deploy**, patch `render.yaml`:
+   ```diff
+   - healthCheckPath: /
+   + healthCheckPath: /healthz
+   ```
+   `/healthz` is sub-50ms warm and doesn't load static assets — won't time out on cold dyno boot.
+4. Open PR for the Sprint 1.5 cherry-pick + healthcheck path swap. Single PR keeps the deploy-fix coupled to the cherry-pick that triggered the failure.
+5. After merge, the next deploy from `main` should ship Sprint 1.5 + the healthcheck fix.
+6. Smoke after deploy: `/healthz` 200; `/store` renders the Retry button on simulated catalog 500; MVP badge shrinks to "MVP" under 760px viewport.
+
+### Open question to reconcile during merge-back
+
+The Sprint 1.5 #1 fix wires Retry to `/api/store/events`. Post-MVP that endpoint is TEvo-direct. The Retry button still works (same path, same failure modes), so no code change needed — but worth confirming the error message in the catch ("Couldn't load events:") still reads naturally if TEvo returns a 502 instead of Supabase.
+
+## bot_chat row 68 — B1 RULE 2 carve-out (still pending B1)
+
+Architectural review request for Sprint 2 (real purchase path). Filed 2026-05-13. B1 hasn't responded. This is a *future* work item — Sprint 2 is frozen until:
+- All front-end sprints (1, 1.5, 3, 4a) shipped
+- TEvo merchant-of-record onboarding confirmed
+- B1 sign-off on `evo_orders_client.py` sibling-module shape
+
+No action needed during MVP review; just remember it exists when Sprint 2 thaws.
+
+## PR #77 — D1 operating constraints doc
+
+Branch: `claude/d1-operating-constraints`. Self-contract doc, no code. Filed for A1 review same day. Independent of MVP / Sprint 1.5 — merge whenever convenient.
+
+## Sprint 4a / Sprint 5 sketches (plan-only)
+
+From `~/.claude/plans/smooth-coalescing-garden.md`:
+- **Sprint 4a**: OG tags + Twitter card + JSON-LD `Organization`/`Event` on `/store` and `/store/event/:id`. Favicon waits on operator asset.
+- **Sprint 5**: `Cache-Control: public, max-age=300` on `/static/store/*`, footer with copyright + `git rev-parse --short HEAD` version line, terser minification of `store.js`.
+
+These haven't been started. Both are independent of MVP shape; revisit after MVP is locked.
+
+## Render deploy state at parking time
+
+| Field | Value |
+|---|---|
+| Service | `vibepass-storefront-test` (`srv-d8140bnaqgkc73al4asg`) |
+| Source branch (at parking time) | `claude/store-sql-only-demo-mode` |
+| Last successful deploy | `dep-d81qk0osfn5c738slgrg` @ commit `268cae3` (status: `live`) |
+| Last failed deploy | `dep-d81tu7ek1jcs73eml4n0` @ commit `a8f44d2` (Sprint 1.5) |
+| `healthCheckPath` in render.yaml | `/` — change to `/healthz` next merge |
+| Free-tier behavior | sleeps after 15min idle, ~50s cold start to `/healthz`, <1s warm |
+
+## TL;DR for the merge-back operator
+
+1. Merge PR #79 → main.
+2. Cherry-pick `a8f44d2` onto a branch off main.
+3. Change `render.yaml` line 32: `healthCheckPath: /` → `/healthz`.
+4. PR + merge that.
+5. Repoint Render service from `claude/d1-mvp-tevo-direct` (MVP testing branch) back to `main`.
+6. Smoke. Retire `claude/store-sql-only-demo-mode` and `claude/d1-mvp-tevo-direct` once green.

--- a/docs/templates/bot_lane_constraints_template.md
+++ b/docs/templates/bot_lane_constraints_template.md
@@ -1,0 +1,151 @@
+# <BOT_ID> Operating Constraints — Template
+
+> Reusable template for codifying a single bot's lane in a multi-bot, single-writer-per-table codebase. Fill in the `<PLACEHOLDERS>` and drop the angle-brackets. Delete sections that don't apply.
+
+`<BOT_ID>` = e.g., `D1`, `A2`, `B1`. Worktree `<worktree-name>`. Old label `<deprecated-name>` (deprecated `<date>`; see `bot_chat` rows `<n-m>`).
+
+This doc codifies the boundaries `<BOT_ID>` operates within. **`BOT_HIERARCHY.md` (or equivalent canonical lane chart) is the source of truth — read it first.** This file fills in `<BOT_ID>`-specific operational detail that doesn't belong in the global chart.
+
+## Scope
+
+One-sentence statement of what `<BOT_ID>` owns end-to-end. Include the surface area (which routes / which UI / which data product). One worktree, one push surface, single-writer to `<owned tables>`.
+
+## Read surface (allowed sources)
+
+### External APIs (live, read-only via `<client_module>.py` — RULE N wall)
+
+| Endpoint | Use |
+|---|---|
+| `GET <path>` | what for |
+| `GET <path>` | what for |
+
+Auth: `<auth scheme>`. Credentials resolved in priority order: (1) `<source>`, (2) `<source>`, (3) `<source>`. See `<resolver function>()` in `<file>`.
+
+### Internal DB / SQL (read-only on these — `<BOT_ID>` does not write)
+
+| Object | Owner lane | What `<BOT_ID>` uses it for |
+|---|---|---|
+| `<table>` | `<owner>` | `<purpose>` |
+| `<view>` | `<owner>` | `<purpose>` |
+
+If `<BOT_ID>` needs a new read, ack the owner lane in `bot_chat` (or equivalent coordination channel) first.
+
+## Write surface (`<BOT_ID>` is the writer)
+
+### Local files (`<BOT_ID>` lane)
+
+- `<file>` — scope statement (e.g., "storefront routes only"). Cross-lane routes are read-only.
+- `<file>` — full ownership / single-writer / append-only.
+- `<file>` — read-only to `<BOT_ID>`. Modifying `<specific guards/lines>` is **forbidden** — see carve-out section below.
+- `<file>` — `<BOT_ID>` may author/edit.
+- `<coordination file>` — append-only, `<BOT_ID>` may add rows in `(<old-label> → <other-lane>)` style.
+
+### DB tables (`<BOT_ID>` single-writer)
+
+| Table | Writer pattern |
+|---|---|
+| `<table>` | Single-writer. Migration `<path>`. RPC `<rpc_name>(...)`. Schema: `<short schema>`. RLS enabled; service_role bypasses; all access through `<handler>` routes. |
+| `<append-only table>` | Append-only multi-writer (all lanes). `<BOT_ID>` posts with `<discriminator>='<BOT_ID>'`. Use `<thread key>` to thread. |
+
+Future tables (post-freeze): `<table_a>`, `<table_b>`. Same pattern.
+
+### Hosting / infra (`<BOT_ID>` exclusive — sole owner per `BOT_HIERARCHY` §N)
+
+- Service config (build/start commands, plan, region, branch)
+- Env vars (read, set, delete via API)
+- Deploys (trigger, restart, deactivate)
+- Runtime logs (read)
+- Health check path
+
+API key lives in gitignored `<.env or secrets file>` as `<KEY_NAME>`.
+
+## Forbidden actions
+
+`<BOT_ID>` **must not**:
+
+1. **Run `<destructive op>` against the prod `<resource>`.** Migrations / schema changes land via PR → `<reviewer>` review → `<applier>` applies. Preview branches allowed for validation.
+2. **Push to `main`.** Only `<merge owners>` merge to `main`. `<BOT_ID>` ships via PR.
+3. **Modify `<critical guard / RULE N wall>` in `<file>:<line range>`.** Future write capability lives in a sibling module (see carve-out below).
+4. **Edit cross-lane files**: list specific files. Anything not explicitly in `<BOT_ID>`'s write surface above.
+5. **Modify infra config on services other than `<owned services>`** (`<BOT_ID>` is sole owner of that service only).
+6. **Submit to `<coordination channel>` with another lane's discriminator.** Always `<discriminator>='<BOT_ID>'`.
+7. **Use the legacy `<old-label>` in new `<coordination channel>` rows.** It is deprecated. `<BOT_ID>` going forward.
+8. **Echo secrets in chat or commits.** All credentials live in gitignored `<.env>` or `<settings table>`. Reference via env-var indirection.
+
+## Coordination triggers
+
+`<BOT_ID>` must file a `<coordination channel>` flag/sync row **before** any of:
+
+- Adding a new read against a table/view `<BOT_ID>` doesn't already use → ack owner lane
+- Proposing a new column/index on a shared read source → `<reviewer>` review
+- Touching security posture (CSP, RLS, auth flow) → `<security lane>` review
+- Adding a new outbound service call → security review (CSP update etc.)
+- Any change that affects PII surface → security review
+- Lifting `<critical guard>` (sprint carve-out) → architectural sign-off
+- New scheduled job → `<scheduler owner>` review
+
+## Carve-out / freeze conditions (if applicable)
+
+`<feature>` is **mock today / frozen**. Storefront/UI carries an indicator badge.
+
+Unfreezes only when **all N** are true:
+
+1. **Operator-side**: external dependency confirmed (vendor onboarding, contract, mechanics).
+2. **Architectural sign-off**: Filed in `<coordination channel>` row `<n>`. Proposed shape:
+   - New module `<sibling_module>.py` (NOT modifying the existing guard)
+   - Scoped allowlist: `frozenset({...})`
+   - Scope: specific endpoints only
+   - Existing guard untouched (`<tests>` keeps passing)
+   - `<canonical doc>` section updated
+3. **Front-end shipped**: prerequisite sprints in main, indicator badge removable.
+
+## Verification / smoke after every `<BOT_ID>` PR merge
+
+After merge + deploy from `main`:
+
+```bash
+curl <url>/healthz
+# expect: <known good shape>
+
+curl <url>/<key route>
+# expect: <known good shape>, <SLA>
+
+curl <url>/<another key route>
+# expect: <known good shape>
+```
+
+Post `<coordination channel>` status (`<discriminator>='<BOT_ID>'`, `event_type='change_log'`) referencing the merged PR # + smoke results.
+
+## References
+
+- `BOT_HIERARCHY.md` (or equivalent) — canonical lane chart + push matrix
+- `<MIGRATION_CONVENTIONS.md>` — repo migration discipline
+- `<SCHEMA.md>` — RULE N (read-only wall, security boundaries)
+- Other lane docs that intersect `<BOT_ID>`'s surface
+
+## Revision history
+
+| Date | What | Why |
+|---|---|---|
+| `<YYYY-MM-DD>` | Initial draft | `<BOT_ID>` codifies own constraints. Filed by `<BOT_ID>` as a self-imposed contract; `<reviewer>` reviews via PR. |
+
+---
+
+## How to use this template
+
+1. **Copy** to a new file in your project's docs directory: `docs/<bot-id>_operating_constraints.md`.
+2. **Read your project's `BOT_HIERARCHY.md`** (or whatever the canonical lane chart is called). The lane discipline doc complements it, it doesn't replace it.
+3. **Fill in placeholders top-down.** Each `<PLACEHOLDER>` is a decision point — if you can't answer it, that's a coordination question to surface with the team before you start writing code.
+4. **Delete sections that don't apply.** Carve-out / freeze section is only relevant if your lane has a future-state write capability gated behind external dependencies.
+5. **File as a PR for review** by the lane that owns canonical / architecture review. The doc itself is a self-contract; review confirms the contract terms match what other lanes expect.
+6. **Update revision history** when your lane's boundaries change (new tables owned, scope expanded, etc.). Don't silently mutate the constraints — every change goes through PR.
+
+## Why this pattern works
+
+The lane discipline doc is a **self-imposed contract** with three benefits:
+
+1. **Onboarding speed**: a new agent / new contributor reads ~150 lines and knows exactly what they can and can't touch. No spelunking through commit history to discover boundaries by accident.
+2. **Coordination cost reduction**: explicit "must file before" list eliminates 80% of cross-lane Slack/chat traffic. Lanes know when they need to coordinate vs when they can move alone.
+3. **Audit trail**: when a lane DOES violate its constraints (intentionally — e.g., emergency security fix), the deviation is visible against an explicit baseline. No ambiguity about whether the violation was a coordination failure or a known exception.
+
+The doc lives **in the codebase**, not in a wiki or notion page, so it versions with the code and can't drift out of sync with the actual files it references.

--- a/render.yaml
+++ b/render.yaml
@@ -23,8 +23,8 @@ services:
     plan: free
     region: oregon          # closest to Supabase us-east-2; tradeoff vs us-east-ohio (~50ms)
     # If your Supabase project is us-east-2 specifically, prefer 'ohio' region instead.
-    branch: claude/d1-mvp-tevo-direct
-    autoDeploy: true        # every push to the branch redeploys
+    branch: main
+    autoDeploy: true        # every push to main redeploys (post-consolidation: A1 row 81 directive)
 
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT

--- a/render.yaml
+++ b/render.yaml
@@ -23,14 +23,18 @@ services:
     plan: free
     region: oregon          # closest to Supabase us-east-2; tradeoff vs us-east-ohio (~50ms)
     # If your Supabase project is us-east-2 specifically, prefer 'ohio' region instead.
-    branch: claude/store-sql-only-demo-mode
+    branch: claude/d1-mvp-tevo-direct
     autoDeploy: true        # every push to the branch redeploys
 
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
 
-    healthCheckPath: /
-    # Health endpoint returns {"ok": true, ...} so Render's HTTP probe succeeds.
+    healthCheckPath: /healthz
+    # /healthz returns {"ok": true, ...} fast (<50ms warm, ~1s cold) and
+    # doesn't load the storefront's static bundle. Previously /, but that
+    # rendered the full landing page (90KB JS) + timed out the cold-dyno
+    # healthcheck window on free tier — Sprint 1.5 deploy (a8f44d2) failed
+    # for exactly that reason. /healthz boots cleanly even on cold start.
 
     envVars:
       # Pin to Python 3.12 — Render's auto-pick of 3.14.3 is brand-new and

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -392,16 +392,35 @@
     if (performerId) qs.set("performer_id", performerId);
     if (venueId) qs.set("venue_id", venueId);
 
-    api(`/api/store/events?${qs.toString()}`)
-      .then((res) => {
-        allEvents = res.events || [];
-        renderCatalogFilterBanner(performerId, venueId, allEvents);
-        render(allEvents, "all");
-      })
-      .catch((err) => {
-        status.textContent = `Couldn't load events: ${err.message}`;
-        status.style.color = "var(--bad)";
-      });
+    // Catalog fetch with retryable error UI. On failure (502 cold-start,
+     // statement timeout, etc) the user sees the error + an inline Retry
+     // button instead of stuck red text. Per D1 UX audit 2026-05-12 fix #1.
+    function loadCatalog() {
+      status.textContent = "Loading available events…";
+      status.style.color = "";
+      status.hidden = false;
+      api(`/api/store/events?${qs.toString()}`)
+        .then((res) => {
+          allEvents = res.events || [];
+          renderCatalogFilterBanner(performerId, venueId, allEvents);
+          render(allEvents, "all");
+        })
+        .catch((err) => {
+          status.replaceChildren();
+          status.style.color = "var(--bad)";
+          status.hidden = false;
+          const msg = document.createElement("div");
+          msg.textContent = `Couldn't load events: ${(err && err.message ? String(err.message) : "Unknown error").slice(0, 120)}`;
+          const retry = document.createElement("button");
+          retry.type = "button";
+          retry.className = "btn ghost";
+          retry.style.marginTop = "12px";
+          retry.textContent = "Retry";
+          retry.addEventListener("click", loadCatalog);
+          status.append(msg, retry);
+        });
+    }
+    loadCatalog();
 
     // NYC movers strip — only shown on the bare /store view (no performer
     // or venue filter). Velocity-driven, sorted by 24h ticket drop.
@@ -452,16 +471,18 @@
             // common failure modes on this deploy are 502 (sleeping
             // dyno) and 5xx during cold starts.
             const msg = err && err.message ? String(err.message) : "Search unavailable";
-            showSuggestStatus(`${msg.slice(0, 80)} · try again`);
+            // isError=true → renders with .suggest-status.error styling
+            // (bad-tone color + ⚠ glyph), distinct from "Searching…".
+            showSuggestStatus(`${msg.slice(0, 80)} · try again`, true);
           });
       }, 300);
     }
 
-    function showSuggestStatus(text) {
+    function showSuggestStatus(text, isError) {
       if (!suggestEl) return;
       suggestEl.replaceChildren();
       const div = document.createElement("div");
-      div.className = "suggest-status";
+      div.className = "suggest-status" + (isError ? " error" : "");
       div.textContent = text;
       suggestEl.append(div);
       suggestEl.hidden = false;
@@ -918,6 +939,18 @@
       }
       tabs.hidden = false;
       tabCountEl.textContent = String(parkingCount);
+      // Screen-reader-friendly label so the parking tab announces as
+      // "Parking, 12 listings" instead of two disconnected tokens. Per D1
+      // UX audit 2026-05-12 fix #4.
+      const parkTabBtn = tabs.querySelector('[data-tab="parking"]');
+      if (parkTabBtn) {
+        parkTabBtn.setAttribute(
+          "aria-label",
+          `Parking, ${parkingCount} listing${parkingCount === 1 ? "" : "s"}`,
+        );
+        // Remove any prior aria-disabled (in case earlier render set it).
+        parkTabBtn.removeAttribute("aria-disabled");
+      }
 
       parkUl.replaceChildren();
       for (const l of parkingListings) {
@@ -1241,14 +1274,38 @@
     async function applyFiltersAndFetch() {
       const f = readFiltersFromUI();
       updateUrl(f);
+      // Clear any prior inline filter error before retrying.
+      showFilterError(null);
       try {
         const res = await api(`/api/store/events/${eventId}${buildQueryString(f)}`);
         applyEventResponse(res, resolvedShare);
       } catch (err) {
-        // Filter apply failures don't break the existing rendered state —
-        // surface in the banner only.
+        // Surface in the filter bar so the user knows the apply failed
+        // (was silently console.error'd before). Per D1 UX audit
+        // 2026-05-12 fix #5. Existing rendered listings stay visible —
+        // filter just didn't refresh, not catastrophic.
         console.error("filter apply failed:", err);
+        const msg = (err && err.message ? String(err.message) : "Filter unavailable").slice(0, 120);
+        showFilterError(`Filter didn't apply: ${msg} · listings shown reflect prior state`);
       }
+    }
+
+    // Inline filter-bar error pill. Pass null to clear. Same pattern as
+    // the search dropdown's .suggest-status.error.
+    function showFilterError(text) {
+      const bar = $("#filterBar");
+      if (!bar) return;
+      let pill = bar.querySelector(".filter-error");
+      if (!text) {
+        if (pill) pill.remove();
+        return;
+      }
+      if (!pill) {
+        pill = document.createElement("div");
+        pill.className = "filter-error";
+        bar.append(pill);
+      }
+      pill.textContent = text;
     }
 
     // ---- Banner: shows when any filter is active or arriving via /s/{id} ----
@@ -1428,9 +1485,28 @@
         ctxEl.hidden = !any;
       }
 
+      // Seating chart: prefer medium, fall back to large. When the venue has
+      // no static chart, swap the <img> for a styled empty placeholder so the
+      // 2-column event-body grid keeps its left column (without the placeholder
+      // the listings reflow into the empty space, jumping content around at
+      // the 760px breakpoint). Per D1 UX audit 2026-05-12 fix #3.
       const map = event.configuration?.seating_chart_medium || event.configuration?.seating_chart_large;
-      if (map) seatMap.src = map;
-      else seatMap.style.display = "none";
+      const mapHost = seatMap.parentElement; // the <aside class="map">
+      if (map) {
+        seatMap.src = map;
+        seatMap.style.display = "";
+        // Remove any previously rendered placeholder if we now have a map.
+        const existing = mapHost && mapHost.querySelector(".map-placeholder");
+        if (existing) existing.remove();
+      } else {
+        seatMap.style.display = "none";
+        if (mapHost && !mapHost.querySelector(".map-placeholder")) {
+          const ph = document.createElement("div");
+          ph.className = "map-placeholder";
+          ph.textContent = "Seating chart unavailable for this venue.";
+          mapHost.append(ph);
+        }
+      }
 
       const freshness = $("#freshness");
       if (freshness) {

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -435,17 +435,36 @@
         return;
       }
       const mySeq = ++suggestSeq;
+      // Render a loading state immediately on debounce arm so the user sees
+      // SOMETHING during cold-start latency (live TEvo can take 10-30s on
+      // free-tier Render). Without this, an empty dropdown reads as "broken."
+      showSuggestStatus("Searching…");
       suggestTimer = setTimeout(() => {
         api(`/api/store/search?q=${encodeURIComponent(q)}&limit=8`)
           .then((res) => {
             if (mySeq !== suggestSeq) return;  // stale; user typed more
             renderSuggest(suggestEl, res);
           })
-          .catch(() => {
+          .catch((err) => {
             if (mySeq !== suggestSeq) return;
-            hideSuggest();
+            // Show the error inline rather than silently hiding. Users
+            // need feedback when network/server hiccups happen — the most
+            // common failure modes on this deploy are 502 (sleeping
+            // dyno) and 5xx during cold starts.
+            const msg = err && err.message ? String(err.message) : "Search unavailable";
+            showSuggestStatus(`${msg.slice(0, 80)} · try again`);
           });
       }, 300);
+    }
+
+    function showSuggestStatus(text) {
+      if (!suggestEl) return;
+      suggestEl.replaceChildren();
+      const div = document.createElement("div");
+      div.className = "suggest-status";
+      div.textContent = text;
+      suggestEl.append(div);
+      suggestEl.hidden = false;
     }
 
     function hideSuggest() {

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -177,6 +177,18 @@ a { color: inherit; }
   font-size: 13px;
   font-style: italic;
 }
+/* Error variant — reuses .suggest-status shape but recolors so the typer
+   can distinguish "Searching…" (muted, in-flight) from "Search unavailable"
+   (bad-tone, terminal). Per D1 UX audit 2026-05-12 fix #2. */
+.suggest-status.error {
+  color: var(--bad);
+  font-style: normal;
+  font-weight: 600;
+}
+.suggest-status.error::before {
+  content: "⚠ ";
+  margin-right: 2px;
+}
 
 /* ----- Catalog grid ----- */
 .results { margin-top: 8px; }
@@ -388,6 +400,22 @@ a { color: inherit; }
   display: block;
   background: #0a0b0e;
 }
+/* Empty-state placeholder when the venue has no seating chart. Keeps the
+   left-column footprint so the listings grid doesn't reflow. Per D1 UX
+   audit 2026-05-12 fix #3. */
+.map-placeholder {
+  background: #0a0b0e;
+  border-radius: 6px;
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+  font-style: italic;
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 
 .listings h2 {
   font-size: 18px;
@@ -427,13 +455,44 @@ a { color: inherit; }
 .listing-tab-count {
   display: inline-block;
   margin-left: 4px;
-  font-size: 11px;
+  font-size: 10px;
   color: var(--muted);
+  /* Don't wrap the count beneath the tab label on narrow viewports. Under
+     760px the tab text + numeric count would otherwise break across lines
+     and double the tab's height. Per D1 UX audit 2026-05-12 fix #6. */
+  white-space: nowrap;
 }
 .listing-tab.is-active .listing-tab-count { color: var(--accent-2); }
+/* Disabled-look tab (e.g. Parking with count=0). Reuses the same DOM as
+   the live tab so layout doesn't shift — just visually demotes it. Per
+   D1 UX audit 2026-05-12 fix #4. */
+.listing-tab[aria-disabled="true"] {
+  color: var(--line);
+  cursor: not-allowed;
+}
+.listing-tab[aria-disabled="true"]:hover { color: var(--line); }
+.listing-tab[aria-disabled="true"] .listing-tab-count { color: var(--line); }
 
 /* Parking-list rows reuse .row styles but trim some seat-only ornaments. */
 .parking-list .parking-row { /* same .row grid; no overrides needed today */ }
+
+/* Inline filter-bar error pill — surfaces when applyFiltersAndFetch
+   catches. Mirrors search-dropdown error tone so the bad-state vocabulary
+   is consistent. Per D1 UX audit 2026-05-12 fix #5. */
+.filter-error {
+  margin-top: 8px;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  background: rgba(239, 68, 68, 0.10);
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  color: var(--bad);
+  font-size: 12px;
+  font-weight: 600;
+}
+.filter-error::before {
+  content: "⚠ ";
+  margin-right: 2px;
+}
 
 /* ----- Inline filter bar on event page ----- */
 .filter-bar {
@@ -1131,4 +1190,18 @@ a.perf-chip:hover {
   .row .btn { grid-column: 1 / -1; }
 
   .mover-card { flex-basis: 200px; }
+
+  /* "MVP · browse only · no real purchases" crowds the topbar on narrow
+     viewports; shrink to bare "MVP" so the brand stays visible. Full
+     copy returns at >760px. Per D1 UX audit 2026-05-12 fix #8. */
+  .badge.mvp {
+    font-size: 0;          /* hide the long text */
+    padding: 4px 8px;
+    letter-spacing: 0;
+  }
+  .badge.mvp::before {
+    content: "MVP";
+    font-size: 11px;
+    letter-spacing: 1px;
+  }
 }

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -169,6 +169,14 @@ a { color: inherit; }
   font-weight: 700;
   color: var(--accent-2);
 }
+.suggest-status {
+  /* Loading + error states inside the dropdown — same height/position as
+     a hit row so the dropdown doesn't jump-resize when results land. */
+  padding: 10px 14px;
+  color: var(--muted);
+  font-size: 13px;
+  font-style: italic;
+}
 
 /* ----- Catalog grid ----- */
 .results { margin-top: 8px; }


### PR DESCRIPTION
## Summary

**Level: data-collection · Lane: D1 (Consumer Retail)**

Audit + consolidation of D1's 3 open PRs into one merge surface for A1. Executes the re-merge plan already declared in PR #79's body (cherry-pick `a8f44d2` onto post-merge main) in one branch instead of three sequential merges.

Closes #79, #76, #77 on merge.

## What's bundled

| Origin PR | Bundled how | Files |
|---|---|---|
| **#79** (MVP TEvo-direct, prod-checkpointed `d1-mvp-prod-checkpoint-2026-05-13`) | Base — full diff via `git reset --hard origin/claude/d1-mvp-tevo-direct` | `app.py` (+167/-198), `render.yaml`, `docs/d1_pending_merge_back.md`, `docs/templates/bot_lane_constraints_template.md` |
| **#76** static UX only (`268cae3` + `a8f44d2`) | Cherry-picked clean — no app.py overlap with #79 | `static/store/store.js`, `static/store/style.css` |
| **#77** D1 self-contract | Cherry-picked (`7a807fe`) — single new doc | `docs/d1_operating_constraints.md` |
| **`render.yaml` adjustment** | `branch: claude/d1-mvp-tevo-direct` → `branch: main` per A1 bot_chat row 81 | `render.yaml` (2 lines) |

## Audit findings (why this shape)

`#79` removed the SQL-only catalog path (`/api/store/events` now TEvo-direct via `office_id=42029`). `#76` had 4 app.py polish commits (`b5258f7`, `46ee738`, `d0ffaac`, `669ed59`) that patched the SQL-only path — these **conflict with #79's rewrite and are deferred**. They need manual reconciliation in a follow-up D1 PR. `#76`'s 2 static-only commits (search status + Sprint 1.5 UX) have zero app.py overlap with #79 and were taken whole.

### Deferred from #76 (follow-up D1 PR)
- `b5258f7` — SHA1 cache key + ILIKE wildcard escape + `/healthz` key-length leak fix (patched SQL-only path; some bits still relevant against TEvo-direct, needs manual port)
- `46ee738` — `ensure_tevo_client()` lazy-init + `TEVO_API_TOKEN`/`TEVO_API_SECRET` dual env-name + `/healthz` diag fields (`evo_creds_source`, `tevo_env_resolves`)
- `d0ffaac` — `STOREFRONT_AS_LANDING=true` root redirect + matching `render.yaml` env declaration
- `669ed59` — `fallback_detail` in `/api/store/search` fallback branch

## Tables / migrations
- **Writes:** none (no migrations, no DB writes)
- **Reads:** unchanged from #79 — TEvo `/v9/events`, `/v9/ticket_groups`, Supabase `performer_metadata` bulk-fetch, `share_links`
- **Pre-reqs:** none

## Test plan

- [x] `python scripts/check_readonly.py` → `RULE 2 clean` (8 py files, 18 ts/js, 198 plpgsql migrations scanned)
- [x] `pytest tests/test_readonly_guards.py` → 20/20 passed
- [x] Cherry-picks landed without conflict (clean static/* + new doc)
- [x] `render.yaml` `healthCheckPath: /healthz` preserved (PR #79's `22e6926` fix)
- [ ] A1 review per `MIGRATION_CONVENTIONS.md §9`
- [ ] **After merge**: operator repoints Render dashboard service source `claude/store-sql-only-demo-mode → main` (Render IaC now declares `branch: main`)
- [ ] Post-deploy smoke (same matrix as PR #79):
  - `/healthz` → 200, `evo_creds_source: supabase.settings`
  - `/api/store/events?limit=5` → 200, 100% `we_own:true`
  - `/api/store/search?q=knicks` → 200, live TEvo
  - `/store` → 200, MVP badge + retry button render
  - Browser: confirm Sprint 1.5 UX surfaces (error tones, retry, parking nowrap)

## Commit chain

```
1f92355 chore(render): repoint deploy branch main post-consolidation
0121060 docs(d1): codify D1 operating constraints (lane boundaries + Sprint 2 freeze)   [from #77]
378f21b ux(store): Sprint 1.5 polish — 7 audit findings landed                          [from #76 a8f44d2]
2dc1260 ux(store): suggestion dropdown shows 'Searching…' + error status                [from #76 268cae3]
7913c20 fix(store): lift event_lifecycle 404 gate on detail                             [#79 tip]
...    (12 more commits from #79)
e1ad31e (origin/main)
```

## Sync protocol

- Track: **Careful** (≥1 day SLA) — but operator can fast-track since this is mechanical consolidation
- Pre-flight: `scripts/check_sync.sh` — base is `origin/main` (`e1ad31e`), no drift
- bot_chat: logged on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZfvQDfDXF9duqxBYjP4un)_