### PR TITLE
d1: follow-up to #84 — /healthz hardening, TEvo creds, search polish, tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ Optional:
 from __future__ import annotations
 
 import hmac
+import logging
 import math
 import os
 import re
@@ -4394,6 +4395,27 @@ _search_cache: dict[str, tuple[float, dict]] = {}
 _SEARCH_CACHE_TTL = 60.0
 
 
+def _normalize_search_key(q: str) -> str:
+    """Normalize a user query for cache slot identity. Collapses runs of
+    whitespace + lowercases + strips, so "  Knicks  ", "knicks", "KNICKS"
+    all collapse to the same slot. Mode (sql vs live) is appended at the
+    callsite so the cache stays correct across STOREFRONT_SQL_ONLY flips."""
+    return re.sub(r"\s+", " ", (q or "").strip().lower())
+
+
+# PostgREST ILIKE pattern wildcards we need to escape so a user-supplied
+# query like "%" doesn't become a match-everything pattern. Backslash
+# escaped FIRST so we don't double-escape our own escapes.
+_ILIKE_WILDCARDS = ("\\", "%", "_")
+
+
+def _escape_ilike(s: str) -> str:
+    """Escape PostgREST ILIKE wildcards in a user-supplied substring."""
+    for ch in _ILIKE_WILDCARDS:
+        s = s.replace(ch, "\\" + ch)
+    return s
+
+
 def _search_cache_get(key: str) -> dict | None:
     hit = _search_cache.get(key)
     if not hit:
@@ -4427,7 +4449,10 @@ def _search_sql_only(db, q_norm: str, limit: int) -> dict:
     safe_q = re.sub(r"[,.()\"]", " ", q_norm).strip()
     if not safe_q:
         return {"events": [], "performers": [], "venues": [], "source": "sql"}
-    pattern = f"%{safe_q}%"
+    # Escape ILIKE wildcards (%, _, \) so a user-supplied "%" doesn't
+    # become a match-everything pattern. We wrap with our own %...%
+    # after the escape.
+    pattern = f"%{_escape_ilike(safe_q)}%"
 
     # Events: search by event name, venue name, venue location, primary
     # performer name. Limit to future + active so we don't surface ghosts.
@@ -4543,15 +4568,37 @@ def _search_live(db, q_norm: str, limit: int) -> dict:
     returned event IDs against our SQL to tag we_own + from_price. Used in
     non-SQL-only deployments."""
     today_iso = datetime.now(timezone.utc).date().isoformat()
+    # Lazy-init client so we can serve search even if boot creds were stale.
+    live_client = ensure_tevo_client()
+    if live_client is None:
+        # Creds genuinely missing — fall back to SQL with explicit signal.
+        payload = _search_sql_only(db, q_norm, limit)
+        payload["fallback"] = True
+        payload["fallback_reason"] = "tevo_unconfigured"
+        return payload
     try:
-        resp = client.search_suggestions(
+        resp = live_client.search_suggestions(
             q_norm, entities="events,performers,venues",
             fuzzy=True, limit=20, occurs_at_gte=today_iso,
         )
     except RuntimeError as e:
-        # Don't break the page on TEvo error; fall back to SQL.
-        print(f"search_live TEvo failed, falling back to SQL: {e}")
-        return _search_sql_only(db, q_norm, limit)
+        # Don't break the page on TEvo error; fall back to SQL with a
+        # structured signal so clients can show a "live search degraded"
+        # hint. Status code (parsed out of the sanitized RuntimeError
+        # message — evo_client.py strips URL + body since PR #66/#81) is
+        # the only upstream detail we surface; full error stays in logs.
+        logging.warning(
+            "search_live TEvo failed, falling back to SQL: %s",
+            str(e)[:200],
+        )
+        m = re.search(r"\b(\d{3})\b", str(e))
+        upstream_status = int(m.group(1)) if m else None
+        payload = _search_sql_only(db, q_norm, limit)
+        payload["fallback"] = True
+        payload["fallback_reason"] = "tevo_unavailable"
+        if upstream_status:
+            payload["fallback_detail"] = {"tevo_status": upstream_status}
+        return payload
 
     s = (resp.get("suggestions") or {})
     ev_in = s.get("events", []) or []
@@ -4627,7 +4674,10 @@ def store_search(q: str, limit: int = 8):
 
     # Cap at 50; the upstream cap is 20, so anything past that just trims.
     lim = max(1, min(int(limit), 50))
-    cache_key = f"{q_norm.lower()}|{lim}|{'sql' if STOREFRONT_SQL_ONLY else 'live'}"
+    # Normalize so "  Knicks  ", "knicks", "KNICKS" all hit the same slot.
+    # Mode (sql vs live) still differentiates so flipping STOREFRONT_SQL_ONLY
+    # doesn't serve stale-mode cache entries.
+    cache_key = f"{_normalize_search_key(q_norm)}|{lim}|{'sql' if STOREFRONT_SQL_ONLY else 'live'}"
     cached = _search_cache_get(cache_key)
     if cached is not None:
         return {**cached, "q": q_norm, "source": "cache", "latency_ms": 0}

--- a/app.py
+++ b/app.py
@@ -4175,7 +4175,13 @@ def store_events(
             if not batch:
                 break
             raw_events.extend(batch)
-            if len(raw_events) >= cap:
+            # Stop when we have enough rows to fill the requested window AFTER
+            # slicing off the leading offset_in_first_page rows. Using `>= cap`
+            # alone short-circuits the loop before the second page when offset
+            # is non-aligned (e.g. offset=25, cap=60: page-1 fills 60 rows,
+            # break fires, slice yields only 35). Caught by test_pagination_
+            # offset_non_aligned.
+            if len(raw_events) >= offset_in_first_page + cap:
                 break
             # Stop early if we've hit the total.
             total = int(resp.get("total_entries") or 0)

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta, timezone
 import requests
 from fastapi import Body, Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -402,9 +402,21 @@ async def _runtime_error_handler(request, exc: RuntimeError):
 # UI rebuild prep. JSON API endpoints below remain available for whatever
 # UI gets built next.
 
+STOREFRONT_AS_LANDING = os.environ.get("STOREFRONT_AS_LANDING", "false").lower() == "true"
+
+
 @app.get("/")
 def root_health():
-    """Liveness probe. Phase-1 data-collection mode."""
+    """Liveness probe. Default response is the data-collection JSON used
+    by every prior phase. When STOREFRONT_AS_LANDING=true (set in Render
+    env for the storefront test service), the root path 302-redirects
+    to /store so customers land on the public catalog instead of a
+    debug JSON blob.
+
+    Operators with non-storefront services keep the default behavior.
+    """
+    if STOREFRONT_AS_LANDING:
+        return RedirectResponse(url="/store", status_code=302)
     return {"ok": True, "phase": "data-collection", "ui": "rebuild-pending"}
 
 

--- a/app.py
+++ b/app.py
@@ -123,7 +123,15 @@ def require_sb():
 
 
 def resolve_tevo_creds():
-    """Prefer Supabase settings table, fall back to env vars."""
+    """Prefer Supabase settings table, fall back to env vars.
+
+    Env-var fallback accepts either naming convention:
+      - `TEVO_TOKEN`     + `TEVO_SECRET`      (legacy)
+      - `TEVO_API_TOKEN` + `TEVO_API_SECRET`  (what Render's IaC sets)
+
+    Returns (token, secret, source). Source is one of:
+      "supabase.settings" | "env" | "missing"
+    """
     if sb is not None:
         try:
             res = (
@@ -139,7 +147,38 @@ def resolve_tevo_creds():
                 return t, s, "supabase.settings"
         except Exception as e:
             print(f"Could not load TEvo creds from settings: {e}")
-    return os.environ.get("TEVO_TOKEN"), os.environ.get("TEVO_SECRET"), "env"
+    # Env fallback — accept either name convention.
+    env_t = os.environ.get("TEVO_TOKEN") or os.environ.get("TEVO_API_TOKEN")
+    env_s = os.environ.get("TEVO_SECRET") or os.environ.get("TEVO_API_SECRET")
+    if env_t and env_s:
+        return env_t, env_s, "env"
+    return None, None, "missing"
+
+
+def ensure_tevo_client():
+    """Lazy-initialize the EvoClient if the boot-time attempt failed.
+
+    Boot can fail to populate `client` when:
+      - Supabase keys were stale at boot (resolve_tevo_creds raises silently)
+      - Env vars were missing or mis-named
+      - STOREFRONT_SQL_ONLY=true at boot, so we intentionally skipped the
+        client creation, and now the operator wants to flip live
+
+    Called from any request path that needs TEvo. Idempotent — returns
+    the existing client when already populated. Re-resolves creds and
+    builds the client on demand otherwise. Avoids forcing a redeploy
+    every time creds change.
+    """
+    global client, TOKEN, SECRET, CREDS_SOURCE
+    if client is not None:
+        return client
+    t, s, src = resolve_tevo_creds()
+    if not (t and s):
+        return None  # caller decides what to do; usually 502
+    TOKEN, SECRET, CREDS_SOURCE = t, s, src
+    client = EvoClient(TOKEN, SECRET, sandbox=SANDBOX)
+    print(f"TEvo client lazy-initialized (creds source: {src})")
+    return client
 
 
 SANDBOX = os.environ.get("TEVO_SANDBOX", "false").lower() == "true"
@@ -375,9 +414,14 @@ def healthz():
 
     Reports:
       python_version, is_production, storefront_sql_only,
-      supabase_url_set, supabase_service_role_key_length,
-      supabase_anon_key_length, evo_client_configured,
+      supabase_url_set, supabase_service_role_key_set,
+      supabase_anon_key_set, evo_client_configured, evo_creds_source,
+      tevo_env_resolves (set-booleans per env-var name),
       supabase_smoke: pass | fail (with truncated error message)
+
+    Privacy note: key *lengths* used to leak here, exposing which key
+    format was loaded (200+ legacy JWT vs ~40 new sb_*_*). Recon-grade.
+    Replaced with set/unset booleans per b5258f7 item 4.
     """
     import sys as _sys
     out = {
@@ -386,10 +430,17 @@ def healthz():
         "is_production": _is_production(),
         "storefront_sql_only": STOREFRONT_SQL_ONLY,
         "supabase_url_set": bool(SUPABASE_URL),
-        "supabase_service_role_key_length": len(SUPABASE_SERVICE_ROLE_KEY or ""),
-        "supabase_anon_key_length": len(SUPABASE_ANON_KEY or ""),
+        "supabase_service_role_key_set": bool(SUPABASE_SERVICE_ROLE_KEY),
+        "supabase_anon_key_set": bool(SUPABASE_ANON_KEY),
         "supabase_client_initialized": sb is not None,
         "evo_client_configured": client is not None,
+        "evo_creds_source": CREDS_SOURCE,
+        "tevo_env_resolves": {
+            "TEVO_TOKEN_set": bool(os.environ.get("TEVO_TOKEN")),
+            "TEVO_API_TOKEN_set": bool(os.environ.get("TEVO_API_TOKEN")),
+            "TEVO_SECRET_set": bool(os.environ.get("TEVO_SECRET")),
+            "TEVO_API_SECRET_set": bool(os.environ.get("TEVO_API_SECRET")),
+        },
     }
     # Tiny safe query against a table we know exists.
     if sb is None:

--- a/render.yaml
+++ b/render.yaml
@@ -45,6 +45,12 @@ services:
       # ---- Demo mode (the new flag this PR introduces) ----
       - key: STOREFRONT_SQL_ONLY
         value: "true"
+      # ---- Storefront-as-landing flag ----
+      # Makes / redirect to /store so customers don't see the debug
+      # data-collection JSON. Storefront-test service is the only Render
+      # service that should set this true.
+      - key: STOREFRONT_AS_LANDING
+        value: "true"
       # ---- Storefront constants ----
       - key: ALLOWED_EMAIL_DOMAIN
         value: s4kent.com

--- a/tests/test_store_events.py
+++ b/tests/test_store_events.py
@@ -1,0 +1,215 @@
+"""Tests for /api/store/events TEvo-direct catalog (PR #84 rewrite).
+
+Covers:
+  - office_id passthrough to client.list_events()
+  - CANCELLED-name filter
+  - Pagination math (post-PR #90 fix): offset that's NOT a multiple of
+    per_page returns the correct slice
+  - performer_metadata fallback when the SQL bulk-fetch raises
+
+These tests never make a real HTTP call. client.list_events and the
+SQL bulk-fetch helper are both monkeypatched with synthetic data.
+
+Audit ref: row 96 item 6 (D1 follow-up).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---- Env setup BEFORE importing app ----
+# app.py at import time runs resolve_tevo_creds() and sys.exit()'s if it
+# can't build an EvoClient. Provide fake creds so the import succeeds; we
+# replace `app.client` with a stub once we own the test process.
+os.environ.setdefault("STOREFRONT_SQL_ONLY", "false")
+os.environ.setdefault("TEVO_API_TOKEN", "test-token")
+os.environ.setdefault("TEVO_API_SECRET", "test-secret")
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
+os.environ.setdefault("AUTH_DISABLED", "true")  # don't gate routes in tests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Skip the whole module if fastapi/starlette test stack isn't available
+# (the readonly-guards-only minimal env). Lets tests/test_readonly_guards.py
+# keep running on bare Python.
+fastapi = pytest.importorskip("fastapi")
+starlette_testclient = pytest.importorskip("fastapi.testclient")
+
+import app as app_module  # noqa: E402
+
+TestClient = starlette_testclient.TestClient
+
+
+# ---------- Helpers ----------
+
+def _ev(eid: int, name: str = None, performer_id: int = 16303,
+        performer_name: str = "New York Knicks") -> dict:
+    """Synthetic /v9/events item shaped to match TEvo's list response."""
+    return {
+        "id": eid,
+        "name": name or f"Test Event {eid}",
+        "occurs_at": "2026-06-01T19:00:00Z",
+        "occurs_at_local": "2026-06-01T19:00:00-04:00",
+        "available_count": 100,
+        "owned_by_office": True,
+        "tbd": False,
+        "popularity_score": 0.5,
+        "venue": {
+            "id": 896, "name": "Madison Square Garden",
+            "location": "New York, NY", "city": "New York", "state": "NY",
+        },
+        "performances": [
+            {"primary": True,
+             "performer": {"id": performer_id, "name": performer_name}},
+        ],
+    }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """FastAPI TestClient with TEvo + Supabase calls stubbed."""
+    # Stub _bulk_performer_assets so we don't actually hit Supabase.
+    monkeypatch.setattr(
+        app_module, "_bulk_performer_assets",
+        lambda db, pids: {16303: {
+            "logo_default_url": "https://test/knicks.png",
+            "color_primary": "1d428a", "espn_league": "NBA",
+        }} if 16303 in pids else {},
+    )
+    # Stub require_sb so the bulk-fetch helper sees a non-None db param.
+    monkeypatch.setattr(app_module, "require_sb", lambda: object())
+    return TestClient(app_module.app)
+
+
+class _FakeEvoClient:
+    """Replaces app.client. Records every list_events call kwargs for
+    assertions; returns from a programmable page-keyed payload map."""
+
+    def __init__(self, pages: dict[int, list[dict]], total: int | None = None):
+        self.pages = pages
+        self.total = total if total is not None else sum(len(v) for v in pages.values())
+        self.calls: list[dict] = []
+
+    def list_events(self, **kwargs):
+        self.calls.append(kwargs)
+        page = kwargs.get("page", 1)
+        return {"events": self.pages.get(page, []),
+                "total_entries": self.total}
+
+
+# ---------- Tests ----------
+
+def test_office_id_passthrough(client, monkeypatch):
+    fake = _FakeEvoClient({1: [_ev(1)]})
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=1")
+    assert r.status_code == 200
+    assert r.json()["count"] == 1
+    # The fake should have been called with office_id=TEVO_OFFICE_ID.
+    assert fake.calls, "list_events was never invoked"
+    assert fake.calls[0].get("office_id") == app_module.TEVO_OFFICE_ID
+
+
+def test_cancelled_name_filter(client, monkeypatch):
+    fake = _FakeEvoClient({1: [
+        _ev(1, "Real Event"),
+        _ev(2, "CANCELLED — Postponed Show"),
+        _ev(3, "Another Real Event"),
+        # CANCELLED match is case-insensitive (filter uses .upper())
+        _ev(4, "cancelled lower-case marker"),
+    ]})
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=10")
+    out_ids = [e["id"] for e in r.json()["events"]]
+    assert out_ids == [1, 3], (
+        f"CANCELLED filter should drop ids 2 and 4; got {out_ids}"
+    )
+
+
+def test_pagination_offset_aligned(client, monkeypatch):
+    """offset=0 with limit=5 returns the first 5 events."""
+    fake = _FakeEvoClient({1: [_ev(i) for i in range(1, 11)]})
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=5&offset=0")
+    out_ids = [e["id"] for e in r.json()["events"]]
+    assert out_ids == [1, 2, 3, 4, 5]
+
+
+def test_pagination_offset_non_aligned(client, monkeypatch):
+    """offset=25 with limit=60 returns records 26..85 (1-indexed), NOT 1..60.
+
+    Pre-PR-#90 the handler did `start_page = (offset // per_page) + 1`
+    which skipped to TEvo page 1 (cap=60, per_page=60, start_page=1) and
+    returned records 1-60. The fix is to slice raw_events[offset%per_page:].
+    Verify: with limit=60 and offset=25, we get ids [26..85] from a fake
+    that emits sequential ids across two TEvo pages.
+    """
+    # cap=60 → per_page=60. start_page=1 (25//60+1=1). offset_in_first_page=25.
+    # pages_needed = ((25+60)+60-1)//60 = 144//60 = 2. So pages 1 and 2.
+    fake = _FakeEvoClient({
+        1: [_ev(i) for i in range(1, 61)],   # ids 1..60
+        2: [_ev(i) for i in range(61, 121)], # ids 61..120
+    })
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=60&offset=25")
+    out_ids = [e["id"] for e in r.json()["events"]]
+    assert out_ids == list(range(26, 86)), (
+        f"offset=25 limit=60 must return ids 26..85, got first={out_ids[:3]} "
+        f"last={out_ids[-3:]} len={len(out_ids)}"
+    )
+
+
+def test_performer_metadata_fallback(client, monkeypatch):
+    """If the Supabase bulk-fetch raises, cards still render with null
+    logo/color/league — catalog never breaks on enrichment failure."""
+    def _raise(*args, **kwargs):
+        raise RuntimeError("supabase down")
+    monkeypatch.setattr(app_module, "_bulk_performer_assets", _raise)
+    fake = _FakeEvoClient({1: [_ev(1)]})
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=1")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 1
+    card = body["events"][0]
+    assert card["primary_performer_logo"] is None
+    assert card["primary_performer_color"] is None
+    assert card["primary_performer_league"] is None
+    # Performer name + id still come through (those are TEvo data).
+    assert card["primary_performer_name"] == "New York Knicks"
+    assert card["primary_performer_id"] == 16303
+
+
+def test_performer_media_when_available(client, monkeypatch):
+    """When Supabase has the performer in performer_metadata, the card
+    surfaces logo + color + league."""
+    fake = _FakeEvoClient({1: [_ev(1)]})
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=1")
+    card = r.json()["events"][0]
+    assert card["primary_performer_logo"] == "https://test/knicks.png"
+    assert card["primary_performer_color"] == "1d428a"
+    assert card["primary_performer_league"] == "NBA"
+
+
+def test_we_own_always_true_with_office_filter(client, monkeypatch):
+    """With office_id filter applied at TEvo, every event in the response
+    has owned_by_office=true, so we_own surfaces true on every card."""
+    fake = _FakeEvoClient({1: [_ev(i) for i in range(1, 4)]})
+    monkeypatch.setattr(app_module, "client", fake)
+    r = client.get("/api/store/events?limit=3")
+    assert all(e["we_own"] is True for e in r.json()["events"])
+
+
+def test_503_when_client_unconfigured(client, monkeypatch):
+    """When `client` is None at request time, we return 503 — not 500."""
+    monkeypatch.setattr(app_module, "client", None)
+    r = client.get("/api/store/events?limit=5")
+    assert r.status_code == 503
+    assert "TEvo client not configured" in r.json().get("detail", "")


### PR DESCRIPTION
## Status: DRAFT — iterating live on Render

Render service `vibepass-storefront-test` repointed at this branch for incremental smoke. Each push auto-deploys; PR will be marked ready-for-review once all 5 commits are confirmed live + green.

## What's in this PR (5 commits)

| Commit | Items | Test coverage |
|---|---|---|
| `7087ac6` | `/healthz` `_key_length` → bool · dual `TEVO_API_*` env names · `ensure_tevo_client()` lazy-init · `evo_creds_source` + `tevo_env_resolves` diag | live `/healthz` verified |
| `ba96c64` | `_search_cache` key normalize · ILIKE `% _ \` escape · `_search_live` fallback structured signal (`fallback`/`fallback_reason`/`fallback_detail.tevo_status`) | (manual: search smoke + cache hits) |
| `fa53028` | `STOREFRONT_AS_LANDING=true` → `/` 302 to `/store` | smoke `curl /` returns 302 |
| `c1d3955` | `tests/test_store_events.py` — 8 cases | 8/8 pass locally |
| `29ade79` | Pagination early-stop fix (PR #90 partial-fix follow-up) | caught by `test_pagination_offset_non_aligned` |

## Audit row 96 status

| Item | State |
|---|---|
| 1. Pagination math | PR #90 sliced correctly but early-stop fired too soon for non-aligned offsets — closed in `29ade79` |
| 2. `STOREFRONT_RESERVE_REQUIRES_AUTH` default | Closed in PR #90 |
| 3. CORS fail-fast | Closed in PR #90 |
| 4. `/api/store/events` 502 scrub | Closed in PR #90 |
| 5. `include_inactive` dead param | Deferred (per A1: intentional per docstring) |
| **6. Tests for store_events** | Closed in `c1d3955` (8/8 pass) |
| **7. Reconcile 4 polish commits from #76** | Closed across `7087ac6` + `ba96c64` + `fa53028` |

## Tests (local, 8/8 pass)

```
tests/test_store_events.py::test_office_id_passthrough              PASSED
tests/test_store_events.py::test_cancelled_name_filter              PASSED
tests/test_store_events.py::test_pagination_offset_aligned          PASSED
tests/test_store_events.py::test_pagination_offset_non_aligned      PASSED
tests/test_store_events.py::test_performer_metadata_fallback        PASSED
tests/test_store_events.py::test_performer_media_when_available     PASSED
tests/test_store_events.py::test_we_own_always_true_with_office_filter PASSED
tests/test_store_events.py::test_503_when_client_unconfigured       PASSED
```

`test_pagination_offset_non_aligned` is the one that caught the PR #90 partial-fix.

## Live smoke (post-deploy verified so far)

```
$ curl /healthz
{"ok":true, ..., "supabase_service_role_key_set":true, "supabase_anon_key_set":true,
 "evo_creds_source":"supabase.settings",
 "tevo_env_resolves":{"TEVO_TOKEN_set":false, "TEVO_API_TOKEN_set":true,
                       "TEVO_SECRET_set":false, "TEVO_API_SECRET_set":true}}
```

Remaining smoke (will fill in when final deploy is live):
- `curl /` → 302 `/store`
- `curl /api/store/events?limit=5` → 100% we_own
- `curl /api/store/search?q=%25` → 200 with escaped ILIKE pattern (no match-everything)

## Re-merge path

When ready: mark ready-for-review → A1 reviews + merges → render.yaml `branch: main` stays → Render auto-redeploys from main and picks up everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)