### PR TITLE
fix(data): restore ESPN gameday + roster crons (2 dropped, both 61h stale)

### DIFF
--- a/supabase/migrations/20260514185000_espn_gameday_cron.sql
+++ b/supabase/migrations/20260514185000_espn_gameday_cron.sql
@@ -1,0 +1,45 @@
+-- Migration 20260514185000 · level:admin · lane:Audit/Push · writes:cron(espn-gameday-10min) · reads:- · pre:20260514183000
+-- Data-bug fix #1: ESPN event_snapshots stale 61h.
+--
+-- Root cause: there is no scheduled cron invoking the `espn-collect` edge
+-- function with `?scope=gameday`. Without that scope, `espn_event_snapshots`
+-- (per-event scores, spreads, win probabilities, attendance) never refreshes
+-- — only team_snapshots / news / standings do.
+--
+-- History: jobid 25 used to fire this every 10 min until 2026-05-09. The job
+-- was dropped during one of the cron cleanups (likely cron-cascade-alignment
+-- 20260510080000 or the IO-diet 20260513185058) without a replacement.
+--
+-- Symptom: `max(captured_at) FROM espn_event_snapshots` stuck at
+-- `2026-05-12 04:40:46` — 61 hours stale — until A1 manually invoked the
+-- edge fn via pg_net (request_id 12483 at 2026-05-14 18:01 UTC, succeeded
+-- with 30 event_snaps_inserted out of 32 processed; 2 errors were the
+-- expected stale-event-id 404s).
+--
+-- Fix: re-schedule the cron at the historical cadence (every 10 min).
+-- Created as ACTIVE=FALSE so it joins the paused-fleet from bot_chat row 106
+-- (operator directive 2026-05-14 17:15 UTC). Will resume with the rest.
+--
+-- The edge fn's per-event try/catch handles 404s gracefully (e.g. stale
+-- event IDs from postponed/cancelled games) — one 404 doesn't stop the loop.
+--
+-- ## Already applied to prod
+-- Applied via MCP at 2026-05-14 ~18:05 UTC. Jobid 128 created + paused.
+-- Idempotent codification per SYNC_PROTOCOL §5.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'espn-gameday-10min') THEN
+    PERFORM cron.schedule(
+      'espn-gameday-10min',
+      '*/10 * * * *',
+      $cmd$ SELECT public._cron_invoke_edge_fn(
+              'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/espn-collect?scope=gameday',
+              '{}'::jsonb); $cmd$
+    );
+    PERFORM cron.alter_job(
+      job_id := (SELECT jobid FROM cron.job WHERE jobname = 'espn-gameday-10min'),
+      active := false
+    );
+  END IF;
+END $$;

--- a/supabase/migrations/20260514185100_espn_roster_cron.sql
+++ b/supabase/migrations/20260514185100_espn_roster_cron.sql
@@ -1,0 +1,39 @@
+-- Migration 20260514185100 · level:admin · lane:Audit/Push · writes:cron(espn-roster-10min) · reads:- · pre:20260514185000
+-- Data-bug fix #2: ESPN injuries_snapshots stale 61h.
+--
+-- Same shape as the gameday cron restoration in 20260514185000.
+-- Historical jobid 24 fired `espn-collect?scope=roster` every 10 min until
+-- 2026-05-09 — dropped in the same cron cleanup that killed jobid 25.
+-- Result: per-athlete injury rows stopped updating while team_daily kept
+-- working (team_daily intentionally has injuries=false in its scope).
+--
+-- One-shot verification 2026-05-14 18:06 UTC (request_id 12484): scope=roster
+-- ran cleanly, inserted 126 injuries, log confirms `injuries=true` and all
+-- leagues reporting team-counts (mlb=30, etc.).
+--
+-- Schedule offset by 5 min from the gameday cron (jobid 128) to avoid
+-- simultaneous ESPN API hits and the pg_cron worker-pool startup-timeout
+-- pattern that hit every job during the IO incident.
+--
+-- Created ACTIVE=FALSE so it joins the paused fleet from bot_chat row 106.
+--
+-- ## Already applied to prod
+-- Applied via MCP at 2026-05-14 ~18:07 UTC. Jobid 129 created + paused.
+-- Idempotent codification per SYNC_PROTOCOL §5.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'espn-roster-10min') THEN
+    PERFORM cron.schedule(
+      'espn-roster-10min',
+      '5-59/10 * * * *',
+      $cmd$ SELECT public._cron_invoke_edge_fn(
+              'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/espn-collect?scope=roster',
+              '{}'::jsonb); $cmd$
+    );
+    PERFORM cron.alter_job(
+      job_id := (SELECT jobid FROM cron.job WHERE jobname = 'espn-roster-10min'),
+      active := false
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
**Data bug #1** from the post-pause audit. ESPN `event_snapshots` was stale 61h.

| | Before | After |
|---|---|---|
| `espn_event_snapshots` max(captured_at) | 2026-05-12 04:40 UTC | **2026-05-14 18:01 UTC** |
| Staleness | 61 hours | **0 minutes** |
| New rows inserted from one-shot | — | **30** (32 events processed, 2 expected 404s) |

## Root cause
There is NO cron currently firing `espn-collect?scope=gameday`. The historical jobid 25 (every 10 min) was dropped between 2026-05-09 and 2026-05-12 during one of the cron cleanups (`cron-cascade-alignment` or `IO-diet`), without replacement. `espn-team-daily` (jobid 113) only runs `scope=team_daily` — different path; produces team_snaps/news but not event_snaps.

Manual one-shot via pg_net (request_id 12483 at 18:01 UTC) confirmed: endpoint healthy, edge fn handles 404s correctly (per-event try/catch + continue), the gap was just the missing schedule.

## Fix
- Recreates jobid 128 `espn-gameday-10min`
- ACTIVE=FALSE so it joins the paused-fleet (bot_chat row 106 directive)
- Will resume with the rest when operator OKs cron resume

## Already applied to prod
Applied via MCP at 2026-05-14 ~18:05 UTC. Idempotent codification per SYNC_PROTOCOL §5 (DO block + IF NOT EXISTS guard).

## Verification post-resume
After operator resumes crons, watch:
```sql
SELECT max(captured_at) FROM espn_event_snapshots;  -- should advance every 10 min
SELECT count(*) FROM espn_runs WHERE started_at > now() - interval '1 hour'; -- should grow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)