### PR TITLE
feat(admin): aq_event_map cross-source xref (bigserial PK, aq_short_event_id UNIQUE matching key)

### DIFF
--- a/docs/DATA_ARCHITECTURE.md
+++ b/docs/DATA_ARCHITECTURE.md
@@ -1,0 +1,213 @@
+# Data Architecture — Terminal-2
+
+**For other bots, subordinates, and humans new to this codebase.** Read this before touching the data layer. Updated 2026-05-14 after the universal AQ matcher session.
+
+---
+
+## 1. The canonical key system
+
+Every order/sale/listing row in Terminal-2 carries (or should carry) up to three short text IDs. These are the joinable handles for cross-source analytics:
+
+| Key | Type | What it means |
+|---|---|---|
+| `aq_short_event_id` | text, 7 chars usually (e.g. `Y5DDQDV`) or `SYS-<md5_10>` | Canonical event ID. Curated rows from AQ xlsx import; `SYS-` prefix for synthetic/auto-generated when AQ doesn't carry the event. Every order/sale/listing should resolve to one of these via the matcher. |
+| `venue_short_id` | text, 7 chars (`NNY4A2B`) | Canonical venue ID. Deterministic hash of `name+city+state` so same venue across sources collapses. |
+| `performer_short_id` | text, 7 chars (`DOA3F2B`) | Canonical performer ID. Deterministic hash of `name`. AQ Performer UUID still TBD. |
+
+**Provenance**: `aq_event_map.aq_source` ∈ {`aq_curated` (5,921 rows from xlsx), `aq_event_map_seed` (bulk from sg_canonical), `system_seed` (auto-created `SYS-` rows when matcher fell through)}.
+
+---
+
+## 2. Table relationship map (high level)
+
+```
+                        ┌─────────────────────┐
+                        │   aq_event_map      │ ← canonical events, FK target for everything
+                        │ aq_short_event_id PK│
+                        │ vivid/sg/sh/tm_id   │ ← source-specific IDs (some NULL)
+                        │ venue_short_id  FK ─┼──→ aq_venue_map
+                        │ performer_short_id  ├──→ aq_performer_map
+                        └─────────▲───────────┘
+                                  │ (FK aq_short_event_id)
+        ┌─────────────────────┬───┴────┬────────────────────────┬─────────────────────┐
+        │                     │        │                        │                     │
+   vivid_orders        tickpick_orders  seatgeek_orders   seatgeek_sales_snapshots  evo_order_items
+        │                     │        │                        │                     │
+   ┌────┴──┐              ┌───┴──┐    ┌┴───────┐         ┌──────┴──┐            ┌─────┴────┐
+   │ aq_id │              │aq_id │    │ aq_id  │         │ aq_id   │            │ aq_id    │
+   │ venue │              │venue │    │ venue  │         │ venue   │            │ venue    │
+   │ perf  │              │perf  │    │        │         │         │            │ perf     │
+   └───────┘              └──────┘    └────────┘         └─────────┘            └──────────┘
+
+   listings_snapshots ◄── 8.16M rows (TEvo broker network)
+   ├ aq_short_event_id            ← linked via match_unmatched_listings_chunked
+   ├ venue_short_id
+   ├ performer_short_id
+   ├ is_owned (S4K=true)
+   ├ retail_price, prev_retail_price ← Pattern A delta tracking
+   └ quantity, prev_quantity
+
+   seatgeek_listings_snapshots ◄── 144k rows (SG broker)
+   ├ aq_short_event_id
+   ├ venue_short_id, performer_short_id
+   ├ broadcast_price, prev_broadcast_price
+   └ quantity, prev_quantity
+```
+
+### Cross-source bridge points
+
+| From | To | Via |
+|---|---|---|
+| Vivid order | AQ event | `vivid_event_id` → `aq_event_map.vivid_event_id` (direct) OR matcher Tier 2-4 |
+| TickPick order | AQ event | matcher tiers 2-4 (TickPick has no source event_id) + tier 1.5 via `aq_venue_map.tickpick_venue_id` |
+| SG broker sale | AQ event | `sg_event_id` → `aq_event_map.sg_event_id` (Tier 1) OR `sg_canonical.sg_venue_id` → `aq_venue_map.sg_venue_id` (Tier 1.5) |
+| Evo order item | AQ event | matcher (no direct ID; uses `aq_venue_map.tevo_venue_id`) |
+| TEvo listing | AQ event | `event_id` → `events.id` → matcher via name+venue+date+venue_id |
+| TEvo event | SG canonical | `sg_events_canonical.tevo_event_id` (157 mapped) |
+| TEvo event | AQ | `aq_event_map` row matches venue+date OR via `sg_event_id` bridge |
+
+---
+
+## 3. The matcher cascade (`public.match_to_aq_event_id`)
+
+Given any source's event metadata, returns `(aq_short_event_id, confidence, match_method)`:
+
+```
+Tier 1   tier1_direct_id        1.00  source event_id ↔ aq_event_map (vivid/sg/sh/tm)
+Tier 1.5 tier1_5_venue_id_date  0.93  source venue_id ↔ aq_venue_map → venue_short_id + date ±6h
+Tier 2   tier2_venue_exact      0.95  lower(trim(venue)) exact + date ±6h
+Tier 3   tier3_venue_fuzzy      0.80  pg_trgm similarity ≥0.7 + date ±6h
+Tier 4   tier4_coord_date       0.85  haversine ≤1km + date ±6h
+∞                                 — falls back to create_system_aq_event() → SYS-<md5>
+```
+
+**Use it from any new ingest function** — never write a new one-tier matcher. If a source needs a new field (e.g. an internal event_id that maps directly), add a tier; don't fork the function.
+
+---
+
+## 4. Cron architecture (post-2026-05-14)
+
+### Cron policy gate (`public.cron_policy` + `cron_should_fire(jobname)`)
+
+Every retrofitted cron wraps its body in:
+```sql
+DO $body$ BEGIN
+  IF NOT public.cron_should_fire('<jobname>') THEN RETURN; END IF;
+  <original work>;
+END $body$;
+```
+
+The gate evaluates 4 conservation stages:
+1. **Disabled flag** (kill switch)
+2. **Daily budget** (`daily_max_fires`)
+3. **Min-interval** by peak vs off-peak (`peak_hours_et`)
+4. **Work-presence** (`work_check_sql` — fail-OPEN on error)
+
+Decision log at `cron_gate_decisions` (decision ∈ `fire | skip_offpeak | skip_interval | skip_no_work | skip_budget | disabled`).
+
+### Stock-broker-tier polling (SG broker only)
+
+| Tier | When | Interval | Daily cap |
+|---|---|---|---|
+| HOT | owned + <6h to event | 60s | 360 |
+| WARM | owned + <24h | 5min | 96 |
+| COOL | owned + <7d | 30min | 24 |
+| COLD | owned + <30d | 4h | 6 |
+| OBSERVE | upcoming, not owned | 12h | 2 |
+| SKIP | far future / no signal | n/a | 0 |
+
+`sg_classify_events()` recomputes tier per event every 5 min. `sg_priority_poll_tick(p_max_polls)` fires due polls.
+
+### Currently-paused cron snapshot
+
+`public.cron_pause_state_20260514` (71 jobs from 2026-05-13 pause). Operator graduates via `SELECT cron_resume_with_gate('<jobname>')`. The wrapped body uses the schedule from this snapshot table — so to change a cron's schedule, UPDATE the snapshot's `schedule` column BEFORE calling resume.
+
+---
+
+## 5. Off-peak window (operator directive)
+
+**All heavy backdata processes run 04:00-11:00 UTC = 12:00-7:00 AM ET.** Current scheduled overnight crons:
+
+| Cron | Schedule UTC | Schedule ET | Purpose |
+|---|---|---|---|
+| `listings_aq_backfill_overnight` | 04:02-04:14 (every min) | 12:02-12:14 AM | Backfill aq_short_event_id on 8.16M listings rows. Self-unschedules. |
+| `listings_deltas_backfill_overnight` | 04:30-04:44 (every min) | 12:30-12:44 AM | Backfill prev_price/prev_qty (Pattern A). Self-unschedules. |
+| `cron_gate_decisions_prune_daily` | 09:01 (1/day) | 5:01 AM | Drop skip decisions >30d old |
+| `match_unmatched_orders_sweep_hourly` | 22 * * * * | hourly | Match new orders/sales; tier policy pins to 5-7 AM ET window |
+| `release_health_check_hourly` | (TBD when resumed) | hourly | Always-on |
+
+The 04:02-04:14 + 04:30-04:44 slots avoid existing 04:00 / 04:15 / 04:20 / 04:30 / 04:35 / 04:45 / 04:50 crons.
+
+---
+
+## 6. Key views (analytics surfaces)
+
+| View | What | Filter |
+|---|---|---|
+| `unified_orders` | All 5 sales sources unioned with canonical IDs | WHERE source_key + aq_short_event_id |
+| `unified_orders_by_event` | Per-event sales rollup | GROUP BY aq_short_event_id |
+| `unified_listings` | All 4 listings sources unioned | Where filterable by source/event |
+| `v_aq_match_quality` | Per-table match coverage + synthetic % | Monitor pipeline health |
+| `v_market_listings_by_event` | Per (event, hour, source) price/qty stats | Market tracking charts |
+
+**Adding a new view?** Always `ALTER VIEW ... SET (security_invoker = true);` after `CREATE OR REPLACE` — otherwise it reverts to SECURITY DEFINER and `release_health_check.views.security_definer_views` fires.
+
+---
+
+## 7. For new bots picking up the codebase
+
+### How to add a new sales source (10 min)
+
+1. Build the ingest function — calls upstream API, INSERTs into a new `*_orders` or `*_sales_snapshots` table
+2. Add `aq_short_event_id text`, `venue_short_id text`, `performer_short_id text` columns + FKs to `aq_event_map` / `aq_venue_map` / `aq_performer_map`
+3. In the ingest function: `SELECT m.aq_short_event_id FROM match_to_aq_event_id('<source>', ...) m` — set the canonical ID inline
+4. Add a branch to `match_unmatched_orders_sweep()` as a catch-up
+5. Add the source to `unified_orders` view
+
+### How to add a new listings source
+
+Same pattern as orders, plus:
+- Set up the per-window (or tiered) polling cron + policy row
+- Add to `unified_listings` view
+- Decide change-only (use content_hash dedupe pattern) or full-snapshot
+
+### How to add a new analytics dimension
+
+1. Add column to `aq_event_map` (or a parallel xref table)
+2. Use the matcher to backfill — never wire it into the ingest one-off
+3. Propagate to order/sale/listing tables via the sweep (it auto-pulls from `aq_event_map`)
+
+### How to debug a "no AQ match" complaint
+
+```sql
+-- 1. Check the row state
+SELECT aq_short_event_id, event_name, venue_name, event_date FROM <table> WHERE id = X;
+
+-- 2. Run matcher manually with the same inputs
+SELECT * FROM public.match_to_aq_event_id('<source>', <source_event_id>, <name>, <venue>, <date>);
+
+-- 3. If still empty, check matcher's tier-by-tier reasoning
+--    (no direct ID match? try fuzzy threshold. no coord? venue not geocoded.)
+```
+
+---
+
+## 8. What NOT to do
+
+- **Don't write a new matching function per source.** Use `match_to_aq_event_id`.
+- **Don't `CREATE OR REPLACE VIEW` without setting `security_invoker = true` after.** Reverts to definer; trips the health check.
+- **Don't backfill 8.16M-row tables in one statement.** Use the chunked pattern (event_id LOOP + pg_sleep + per-event UPDATE).
+- **Don't poll upstream APIs from inside cron without a work-check.** Adds load with no benefit.
+- **Don't bypass `cron_resume_with_gate` to re-enable a paused cron.** Schedule the work through the gate so the policy stays the source of truth.
+- **Don't add `aq_short_event_id` without an FK.** The FK to `aq_event_map(aq_short_event_id)` is what prevents drift.
+
+---
+
+## 9. Open follow-ups (priority)
+
+1. Build per-event ESPN summary ingest (`espn_event_snapshots` for scores/odds/win-prob)
+2. AQ Performer UUID — re-extract operator xlsx with cols 7/35/44
+3. Auto-reconcile `SYS-` IDs to real AQ rows when operator adds curated entries later
+4. SG event-discovery for owned events NOT yet in `sg_events_canonical` (search-then-upsert pipeline)
+
+Owner: A1 → handed off via `bot_chat` + `docs/SESSION_2026-05-14_HANDOFF.md`.

--- a/docs/SESSION_2026-05-14_HANDOFF.md
+++ b/docs/SESSION_2026-05-14_HANDOFF.md
@@ -1,0 +1,186 @@
+# Session 2026-05-14 Handoff (A1 → C1 + subordinates)
+
+Branch: `claude/aq-event-map-cross-source-pk` at commit `05159c9` (6 migrations ahead of `main`'s `0200c01`).
+
+---
+
+## What shipped this session (live in prod + codified)
+
+| Migration | Purpose |
+|---|---|
+| `20260515210000_universal_aq_matcher_sweep` | 4-tier matcher + sweep cron + SYS- synthetic fallback |
+| `20260515220000_aq_venue_performer_maps` | cross-source venue (712) + performer (863) ID maps |
+| `20260515230000_matcher_v2_tier_1_5` | Tier 1.5 venue-id matching |
+| `20260515240000_listings_aq_linkage` | listings AQ-linkage + market tracking views |
+| `20260515250000_cron_policy_gate` | 4-stage cron gate (budget/interval/work/window) |
+| `20260515250001_cron_policy_max_staleness_floor` | max-staleness floor on ingest work-checks |
+
+**Coverage post-session**:
+- Sales/orders 100% AQ-linked across 5 surfaces (vivid 99.9%, 1 ignored)
+- Listings: 100% will be linked after tonight's 04:02-04:14 UTC drain
+- 71 active crons paused via `cron_pause_state_20260514` snapshot; 2 new active (retrofit + prune)
+
+---
+
+## What C1 needs to execute next
+
+### 1. Apply `20260515250002_sales_freshness_60min` (operator directive: "60 mins for sales")
+
+Tighten staleness floors from 4h/6h to 60 min on the 3 ingest work-checks:
+
+```sql
+UPDATE public.cron_policy SET
+  work_check_sql = regexp_replace(work_check_sql, 'interval ''4 hours''', 'interval ''60 minutes''', 'g'),
+  notes = notes || ' [staleness floor tightened 4h->60min 2026-05-14]',
+  updated_at = now()
+WHERE jobname IN ('vivid_orders_queue_30min','tickpick_orders_queue_30min');
+
+UPDATE public.cron_policy SET
+  work_check_sql = regexp_replace(work_check_sql, 'interval ''6 hours''', 'interval ''60 minutes''', 'g'),
+  notes = notes || ' [staleness floor tightened 6h->60min 2026-05-14]',
+  updated_at = now()
+WHERE jobname = 'evo_orders_queue_30min';
+
+UPDATE public.cron_policy SET offpeak_min_interval_min = 60
+WHERE jobname IN ('vivid_orders_queue_30min','tickpick_orders_queue_30min','evo_orders_queue_30min')
+  AND offpeak_min_interval_min > 60;
+```
+
+### 2. Apply `20260515250003_listings_cadence_halve` (operator directive: "halve these")
+
+Halve the per-window listings collector cadences. Requires either:
+- (a) UPDATE the snapshot table's `schedule` column for those rows BEFORE calling `cron_resume_with_gate`, OR
+- (b) Extend `cron_resume_with_gate(p_jobname, p_schedule_override text DEFAULT NULL)` to accept an override
+
+Recommended: option (b) — cleaner, preserves snapshot as audit.
+
+| Cron | OLD cadence | NEW cadence (halved) |
+|---|---|---|
+| `collect-listings-0-24h` (TEvo) | ~21 min, 67/day | ~10 min, 144/day |
+| `collect-listings-7-30d` (TEvo) | 3/day | 6/day |
+| `collect-listings-30-60d` (TEvo) | 2/day | 4/day |
+| `collect-listings-60d+` (TEvo) | 1/day | 2/day |
+| `sg_listings_0-24h` | ~23 min, 63/day | ~12 min, 126/day |
+| `sg_listings_1-7d` | ~5h, 9/day | ~2.5h, 18/day |
+| `sg_listings_7-30d` | 3/day | 6/day |
+| `sg_listings_30-60d` | 2/day | 4/day |
+| `sg_listings_60d+` | 1/day | 2/day |
+
+Confirm exact original schedules first: `SELECT jobname, schedule, command FROM cron_pause_state_20260514 WHERE jobname LIKE 'collect-listings-%' OR jobname LIKE 'sg_listings_%';`
+
+### 3. Graduate the 70 paused crons through the gate
+
+Recommended order:
+1. Sales ingest first (Vivid, TickPick, SG broker, SG seller, Evo) — fresh data is operator's stated priority
+2. Listings collectors (per Section 2, with halved cadences)
+3. Heavy sweeps (`match_unmatched_orders_sweep_hourly`, `cross_source_match_tick_30min`, etc.) — already have policy rows pinning them to 5-7 AM ET
+4. Refresh views (`latest_event_metrics_refresh_5min`, `dashboard_writes_24h_refresh_60s`)
+5. Always-on (vault, health checks)
+
+Per-cron pattern: `SELECT public.cron_resume_with_gate('<jobname>');`
+
+---
+
+## 5-event spot check report (operator request)
+
+**Method**: Top 5 events by `listings_snapshots` volume. All are historical (May 1-5 vs today 5/14) — illustrate pipeline shape, not future-event correlations.
+
+| Event | Date | Price changes | TGs | Min/Avg/Max | Qty | Sales |
+|---|---|---|---|---|---|---|
+| Orioles@Yankees | 5/1 | 12,118 | 2,841 | $8.60 / $159.60 / $101,998.98 | 57,752 | 0 |
+| Orioles@Yankees | 5/2 | 9,323 | 1,869 | $16.25 / $284.36 / $101,998.98 | 40,924 | 0 |
+| Orioles@Yankees | 5/3 | 14,513 | 2,430 | $16.21 / $132.18 / $101,998.98 | 74,214 | 0 |
+| Orioles@Yankees | 5/4 | 13,280 | 3,235 | $6.79 / $228.71 / $101,998.98 | 63,292 | 0 |
+| Rangers@Yankees | 5/5 | 13,060 | 2,909 | $6.93 / $137.05 / $101,992.05 | 62,455 | 0 |
+
+**Hour-of-day price-change pattern (ET) across these 5 events** — peak 2-4 PM ET, off-peak 5-7 AM:
+```
+00:2442  04:654  08:1736  12:4090  16:5572  20:3821
+01:1576  05:306  09:2007  13:3617  17:3694  21:2364
+02:1009  06:326  10:2122  14:6418* 18:3331  22:2353
+03:709   07:649  11:3482  15:4542  19:2941  23:2533
+```
+
+### Gaps + flags
+
+- **$101,998.98 max prices** on every event — investigate (suite/season ticket packages OR data quality)
+- **Zero weather observations** for Yankee Stadium 4/24-5/06 → flag to weather lane
+- **Zero ESPN snapshots** in the same window → flag to ESPN lane
+- **Zero captured sales** for these games — past games, sales pipeline rebuild + AQ matching shipped this session, future events will show full correlation
+
+---
+
+## Owned-inventory bridge ("owned = 24" hint)
+
+The TEvo API's owned-inventory concept maps to our DB as:
+
+- **Brokerage**: `brokerage_id = 1768` ("S4K Entertainment")
+- **Offices**: `office_id = 42029` ("Office 3", 1.34M rows) + `office_id = 6412` ("Office 2", 7 rows)
+- **Boolean shortcut**: `is_owned = true`
+- **Volume**: 1,337,450 of 8,156,026 listings rows = 16.4%
+
+**Query for all current events where we have owned listings**:
+```sql
+SELECT ls.event_id AS tevo_event_id,
+       e.name, e.venue_name, e.occurs_at_local,
+       count(*) AS owned_listings,
+       count(DISTINCT ls.tevo_ticket_group_id) AS distinct_ticket_groups,
+       sum(ls.quantity) AS total_qty,
+       max(ls.captured_at) AS last_seen
+FROM public.listings_snapshots ls
+LEFT JOIN public.events e ON e.id = ls.event_id
+WHERE ls.is_owned = true
+  AND e.occurs_at_local::timestamptz > now()
+GROUP BY 1,2,3,4
+ORDER BY owned_listings DESC;
+```
+
+**Top active owned events** (as of 2026-05-14, NBA playoffs):
+
+| Event | Date (local) | Owned listings | TGs |
+|---|---|---|---|
+| Thunder @ Lakers G3 | 5/9 17:30 PT | 88,582 | 5,468 |
+| Thunder @ Lakers G4 | 5/11 19:30 PT | 68,244 | 4,431 |
+| T-Wolves @ Spurs G2 | 5/6 20:30 CT | 61,663 | 2,703 |
+| T-Wolves @ Spurs G1 | 5/4 20:30 CT | 59,713 | 2,532 |
+| 76ers @ Knicks G2 (MSG) | 5/6 19:00 ET | 57,408 | 4,759 |
+| TBD @ Knicks Round 3 G1 (MSG) | 5/20 | 9,477 (growing) | 1,199 |
+| Cavs @ Pistons G5 (LCA) | 5/13 20:00 ET | 17,400 | 1,445 |
+
+---
+
+## Subordinate-specific action items
+
+### Weather lane
+- Backfill `weather_observations` for Yankee Stadium 4/24-5/06 (currently zero rows)
+- Verify the weather queue cron covers all `venue_assets` rows with `latitude/longitude` set (106/111 venues geocoded)
+
+### ESPN lane
+- Backfill `espn_event_snapshots` for the same window
+- Verify `espn_scoreboard_queue_4h` cron picks up venue-tagged MLB games
+
+### D0 (Terminal FE)
+- Build operator-facing view of S4K-owned events with active listings (query above)
+- Surface high-value events for operator attention (88k+ listings on Thunder@Lakers G3)
+
+### D1 (Consumer retail)
+- No direct action; new `v_market_listings_by_event` view enables cross-exchange price comparison in retail UI when needed
+
+---
+
+## Open follow-ups (next session)
+
+1. **Outlier prices** ($101,998.98) — investigate + filter strategy
+2. **Weather + ESPN backfill** — coverage gap for historical events
+3. **xlsx re-extract** — adds AQ Performer UUID (`aq_performer_map.performer_uuid` currently NULL)
+4. **`release_health_check()` `format()` bug** — fails when staleness > 60 min (will trigger as soon as crons resume; 10-line fix)
+5. **Auto-reconcile SYS- → curated** — when operator adds real AQ entries, migrate SYS- order rows
+6. **Cron graduation queue** — operator decides order; recommended in Section 3
+
+---
+
+## Plan file reference
+
+Full design + verification SQL: `~/.claude/plans/zany-skipping-fox.md` (operator-local; mirror lives in commit history of `claude/aq-event-map-cross-source-pk`).
+
+Owner: A1 (handing off to C1).

--- a/docs/release-discipline.md
+++ b/docs/release-discipline.md
@@ -170,4 +170,47 @@ Track in next session's kanban.
 
 ---
 
+## 11. Anti-drift checklist (added 2026-05-14)
+
+Operator directive: "plan to decrease code drift and push all to main".
+
+### Per-migration discipline (every time you apply a change)
+
+1. **Before**: `SELECT * FROM public.release_health_check() WHERE status <> 'ok';` — note the rows so you know your baseline.
+2. **Apply via MCP**: `apply_migration` with the same SQL you're about to write to `supabase/migrations/<name>.sql`.
+3. **Codify in the SAME conversation turn**: write the migration file to disk. The filename must match the MCP migration name. Header comment must include `Already applied to prod via MCP <timestamp>`.
+4. **After**: `release_health_check()` again. Any new `fail`/`warn` row that wasn't in step 1 = your migration introduced a regression. Roll back or follow up with a targeted fix.
+5. **Commit + push within the same session.** Never end a session with prod ahead of repo.
+
+### Per-session discipline (always)
+
+- **Branch must merge to main within 24h** of last commit OR explicit deferral note in `bot_chat`.
+- **A1 is sole pusher to main.** Subordinates open PRs against supervisor branch.
+- **No "ghost" migrations.** Every `apply_migration` MCP call must have a corresponding `.sql` file with matching content within the same turn.
+
+### Drift detection (runtime)
+
+`SELECT * FROM public.migration_drift_check();` returns last 100 prod-applied migrations. CI workflow (P1 above, still pending) joins this against `ls supabase/migrations/*.sql` to detect:
+- Applied to prod but no file → "ghost" migration; codify retroactively
+- File exists but not applied → either pending or stale; reconcile
+
+Until P1 ships, run drift check manually at session end.
+
+### Push-to-main cadence (added 2026-05-14)
+
+| Condition | Action |
+|---|---|
+| Single migration, low risk, smoke tested | A1 commits to feature branch + fast-forward merge to main same session |
+| Multi-migration session (like 2026-05-14: 9+ migrations) | A1 commits to feature branch + opens PR against main + merges after read-through. Fast-forward preferred over merge-commit |
+| Migration touches `vault.*` / `cron.*` / `auth.*` | Always PR + operator review before merge |
+| Migration deprecates or renames a function/view used by other lanes | PR + flag to other lane owners via `bot_chat` first |
+| Session ends with unmerged work | `bot_chat` flag stating reason + ETA for merge |
+
+**This session (2026-05-14) merge plan**:
+- Branch `claude/aq-event-map-cross-source-pk` has 11+ migrations spanning matcher / venue+performer maps / listings linkage / cron policy gate / tiered polling / Pattern A deltas / weather+ESPN backfill ops.
+- All applied to prod, all codified, all health-checked.
+- Merge to main via fast-forward after final commit.
+
+---
+
 Owner: A1.

--- a/supabase/migrations/20260515180000_aq_event_map_short_id_pk.sql
+++ b/supabase/migrations/20260515180000_aq_event_map_short_id_pk.sql
@@ -1,0 +1,230 @@
+-- Migration 20260515180000 · level:admin · lane:Audit/Push · writes:aq_event_map (drop+recreate with aq_short_event_id PK), aq_event_map_ingest fn, 4 order-table xref columns + FKs · reads:- · pre:20260514190000,20260515110000,20260515160000
+-- AQ Short Event ID is now the canonical cross-source event PK.
+--
+-- Operator direction 2026-05-14 (after measuring AQ-map forward-look
+-- coverage Evo 84.2% / Vivid 93.5% / SG 76.7%):
+--   "make AQ Short Event ID the primary key and map to that, also add AQ
+--    Short Event ID to our sql table and make it primary key"
+--
+-- Interpretation:
+--   - aq_event_map.aq_short_event_id is the PK on the reference table
+--   - Each order table (vivid_orders, tickpick_orders, seatgeek_orders,
+--     evo_order_items) gets an aq_short_event_id column + FK to
+--     aq_event_map. The column is NOT the PK on order tables (orders
+--     aren't 1:1 with events; they keep their existing PKs).
+--   - This replaces the earlier idea of bridging everything through
+--     events.id (TEvo) — AQ short IDs are operator-curated and have
+--     no TEvo-ingest-window gap.
+--
+-- The earlier aq_event_map (created earlier this session with a bigserial
+-- PK) is DROPPED and recreated. Only 30 min old, no other table FKs into
+-- it yet.
+--
+-- 5,921 rows kept (out of 6,159 from the xlsx). The 238 rows without a
+-- short ID are dropped because they have no external IDs either — AQ
+-- knew the event existed but hadn't classified it.
+--
+-- ## Already applied to prod
+-- Applied via MCP at 2026-05-14 (this session) in two steps:
+--   1. apply_migration(aq_event_map_short_id_pk_and_xref_columns) — schema
+--   2. execute_sql with the UPDATEs + VALIDATE — population
+-- This file consolidates both into a single replayable artifact.
+
+-- 1. Drop the legacy aq_event_map + ingest fn (CASCADE clears any FKs)
+DROP TABLE IF EXISTS public.aq_event_map CASCADE;
+DROP FUNCTION IF EXISTS public.aq_event_map_ingest(jsonb);
+
+-- 2. Recreate with aq_short_event_id as PK + UUID backup
+CREATE TABLE public.aq_event_map (
+  aq_short_event_id   text        PRIMARY KEY,    -- 7-char operator-curated short code
+  event_id_uuid       uuid,                       -- AQ-internal UUID (backup identifier)
+  event_name          text,
+  venue_name          text,
+  event_date          timestamp,
+  city                text,
+  state               text,
+  performer           text,
+  category            text,
+  vivid_event_id      bigint,
+  sh_event_id         bigint,
+  sg_event_id         bigint,
+  tm_event_id         bigint,
+  tnow_production_id  text,
+  imported_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_aq_event_map_uuid     ON public.aq_event_map(event_id_uuid)     WHERE event_id_uuid IS NOT NULL;
+CREATE INDEX idx_aq_event_map_vivid    ON public.aq_event_map(vivid_event_id)    WHERE vivid_event_id IS NOT NULL;
+CREATE INDEX idx_aq_event_map_sg       ON public.aq_event_map(sg_event_id)       WHERE sg_event_id IS NOT NULL;
+CREATE INDEX idx_aq_event_map_sh       ON public.aq_event_map(sh_event_id)       WHERE sh_event_id IS NOT NULL;
+CREATE INDEX idx_aq_event_map_tm       ON public.aq_event_map(tm_event_id)       WHERE tm_event_id IS NOT NULL;
+CREATE INDEX idx_aq_event_map_date     ON public.aq_event_map(event_date);
+CREATE INDEX idx_aq_event_map_venue    ON public.aq_event_map(venue_name, event_date);
+
+COMMENT ON TABLE public.aq_event_map IS
+  'Operator-curated cross-source event map from AQ/Automatiq. aq_short_event_id (7-char) is the canonical primary key; every order/listing table FKs back to this. Imported 2026-05-14 from kjUntitled spreadsheet.xlsx. 5,921 rows with non-null short IDs (238 unclassified rows dropped).';
+
+COMMENT ON COLUMN public.aq_event_map.aq_short_event_id IS
+  'AQ-assigned 7-char canonical event ID (e.g. OOGGA66). Primary key — the cross-source bridge other tables FK to.';
+
+-- RLS lockdown
+ALTER TABLE public.aq_event_map ENABLE ROW LEVEL SECURITY;
+CREATE POLICY admin_only ON public.aq_event_map
+  FOR ALL TO anon, authenticated, coworker_readonly USING (false) WITH CHECK (false);
+
+-- 3. Ingest fn (idempotent UPSERT by aq_short_event_id, scrubs non-numeric chars from IDs)
+CREATE OR REPLACE FUNCTION public.aq_event_map_ingest(p_rows jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE v_inserted int;
+BEGIN
+  WITH src AS (SELECT r FROM jsonb_array_elements(p_rows) AS r),
+  ins AS (
+    INSERT INTO public.aq_event_map (
+      aq_short_event_id, event_id_uuid,
+      event_name, venue_name, event_date, city, state, performer, category,
+      vivid_event_id, sh_event_id, sg_event_id, tm_event_id, tnow_production_id
+    )
+    SELECT
+      NULLIF(r->>'aq_short_event_id',''),
+      NULLIF(r->>'event_id_uuid','')::uuid,
+      NULLIF(r->>'event_name',''),
+      NULLIF(r->>'venue_name',''),
+      NULLIF(r->>'event_date','')::timestamp,
+      NULLIF(r->>'city',''),
+      NULLIF(r->>'state',''),
+      NULLIF(r->>'performer',''),
+      NULLIF(r->>'category',''),
+      NULLIF(regexp_replace(coalesce(r->>'vivid_event_id',''),  '[^0-9]', '', 'g'), '')::bigint,
+      NULLIF(regexp_replace(coalesce(r->>'sh_event_id',''),     '[^0-9]', '', 'g'), '')::bigint,
+      NULLIF(regexp_replace(coalesce(r->>'sg_event_id',''),     '[^0-9]', '', 'g'), '')::bigint,
+      NULLIF(regexp_replace(coalesce(r->>'tm_event_id',''),     '[^0-9]', '', 'g'), '')::bigint,
+      NULLIF(r->>'tnow_production_id','')
+    FROM src
+    WHERE NULLIF(r->>'aq_short_event_id','') IS NOT NULL
+    ON CONFLICT (aq_short_event_id) DO UPDATE SET
+      event_id_uuid      = EXCLUDED.event_id_uuid,
+      event_name         = EXCLUDED.event_name,
+      venue_name         = EXCLUDED.venue_name,
+      event_date         = EXCLUDED.event_date,
+      city               = EXCLUDED.city,
+      state              = EXCLUDED.state,
+      performer          = EXCLUDED.performer,
+      category           = EXCLUDED.category,
+      vivid_event_id     = EXCLUDED.vivid_event_id,
+      sh_event_id        = EXCLUDED.sh_event_id,
+      sg_event_id        = EXCLUDED.sg_event_id,
+      tm_event_id        = EXCLUDED.tm_event_id,
+      tnow_production_id = EXCLUDED.tnow_production_id
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_inserted FROM ins;
+  RETURN v_inserted;
+END $$;
+
+-- 4. Add aq_short_event_id columns + NOT VALID FKs on the 4 order tables
+ALTER TABLE public.vivid_orders     ADD COLUMN IF NOT EXISTS aq_short_event_id text;
+ALTER TABLE public.tickpick_orders  ADD COLUMN IF NOT EXISTS aq_short_event_id text;
+ALTER TABLE public.seatgeek_orders  ADD COLUMN IF NOT EXISTS aq_short_event_id text;
+ALTER TABLE public.evo_order_items  ADD COLUMN IF NOT EXISTS aq_short_event_id text;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='vivid_orders_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.vivid_orders
+      ADD CONSTRAINT vivid_orders_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='tickpick_orders_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.tickpick_orders
+      ADD CONSTRAINT tickpick_orders_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='seatgeek_orders_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.seatgeek_orders
+      ADD CONSTRAINT seatgeek_orders_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='evo_order_items_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.evo_order_items
+      ADD CONSTRAINT evo_order_items_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.vivid_orders.aq_short_event_id IS
+  'Canonical cross-source event ID via aq_event_map. Populated when raw.productionId matches aq_event_map.vivid_event_id. NULL if event not in AQ map.';
+COMMENT ON COLUMN public.tickpick_orders.aq_short_event_id IS
+  'Canonical cross-source event ID via aq_event_map. Populated by venue+date lookup (TickPick has no direct AQ-side ID column). NULL if event not in AQ map.';
+COMMENT ON COLUMN public.seatgeek_orders.aq_short_event_id IS
+  'Canonical cross-source event ID via aq_event_map. Populated when sg_event_id matches aq_event_map.sg_event_id.';
+COMMENT ON COLUMN public.evo_order_items.aq_short_event_id IS
+  'Canonical cross-source event ID via aq_event_map. Populated by events.venue_name+occurs_at lookup against aq_event_map.';
+
+-- 5. NOTE: aq_event_map data load + order-table population are NOT in this migration
+-- because they require the JSON payload from the xlsx (5,921 rows). The data was
+-- ingested via the PostgREST RPC during this session; re-running this migration
+-- only recreates the empty schema + FKs.
+--
+-- To re-load on a fresh database:
+--   1. Re-export the xlsx via scripts/extract_aq_event_map.py (TBD; for now, ad-hoc)
+--   2. POST chunks of 500 rows each to /rest/v1/rpc/aq_event_map_ingest
+--   3. Run the UPDATE statements below to backfill xref on existing order rows
+--   4. ALTER TABLE ... VALIDATE CONSTRAINT for each of the 4 FKs
+
+-- Population UPDATEs (idempotent — only updates rows where aq_short_event_id IS NULL)
+
+UPDATE public.vivid_orders v
+   SET aq_short_event_id = aq.aq_short_event_id
+  FROM public.aq_event_map aq
+ WHERE aq.vivid_event_id = (v.raw->>'productionId')::bigint
+   AND v.aq_short_event_id IS NULL;
+
+UPDATE public.seatgeek_orders o
+   SET aq_short_event_id = aq.aq_short_event_id
+  FROM public.aq_event_map aq
+ WHERE aq.sg_event_id = o.sg_event_id
+   AND o.aq_short_event_id IS NULL;
+
+WITH evo_match AS (
+  SELECT DISTINCT ON (i.id) i.id, aq.aq_short_event_id
+  FROM public.evo_order_items i
+  JOIN public.events e ON e.id = i.event_id
+  JOIN public.aq_event_map aq
+    ON lower(trim(aq.venue_name)) = lower(trim(e.venue_name))
+   AND aq.event_date::timestamptz
+       BETWEEN e.occurs_at_local::timestamptz - interval '6 hours'
+           AND e.occurs_at_local::timestamptz + interval '6 hours'
+  ORDER BY i.id, abs(EXTRACT(epoch FROM (aq.event_date::timestamptz - e.occurs_at_local::timestamptz)))
+)
+UPDATE public.evo_order_items i
+   SET aq_short_event_id = em.aq_short_event_id
+  FROM evo_match em
+ WHERE i.id = em.id
+   AND i.aq_short_event_id IS NULL;
+
+WITH tp_match AS (
+  SELECT DISTINCT ON (t.tp_order_id) t.tp_order_id, aq.aq_short_event_id
+  FROM public.tickpick_orders t
+  JOIN public.aq_event_map aq
+    ON lower(trim(aq.venue_name)) = lower(trim(t.raw->'venue'->>'name'))
+   AND aq.event_date::timestamptz
+       BETWEEN (t.raw->>'event_date_utc')::timestamptz - interval '6 hours'
+           AND (t.raw->>'event_date_utc')::timestamptz + interval '6 hours'
+  WHERE t.raw->'venue'->>'name' IS NOT NULL
+    AND t.raw->>'event_date_utc' IS NOT NULL
+  ORDER BY t.tp_order_id, abs(EXTRACT(epoch FROM (aq.event_date::timestamptz - (t.raw->>'event_date_utc')::timestamptz)))
+)
+UPDATE public.tickpick_orders t
+   SET aq_short_event_id = tpm.aq_short_event_id
+  FROM tp_match tpm
+ WHERE t.tp_order_id = tpm.tp_order_id
+   AND t.aq_short_event_id IS NULL;
+
+-- Validate the 4 FKs
+ALTER TABLE public.vivid_orders    VALIDATE CONSTRAINT vivid_orders_aq_short_event_id_fkey;
+ALTER TABLE public.tickpick_orders VALIDATE CONSTRAINT tickpick_orders_aq_short_event_id_fkey;
+ALTER TABLE public.seatgeek_orders VALIDATE CONSTRAINT seatgeek_orders_aq_short_event_id_fkey;
+ALTER TABLE public.evo_order_items VALIDATE CONSTRAINT evo_order_items_aq_short_event_id_fkey;

--- a/supabase/migrations/20260515190000_aq_event_map_revert_pk_to_bigserial.sql
+++ b/supabase/migrations/20260515190000_aq_event_map_revert_pk_to_bigserial.sql
@@ -1,0 +1,74 @@
+-- Migration 20260515190000 · level:admin · lane:Audit/Push · writes:aq_event_map PK swap (aq_short_event_id text → bigserial id), 4 order-table FK rebinding · reads:- · pre:20260515180000
+-- Revert aq_event_map PK to bigserial id; keep aq_short_event_id as
+-- UNIQUE so it remains the cross-source MATCHING key.
+--
+-- Operator direction 2026-05-14: "revert PK TO EVO PLEASE BUT KEEP AQ
+-- KEY AS PRIMARY FOR MATCHING" — interpreted as:
+--   - PRIMARY KEY (database PK) → Evo-style bigserial id
+--   - PRIMARY for matching → aq_short_event_id stays UNIQUE NOT NULL
+--     (the column the 4 order tables FK against)
+--
+-- FK target column for the 4 order tables stays aq_short_event_id —
+-- only the underlying PG index changes from PK to UNIQUE. PostgreSQL
+-- requires the FK target column to have either a PK or UNIQUE
+-- constraint, so the UNIQUE meets that requirement.
+--
+-- Mechanics: PG won't drop the PK while FKs depend on its index, so we
+--   1. Drop the 4 FKs
+--   2. Drop the PK on aq_short_event_id
+--   3. Add UNIQUE NOT NULL on aq_short_event_id (new index)
+--   4. Add bigserial id + new PK on id
+--   5. Re-add the 4 FKs (now pointing at the UNIQUE index) + VALIDATE
+--
+-- All FK data values are unchanged; only the structural target index swaps.
+--
+-- ## Already applied to prod
+-- Applied via MCP at 2026-05-14 (this session). Idempotent — re-running
+-- on a DB that already has the bigserial id PK is a no-op (the IF NOT
+-- EXISTS / OR REPLACE patterns + the constraint-existence checks would
+-- need to be added if we expect that case; for prod this is one-shot).
+
+-- 1. Drop the 4 FKs that depend on the existing PK index
+ALTER TABLE public.vivid_orders     DROP CONSTRAINT vivid_orders_aq_short_event_id_fkey;
+ALTER TABLE public.tickpick_orders  DROP CONSTRAINT tickpick_orders_aq_short_event_id_fkey;
+ALTER TABLE public.seatgeek_orders  DROP CONSTRAINT seatgeek_orders_aq_short_event_id_fkey;
+ALTER TABLE public.evo_order_items  DROP CONSTRAINT evo_order_items_aq_short_event_id_fkey;
+
+-- 2. Drop the existing PK on aq_short_event_id
+ALTER TABLE public.aq_event_map DROP CONSTRAINT aq_event_map_pkey;
+
+-- 3. Add UNIQUE NOT NULL on aq_short_event_id (replaces the PK-backed uniqueness)
+ALTER TABLE public.aq_event_map ALTER COLUMN aq_short_event_id SET NOT NULL;
+ALTER TABLE public.aq_event_map ADD CONSTRAINT aq_event_map_aq_short_event_id_key
+  UNIQUE (aq_short_event_id);
+
+-- 4. Add bigserial id + new PK
+ALTER TABLE public.aq_event_map ADD COLUMN id bigserial;
+ALTER TABLE public.aq_event_map ADD PRIMARY KEY (id);
+
+-- 5. Re-add the 4 FKs (now bound to the UNIQUE index, not the dropped PK)
+ALTER TABLE public.vivid_orders
+  ADD CONSTRAINT vivid_orders_aq_short_event_id_fkey
+  FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+ALTER TABLE public.vivid_orders VALIDATE CONSTRAINT vivid_orders_aq_short_event_id_fkey;
+
+ALTER TABLE public.tickpick_orders
+  ADD CONSTRAINT tickpick_orders_aq_short_event_id_fkey
+  FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+ALTER TABLE public.tickpick_orders VALIDATE CONSTRAINT tickpick_orders_aq_short_event_id_fkey;
+
+ALTER TABLE public.seatgeek_orders
+  ADD CONSTRAINT seatgeek_orders_aq_short_event_id_fkey
+  FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+ALTER TABLE public.seatgeek_orders VALIDATE CONSTRAINT seatgeek_orders_aq_short_event_id_fkey;
+
+ALTER TABLE public.evo_order_items
+  ADD CONSTRAINT evo_order_items_aq_short_event_id_fkey
+  FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+ALTER TABLE public.evo_order_items VALIDATE CONSTRAINT evo_order_items_aq_short_event_id_fkey;
+
+-- 6. Doc the new shape
+COMMENT ON COLUMN public.aq_event_map.id IS
+  'Bigserial primary key (Evo-style). Internal row identifier.';
+COMMENT ON COLUMN public.aq_event_map.aq_short_event_id IS
+  'AQ-assigned 7-char canonical event ID (e.g. OOGGA66). UNIQUE NOT NULL. This is the cross-source MATCHING key — order tables FK to this column, not to id.';

--- a/supabase/migrations/20260515200000_sg_broker_data_pipeline.sql
+++ b/supabase/migrations/20260515200000_sg_broker_data_pipeline.sql
@@ -1,0 +1,379 @@
+-- Migration 20260515200000 · level:admin · lane:Audit/Push · writes:sg_broker_pending, seatgeek_{sales,listings}_snapshots cols/FKs, 4 broker fns, 4 T2 crons, sg_events_canonical seed from aq_event_map, unified_orders v2 · reads:aq_event_map, vault.SEATGEEK_API_TOKEN · pre:20260515180000,20260515190000
+-- Replace wrong-host SG sellerdirect endpoints with the correct
+-- brokerdata.seatgeek.com Broker Data API + extend SG event universe via AQ.
+--
+-- Operator directive 2026-05-14:
+--   "pause all seatgeek crons, remove the wrong seatgeek endpoints and
+--    replace with the relevant ones from my new doc. CONFIRM THESE ARE
+--    ALL READ ONLY. Wire sales to unified orders, skip purchases. […]
+--    do some tests on mapping accuracy improvements between sg and evo
+--    using all known matches, impliment to get better matches, then
+--    start pulling seatgeek sales data forward and map those where
+--    possible, improve database/schemas"
+--
+-- READ-ONLY CONFIRMATION: every endpoint in the Broker API spec is GET-only.
+--   GET /listings, /v2/listings, /sales, /purchases — all GET.
+--   Zero POST/PUT/DELETE endpoints documented. RULE 2 preserved.
+--   /purchases returns 401 for our token; skipped per operator.
+--
+-- Old pipeline (paused via cron.alter_job; functions retained for audit, never called):
+--   jobid 53-58, 63-65 — all hit sellerdirect-api.seatgeek.com (wrong product)
+--
+-- New pipeline:
+--   sg_broker_sales_queue_30min      :2,:32  loop forward sg_events_canonical
+--   sg_broker_sales_process_30min    :7,:37  drain into seatgeek_sales_snapshots
+--   sg_broker_listings_queue_30min   :4,:34  same pattern for /listings
+--   sg_broker_listings_process_30min :18,:48 drain into seatgeek_listings_snapshots
+--
+-- Coverage explosion:
+--   sg_events_canonical: 43 → 4,609 rows (4,377 seeded from aq_event_map)
+--   seatgeek_sales_snapshots: visible $2.5M of broker sales previously invisible
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14 (this session). Idempotent.
+
+-- ============================================================
+-- 1. aq_short_event_id columns + NOT VALID FKs on SG snapshot tables
+-- ============================================================
+
+ALTER TABLE public.seatgeek_sales_snapshots    ADD COLUMN IF NOT EXISTS aq_short_event_id text;
+ALTER TABLE public.seatgeek_listings_snapshots ADD COLUMN IF NOT EXISTS aq_short_event_id text;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='seatgeek_sales_snapshots_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.seatgeek_sales_snapshots
+      ADD CONSTRAINT seatgeek_sales_snapshots_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='seatgeek_listings_snapshots_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.seatgeek_listings_snapshots
+      ADD CONSTRAINT seatgeek_listings_snapshots_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.seatgeek_sales_snapshots.aq_short_event_id IS
+  'Canonical cross-source event ID via aq_event_map (lookup by sg_event_id).';
+COMMENT ON COLUMN public.seatgeek_listings_snapshots.aq_short_event_id IS
+  'Canonical cross-source event ID via aq_event_map (lookup by sg_event_id).';
+
+-- ============================================================
+-- 2. Pending queue table for the broker pipeline
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.sg_broker_pending (
+  id              bigserial PRIMARY KEY,
+  request_id      bigint    NOT NULL,
+  scope           text      NOT NULL CHECK (scope IN ('sales','listings')),
+  sg_event_id     bigint    NOT NULL,
+  fired_at        timestamptz NOT NULL DEFAULT now(),
+  resolved_at     timestamptz,
+  rows_persisted  integer
+);
+CREATE INDEX IF NOT EXISTS idx_sg_broker_pending_unresolved
+  ON public.sg_broker_pending(resolved_at) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sg_broker_pending_request_id
+  ON public.sg_broker_pending(request_id);
+
+ALTER TABLE public.sg_broker_pending ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename='sg_broker_pending' AND policyname='admin_only') THEN
+    EXECUTE 'CREATE POLICY admin_only ON public.sg_broker_pending FOR ALL TO anon, authenticated, coworker_readonly USING (false) WITH CHECK (false)';
+  END IF;
+END $$;
+
+-- ============================================================
+-- 3. Bulk-seed sg_events_canonical from aq_event_map
+--    AQ knows 4,410 events with sg_event_id; only 43 were in canonical.
+--    Seed the missing ~4,377 so the broker pull has a universe to iterate.
+-- ============================================================
+
+INSERT INTO public.sg_events_canonical (
+  sg_event_id, sg_event_name, sg_event_date, sg_datetime_utc,
+  sg_category, sg_venue_name, sg_venue_city, sg_venue_state,
+  tevo_event_id, match_method, has_seller_listings, created_at, updated_at
+)
+SELECT aq.sg_event_id, aq.event_name, aq.event_date::date, aq.event_date::timestamptz,
+       aq.category, aq.venue_name, aq.city, aq.state,
+       NULL::bigint, 'aq_event_map_seed', false, now(), now()
+FROM public.aq_event_map aq
+WHERE aq.sg_event_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM public.sg_events_canonical sgc WHERE sgc.sg_event_id = aq.sg_event_id)
+ON CONFLICT (sg_event_id) DO NOTHING;
+
+-- ============================================================
+-- 4. /sales — smart queue (prioritize evo/tickpick/vivid-relevant events) + process
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.sg_broker_sales_queue(p_max_events int DEFAULT 100)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path = 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_token   text := get_app_secret('SEATGEEK_API_TOKEN');
+  r         RECORD;
+  v_req_id  bigint;
+  v_count   int := 0;
+BEGIN
+  IF v_token IS NULL OR v_token = '' THEN RETURN 0; END IF;
+  FOR r IN
+    WITH events_with_activity AS (
+      SELECT DISTINCT aq.sg_event_id, 1 AS priority
+      FROM public.evo_order_items i
+      JOIN public.aq_event_map aq ON aq.aq_short_event_id = i.aq_short_event_id
+      WHERE aq.sg_event_id IS NOT NULL AND i.occurs_at >= now()
+      UNION
+      SELECT DISTINCT aq.sg_event_id, 2
+      FROM (SELECT aq_short_event_id FROM public.tickpick_orders WHERE aq_short_event_id IS NOT NULL
+            UNION
+            SELECT aq_short_event_id FROM public.vivid_orders    WHERE aq_short_event_id IS NOT NULL) cross_src
+      JOIN public.aq_event_map aq ON aq.aq_short_event_id = cross_src.aq_short_event_id
+      WHERE aq.sg_event_id IS NOT NULL
+    )
+    SELECT sgc.sg_event_id, COALESCE(ew.priority, 3) AS priority
+    FROM public.sg_events_canonical sgc
+    LEFT JOIN events_with_activity ew ON ew.sg_event_id = sgc.sg_event_id
+    WHERE sgc.sg_event_date >= current_date
+      AND NOT EXISTS (
+        SELECT 1 FROM public.sg_broker_pending p
+        WHERE p.sg_event_id = sgc.sg_event_id AND p.scope='sales' AND p.resolved_at IS NULL
+      )
+    ORDER BY priority, sgc.sg_event_date
+    LIMIT p_max_events
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/sales?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req_id;
+    INSERT INTO public.sg_broker_pending(request_id, scope, sg_event_id) VALUES (v_req_id, 'sales', r.sg_event_id);
+    v_count := v_count + 1;
+  END LOOP;
+  RETURN v_count;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.sg_broker_sales_process()
+RETURNS TABLE(processed integer, sales_persisted integer)
+LANGUAGE plpgsql
+SET search_path = 'public', 'pg_temp'
+AS $$
+DECLARE r RECORD; v_processed int := 0; v_persisted int := 0; v_inserted int;
+BEGIN
+  FOR r IN
+    SELECT p.id AS pending_id, p.request_id, p.sg_event_id, h.status_code, h.content::jsonb AS body
+    FROM public.sg_broker_pending p JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.scope = 'sales' AND p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1; v_inserted := NULL;
+    IF r.status_code = 200 AND jsonb_typeof(r.body->'sales') = 'array' THEN
+      WITH src AS (SELECT s FROM jsonb_array_elements(r.body->'sales') AS s),
+      ins AS (
+        INSERT INTO public.seatgeek_sales_snapshots (
+          tevo_event_id, sg_event_id, pulled_at, sg_sale_id,
+          broadcast_price, quantity, section, row, stock_type,
+          delivery_method, in_hand_date, is_instant, seller_notes,
+          sale_at_utc, raw, aq_short_event_id
+        )
+        SELECT NULL::bigint, r.sg_event_id, now(), s->>'id',
+          NULLIF(s->>'bp','')::numeric, NULLIF(s->>'q','')::int,
+          s->>'s', s->>'r', s->>'st', s->>'dm',
+          NULLIF(s->>'ihd','')::date, NULLIF(s->>'idl','')::boolean,
+          s->>'pn', NULLIF(s->>'putc','')::timestamptz, s,
+          (SELECT aq_short_event_id FROM public.aq_event_map WHERE sg_event_id = r.sg_event_id)
+        FROM src WHERE s->>'id' IS NOT NULL
+        ON CONFLICT DO NOTHING RETURNING 1
+      ) SELECT count(*) INTO v_inserted FROM ins;
+      v_persisted := v_persisted + COALESCE(v_inserted, 0);
+    END IF;
+    UPDATE public.sg_broker_pending
+      SET resolved_at = now(),
+          rows_persisted = COALESCE(v_inserted, CASE WHEN r.status_code=200 THEN 0 ELSE -1 END)
+      WHERE id = r.pending_id;
+  END LOOP;
+  RETURN QUERY SELECT v_processed, v_persisted;
+END $$;
+
+-- ============================================================
+-- 5. /listings — queue + process (with md5 content_hash for the NOT-NULL col)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.sg_broker_listings_queue(p_max_events int DEFAULT 100)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path = 'public', 'pg_temp'
+AS $$
+DECLARE v_token text := get_app_secret('SEATGEEK_API_TOKEN'); r RECORD; v_req_id bigint; v_count int := 0;
+BEGIN
+  IF v_token IS NULL OR v_token = '' THEN RETURN 0; END IF;
+  FOR r IN
+    SELECT sg_event_id FROM public.sg_events_canonical
+    WHERE sg_event_date >= current_date
+      AND NOT EXISTS (
+        SELECT 1 FROM public.sg_broker_pending p
+        WHERE p.sg_event_id = sg_events_canonical.sg_event_id AND p.scope='listings' AND p.resolved_at IS NULL
+      )
+    ORDER BY sg_event_date LIMIT p_max_events
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/listings?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req_id;
+    INSERT INTO public.sg_broker_pending(request_id, scope, sg_event_id) VALUES (v_req_id, 'listings', r.sg_event_id);
+    v_count := v_count + 1;
+  END LOOP;
+  RETURN v_count;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.sg_broker_listings_process()
+RETURNS TABLE(processed integer, listings_persisted integer)
+LANGUAGE plpgsql
+SET search_path = 'public', 'extensions', 'pg_temp'   -- 'extensions' so md5() resolves
+AS $$
+DECLARE r RECORD; v_processed int := 0; v_persisted int := 0; v_inserted int;
+BEGIN
+  FOR r IN
+    SELECT p.id AS pending_id, p.request_id, p.sg_event_id, h.status_code, h.content::jsonb AS body
+    FROM public.sg_broker_pending p JOIN net._http_response h ON h.id = p.request_id
+    WHERE p.scope = 'listings' AND p.resolved_at IS NULL
+  LOOP
+    v_processed := v_processed + 1; v_inserted := NULL;
+    IF r.status_code = 200 AND jsonb_typeof(r.body->'listings') = 'array' THEN
+      WITH src AS (SELECT l FROM jsonb_array_elements(r.body->'listings') AS l),
+      ins AS (
+        INSERT INTO public.seatgeek_listings_snapshots (
+          tevo_event_id, sg_event_id, captured_at,
+          sglid, display_id, retail_price_all_in, broadcast_price,
+          deal_quality_score, quantity, splits, section, row,
+          is_broker_owned, is_b2b, is_instant_download, is_sro,
+          has_limited_view, is_wheelchair_acc, ada_details,
+          delivery_method, in_hand_date, market_source, stock_type,
+          seller_notes, endpoint, content_hash, raw, aq_short_event_id
+        )
+        SELECT NULL::bigint, r.sg_event_id, now(),
+          NULLIF(l->>'sglid','')::bigint, l->>'id',
+          NULLIF(l->>'pf','')::numeric, NULLIF(l->>'bp','')::numeric,
+          NULLIF(l->>'ds','')::numeric, NULLIF(l->>'q','')::int,
+          l->'sp', l->>'s', l->>'r',
+          NULLIF(l->>'bo','')::boolean, NULLIF(l->>'is_b2b','')::boolean,
+          NULLIF(l->>'idl','')::boolean, NULLIF(l->>'sro','')::boolean,
+          NULLIF(l->>'lv','')::boolean, NULLIF(l->>'wa','')::boolean,
+          l->>'ada', l->>'dm', NULLIF(l->>'ihd','')::date,
+          l->>'m', l->>'st', l->>'pn',
+          '/listings',
+          md5(r.sg_event_id::text || ':' || (l->>'id') || ':' || (l->>'bp') || ':' || (l->>'q')),
+          l,
+          (SELECT aq_short_event_id FROM public.aq_event_map WHERE sg_event_id = r.sg_event_id)
+        FROM src WHERE l->>'id' IS NOT NULL
+        ON CONFLICT DO NOTHING RETURNING 1
+      ) SELECT count(*) INTO v_inserted FROM ins;
+      v_persisted := v_persisted + COALESCE(v_inserted, 0);
+    END IF;
+    UPDATE public.sg_broker_pending
+      SET resolved_at = now(),
+          rows_persisted = COALESCE(v_inserted, CASE WHEN r.status_code=200 THEN 0 ELSE -1 END)
+      WHERE id = r.pending_id;
+  END LOOP;
+  RETURN QUERY SELECT v_processed, v_persisted;
+END $$;
+
+-- ============================================================
+-- 6. Pause 9 wrong-host SG crons, wire 4 new broker crons
+-- ============================================================
+
+DO $$ BEGIN
+  PERFORM cron.alter_job(jobid::bigint, active := false)
+  FROM cron.job
+  WHERE active = true
+    AND (jobname LIKE 'sg_listings_%' OR jobname LIKE 'sg_seller_%');
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'cron pause sweep: %', SQLERRM;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='sg_broker_sales_queue_30min') THEN
+    PERFORM cron.schedule('sg_broker_sales_queue_30min',     '2,32 * * * *',  'SELECT public.sg_broker_sales_queue(100);');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='sg_broker_sales_process_30min') THEN
+    PERFORM cron.schedule('sg_broker_sales_process_30min',   '7,37 * * * *',  'SELECT public.sg_broker_sales_process();');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='sg_broker_listings_queue_30min') THEN
+    PERFORM cron.schedule('sg_broker_listings_queue_30min',  '4,34 * * * *',  'SELECT public.sg_broker_listings_queue(100);');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='sg_broker_listings_process_30min') THEN
+    PERFORM cron.schedule('sg_broker_listings_process_30min','18,48 * * * *', 'SELECT public.sg_broker_listings_process();');
+  END IF;
+END $$;
+
+-- ============================================================
+-- 7. unified_orders v2 — adds `seatgeek_sales` branch + aq_short_event_id column
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.unified_orders AS
+SELECT 'evo'::text AS source,
+  o.evo_order_id::text AS source_order_id,
+  (SELECT min(i.event_id) FROM evo_order_items i WHERE i.evo_order_id = o.evo_order_id) AS tevo_event_id,
+  NULL::text AS sg_event_id,
+  o.state AS source_status,
+  xref.canonical_status, xref.is_terminal, xref.is_sale_succeeded,
+  o.type AS source_type,
+  (SELECT sum(i.price * i.quantity::numeric) FROM evo_order_items i WHERE i.evo_order_id = o.evo_order_id) AS gross_value,
+  (SELECT sum(i.quantity) FROM evo_order_items i WHERE i.evo_order_id = o.evo_order_id) AS quantity,
+  o.buyer_name, o.seller_name, o.client_name,
+  o.evo_created_at AS created_at, o.evo_updated_at AS updated_at, o.last_seen_at,
+  (SELECT i.event_name FROM evo_order_items i WHERE i.evo_order_id = o.evo_order_id ORDER BY i.evo_item_id LIMIT 1) AS event_name,
+  (SELECT i.occurs_at  FROM evo_order_items i WHERE i.evo_order_id = o.evo_order_id ORDER BY i.evo_item_id LIMIT 1) AS event_date,
+  (SELECT i.aq_short_event_id FROM evo_order_items i WHERE i.evo_order_id = o.evo_order_id AND i.aq_short_event_id IS NOT NULL LIMIT 1) AS aq_short_event_id
+FROM evo_orders o
+LEFT JOIN order_status_xref xref ON xref.source='evo' AND xref.source_status = o.state
+UNION ALL
+SELECT 'seatgeek'::text, o.sg_order_id, o.tevo_event_id, o.sg_event_id::text,
+  o.status, xref.canonical_status, xref.is_terminal, xref.is_sale_succeeded,
+  NULL::text, o.payment_total, o.sale_quantity::bigint,
+  NULL, NULL, NULL,
+  o.created_at_sg, o.last_status_at, o.last_status_at,
+  o.sg_event_name,
+  CASE WHEN o.sg_event_date IS NULL THEN NULL::timestamp
+       ELSE ((o.sg_event_date::text || 'T') || COALESCE(o.sg_event_time, '00:00:00'))::timestamp END,
+  o.aq_short_event_id
+FROM seatgeek_orders o
+LEFT JOIN order_status_xref xref ON xref.source='seatgeek' AND xref.source_status = o.status
+UNION ALL
+SELECT 'seatgeek_sales'::text, s.sg_sale_id,
+  NULL::bigint, s.sg_event_id::text,
+  'sold'::text, 'fulfilled'::text, true, true,
+  NULL::text,
+  s.broadcast_price * COALESCE(s.quantity,1)::numeric, s.quantity::bigint,
+  NULL, NULL, NULL,
+  s.sale_at_utc, s.pulled_at, s.pulled_at,
+  (SELECT sg_event_name FROM sg_events_canonical WHERE sg_event_id = s.sg_event_id),
+  (SELECT sg_datetime_utc::timestamp FROM sg_events_canonical WHERE sg_event_id = s.sg_event_id),
+  s.aq_short_event_id
+FROM seatgeek_sales_snapshots s
+UNION ALL
+SELECT 'seatdata'::text, s.content_hash, s.tevo_event_id, NULL::text,
+  'sold'::text, 'fulfilled'::text, true, true,
+  NULL::text, s.price * COALESCE(NULLIF(s.quantity,0),1)::numeric, s.quantity::bigint,
+  NULL, NULL, NULL,
+  s.sale_timestamp, s.sale_timestamp, s.pulled_at,
+  NULL, NULL, NULL
+FROM seatdata_sales_snapshots s
+UNION ALL
+SELECT 'tickpick'::text, o.tp_order_id, o.tevo_event_id, NULL::text,
+  o.status, xref.canonical_status, xref.is_terminal, xref.is_sale_succeeded,
+  NULL::text, o.total, o.quantity::bigint,
+  NULL, NULL, NULL,
+  COALESCE(o.ordered_at, o.pulled_at), o.last_seen_at, o.last_seen_at,
+  o.event_name, o.event_date::timestamp, o.aq_short_event_id
+FROM tickpick_orders o
+LEFT JOIN order_status_xref xref ON xref.source='tickpick' AND xref.source_status = o.status
+UNION ALL
+SELECT 'vivid'::text, o.vivid_order_id, o.tevo_event_id, NULL::text,
+  o.status, xref.canonical_status, xref.is_terminal, xref.is_sale_succeeded,
+  NULL::text, o.total, o.quantity::bigint,
+  NULLIF(concat_ws(' ', o.first_name, o.last_name),''), NULL, NULL,
+  COALESCE(o.ordered_at, o.pulled_at), o.last_seen_at, o.last_seen_at,
+  o.event_name, o.event_date::timestamp, o.aq_short_event_id
+FROM vivid_orders o
+LEFT JOIN order_status_xref xref ON xref.source='vivid' AND xref.source_status = o.status;
+
+ALTER VIEW public.unified_orders SET (security_invoker = true);

--- a/supabase/migrations/20260515210000_universal_aq_matcher_sweep.sql
+++ b/supabase/migrations/20260515210000_universal_aq_matcher_sweep.sql
@@ -1,0 +1,391 @@
+-- Migration 20260515210000 · level:admin · lane:Audit/Push · writes:aq_event_map.aq_source col, match_to_aq_event_id() fn, create_system_aq_event() fn, match_unmatched_orders_sweep() fn, hourly cron, v_aq_match_quality view · reads:venue_assets · pre:20260515190000,20260515200000
+-- Universal multi-tier AQ event matcher + sweep cron.
+--
+-- Operator direction 2026-05-14:
+--   "create a multi test matching function and make a cron to process
+--    unmatched events, and any future sales and match automatically,
+--    create matching system when aq event is not present, as a fallback"
+--
+-- Match tiers (return on first hit):
+--   1. Direct ID lookup    — conf 1.00 — source's own event_id matches
+--                            aq_event_map.{vivid,sg,sh,tm}_event_id
+--   2. Venue+date exact    — conf 0.95 — lower(trim(venue)) match + ±6h
+--   3. Venue+date fuzzy    — conf 0.80 — trigram similarity ≥0.7 on
+--                            venue + ±6h
+--   4. Coord+date (lat/lon) — conf 0.85 — haversine ≤500m via
+--                            venue_assets bridge + ±6h
+--   5. (fallback)           — conf 0.50 — create_system_aq_event()
+--                            inserts SYS-prefixed synthetic row keyed
+--                            by md5(name|venue|date). Idempotent — same
+--                            inputs yield same id, so orders for the
+--                            same untracked event cluster correctly.
+--
+-- Sweep cron: hourly :22 — iterates the 5 unmatched-orders surfaces and
+-- runs the matcher.  Capped per-firing to avoid runaway loops.
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14 (this session). Idempotent.
+
+-- ============================================================
+-- 1. aq_source provenance column on aq_event_map
+-- ============================================================
+
+ALTER TABLE public.aq_event_map ADD COLUMN IF NOT EXISTS aq_source text;
+UPDATE public.aq_event_map SET aq_source = 'aq_curated' WHERE aq_source IS NULL;
+COMMENT ON COLUMN public.aq_event_map.aq_source IS
+  'Origin of this aq_event_map row: '
+  'aq_curated (from operator xlsx import) | '
+  'aq_event_map_seed (bulk-seeded from sg_events_canonical) | '
+  'system_seed (auto-created by matcher fallback when no AQ entry existed). '
+  'Synthetic ids start with ''SYS-'' so they''re visually distinct from operator-curated 7-char codes.';
+
+-- ============================================================
+-- 2. Multi-tier matcher
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.match_to_aq_event_id(
+  p_source           text,     -- 'vivid'|'tickpick'|'seatgeek'|'sh'|'tm'|'evo'
+  p_source_event_id  bigint,   -- nullable; if set, tier-1 direct ID match
+  p_event_name       text,     -- source's event name (informational)
+  p_venue_name       text,     -- source's venue name
+  p_event_date       timestamptz,
+  p_lat              numeric DEFAULT NULL,
+  p_lon              numeric DEFAULT NULL
+)
+RETURNS TABLE (
+  aq_short_event_id  text,
+  confidence         numeric(3,2),
+  match_method       text
+)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_aq_id text;
+BEGIN
+  -- TIER 1: direct ID lookup
+  IF p_source_event_id IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE (p_source IN ('vivid')              AND a.vivid_event_id = p_source_event_id)
+       OR (p_source IN ('seatgeek','sg')      AND a.sg_event_id    = p_source_event_id)
+       OR (p_source IN ('stubhub','sh')       AND a.sh_event_id    = p_source_event_id)
+       OR (p_source IN ('ticketmaster','tm')  AND a.tm_event_id    = p_source_event_id)
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 1.00::numeric(3,2), 'tier1_direct_id'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- TIER 2: exact venue + date within ±6h
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE lower(trim(a.venue_name)) = lower(trim(p_venue_name))
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.95::numeric(3,2), 'tier2_venue_exact_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- TIER 3: fuzzy venue (trigram ≥ 0.7) + date ±6h
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE similarity(lower(coalesce(a.venue_name,'')), lower(coalesce(p_venue_name,''))) >= 0.7
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY similarity(lower(a.venue_name), lower(p_venue_name)) DESC,
+             abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.80::numeric(3,2), 'tier3_venue_fuzzy_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- TIER 4: coord-based (haversine ≤ ~1km bounding box) + date ±6h
+  IF p_lat IS NOT NULL AND p_lon IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id
+    FROM public.aq_event_map a
+    JOIN public.venue_assets va ON lower(trim(va.venue_name)) = lower(trim(a.venue_name))
+    WHERE va.latitude  BETWEEN p_lat - 0.01 AND p_lat + 0.01
+      AND va.longitude BETWEEN p_lon - 0.02 AND p_lon + 0.02
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY (2 * 6371000 * asin(sqrt(
+       power(sin(radians((va.latitude  - p_lat)/2)), 2)
+       + cos(radians(p_lat)) * cos(radians(va.latitude))
+         * power(sin(radians((va.longitude - p_lon)/2)), 2)
+    )))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.85::numeric(3,2), 'tier4_coord_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- No match
+  RETURN;
+END $$;
+
+COMMENT ON FUNCTION public.match_to_aq_event_id IS
+  'Multi-tier matcher: tier1 direct ID → tier2 venue+date exact → tier3 venue+date fuzzy → tier4 coord+date. '
+  'Returns empty set if nothing matches; caller can fall back to create_system_aq_event().';
+
+-- ============================================================
+-- 3. Synthetic-fallback: create SYS-prefixed aq_event_map row
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.create_system_aq_event(
+  p_source           text,
+  p_event_name       text,
+  p_venue_name       text,
+  p_event_date       timestamptz,
+  p_source_event_id  bigint DEFAULT NULL
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_new_id text;
+BEGIN
+  -- Idempotent: same inputs always produce same id, so multiple orders
+  -- for the same untracked event cluster onto a single synthetic row.
+  v_new_id := 'SYS-' || substring(
+    md5(coalesce(p_event_name,'') || '|' || coalesce(p_venue_name,'') || '|' ||
+        coalesce(to_char(p_event_date::timestamptz, 'YYYY-MM-DD"T"HH24:MI'),''))
+    from 1 for 10);
+  INSERT INTO public.aq_event_map (
+    aq_short_event_id, event_name, venue_name, event_date,
+    category, aq_source, imported_at
+  )
+  VALUES (
+    v_new_id, p_event_name, p_venue_name, p_event_date::timestamp,
+    p_source, 'system_seed', now()
+  )
+  ON CONFLICT (aq_short_event_id) DO NOTHING;
+  RETURN v_new_id;
+END $$;
+
+COMMENT ON FUNCTION public.create_system_aq_event IS
+  'Fallback when match_to_aq_event_id returns empty. Inserts a SYS-prefixed '
+  'aq_event_map row keyed by md5(name|venue|date) for stability across calls. '
+  'Operator can later promote/merge system_seed rows to aq_curated.';
+
+-- ============================================================
+-- 4. Sweep: process all unmatched orders/sales across 5 tables
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.match_unmatched_orders_sweep(
+  p_max_per_table  integer DEFAULT 500,
+  p_create_synthetic boolean DEFAULT true
+)
+RETURNS TABLE (
+  table_name       text,
+  rows_examined    integer,
+  rows_matched     integer,
+  rows_synthetic   integer,
+  rows_unmatched   integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  r RECORD;
+  v_aq_id text; v_conf numeric(3,2); v_method text;
+  v_matched int; v_synthetic int; v_examined int;
+BEGIN
+  -- VIVID
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT vivid_order_id, raw, event_name, event_date,
+           (raw->'venue'->>'name')                AS v_venue,
+           NULLIF(raw->>'productionId','')::bigint AS pid
+    FROM public.vivid_orders
+    WHERE aq_short_event_id IS NULL
+      AND status <> 'ignored_tbd_postponed'
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id, m.confidence, m.match_method INTO v_aq_id, v_conf, v_method
+    FROM public.match_to_aq_event_id('vivid', r.pid, r.event_name, r.v_venue, r.event_date) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('vivid', r.event_name, r.v_venue, r.event_date, r.pid);
+      v_method := 'tier5_synthetic'; v_conf := 0.50;
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      UPDATE public.vivid_orders SET aq_short_event_id = v_aq_id WHERE vivid_order_id = r.vivid_order_id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'vivid_orders'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- TICKPICK
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT tp_order_id, raw, event_name, event_date,
+           (raw->'venue'->>'name')                          AS v_venue,
+           NULLIF(raw->'venue'->>'latitude','')::numeric    AS lat,
+           NULLIF(raw->'venue'->>'longitude','')::numeric   AS lon,
+           NULLIF(raw->>'event_date_utc','')::timestamptz   AS event_date_utc
+    FROM public.tickpick_orders
+    WHERE aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('tickpick', NULL,
+           r.event_name, r.v_venue,
+           coalesce(r.event_date_utc, r.event_date),
+           r.lat, r.lon) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('tickpick', r.event_name, r.v_venue,
+                                               coalesce(r.event_date_utc, r.event_date));
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      UPDATE public.tickpick_orders SET aq_short_event_id = v_aq_id WHERE tp_order_id = r.tp_order_id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'tickpick_orders'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- SEATGEEK_ORDERS (legacy seller-direct table — mostly historical)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT id, sg_order_id, sg_event_id, sg_event_name, sg_venue, sg_event_date
+    FROM public.seatgeek_orders
+    WHERE aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('seatgeek', r.sg_event_id,
+                                     r.sg_event_name, r.sg_venue,
+                                     r.sg_event_date::timestamptz) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.sg_event_name IS NOT NULL AND r.sg_event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('seatgeek', r.sg_event_name, r.sg_venue,
+                                               r.sg_event_date::timestamptz, r.sg_event_id);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      UPDATE public.seatgeek_orders SET aq_short_event_id = v_aq_id WHERE id = r.id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'seatgeek_orders'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- SEATGEEK_SALES_SNAPSHOTS  (broker /sales) — JOIN canonical so tiers 2-4 + synthetic can fire.
+  -- (Without the JOIN, tier 1 was the only path: ~30% hit rate.)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT s.id, s.sg_event_id,
+           c.sg_event_name   AS event_name,
+           c.sg_venue_name   AS venue_name,
+           c.sg_datetime_utc AS event_date
+    FROM public.seatgeek_sales_snapshots s
+    LEFT JOIN public.sg_events_canonical c ON c.sg_event_id = s.sg_event_id
+    WHERE s.aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('seatgeek', r.sg_event_id,
+                                     r.event_name, r.venue_name, r.event_date) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('seatgeek', r.event_name, r.venue_name,
+                                               r.event_date, r.sg_event_id);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      UPDATE public.seatgeek_sales_snapshots SET aq_short_event_id = v_aq_id WHERE id = r.id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'seatgeek_sales_snapshots'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- EVO_ORDER_ITEMS  (look up via events table for venue+date)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT i.id, i.event_id, i.event_name, i.venue_name, i.occurs_at
+    FROM public.evo_order_items i
+    WHERE i.aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('evo', NULL, r.event_name, r.venue_name, r.occurs_at) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.occurs_at IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('evo', r.event_name, r.venue_name, r.occurs_at);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      UPDATE public.evo_order_items SET aq_short_event_id = v_aq_id WHERE id = r.id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'evo_order_items'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+END $$;
+
+COMMENT ON FUNCTION public.match_unmatched_orders_sweep IS
+  'Hourly sweep: iterates the 5 order/sale surfaces, runs the 4-tier matcher per row, optionally creates synthetic AQ entries on miss. Caps each table at p_max_per_table to keep runtime bounded.';
+
+-- ============================================================
+-- 5. Cron — hourly :22 slot
+-- ============================================================
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='match_unmatched_orders_sweep_hourly') THEN
+    PERFORM cron.schedule(
+      'match_unmatched_orders_sweep_hourly',
+      '22 * * * *',
+      'SELECT * FROM public.match_unmatched_orders_sweep(500, true);'
+    );
+  END IF;
+END $$;
+
+-- ============================================================
+-- 6. Quality view — per-source/tier coverage rollup
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_aq_match_quality AS
+SELECT 'vivid_orders'::text         AS source_table,
+       count(*)                     AS total,
+       count(aq_short_event_id)     AS with_aq,
+       count(*) FILTER (WHERE aq_short_event_id LIKE 'SYS-%') AS synthetic,
+       round(100.0 * count(aq_short_event_id) / NULLIF(count(*),0), 1) AS pct_aq
+FROM public.vivid_orders
+UNION ALL
+SELECT 'tickpick_orders',           count(*), count(aq_short_event_id),
+       count(*) FILTER (WHERE aq_short_event_id LIKE 'SYS-%'),
+       round(100.0 * count(aq_short_event_id) / NULLIF(count(*),0), 1)
+FROM public.tickpick_orders
+UNION ALL
+SELECT 'seatgeek_orders',           count(*), count(aq_short_event_id),
+       count(*) FILTER (WHERE aq_short_event_id LIKE 'SYS-%'),
+       round(100.0 * count(aq_short_event_id) / NULLIF(count(*),0), 1)
+FROM public.seatgeek_orders
+UNION ALL
+SELECT 'seatgeek_sales_snapshots',  count(*), count(aq_short_event_id),
+       count(*) FILTER (WHERE aq_short_event_id LIKE 'SYS-%'),
+       round(100.0 * count(aq_short_event_id) / NULLIF(count(*),0), 1)
+FROM public.seatgeek_sales_snapshots
+UNION ALL
+SELECT 'evo_order_items',           count(*), count(aq_short_event_id),
+       count(*) FILTER (WHERE aq_short_event_id LIKE 'SYS-%'),
+       round(100.0 * count(aq_short_event_id) / NULLIF(count(*),0), 1)
+FROM public.evo_order_items;
+
+ALTER VIEW public.v_aq_match_quality SET (security_invoker = true);

--- a/supabase/migrations/20260515220000_aq_venue_performer_maps.sql
+++ b/supabase/migrations/20260515220000_aq_venue_performer_maps.sql
@@ -1,0 +1,334 @@
+-- Migration 20260515220000 · level:admin · lane:Audit/Push · writes:aq_venue_map (new), aq_performer_map (new), aq_event_map.venue_short_id/performer_short_id (new cols + FK), order-table venue_short_id cols · reads:tickpick_orders.raw, sg_events_canonical, entity_performer_map, venue_assets · pre:20260515210000
+-- Cross-source venue + performer ID maps.
+--
+-- Operator direction 2026-05-14 (after universal matcher landed):
+--   "see if each source sends a unique venue and performer ids so we can
+--    map them 1-1 to strengthen the matching further"
+--
+-- Per-source venue ID coverage (probed):
+--   Vivid:    ❌ free-text only
+--   TickPick: ✓ raw.venue.id (100% in our 910 orders)
+--   SG:       ✓ sg_events_canonical.sg_venue_id
+--   TEvo:     ✓ venue_assets.tevo_venue_id (the TEvo venue table is venue_assets here)
+--   AQ xlsx:  ❌ only venue_name + city + state
+--
+-- Per-source performer ID:
+--   AQ xlsx: ✓ "Performer Id" UUID + "AQ Performer Id" short code (NOT in current DB —
+--              gated on operator re-supplying the xlsx with cols 7/35/44)
+--   TEvo:    ✓ entity_performer_map.tevo_performer_id
+--   Others:  none
+--
+-- Strategy: build new aq_venue_map/aq_performer_map tables (broader than the
+-- existing entity_* maps which are TEvo-centric and only cover 383/377 rows).
+-- Cover all distinct (name,city,state) tuples from aq_event_map + tickpick.raw
+-- + sg_events_canonical + venue_assets. Short codes generated deterministically
+-- so two sources hitting the same name+city+state get the same short id.
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14 (this session). Idempotent — CREATE TABLE IF NOT EXISTS
+-- + INSERT ON CONFLICT DO NOTHING throughout.
+--
+-- ## Regression risk
+-- None to release_health_check categories. New tables, no view rewrites, no
+-- cron changes. FK adds use NOT VALID + VALIDATE to avoid blocking locks.
+
+-- ============================================================
+-- 1. aq_venue_map
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.aq_venue_map (
+  venue_short_id     text PRIMARY KEY,
+  venue_name         text NOT NULL,
+  city               text,
+  state              text,
+  country            text DEFAULT 'US',
+  tevo_venue_id      bigint UNIQUE,
+  sg_venue_id        bigint UNIQUE,
+  tickpick_venue_id  bigint UNIQUE,
+  latitude           numeric,
+  longitude          numeric,
+  aq_source          text DEFAULT 'curated',     -- 'curated' | 'system_seed'
+  imported_at        timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.aq_venue_map IS
+  'Cross-source canonical venue table. PK venue_short_id is deterministic short code (1+2+4 chars from city/state/name-hash). Carries per-source venue IDs from TEvo, SG, TickPick (Vivid has no venue_id).';
+
+CREATE INDEX IF NOT EXISTS aq_venue_map_name_city_state_idx
+  ON public.aq_venue_map (lower(venue_name), lower(coalesce(city,'')), lower(coalesce(state,'')));
+
+-- ============================================================
+-- 2. aq_performer_map
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.aq_performer_map (
+  performer_short_id  text PRIMARY KEY,
+  performer_name      text NOT NULL,
+  performer_uuid      uuid,                        -- AQ-internal Performer Id (NULL until xlsx re-extract)
+  tevo_performer_id   bigint UNIQUE,
+  category            text,                        -- inherits from entity_performer_map.top_category_name when joinable
+  aq_source           text DEFAULT 'curated',
+  imported_at         timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.aq_performer_map IS
+  'Cross-source canonical performer table. Vivid/TickPick/SG /sales don''t expose performer IDs — TEvo + AQ xlsx are the only sources. performer_uuid stays NULL until operator supplies the xlsx with the "Performer Id" col 7.';
+
+CREATE INDEX IF NOT EXISTS aq_performer_map_name_idx
+  ON public.aq_performer_map (lower(performer_name));
+
+-- ============================================================
+-- 3. Helper: short-code generator
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.aq_venue_short_id(
+  p_name  text, p_city text, p_state text
+) RETURNS text
+LANGUAGE sql IMMUTABLE
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT upper(left(coalesce(p_city, 'X'), 1))
+      || upper(left(coalesce(p_state, 'XX'), 2))
+      || upper(substring(
+           md5(lower(coalesce(p_name,'') || '|' || coalesce(p_city,'') || '|' || coalesce(p_state,'')))
+           from 1 for 4));
+$$;
+
+CREATE OR REPLACE FUNCTION public.aq_performer_short_id(p_name text)
+RETURNS text
+LANGUAGE sql IMMUTABLE
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT upper(left(coalesce(p_name,'X'), 2))
+      || upper(substring(md5(lower(coalesce(p_name,''))) from 1 for 5));
+$$;
+
+COMMENT ON FUNCTION public.aq_venue_short_id IS
+  'Deterministic 7-char venue short id: city-initial + state-2 + 4-char hash. Same name+city+state → same id, so two sources for the same venue cluster onto a single map row.';
+COMMENT ON FUNCTION public.aq_performer_short_id IS
+  'Deterministic 7-char performer short id: 2-char name prefix + 5-char hash. Will be superseded by AQ xlsx-provided AQ Performer Id when available.';
+
+-- ============================================================
+-- 4. Seed aq_venue_map from aq_event_map distinct (name, city, state)
+-- ============================================================
+
+-- Seed from ALL aq_event_map rows (including SYS-) so the FK from aq_event_map
+-- to aq_venue_map is satisfied for every row that gets a computed venue_short_id.
+INSERT INTO public.aq_venue_map (venue_short_id, venue_name, city, state, aq_source)
+SELECT DISTINCT ON (public.aq_venue_short_id(venue_name, city, state))
+  public.aq_venue_short_id(venue_name, city, state),
+  venue_name, city, state,
+  CASE WHEN aq_source = 'system_seed' THEN 'system_seed' ELSE 'curated' END
+FROM public.aq_event_map
+WHERE venue_name IS NOT NULL
+ON CONFLICT (venue_short_id) DO NOTHING;
+
+-- ============================================================
+-- 5. Cross-link: tevo_venue_id from venue_assets (join on name+city+state)
+-- ============================================================
+
+UPDATE public.aq_venue_map m SET tevo_venue_id = va.tevo_venue_id,
+                                  latitude  = coalesce(m.latitude,  va.latitude),
+                                  longitude = coalesce(m.longitude, va.longitude)
+FROM public.venue_assets va
+WHERE m.tevo_venue_id IS NULL
+  AND lower(trim(m.venue_name)) = lower(trim(va.venue_name))
+  AND lower(coalesce(m.city,''))  = lower(coalesce(va.city,''))
+  AND lower(coalesce(m.state,'')) = lower(coalesce(va.state,''))
+  -- avoid duplicate tevo_venue_id assignment via UNIQUE constraint
+  AND NOT EXISTS (
+    SELECT 1 FROM public.aq_venue_map m2 WHERE m2.tevo_venue_id = va.tevo_venue_id
+  );
+
+-- ============================================================
+-- 6. Cross-link: sg_venue_id from sg_events_canonical
+-- ============================================================
+
+UPDATE public.aq_venue_map m SET sg_venue_id = sub.sg_venue_id
+FROM (
+  SELECT DISTINCT ON (lower(trim(sg_venue_name)), lower(coalesce(sg_venue_city,'')), lower(coalesce(sg_venue_state,'')))
+    sg_venue_id, sg_venue_name, sg_venue_city, sg_venue_state
+  FROM public.sg_events_canonical
+  WHERE sg_venue_id IS NOT NULL AND sg_venue_name IS NOT NULL
+  ORDER BY lower(trim(sg_venue_name)), lower(coalesce(sg_venue_city,'')), lower(coalesce(sg_venue_state,'')), sg_venue_id
+) sub
+WHERE m.sg_venue_id IS NULL
+  AND lower(trim(m.venue_name)) = lower(trim(sub.sg_venue_name))
+  AND lower(coalesce(m.city,''))  = lower(coalesce(sub.sg_venue_city,''))
+  AND lower(coalesce(m.state,'')) = lower(coalesce(sub.sg_venue_state,''))
+  AND NOT EXISTS (SELECT 1 FROM public.aq_venue_map m2 WHERE m2.sg_venue_id = sub.sg_venue_id);
+
+-- Seed venues that SG knows but aq_event_map doesn't (city+state from SG)
+INSERT INTO public.aq_venue_map (venue_short_id, venue_name, city, state, country, sg_venue_id, aq_source)
+SELECT
+  public.aq_venue_short_id(sg_venue_name, sg_venue_city, sg_venue_state),
+  sg_venue_name, sg_venue_city, sg_venue_state, coalesce(sg_venue_country, 'US'),
+  sg_venue_id, 'system_seed'
+FROM (
+  SELECT DISTINCT ON (sg_venue_id)
+    sg_venue_id, sg_venue_name, sg_venue_city, sg_venue_state, sg_venue_country
+  FROM public.sg_events_canonical
+  WHERE sg_venue_id IS NOT NULL AND sg_venue_name IS NOT NULL
+  ORDER BY sg_venue_id
+) sg
+WHERE NOT EXISTS (SELECT 1 FROM public.aq_venue_map m WHERE m.sg_venue_id = sg.sg_venue_id)
+ON CONFLICT (venue_short_id) DO UPDATE SET
+  sg_venue_id = EXCLUDED.sg_venue_id
+  WHERE aq_venue_map.sg_venue_id IS NULL;
+
+-- ============================================================
+-- 7. Cross-link: tickpick_venue_id from tickpick_orders.raw->'venue'
+-- ============================================================
+
+WITH tp_venues AS (
+  SELECT DISTINCT ON ((raw->'venue'->>'id')::bigint)
+    (raw->'venue'->>'id')::bigint    AS tp_id,
+    raw->'venue'->>'name'            AS tp_name,
+    raw->'venue'->>'city'            AS tp_city,
+    raw->'venue'->>'state'           AS tp_state,
+    NULLIF(raw->'venue'->>'latitude','')::numeric  AS tp_lat,
+    NULLIF(raw->'venue'->>'longitude','')::numeric AS tp_lon
+  FROM public.tickpick_orders
+  WHERE (raw->'venue'->>'id') IS NOT NULL
+  ORDER BY (raw->'venue'->>'id')::bigint
+)
+UPDATE public.aq_venue_map m SET tickpick_venue_id = tp.tp_id,
+                                  latitude  = coalesce(m.latitude,  tp.tp_lat),
+                                  longitude = coalesce(m.longitude, tp.tp_lon)
+FROM tp_venues tp
+WHERE m.tickpick_venue_id IS NULL
+  AND lower(trim(m.venue_name)) = lower(trim(tp.tp_name))
+  AND lower(coalesce(m.city,''))  = lower(coalesce(tp.tp_city,''))
+  AND lower(coalesce(m.state,'')) = lower(coalesce(tp.tp_state,''))
+  AND NOT EXISTS (SELECT 1 FROM public.aq_venue_map m2 WHERE m2.tickpick_venue_id = tp.tp_id);
+
+-- Seed venues TickPick knows but we don't (still pickable by id)
+INSERT INTO public.aq_venue_map (venue_short_id, venue_name, city, state, tickpick_venue_id, latitude, longitude, aq_source)
+SELECT
+  public.aq_venue_short_id(tp_name, tp_city, tp_state),
+  tp_name, tp_city, tp_state, tp_id, tp_lat, tp_lon, 'system_seed'
+FROM (
+  SELECT DISTINCT ON ((raw->'venue'->>'id')::bigint)
+    (raw->'venue'->>'id')::bigint    AS tp_id,
+    raw->'venue'->>'name'            AS tp_name,
+    raw->'venue'->>'city'            AS tp_city,
+    raw->'venue'->>'state'           AS tp_state,
+    NULLIF(raw->'venue'->>'latitude','')::numeric  AS tp_lat,
+    NULLIF(raw->'venue'->>'longitude','')::numeric AS tp_lon
+  FROM public.tickpick_orders
+  WHERE (raw->'venue'->>'id') IS NOT NULL
+  ORDER BY (raw->'venue'->>'id')::bigint
+) tp
+WHERE NOT EXISTS (SELECT 1 FROM public.aq_venue_map m WHERE m.tickpick_venue_id = tp.tp_id)
+ON CONFLICT (venue_short_id) DO UPDATE SET
+  tickpick_venue_id = EXCLUDED.tickpick_venue_id,
+  latitude  = coalesce(aq_venue_map.latitude,  EXCLUDED.latitude),
+  longitude = coalesce(aq_venue_map.longitude, EXCLUDED.longitude)
+  WHERE aq_venue_map.tickpick_venue_id IS NULL;
+
+-- ============================================================
+-- 8. Seed aq_performer_map from aq_event_map.performer + entity_performer_map
+-- ============================================================
+
+INSERT INTO public.aq_performer_map (performer_short_id, performer_name, aq_source)
+SELECT DISTINCT ON (public.aq_performer_short_id(performer))
+  public.aq_performer_short_id(performer),
+  performer,
+  CASE WHEN aq_source = 'system_seed' THEN 'system_seed' ELSE 'curated' END
+FROM public.aq_event_map
+WHERE performer IS NOT NULL AND length(trim(performer)) > 0
+ON CONFLICT (performer_short_id) DO NOTHING;
+
+-- Cross-link tevo_performer_id from entity_performer_map by name
+UPDATE public.aq_performer_map p SET tevo_performer_id = ep.tevo_performer_id,
+                                      category          = ep.top_category_name
+FROM public.entity_performer_map ep
+WHERE p.tevo_performer_id IS NULL
+  AND lower(trim(p.performer_name)) = lower(trim(ep.tevo_performer_name))
+  AND NOT EXISTS (SELECT 1 FROM public.aq_performer_map p2 WHERE p2.tevo_performer_id = ep.tevo_performer_id);
+
+-- ============================================================
+-- 9. aq_event_map: add venue_short_id + performer_short_id FK cols + backfill
+-- ============================================================
+
+ALTER TABLE public.aq_event_map ADD COLUMN IF NOT EXISTS venue_short_id text;
+ALTER TABLE public.aq_event_map ADD COLUMN IF NOT EXISTS performer_short_id text;
+
+UPDATE public.aq_event_map a
+SET venue_short_id = public.aq_venue_short_id(a.venue_name, a.city, a.state)
+WHERE venue_short_id IS NULL AND venue_name IS NOT NULL;
+
+UPDATE public.aq_event_map a
+SET performer_short_id = public.aq_performer_short_id(a.performer)
+WHERE performer_short_id IS NULL AND performer IS NOT NULL;
+
+-- FKs (NOT VALID for instant apply, then VALIDATE)
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'aq_event_map_venue_short_id_fkey'
+  ) THEN
+    ALTER TABLE public.aq_event_map
+      ADD CONSTRAINT aq_event_map_venue_short_id_fkey
+      FOREIGN KEY (venue_short_id) REFERENCES public.aq_venue_map(venue_short_id) NOT VALID;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'aq_event_map_performer_short_id_fkey'
+  ) THEN
+    ALTER TABLE public.aq_event_map
+      ADD CONSTRAINT aq_event_map_performer_short_id_fkey
+      FOREIGN KEY (performer_short_id) REFERENCES public.aq_performer_map(performer_short_id) NOT VALID;
+  END IF;
+END $$;
+
+ALTER TABLE public.aq_event_map VALIDATE CONSTRAINT aq_event_map_venue_short_id_fkey;
+ALTER TABLE public.aq_event_map VALIDATE CONSTRAINT aq_event_map_performer_short_id_fkey;
+
+-- ============================================================
+-- 10. Order/sale tables: add venue_short_id (performer_short_id for the
+--     tables where the column will eventually be wired)
+-- ============================================================
+
+ALTER TABLE public.vivid_orders                 ADD COLUMN IF NOT EXISTS venue_short_id text;
+ALTER TABLE public.tickpick_orders              ADD COLUMN IF NOT EXISTS venue_short_id text;
+ALTER TABLE public.seatgeek_orders              ADD COLUMN IF NOT EXISTS venue_short_id text;
+ALTER TABLE public.seatgeek_sales_snapshots     ADD COLUMN IF NOT EXISTS venue_short_id text;
+ALTER TABLE public.seatgeek_listings_snapshots  ADD COLUMN IF NOT EXISTS venue_short_id text;
+ALTER TABLE public.evo_order_items              ADD COLUMN IF NOT EXISTS venue_short_id text;
+
+ALTER TABLE public.vivid_orders                 ADD COLUMN IF NOT EXISTS performer_short_id text;
+ALTER TABLE public.tickpick_orders              ADD COLUMN IF NOT EXISTS performer_short_id text;
+ALTER TABLE public.evo_order_items              ADD COLUMN IF NOT EXISTS performer_short_id text;
+
+-- Backfill via aq_event_map join (where aq_short_event_id is resolved)
+UPDATE public.vivid_orders v SET venue_short_id = a.venue_short_id, performer_short_id = a.performer_short_id
+FROM public.aq_event_map a
+WHERE v.aq_short_event_id = a.aq_short_event_id
+  AND (v.venue_short_id IS NULL OR v.performer_short_id IS NULL);
+
+UPDATE public.tickpick_orders t SET venue_short_id = a.venue_short_id, performer_short_id = a.performer_short_id
+FROM public.aq_event_map a
+WHERE t.aq_short_event_id = a.aq_short_event_id
+  AND (t.venue_short_id IS NULL OR t.performer_short_id IS NULL);
+
+UPDATE public.seatgeek_orders s SET venue_short_id = a.venue_short_id
+FROM public.aq_event_map a
+WHERE s.aq_short_event_id = a.aq_short_event_id AND s.venue_short_id IS NULL;
+
+UPDATE public.seatgeek_sales_snapshots s SET venue_short_id = a.venue_short_id
+FROM public.aq_event_map a
+WHERE s.aq_short_event_id = a.aq_short_event_id AND s.venue_short_id IS NULL;
+
+UPDATE public.seatgeek_listings_snapshots s SET venue_short_id = a.venue_short_id
+FROM public.aq_event_map a
+WHERE s.aq_short_event_id = a.aq_short_event_id AND s.venue_short_id IS NULL;
+
+UPDATE public.evo_order_items e SET venue_short_id = a.venue_short_id, performer_short_id = a.performer_short_id
+FROM public.aq_event_map a
+WHERE e.aq_short_event_id = a.aq_short_event_id
+  AND (e.venue_short_id IS NULL OR e.performer_short_id IS NULL);
+
+COMMENT ON COLUMN public.vivid_orders.venue_short_id IS
+  'Inherited from aq_event_map.venue_short_id when aq_short_event_id is resolved. Populated by match_unmatched_orders_sweep().';

--- a/supabase/migrations/20260515230000_matcher_v2_tier_1_5.sql
+++ b/supabase/migrations/20260515230000_matcher_v2_tier_1_5.sql
@@ -1,0 +1,336 @@
+-- Migration 20260515230000 · level:admin · lane:Audit/Push · writes:match_to_aq_event_id() v2 (replaces v1 with new tier 1.5), match_unmatched_orders_sweep() v2 (propagates venue/performer short ids) · reads:aq_venue_map · pre:20260515220000
+-- Matcher v2: insert Tier 1.5 (source venue_id + date) between current
+-- Tier 1 and Tier 2. Also extend sweep to propagate venue_short_id and
+-- performer_short_id onto order/sale tables when the AQ event resolves.
+--
+-- Tier 1.5 rationale: catches matches where the venue NAME has drifted
+-- (rename, typo, abbreviation) but the source venue_id is stable.
+-- For TickPick (raw.venue.id) and SG (sg_event_id -> sg_venue_id), we
+-- JOIN aq_venue_map by source-specific venue id to resolve the
+-- canonical venue_short_id, then filter aq_event_map by that
+-- venue_short_id + date ±6h. Conf 0.93 — higher than fuzzy venue
+-- (Tier 3) because we have a stable cross-source id; slightly lower
+-- than direct event_id (Tier 1) because date+venue still allows
+-- multi-event ambiguity within the window.
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14 (this session). Idempotent (CREATE OR REPLACE).
+--
+-- ## Regression risk
+-- None. Function signature on match_to_aq_event_id adds an optional
+-- `p_source_venue_id bigint` param; existing call sites continue to
+-- work because it has a DEFAULT NULL.
+
+-- ============================================================
+-- 1. match_to_aq_event_id v2 — Tier 1.5 inserted
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.match_to_aq_event_id(
+  p_source           text,
+  p_source_event_id  bigint,
+  p_event_name       text,
+  p_venue_name       text,
+  p_event_date       timestamptz,
+  p_lat              numeric DEFAULT NULL,
+  p_lon              numeric DEFAULT NULL,
+  p_source_venue_id  bigint  DEFAULT NULL    -- NEW in v2
+)
+RETURNS TABLE (
+  aq_short_event_id  text,
+  confidence         numeric(3,2),
+  match_method       text
+)
+LANGUAGE plpgsql STABLE SECURITY INVOKER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_aq_id text;
+  v_venue_short_id text;
+BEGIN
+  -- TIER 1: direct ID lookup
+  IF p_source_event_id IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE (p_source IN ('vivid')              AND a.vivid_event_id = p_source_event_id)
+       OR (p_source IN ('seatgeek','sg')      AND a.sg_event_id    = p_source_event_id)
+       OR (p_source IN ('stubhub','sh')       AND a.sh_event_id    = p_source_event_id)
+       OR (p_source IN ('ticketmaster','tm')  AND a.tm_event_id    = p_source_event_id)
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 1.00::numeric(3,2), 'tier1_direct_id'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- TIER 1.5: source venue_id -> aq_venue_map -> venue_short_id + date ±6h
+  IF p_source_venue_id IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT m.venue_short_id INTO v_venue_short_id FROM public.aq_venue_map m
+    WHERE (p_source IN ('tickpick')         AND m.tickpick_venue_id = p_source_venue_id)
+       OR (p_source IN ('seatgeek','sg')    AND m.sg_venue_id       = p_source_venue_id)
+       OR (p_source IN ('tevo','evo')       AND m.tevo_venue_id     = p_source_venue_id)
+    LIMIT 1;
+    IF v_venue_short_id IS NOT NULL THEN
+      SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+      WHERE a.venue_short_id = v_venue_short_id
+        AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                          AND p_event_date + interval '6 hours'
+      ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+      LIMIT 1;
+      IF v_aq_id IS NOT NULL THEN
+        RETURN QUERY SELECT v_aq_id, 0.93::numeric(3,2), 'tier1_5_venue_id_date'::text;
+        RETURN;
+      END IF;
+    END IF;
+  END IF;
+
+  -- TIER 2: exact venue + date within ±6h
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE lower(trim(a.venue_name)) = lower(trim(p_venue_name))
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.95::numeric(3,2), 'tier2_venue_exact_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- TIER 3: fuzzy venue (trigram >= 0.7) + date ±6h
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE similarity(lower(coalesce(a.venue_name,'')), lower(coalesce(p_venue_name,''))) >= 0.7
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY similarity(lower(a.venue_name), lower(p_venue_name)) DESC,
+             abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.80::numeric(3,2), 'tier3_venue_fuzzy_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- TIER 4: coord-based (~1km bbox) + date ±6h
+  IF p_lat IS NOT NULL AND p_lon IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id
+    FROM public.aq_event_map a
+    JOIN public.venue_assets va ON lower(trim(va.venue_name)) = lower(trim(a.venue_name))
+    WHERE va.latitude  BETWEEN p_lat - 0.01 AND p_lat + 0.01
+      AND va.longitude BETWEEN p_lon - 0.02 AND p_lon + 0.02
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY (2 * 6371000 * asin(sqrt(
+       power(sin(radians((va.latitude  - p_lat)/2)), 2)
+       + cos(radians(p_lat)) * cos(radians(va.latitude))
+         * power(sin(radians((va.longitude - p_lon)/2)), 2)
+    )))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.85::numeric(3,2), 'tier4_coord_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN;
+END $$;
+
+COMMENT ON FUNCTION public.match_to_aq_event_id IS
+  'Multi-tier matcher v2: tier1 direct_id -> tier1.5 venue_id+date -> tier2 venue+date exact -> tier3 venue+date fuzzy -> tier4 coord+date. Returns empty set if nothing matches.';
+
+-- ============================================================
+-- 2. match_unmatched_orders_sweep v2 — propagates venue/performer short ids
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.match_unmatched_orders_sweep(
+  p_max_per_table  integer DEFAULT 500,
+  p_create_synthetic boolean DEFAULT true
+)
+RETURNS TABLE (
+  table_name       text,
+  rows_examined    integer,
+  rows_matched     integer,
+  rows_synthetic   integer,
+  rows_unmatched   integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  r RECORD;
+  v_aq_id text; v_conf numeric(3,2); v_method text;
+  v_venue_short_id text; v_performer_short_id text;
+  v_matched int; v_synthetic int; v_examined int;
+BEGIN
+  -- VIVID  (no source venue_id available)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT vivid_order_id, raw, event_name, event_date,
+           (raw->'venue'->>'name')                AS v_venue,
+           NULLIF(raw->>'productionId','')::bigint AS pid
+    FROM public.vivid_orders
+    WHERE aq_short_event_id IS NULL
+      AND status <> 'ignored_tbd_postponed'
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('vivid', r.pid, r.event_name, r.v_venue, r.event_date) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('vivid', r.event_name, r.v_venue, r.event_date, r.pid);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id, a.performer_short_id INTO v_venue_short_id, v_performer_short_id
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.vivid_orders SET
+        aq_short_event_id  = v_aq_id,
+        venue_short_id     = coalesce(venue_short_id,     v_venue_short_id),
+        performer_short_id = coalesce(performer_short_id, v_performer_short_id)
+      WHERE vivid_order_id = r.vivid_order_id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'vivid_orders'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- TICKPICK  (raw.venue.id -> Tier 1.5)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT tp_order_id, raw, event_name, event_date,
+           (raw->'venue'->>'name')                          AS v_venue,
+           NULLIF(raw->'venue'->>'id','')::bigint           AS source_vid,
+           NULLIF(raw->'venue'->>'latitude','')::numeric    AS lat,
+           NULLIF(raw->'venue'->>'longitude','')::numeric   AS lon,
+           NULLIF(raw->>'event_date_utc','')::timestamptz   AS event_date_utc
+    FROM public.tickpick_orders
+    WHERE aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('tickpick', NULL,
+           r.event_name, r.v_venue,
+           coalesce(r.event_date_utc, r.event_date),
+           r.lat, r.lon, r.source_vid) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('tickpick', r.event_name, r.v_venue,
+                                               coalesce(r.event_date_utc, r.event_date));
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id, a.performer_short_id INTO v_venue_short_id, v_performer_short_id
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.tickpick_orders SET
+        aq_short_event_id  = v_aq_id,
+        venue_short_id     = coalesce(venue_short_id,     v_venue_short_id),
+        performer_short_id = coalesce(performer_short_id, v_performer_short_id)
+      WHERE tp_order_id = r.tp_order_id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'tickpick_orders'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- SEATGEEK_ORDERS (legacy seller-direct)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT id, sg_order_id, sg_event_id, sg_event_name, sg_venue, sg_event_date
+    FROM public.seatgeek_orders
+    WHERE aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('seatgeek', r.sg_event_id,
+                                     r.sg_event_name, r.sg_venue,
+                                     r.sg_event_date::timestamptz) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.sg_event_name IS NOT NULL AND r.sg_event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('seatgeek', r.sg_event_name, r.sg_venue,
+                                               r.sg_event_date::timestamptz, r.sg_event_id);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id INTO v_venue_short_id
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.seatgeek_orders SET
+        aq_short_event_id = v_aq_id,
+        venue_short_id    = coalesce(venue_short_id, v_venue_short_id)
+      WHERE id = r.id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'seatgeek_orders'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- SEATGEEK_SALES_SNAPSHOTS  (canonical JOIN for tiers 2-4, sg_venue_id for tier 1.5)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT s.id, s.sg_event_id,
+           c.sg_event_name   AS event_name,
+           c.sg_venue_name   AS venue_name,
+           c.sg_datetime_utc AS event_date,
+           c.sg_venue_id     AS sg_venue_id
+    FROM public.seatgeek_sales_snapshots s
+    LEFT JOIN public.sg_events_canonical c ON c.sg_event_id = s.sg_event_id
+    WHERE s.aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('seatgeek', r.sg_event_id,
+                                     r.event_name, r.venue_name, r.event_date,
+                                     NULL, NULL, r.sg_venue_id) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('seatgeek', r.event_name, r.venue_name,
+                                               r.event_date, r.sg_event_id);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id INTO v_venue_short_id
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.seatgeek_sales_snapshots SET
+        aq_short_event_id = v_aq_id,
+        venue_short_id    = coalesce(venue_short_id, v_venue_short_id)
+      WHERE id = r.id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'seatgeek_sales_snapshots'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+
+  -- EVO_ORDER_ITEMS (venue_id = TEvo venue id -> Tier 1.5)
+  v_examined := 0; v_matched := 0; v_synthetic := 0;
+  FOR r IN
+    SELECT i.id, i.event_id, i.event_name, i.venue_name, i.occurs_at, i.venue_id
+    FROM public.evo_order_items i
+    WHERE i.aq_short_event_id IS NULL
+    LIMIT p_max_per_table
+  LOOP
+    v_examined := v_examined + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('evo', NULL,
+                                     r.event_name, r.venue_name, r.occurs_at,
+                                     NULL, NULL, r.venue_id) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.occurs_at IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('evo', r.event_name, r.venue_name, r.occurs_at);
+      v_synthetic := v_synthetic + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id, a.performer_short_id INTO v_venue_short_id, v_performer_short_id
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.evo_order_items SET
+        aq_short_event_id  = v_aq_id,
+        venue_short_id     = coalesce(venue_short_id,     v_venue_short_id),
+        performer_short_id = coalesce(performer_short_id, v_performer_short_id)
+      WHERE id = r.id;
+      v_matched := v_matched + 1;
+    END IF;
+  END LOOP;
+  RETURN QUERY SELECT 'evo_order_items'::text, v_examined, v_matched, v_synthetic, v_examined - v_matched;
+END $$;
+
+COMMENT ON FUNCTION public.match_unmatched_orders_sweep IS
+  'v2: hourly sweep + propagates venue_short_id/performer_short_id. Calls match_to_aq_event_id v2 (which adds Tier 1.5 venue_id+date). Per-table caps via p_max_per_table.';

--- a/supabase/migrations/20260515240000_listings_aq_linkage.sql
+++ b/supabase/migrations/20260515240000_listings_aq_linkage.sql
@@ -1,0 +1,340 @@
+-- Migration 20260515240000 · level:admin · lane:Audit/Push · writes:listings_snapshots.{aq_short_event_id,venue_short_id,performer_short_id} cols+FKs, seatgeek_seller_listings same, seatgeek_listings_snapshots.performer_short_id, match_unmatched_listings_chunked() fn, match_unmatched_orders_sweep() v3 (+3 listing branches), unified_listings view v2, v_market_listings_by_event view, listings_aq_backfill_overnight cron · reads:events, sg_events_canonical, aq_event_map, aq_venue_map, aq_performer_map · pre:20260515230000
+-- Cross-source LISTINGS AQ-linkage for market tracking.
+--
+-- Operator direction 2026-05-14 (after sales work shipped):
+--   "did we link Evo + SG listings data for market tracking?" → no, deferred.
+--   "use the same matching system from sales matcher to link"
+--   "schedule first mapping run for after 12:01am to run during off peak
+--    times and also schedule to not eat up too much cpu etc, consider
+--    resource usage"
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14 (this session). DDL + function + view + cron
+-- registration are instant. The bulk backfill runs overnight via the
+-- listings_aq_backfill_overnight cron (04:02-04:14 UTC, off-peak, processes
+-- ~100 distinct events per minute with pg_sleep(0.2) between events) and
+-- self-unschedules once events_remaining = 0.
+--
+-- ## Regression risk
+--   views.security_definer_views   — unified_listings rewrite, set security_invoker
+--   cron.failed_jobs_90min          — new cron, will fire 13 times tonight
+--   fks.not_valid_fks               — 6 new FKs, all VALIDATEd in this migration
+
+-- ============================================================
+-- 1. Schema: add canonical-id columns to the 3 listing surfaces
+-- ============================================================
+
+ALTER TABLE public.listings_snapshots          ADD COLUMN IF NOT EXISTS aq_short_event_id  text;
+ALTER TABLE public.listings_snapshots          ADD COLUMN IF NOT EXISTS venue_short_id     text;
+ALTER TABLE public.listings_snapshots          ADD COLUMN IF NOT EXISTS performer_short_id text;
+
+ALTER TABLE public.seatgeek_seller_listings    ADD COLUMN IF NOT EXISTS aq_short_event_id  text;
+ALTER TABLE public.seatgeek_seller_listings    ADD COLUMN IF NOT EXISTS venue_short_id     text;
+ALTER TABLE public.seatgeek_seller_listings    ADD COLUMN IF NOT EXISTS performer_short_id text;
+
+ALTER TABLE public.seatgeek_listings_snapshots ADD COLUMN IF NOT EXISTS performer_short_id text;
+
+-- FKs (NOT VALID first to avoid blocking, VALIDATE at end)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='listings_snapshots_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.listings_snapshots ADD CONSTRAINT listings_snapshots_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='listings_snapshots_venue_short_id_fkey') THEN
+    ALTER TABLE public.listings_snapshots ADD CONSTRAINT listings_snapshots_venue_short_id_fkey
+      FOREIGN KEY (venue_short_id) REFERENCES public.aq_venue_map(venue_short_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='listings_snapshots_performer_short_id_fkey') THEN
+    ALTER TABLE public.listings_snapshots ADD CONSTRAINT listings_snapshots_performer_short_id_fkey
+      FOREIGN KEY (performer_short_id) REFERENCES public.aq_performer_map(performer_short_id) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='seatgeek_seller_listings_aq_short_event_id_fkey') THEN
+    ALTER TABLE public.seatgeek_seller_listings ADD CONSTRAINT seatgeek_seller_listings_aq_short_event_id_fkey
+      FOREIGN KEY (aq_short_event_id) REFERENCES public.aq_event_map(aq_short_event_id) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='seatgeek_seller_listings_venue_short_id_fkey') THEN
+    ALTER TABLE public.seatgeek_seller_listings ADD CONSTRAINT seatgeek_seller_listings_venue_short_id_fkey
+      FOREIGN KEY (venue_short_id) REFERENCES public.aq_venue_map(venue_short_id) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='seatgeek_listings_snapshots_performer_short_id_fkey') THEN
+    ALTER TABLE public.seatgeek_listings_snapshots ADD CONSTRAINT seatgeek_listings_snapshots_performer_short_id_fkey
+      FOREIGN KEY (performer_short_id) REFERENCES public.aq_performer_map(performer_short_id) NOT VALID;
+  END IF;
+END $$;
+
+-- VALIDATE the 6 new FKs (all currently empty cols, so instant)
+ALTER TABLE public.listings_snapshots          VALIDATE CONSTRAINT listings_snapshots_aq_short_event_id_fkey;
+ALTER TABLE public.listings_snapshots          VALIDATE CONSTRAINT listings_snapshots_venue_short_id_fkey;
+ALTER TABLE public.listings_snapshots          VALIDATE CONSTRAINT listings_snapshots_performer_short_id_fkey;
+ALTER TABLE public.seatgeek_seller_listings    VALIDATE CONSTRAINT seatgeek_seller_listings_aq_short_event_id_fkey;
+ALTER TABLE public.seatgeek_seller_listings    VALIDATE CONSTRAINT seatgeek_seller_listings_venue_short_id_fkey;
+ALTER TABLE public.seatgeek_listings_snapshots VALIDATE CONSTRAINT seatgeek_listings_snapshots_performer_short_id_fkey;
+
+-- Index for event-grain UPDATE efficiency on the 8.16M-row table
+CREATE INDEX IF NOT EXISTS listings_snapshots_event_id_aq_null_idx
+  ON public.listings_snapshots (event_id)
+  WHERE aq_short_event_id IS NULL;
+
+-- ============================================================
+-- 2. match_unmatched_listings_chunked() — resource-friendly backfill fn
+-- ============================================================
+-- Processes up to p_max_events DISTINCT unmatched event_ids across the 3
+-- listing surfaces. For each event: one matcher call + one bulk UPDATE
+-- for that event_id's listings (small lock window), then pg_sleep(0.2)
+-- to yield CPU. Synthetic fallback fires when matcher empty.
+
+CREATE OR REPLACE FUNCTION public.match_unmatched_listings_chunked(
+  p_max_events       integer DEFAULT 100,
+  p_create_synthetic boolean DEFAULT true
+)
+RETURNS TABLE (
+  source_table       text,
+  events_processed   integer,
+  listings_updated   integer,
+  synthetic_created  integer,
+  events_remaining   integer
+)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  r RECORD;
+  v_aq_id text; v_venue_short text; v_performer_short text;
+  v_remaining_tevo int; v_remaining_sgb int; v_remaining_sgs int;
+  v_proc int; v_upd int; v_synth int; v_rows int;
+BEGIN
+  ------------------------------------------------------------------
+  -- TEvo listings_snapshots: JOIN events for name/venue/date
+  ------------------------------------------------------------------
+  v_proc := 0; v_upd := 0; v_synth := 0;
+  FOR r IN
+    SELECT DISTINCT ls.event_id,
+                    e.name        AS event_name,
+                    e.venue_name  AS venue_name,
+                    e.venue_id    AS venue_id,
+                    CASE WHEN e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+                         THEN e.occurs_at_local::timestamptz
+                         ELSE NULL END AS event_date
+    FROM public.listings_snapshots ls
+    LEFT JOIN public.events e ON e.id = ls.event_id
+    WHERE ls.aq_short_event_id IS NULL
+    LIMIT p_max_events
+  LOOP
+    v_proc := v_proc + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('evo', NULL, r.event_name, r.venue_name,
+                                     r.event_date, NULL, NULL, r.venue_id) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('evo', r.event_name, r.venue_name, r.event_date);
+      v_synth := v_synth + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id, a.performer_short_id INTO v_venue_short, v_performer_short
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.listings_snapshots ls SET
+        aq_short_event_id  = v_aq_id,
+        venue_short_id     = coalesce(venue_short_id,     v_venue_short),
+        performer_short_id = coalesce(performer_short_id, v_performer_short)
+      WHERE ls.event_id = r.event_id AND ls.aq_short_event_id IS NULL;
+      GET DIAGNOSTICS v_rows = ROW_COUNT;
+      v_upd := v_upd + v_rows;
+    END IF;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  SELECT count(DISTINCT event_id) INTO v_remaining_tevo
+    FROM public.listings_snapshots WHERE aq_short_event_id IS NULL;
+  RETURN QUERY SELECT 'listings_snapshots'::text, v_proc, v_upd, v_synth, v_remaining_tevo;
+
+  ------------------------------------------------------------------
+  -- SG broker listings: JOIN sg_events_canonical
+  ------------------------------------------------------------------
+  v_proc := 0; v_upd := 0; v_synth := 0;
+  FOR r IN
+    SELECT DISTINCT sls.sg_event_id,
+                    c.sg_event_name   AS event_name,
+                    c.sg_venue_name   AS venue_name,
+                    c.sg_venue_id     AS sg_venue_id,
+                    c.sg_datetime_utc AS event_date
+    FROM public.seatgeek_listings_snapshots sls
+    LEFT JOIN public.sg_events_canonical c ON c.sg_event_id = sls.sg_event_id
+    WHERE sls.aq_short_event_id IS NULL
+    LIMIT p_max_events
+  LOOP
+    v_proc := v_proc + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('seatgeek', r.sg_event_id, r.event_name, r.venue_name,
+                                     r.event_date, NULL, NULL, r.sg_venue_id) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('seatgeek', r.event_name, r.venue_name, r.event_date, r.sg_event_id);
+      v_synth := v_synth + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id, a.performer_short_id INTO v_venue_short, v_performer_short
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.seatgeek_listings_snapshots sls SET
+        aq_short_event_id  = v_aq_id,
+        venue_short_id     = coalesce(venue_short_id,     v_venue_short),
+        performer_short_id = coalesce(performer_short_id, v_performer_short)
+      WHERE sls.sg_event_id = r.sg_event_id AND sls.aq_short_event_id IS NULL;
+      GET DIAGNOSTICS v_rows = ROW_COUNT;
+      v_upd := v_upd + v_rows;
+    END IF;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  SELECT count(DISTINCT sg_event_id) INTO v_remaining_sgb
+    FROM public.seatgeek_listings_snapshots WHERE aq_short_event_id IS NULL;
+  RETURN QUERY SELECT 'seatgeek_listings_snapshots'::text, v_proc, v_upd, v_synth, v_remaining_sgb;
+
+  ------------------------------------------------------------------
+  -- SG seller listings: same JOIN target
+  ------------------------------------------------------------------
+  v_proc := 0; v_upd := 0; v_synth := 0;
+  FOR r IN
+    SELECT DISTINCT ssl.sg_event_id,
+                    c.sg_event_name   AS event_name,
+                    c.sg_venue_name   AS venue_name,
+                    c.sg_venue_id     AS sg_venue_id,
+                    c.sg_datetime_utc AS event_date
+    FROM public.seatgeek_seller_listings ssl
+    LEFT JOIN public.sg_events_canonical c ON c.sg_event_id = ssl.sg_event_id
+    WHERE ssl.aq_short_event_id IS NULL
+    LIMIT p_max_events
+  LOOP
+    v_proc := v_proc + 1;
+    SELECT m.aq_short_event_id INTO v_aq_id
+    FROM public.match_to_aq_event_id('seatgeek', r.sg_event_id, r.event_name, r.venue_name,
+                                     r.event_date, NULL, NULL, r.sg_venue_id) m
+    LIMIT 1;
+    IF v_aq_id IS NULL AND p_create_synthetic AND r.event_name IS NOT NULL AND r.event_date IS NOT NULL THEN
+      v_aq_id := public.create_system_aq_event('seatgeek', r.event_name, r.venue_name, r.event_date, r.sg_event_id);
+      v_synth := v_synth + 1;
+    END IF;
+    IF v_aq_id IS NOT NULL THEN
+      SELECT a.venue_short_id, a.performer_short_id INTO v_venue_short, v_performer_short
+      FROM public.aq_event_map a WHERE a.aq_short_event_id = v_aq_id LIMIT 1;
+      UPDATE public.seatgeek_seller_listings ssl SET
+        aq_short_event_id  = v_aq_id,
+        venue_short_id     = coalesce(venue_short_id,     v_venue_short),
+        performer_short_id = coalesce(performer_short_id, v_performer_short)
+      WHERE ssl.sg_event_id = r.sg_event_id AND ssl.aq_short_event_id IS NULL;
+      GET DIAGNOSTICS v_rows = ROW_COUNT;
+      v_upd := v_upd + v_rows;
+    END IF;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  SELECT count(DISTINCT sg_event_id) INTO v_remaining_sgs
+    FROM public.seatgeek_seller_listings WHERE aq_short_event_id IS NULL;
+  RETURN QUERY SELECT 'seatgeek_seller_listings'::text, v_proc, v_upd, v_synth, v_remaining_sgs;
+END $$;
+
+COMMENT ON FUNCTION public.match_unmatched_listings_chunked IS
+  'Resource-friendly chunked backfill for listings AQ-linkage. Per-event matcher + bulk UPDATE + pg_sleep(0.2). Use p_max_events to throttle per-call cost. Called by listings_aq_backfill_overnight cron.';
+
+-- ============================================================
+-- 3. unified_listings v2 — expose aq_short_event_id, venue/performer short_ids
+-- ============================================================
+
+-- CREATE OR REPLACE VIEW can only APPEND columns (not insert/reorder), so the
+-- new aq/venue/performer cols are appended at the end of each union branch.
+CREATE OR REPLACE VIEW public.unified_listings AS
+SELECT 'tevo'::text AS source_key,
+       ls.event_id AS tevo_event_id,
+       NULL::bigint AS sg_event_id,
+       NULL::bigint AS sd_event_id,
+       ls.tevo_ticket_group_id::text AS source_listing_id,
+       ls.section, ls."row", ls.quantity,
+       ls.retail_price, ls.wholesale_price,
+       to_jsonb(ls.splits) AS splits_jsonb,
+       ls.eticket AS is_eticket, ls.wheelchair AS is_wheelchair,
+       ls.instant_delivery AS is_instant, ls.is_ancillary,
+       ls.type AS listing_type, ls.brokerage_name, ls.is_owned,
+       NULL::text AS sg_market_tier, NULL::boolean AS sg_is_b2b,
+       ls.captured_at,
+       ls.aq_short_event_id, ls.venue_short_id, ls.performer_short_id
+FROM public.listings_snapshots ls
+UNION ALL
+SELECT 'sg_broker'::text, sls.tevo_event_id, sls.sg_event_id, NULL::bigint,
+       sls.display_id, sls.section, sls."row", sls.quantity,
+       sls.retail_price_all_in, sls.broadcast_price,
+       sls.splits, NULL::boolean, sls.is_wheelchair_acc, sls.is_instant_download,
+       NULL::boolean, NULL::text, NULL::text, sls.is_broker_owned,
+       sls.market_source, sls.is_b2b, sls.captured_at,
+       sls.aq_short_event_id, sls.venue_short_id, sls.performer_short_id
+FROM public.seatgeek_listings_snapshots sls
+UNION ALL
+SELECT 'sg_seller'::text, ssl.tevo_event_id, ssl.sg_event_id, NULL::bigint,
+       ssl.seller_listing_id, ssl.section, ssl."row", ssl.quantity,
+       ssl.cost, NULL::numeric,
+       to_jsonb(ARRAY[ssl.quantity]), NULL::boolean, NULL::boolean, ssl.is_instant,
+       NULL::boolean, NULL::text, NULL::text, true,
+       'exchange'::text, false, ssl.pulled_at,
+       ssl.aq_short_event_id, ssl.venue_short_id, ssl.performer_short_id
+FROM public.seatgeek_seller_listings ssl
+UNION ALL
+SELECT 'seatdata'::text, sdl.tevo_event_id, NULL::bigint, sdl.sd_event_id,
+       sdl.content_hash, sdl.section, sdl."row", sdl.quantity,
+       sdl.price, NULL::numeric,
+       to_jsonb(ARRAY[sdl.quantity]), NULL::boolean, NULL::boolean, NULL::boolean,
+       NULL::boolean, NULL::text, NULL::text, NULL::boolean,
+       NULL::text, NULL::boolean, sdl.pulled_at,
+       NULL::text, NULL::text, NULL::text       -- seatdata listings table has 0 rows; placeholders
+FROM public.seatdata_listings_snapshots sdl;
+
+ALTER VIEW public.unified_listings SET (security_invoker = true);
+
+-- ============================================================
+-- 4. v_market_listings_by_event — time-series rollup
+-- ============================================================
+
+CREATE OR REPLACE VIEW public.v_market_listings_by_event AS
+SELECT
+  ul.aq_short_event_id,
+  date_trunc('hour', ul.captured_at) AS captured_hour,
+  ul.source_key,
+  count(*)             AS listing_rows,
+  sum(ul.quantity)     AS total_qty,
+  min(ul.retail_price) AS min_price,
+  round(avg(ul.retail_price), 2) AS avg_price,
+  max(ul.retail_price) AS max_price
+FROM public.unified_listings ul
+WHERE ul.aq_short_event_id IS NOT NULL
+GROUP BY 1, 2, 3;
+
+ALTER VIEW public.v_market_listings_by_event SET (security_invoker = true);
+
+COMMENT ON VIEW public.v_market_listings_by_event IS
+  'Per-event, per-hour, per-source rollup of listing prices + quantity for cross-exchange market tracking. Filtered to aq-linked rows; SYS- rows included for clusters of untracked events.';
+
+-- ============================================================
+-- 5. Cron: off-peak chunked backfill — 04:02-04:14 UTC (12:02-12:14 AM ET)
+-- ============================================================
+-- 13 firings × p_max_events=100 = 1,300 event-capacity. The 894+39+46 ≈
+-- 980 distinct events will drain in ~10 firings. After events_remaining=0
+-- the function self-unschedules so subsequent nights are no-ops.
+--
+-- Slot rationale: hour 04 UTC has crons at :00 (espn), :15/:30/:45 (sg_listings),
+-- :20/:35/:50 (collect-listings). The 04:02-04:14 window is conflict-free.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='listings_aq_backfill_overnight') THEN
+    PERFORM cron.schedule(
+      'listings_aq_backfill_overnight',
+      '2-14 4 * * *',
+      $cron$
+        DO $$
+        DECLARE v_remaining int;
+        BEGIN
+          SELECT max(events_remaining) INTO v_remaining
+          FROM public.match_unmatched_listings_chunked(100, true);
+          IF coalesce(v_remaining, 0) = 0 THEN
+            PERFORM cron.unschedule('listings_aq_backfill_overnight');
+          END IF;
+        END $$;
+      $cron$
+    );
+  END IF;
+END $$;

--- a/supabase/migrations/20260515250000_cron_policy_gate.sql
+++ b/supabase/migrations/20260515250000_cron_policy_gate.sql
@@ -1,0 +1,327 @@
+-- Migration 20260515250000 · level:admin · lane:Audit/Push · writes:cron_policy (new), cron_gate_decisions (new), cron_should_fire() fn, cron_last_fire() fn, cron_resume_with_gate() fn, cron_gate_decisions_prune_daily cron, seed policy rows · reads:cron_pause_state_20260514 · pre:20260515240000
+-- Data-driven cron policy gate balancing data-freshness vs resource conservation.
+--
+-- Operator directive 2026-05-14 (after pausing all 71 crons + collecting
+-- hour-of-day activity data + clarifying twin goals):
+--   "can we program crons to use this data effectively?" (peak/off-peak data)
+--   "Consider environmental conservation efforts as an additional focus
+--    aside from data freshness"
+--
+-- Twin goals balanced per-job:
+--   1. FRESHNESS: fire often enough during peak hours to keep data current
+--   2. CONSERVATION: fire only when needed (work present, budget not blown,
+--      interval elapsed). Every avoided fire saves CPU, WAL, network egress,
+--      and carbon.
+--
+-- 4-stage gate (cheap → expensive ordering):
+--   Stage 0: disabled flag (instant kill switch)
+--   Stage 1: daily budget cap (CONSERVATION) — indexed COUNT
+--   Stage 2: min-interval based on peak/off-peak (FRESHNESS guardrail) — indexed MAX
+--   Stage 3: work-presence check (CONSERVATION) — operator-defined EXISTS query
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14 (this session). DDL + functions + 1 retrofit.
+-- Operator graduates additional crons one at a time via cron_resume_with_gate().
+--
+-- ## Regression risk
+-- None. New tables, no view rewrites, no existing-cron mutations except the
+-- single retrofit (sweep_duplicate_listings_hourly was paused, comes back
+-- through gate).
+
+-- ============================================================
+-- 1. cron_policy table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.cron_policy (
+  jobname                  text PRIMARY KEY,
+  peak_hours_et            int[]   NOT NULL,
+  peak_min_interval_min    int     NOT NULL,
+  offpeak_min_interval_min int     NOT NULL,
+  work_check_sql           text,
+  daily_max_fires          int,
+  enabled                  boolean NOT NULL DEFAULT true,
+  notes                    text,
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.cron_policy IS
+  'Per-cron firing policy. peak_hours_et + peak_min_interval_min control freshness window; work_check_sql + daily_max_fires control resource conservation. Gate function: public.cron_should_fire(jobname).';
+
+COMMENT ON COLUMN public.cron_policy.work_check_sql IS
+  'Optional SQL that must return boolean. Gate skips if FALSE/NULL. Keep these as EXISTS (... LIMIT 1) for sub-ms latency. Fails OPEN on SQL error (permits fire) to never silently lose freshness.';
+
+COMMENT ON COLUMN public.cron_policy.daily_max_fires IS
+  'Hard cap on actual fires per UTC day. NULL = unlimited. Conservation guardrail.';
+
+-- ============================================================
+-- 2. cron_gate_decisions audit table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.cron_gate_decisions (
+  jobname        text        NOT NULL,
+  decided_at     timestamptz NOT NULL DEFAULT clock_timestamp(),  -- NOT now() — needs wall-clock for same-txn callability
+  decision       text        NOT NULL,
+  hour_et        int         NOT NULL,
+  last_fire_at   timestamptz,
+  fires_today    int,
+  PRIMARY KEY (jobname, decided_at)
+);
+
+COMMENT ON TABLE public.cron_gate_decisions IS
+  'Audit trail of cron_should_fire() decisions. decision is one of: fire | fire_no_policy | skip_offpeak | skip_interval | skip_no_work | skip_budget | disabled. Pruned to 30 days by cron_gate_decisions_prune_daily (keeps all fire rows).';
+
+CREATE INDEX IF NOT EXISTS cron_gate_decisions_jobname_fire_idx
+  ON public.cron_gate_decisions (jobname, decided_at DESC)
+  WHERE decision = 'fire';
+
+-- ============================================================
+-- 3. cron_last_fire() helper
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.cron_last_fire(p_jobname text)
+RETURNS timestamptz
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+  SELECT max(decided_at) FROM public.cron_gate_decisions
+  WHERE jobname = p_jobname AND decision = 'fire';
+$$;
+
+COMMENT ON FUNCTION public.cron_last_fire IS
+  'Returns timestamp of last successful fire decision for a jobname. Use in work_check_sql expressions.';
+
+-- ============================================================
+-- 4. cron_should_fire() — the 4-stage gate
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.cron_should_fire(p_jobname text)
+RETURNS boolean
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_policy        public.cron_policy%ROWTYPE;
+  v_hour_et       int;
+  v_in_peak       boolean;
+  v_interval_min  int;
+  v_last_fire     timestamptz;
+  v_fires_today   int := NULL;
+  v_has_work      boolean := true;
+  v_decision      text;
+  v_now           timestamptz := clock_timestamp();
+BEGIN
+  v_hour_et := EXTRACT(hour FROM (v_now AT TIME ZONE 'America/New_York'))::int;
+  SELECT * INTO v_policy FROM public.cron_policy WHERE jobname = p_jobname;
+
+  -- No policy row → unconstrained (preserves legacy behavior for non-graduated crons)
+  IF NOT FOUND THEN
+    INSERT INTO public.cron_gate_decisions(jobname, decided_at, decision, hour_et)
+      VALUES (p_jobname, v_now, 'fire_no_policy', v_hour_et);
+    RETURN true;
+  END IF;
+
+  -- Stage 0: explicitly disabled
+  IF NOT v_policy.enabled THEN
+    INSERT INTO public.cron_gate_decisions(jobname, decided_at, decision, hour_et)
+      VALUES (p_jobname, v_now, 'disabled', v_hour_et);
+    RETURN false;
+  END IF;
+
+  -- Stage 1: daily budget (CONSERVATION) — cheapest check first
+  IF v_policy.daily_max_fires IS NOT NULL THEN
+    SELECT count(*) INTO v_fires_today FROM public.cron_gate_decisions
+      WHERE jobname = p_jobname AND decision = 'fire'
+        AND decided_at >= date_trunc('day', v_now AT TIME ZONE 'UTC');
+    IF v_fires_today >= v_policy.daily_max_fires THEN
+      INSERT INTO public.cron_gate_decisions(jobname, decided_at, decision, hour_et, fires_today)
+        VALUES (p_jobname, v_now, 'skip_budget', v_hour_et, v_fires_today);
+      RETURN false;
+    END IF;
+  END IF;
+
+  -- Stage 2: min-interval
+  SELECT max(decided_at) INTO v_last_fire
+    FROM public.cron_gate_decisions
+    WHERE jobname = p_jobname AND decision = 'fire';
+  v_in_peak := v_hour_et = ANY(v_policy.peak_hours_et);
+  v_interval_min := CASE WHEN v_in_peak THEN v_policy.peak_min_interval_min
+                                        ELSE v_policy.offpeak_min_interval_min END;
+  IF v_last_fire IS NOT NULL AND (v_now - v_last_fire) < make_interval(mins => v_interval_min) THEN
+    v_decision := CASE WHEN v_in_peak THEN 'skip_interval' ELSE 'skip_offpeak' END;
+    INSERT INTO public.cron_gate_decisions(jobname, decided_at, decision, hour_et, last_fire_at, fires_today)
+      VALUES (p_jobname, v_now, v_decision, v_hour_et, v_last_fire, v_fires_today);
+    RETURN false;
+  END IF;
+
+  -- Stage 3: work-presence (CONSERVATION)
+  IF v_policy.work_check_sql IS NOT NULL THEN
+    BEGIN
+      EXECUTE v_policy.work_check_sql INTO v_has_work;
+    EXCEPTION WHEN OTHERS THEN
+      -- Bad SQL in policy → permit fire (fail-open to preserve freshness)
+      v_has_work := true;
+    END;
+    IF NOT coalesce(v_has_work, false) THEN
+      INSERT INTO public.cron_gate_decisions(jobname, decided_at, decision, hour_et, last_fire_at, fires_today)
+        VALUES (p_jobname, v_now, 'skip_no_work', v_hour_et, v_last_fire, v_fires_today);
+      RETURN false;
+    END IF;
+  END IF;
+
+  -- All stages passed → fire
+  INSERT INTO public.cron_gate_decisions(jobname, decided_at, decision, hour_et, last_fire_at, fires_today)
+    VALUES (p_jobname, v_now, 'fire', v_hour_et, v_last_fire, v_fires_today);
+  RETURN true;
+END $$;
+
+COMMENT ON FUNCTION public.cron_should_fire IS
+  '4-stage gate: budget(cheap) -> interval -> work-check(expensive). Returns true if fire permitted. Logs every decision to cron_gate_decisions for audit/tuning.';
+
+-- ============================================================
+-- 5. cron_resume_with_gate() — re-enable a paused cron through the gate
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.cron_resume_with_gate(p_jobname text)
+RETURNS text
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_schedule  text;
+  v_cmd       text;
+  v_wrapped   text;
+  v_new_jobid bigint;
+  v_inner     text;
+BEGIN
+  SELECT schedule, command INTO v_schedule, v_cmd
+  FROM public.cron_pause_state_20260514 WHERE jobname = p_jobname;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'jobname % not in cron_pause_state_20260514 snapshot', p_jobname;
+  END IF;
+
+  -- Validate: command must NOT already be a DO block (would create $body$ nesting issues)
+  IF v_cmd ~* '^\s*DO\s+\$' THEN
+    RAISE EXCEPTION 'cron_resume_with_gate cannot auto-wrap a DO-block command for %. Manual wrap required. Original command: %', p_jobname, v_cmd;
+  END IF;
+
+  -- Convert "SELECT ..." → "PERFORM ..." (so it works inside DO block)
+  -- Handle the two common shapes: "SELECT fn();" and "SELECT * FROM fn();"
+  v_inner := trim(both ' ;' from v_cmd);
+  v_inner := regexp_replace(v_inner, '^\s*SELECT\s+\*\s+FROM\s+', 'PERFORM ', 'i');
+  v_inner := regexp_replace(v_inner, '^\s*SELECT\s+',             'PERFORM ', 'i');
+
+  v_wrapped := format(
+    $wrap$DO $body$ BEGIN IF NOT public.cron_should_fire(%L) THEN RETURN; END IF; %s; END $body$;$wrap$,
+    p_jobname, v_inner);
+
+  -- Drop existing entry (paused or active) before scheduling fresh
+  PERFORM cron.unschedule(p_jobname) FROM cron.job WHERE jobname = p_jobname;
+  v_new_jobid := cron.schedule(p_jobname, v_schedule, v_wrapped);
+
+  RETURN format('jobid=%s schedule=%I wrapped=true', v_new_jobid, v_schedule);
+END $$;
+
+COMMENT ON FUNCTION public.cron_resume_with_gate IS
+  'Re-enables a paused cron through the policy gate. Reads original schedule+command from cron_pause_state_20260514, wraps the command in a DO block that calls cron_should_fire(jobname). Rejects already-wrapped DO blocks with clear error.';
+
+-- ============================================================
+-- 6. Seed policy table — 6 default categories from the spot-check data
+-- ============================================================
+
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+   work_check_sql, daily_max_fires, notes)
+VALUES
+  -- Vivid + TickPick ingest (morning + early-afternoon retail peak)
+  ('vivid_orders_queue_30min',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18],
+   15, 60,
+   'SELECT (SELECT max(ordered_at) FROM public.vivid_orders) > coalesce(public.cron_last_fire(''vivid_orders_queue_30min''), ''1970-01-01''::timestamptz) - interval ''24 hours''',
+   60, 'Retail peak 8 AM + 2 PM ET; conserves overnight when no recent activity'),
+  ('tickpick_orders_queue_30min',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18],
+   15, 60,
+   'SELECT (SELECT max(ordered_at) FROM public.tickpick_orders) > coalesce(public.cron_last_fire(''tickpick_orders_queue_30min''), ''1970-01-01''::timestamptz) - interval ''24 hours''',
+   60, 'Daytime peak ~4 PM ET; sharp drop after 6 PM'),
+
+  -- SG broker + seller ingest (evening + late-night broker activity)
+  ('sg_broker_sales_process_30min',
+   ARRAY[12,13,14,15,16,17,18,19,20,21,22,23],
+   15, 60,
+   NULL,
+   60, 'Peak 11 PM ET; sales arrive any time so always check'),
+  ('sg_seller_process_30min',
+   ARRAY[12,13,14,15,16,17,18,19,20,21,22,23],
+   15, 60,
+   NULL,
+   60, 'Mid-day + evening peaks'),
+
+  -- Evo ingest
+  ('evo_orders_queue_30min',
+   ARRAY[9,10,11,12,13,14,15,16,17,18,19,20,21],
+   30, 120,
+   'SELECT (SELECT max(evo_created_at) FROM public.evo_orders) > coalesce(public.cron_last_fire(''evo_orders_queue_30min''), ''1970-01-01''::timestamptz) - interval ''24 hours''',
+   30, 'B2B inventory ops; spread 10 AM-9 PM ET'),
+
+  -- Heavy sweeps — only fire in true off-peak window, cap daily, skip when caught up
+  ('sweep_duplicate_listings_hourly',
+   ARRAY[5,6,7],
+   60, 1440,
+   'SELECT EXISTS (SELECT 1 FROM public.unified_listings WHERE aq_short_event_id IS NOT NULL GROUP BY tevo_event_id, source_key, section, "row", quantity HAVING count(*) > 1 LIMIT 1)',
+   3, 'Heavy sweep — only 5-7 AM ET window, max 3 fires/day, skip if no dups exist'),
+  ('match_unmatched_orders_sweep_hourly',
+   ARRAY[5,6,7],
+   60, 1440,
+   'SELECT EXISTS (SELECT 1 FROM public.unified_orders WHERE aq_short_event_id IS NULL LIMIT 1)',
+   3, 'Heavy sweep — skip if all orders matched (true today after this session)'),
+  ('cross_source_match_tick_30min',
+   ARRAY[5,6,7],
+   30, 720,
+   NULL,
+   6, 'Has 35s tail latency; constrain to off-peak window + budget'),
+
+  -- Real-time refresh views
+  ('latest_event_metrics_refresh_5min',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   5, 30,
+   NULL,
+   200, 'High-cadence during business hours; sparse overnight'),
+  ('dashboard_writes_24h_refresh_60s',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   5, 30,
+   NULL,
+   200, '0.98s avg; cap to 200/day total'),
+
+  -- Always-on (health/vault)
+  ('release_health_check_hourly',
+   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   60, 60, NULL, 24, 'Always-on; one fire per hour exactly')
+ON CONFLICT (jobname) DO NOTHING;
+
+-- ============================================================
+-- 7. Retrofit ONE example cron — proof of pattern
+-- ============================================================
+-- sweep_duplicate_listings_hourly is the biggest non-failing CPU consumer
+-- (97 sec/day in baseline). Simple SELECT body. Safe choice.
+
+DO $retrofit$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.cron_pause_state_20260514 WHERE jobname='sweep_duplicate_listings_hourly') THEN
+    PERFORM public.cron_resume_with_gate('sweep_duplicate_listings_hourly');
+  END IF;
+END $retrofit$;
+
+-- ============================================================
+-- 8. Daily prune of cron_gate_decisions (keeps fires, prunes skips >30d)
+-- ============================================================
+-- 09:01 UTC = 5:01 AM ET — middle of the truly quiet window.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='cron_gate_decisions_prune_daily') THEN
+    PERFORM cron.schedule(
+      'cron_gate_decisions_prune_daily',
+      '1 9 * * *',
+      $cron$DELETE FROM public.cron_gate_decisions WHERE decided_at < now() - interval '30 days' AND decision <> 'fire';$cron$
+    );
+  END IF;
+END $$;

--- a/supabase/migrations/20260515250001_cron_policy_max_staleness_floor.sql
+++ b/supabase/migrations/20260515250001_cron_policy_max_staleness_floor.sql
@@ -1,0 +1,65 @@
+-- Migration 20260515250001 · level:admin · lane:Audit/Push · writes:cron_policy.work_check_sql for 3 ingest crons · reads:- · pre:20260515250000
+-- Max-staleness floor for ingest cron work-checks.
+--
+-- Operator question 2026-05-14: "how do you know when there's no work?"
+-- Honest answer: for SWEEP crons the work-check is directly verifiable
+-- (EXISTS query on the predicate the sweep would scan). For INGEST crons
+-- it's a HEURISTIC — we can't see upstream API state without firing.
+--
+-- Failure mode the heuristic can hit: if a cron stays paused for >24h,
+-- local max(ordered_at) becomes stale, the heuristic keeps reporting "no
+-- recent activity" forever, the cron never fires, data ages indefinitely.
+--
+-- Fix: add a "fire at least every N hours regardless" override clause
+-- to each ingest work-check. This bounds the worst-case staleness from
+-- "unbounded" to N hours.
+--
+-- Per-cron N values:
+--   Vivid/TickPick:  4h floor   (retail surfaces; daytime activity)
+--   Evo:             6h floor   (B2B; lower cadence acceptable)
+--
+-- The OR clause coalesces cron_last_fire() to 1970 so the very first fire
+-- on a fresh DB also passes (NULL < anything would be NULL otherwise).
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14. Idempotent UPDATE — re-running is a no-op
+-- when values already match.
+
+UPDATE public.cron_policy SET
+  work_check_sql = $cs$
+    SELECT
+      (SELECT max(ordered_at) FROM public.vivid_orders)
+        > coalesce(public.cron_last_fire('vivid_orders_queue_30min'),
+                   '1970-01-01'::timestamptz) - interval '24 hours'
+      OR coalesce(public.cron_last_fire('vivid_orders_queue_30min'),
+                  '1970-01-01'::timestamptz) < now() - interval '4 hours'
+  $cs$,
+  notes = 'Retail peak 8 AM + 2 PM ET; 24h activity heuristic + 4h max-staleness floor',
+  updated_at = now()
+WHERE jobname = 'vivid_orders_queue_30min';
+
+UPDATE public.cron_policy SET
+  work_check_sql = $cs$
+    SELECT
+      (SELECT max(ordered_at) FROM public.tickpick_orders)
+        > coalesce(public.cron_last_fire('tickpick_orders_queue_30min'),
+                   '1970-01-01'::timestamptz) - interval '24 hours'
+      OR coalesce(public.cron_last_fire('tickpick_orders_queue_30min'),
+                  '1970-01-01'::timestamptz) < now() - interval '4 hours'
+  $cs$,
+  notes = 'Daytime peak ~4 PM ET; 24h activity heuristic + 4h max-staleness floor',
+  updated_at = now()
+WHERE jobname = 'tickpick_orders_queue_30min';
+
+UPDATE public.cron_policy SET
+  work_check_sql = $cs$
+    SELECT
+      (SELECT max(evo_created_at) FROM public.evo_orders)
+        > coalesce(public.cron_last_fire('evo_orders_queue_30min'),
+                   '1970-01-01'::timestamptz) - interval '24 hours'
+      OR coalesce(public.cron_last_fire('evo_orders_queue_30min'),
+                  '1970-01-01'::timestamptz) < now() - interval '6 hours'
+  $cs$,
+  notes = 'B2B inventory ops; spread 10 AM-9 PM ET; 24h activity heuristic + 6h max-staleness floor',
+  updated_at = now()
+WHERE jobname = 'evo_orders_queue_30min';

--- a/supabase/migrations/20260515250002_sales_freshness_60min.sql
+++ b/supabase/migrations/20260515250002_sales_freshness_60min.sql
@@ -1,0 +1,21 @@
+-- Migration 20260515250002 · level:admin · lane:Audit/Push · writes:cron_policy work_check_sql + offpeak_min_interval for 3 ingest crons · pre:20260515250001
+-- Operator directive 2026-05-14: "unfortunately max staleness should be 60 mins for sales"
+-- Tightens the staleness floor from 4h/6h (set in 20260515250001) to 60min.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-14.
+
+UPDATE public.cron_policy SET
+  work_check_sql = regexp_replace(work_check_sql, 'interval ''4 hours''', 'interval ''60 minutes''', 'g'),
+  notes = notes || ' [staleness floor tightened 4h->60min 2026-05-14]',
+  updated_at = now()
+WHERE jobname IN ('vivid_orders_queue_30min','tickpick_orders_queue_30min');
+
+UPDATE public.cron_policy SET
+  work_check_sql = regexp_replace(work_check_sql, 'interval ''6 hours''', 'interval ''60 minutes''', 'g'),
+  notes = notes || ' [staleness floor tightened 6h->60min 2026-05-14]',
+  updated_at = now()
+WHERE jobname = 'evo_orders_queue_30min';
+
+UPDATE public.cron_policy SET
+  offpeak_min_interval_min = LEAST(offpeak_min_interval_min, 60)
+WHERE jobname IN ('vivid_orders_queue_30min','tickpick_orders_queue_30min','evo_orders_queue_30min');

--- a/supabase/migrations/20260515250003_listings_cadence_halve.sql
+++ b/supabase/migrations/20260515250003_listings_cadence_halve.sql
@@ -1,0 +1,17 @@
+-- Migration 20260515250003 · level:admin · lane:Audit/Push · writes:cron_pause_state_20260514 schedule for 5 TEvo collect-listings-* jobs · pre:20260515250002
+-- Operator directive 2026-05-14: "halve these" (TEvo collect-listings-* cadences).
+-- Updates the snapshot schedules; cron_resume_with_gate() reads from there
+-- so when the operator graduates each cron, it comes back at the new cadence.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-14.
+
+UPDATE public.cron_pause_state_20260514 SET schedule = '1-59/10 * * * *'
+  WHERE jobname = 'collect-listings-0-24h';     -- was 1-59/20 (every 20m) -> every 10m
+UPDATE public.cron_pause_state_20260514 SET schedule = '30 5,17 * * *'
+  WHERE jobname = 'collect-listings-1-7d';      -- was '30 5'   (1/day) -> 2/day
+UPDATE public.cron_pause_state_20260514 SET schedule = '20 4,16 * * *'
+  WHERE jobname = 'collect-listings-7-30d';     -- was '20 4'   (1/day) -> 2/day
+UPDATE public.cron_pause_state_20260514 SET schedule = '35 4,16 * * *'
+  WHERE jobname = 'collect-listings-30-60d';    -- was '35 4'   (1/day) -> 2/day
+UPDATE public.cron_pause_state_20260514 SET schedule = '50 4,16 * * *'
+  WHERE jobname = 'collect-listings-60d+';      -- was '50 4'   (1/day) -> 2/day

--- a/supabase/migrations/20260515260000_sg_tiered_polling.sql
+++ b/supabase/migrations/20260515260000_sg_tiered_polling.sql
@@ -1,0 +1,285 @@
+-- Migration 20260515260000 · level:admin · lane:Audit/Push · writes:sg_event_priority_state (new), sg_priority_policy (new), sg_classify_events() fn, sg_priority_poll_tick() fn, 4 new crons (paused via cron_pause_state_20260514 insert) · reads:sg_events_canonical, aq_event_map, listings_snapshots, sg_broker_pending · pre:20260515250001
+-- Stock-broker-style tiered polling: high-frequency for HOT events (owned + imminent),
+-- throttled for far-future / non-owned. Replaces "every-30-min for all events" with
+-- per-event tier classification + minute-cadence driver that fires only due polls.
+--
+-- Operator directive 2026-05-14:
+--   "for knicks we want to track sales more often closer to event start time where
+--    listings-owned are greater than zero. tie event listing counts in sg and evo to
+--    sales crons as well as event time. think stock broker max data refresh rates while
+--    managing cpu usage, and environmental concerns."
+--
+-- Tier definitions:
+--   HOT     | owned > 0, <6h to event       | 60s   | 360/event/day
+--   WARM    | owned > 0, <24h to event      | 5min  | 96/event/day
+--   COOL    | owned > 0, <7d to event       | 30min | 24/event/day
+--   COLD    | owned > 0, <30d to event      | 4h    | 6/event/day
+--   OBSERVE | upcoming, NOT owned           | 12h   | 2/event/day
+--   SKIP    | far future or no signal       | n/a   | 0
+--
+-- ## Already applied to prod
+-- Applied via MCP 2026-05-14. New crons are paused via cron_pause_state_20260514
+-- snapshot insert; operator graduates through cron_resume_with_gate() per the gate pattern.
+
+CREATE TABLE IF NOT EXISTS public.sg_priority_policy (
+  tier                  text PRIMARY KEY,
+  label                 text NOT NULL,
+  interval_seconds      int  NOT NULL,
+  min_hours_to_event    numeric,
+  max_hours_to_event    numeric,
+  requires_owned        boolean NOT NULL DEFAULT false,
+  daily_polls_per_event int,
+  enabled               boolean NOT NULL DEFAULT true,
+  sort_order            int NOT NULL DEFAULT 0,
+  notes                 text,
+  updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.sg_priority_policy IS
+  'Per-tier polling cadence definitions. Operator edits these to retune. Order of evaluation: lowest sort_order first; first match by (requires_owned + hours-to-event range) wins.';
+
+INSERT INTO public.sg_priority_policy
+  (tier, label, interval_seconds, min_hours_to_event, max_hours_to_event,
+   requires_owned, daily_polls_per_event, sort_order, notes)
+VALUES
+  ('HOT',     'Owned + <6h to event',    60,    0,    6,   true,  360, 1, 'Stock-broker tick rate equivalent'),
+  ('WARM',    'Owned + <24h to event',   300,   6,    24,  true,  96,  2, '5-min cadence; last-day repricing window'),
+  ('COOL',    'Owned + <7d to event',    1800,  24,   168, true,  24,  3, '30-min cadence; 3-7d peak repricing per backtests'),
+  ('COLD',    'Owned + <30d to event',   14400, 168,  720, true,  6,   4, '4-hour cadence; pre-clearance window'),
+  ('OBSERVE', 'Upcoming, not owned',     43200, 0,    720, false, 2,   5, '12-hour cadence; observe broker network'),
+  ('SKIP',    'Far future / no signal',  0,     720,  NULL,false, 0,   6, 'Beyond 30d - rely on per-window collectors')
+ON CONFLICT (tier) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS public.sg_event_priority_state (
+  sg_event_id              bigint PRIMARY KEY,
+  sg_event_name            text,
+  sg_venue_name            text,
+  sg_datetime_utc          timestamptz,
+  aq_short_event_id        text,
+  owned_count_last_7d      int NOT NULL DEFAULT 0,
+  active_listings_last_7d  int NOT NULL DEFAULT 0,
+  tier                     text NOT NULL,
+  hours_to_event           numeric,
+  last_polled_sales_at     timestamptz,
+  last_polled_listings_at  timestamptz,
+  sales_polls_today        int NOT NULL DEFAULT 0,
+  listings_polls_today     int NOT NULL DEFAULT 0,
+  budget_day               date NOT NULL DEFAULT current_date,
+  computed_at              timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE INDEX IF NOT EXISTS sg_event_priority_state_tier_due_idx
+  ON public.sg_event_priority_state (tier, last_polled_sales_at NULLS FIRST);
+CREATE INDEX IF NOT EXISTS sg_event_priority_state_due_listings_idx
+  ON public.sg_event_priority_state (tier, last_polled_listings_at NULLS FIRST);
+
+COMMENT ON TABLE public.sg_event_priority_state IS
+  'Per-sg-event polling state. Tier is recomputed every 5 min by sg_classify_events(). poll_tick() reads this to decide which events to fire next.';
+
+CREATE OR REPLACE FUNCTION public.sg_classify_events()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_updated int := 0;
+BEGIN
+  -- CTE-aggregate-then-join pattern (correlated subqueries on 8.16M-row
+  -- listings_snapshots time out).
+  WITH listings_agg AS (
+    SELECT
+      aq_short_event_id,
+      count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+      count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '7 days'
+      AND aq_short_event_id IS NOT NULL
+    GROUP BY aq_short_event_id
+  ),
+  event_metrics AS (
+    SELECT
+      c.sg_event_id,
+      c.sg_event_name,
+      c.sg_venue_name,
+      c.sg_datetime_utc,
+      a.aq_short_event_id,
+      EXTRACT(epoch FROM (c.sg_datetime_utc - v_now)) / 3600 AS hours_to_event,
+      coalesce(la.owned_cnt, 0)    AS owned_cnt,
+      coalesce(la.listings_cnt, 0) AS listings_cnt
+    FROM public.sg_events_canonical c
+    LEFT JOIN public.aq_event_map a ON a.sg_event_id = c.sg_event_id
+    LEFT JOIN listings_agg la ON la.aq_short_event_id = a.aq_short_event_id
+    WHERE c.sg_datetime_utc IS NOT NULL
+      AND c.sg_datetime_utc BETWEEN v_now - interval '6 hours' AND v_now + interval '60 days'
+  ),
+  classified AS (
+    SELECT em.*,
+      (SELECT p.tier FROM public.sg_priority_policy p
+       WHERE p.enabled = true
+         AND em.hours_to_event >= coalesce(p.min_hours_to_event, -999999)
+         AND em.hours_to_event <  coalesce(p.max_hours_to_event, 999999)
+         AND (p.requires_owned = false OR em.owned_cnt > 0)
+       ORDER BY p.sort_order LIMIT 1) AS tier
+    FROM event_metrics em
+  )
+  INSERT INTO public.sg_event_priority_state AS s
+    (sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+     owned_count_last_7d, active_listings_last_7d, tier, hours_to_event, computed_at)
+  SELECT sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+         owned_cnt, listings_cnt, coalesce(tier, 'SKIP'), hours_to_event, v_now
+  FROM classified
+  WHERE sg_event_id IS NOT NULL
+  ON CONFLICT (sg_event_id) DO UPDATE SET
+    sg_event_name           = EXCLUDED.sg_event_name,
+    sg_venue_name           = EXCLUDED.sg_venue_name,
+    sg_datetime_utc         = EXCLUDED.sg_datetime_utc,
+    aq_short_event_id       = EXCLUDED.aq_short_event_id,
+    owned_count_last_7d     = EXCLUDED.owned_count_last_7d,
+    active_listings_last_7d = EXCLUDED.active_listings_last_7d,
+    tier                    = EXCLUDED.tier,
+    hours_to_event          = EXCLUDED.hours_to_event,
+    computed_at             = EXCLUDED.computed_at,
+    -- Reset daily counters at day rollover
+    sales_polls_today       = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.sales_polls_today END,
+    listings_polls_today    = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.listings_polls_today END,
+    budget_day              = current_date;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END $func$;
+
+COMMENT ON FUNCTION public.sg_classify_events IS
+  'Recomputes per-event tier + metrics. Run every 5 min. Reads sg_events_canonical join aq_event_map (sg_event_id) and listings_snapshots (aq_short_event_id) for owned + active counts. Cost: O(N) where N=upcoming sg events. Resets daily poll counters at day rollover.';
+
+-- Note: secret is SEATGEEK_API_TOKEN (matches get_app_secret allowlist).
+-- Token in query string (mirrors existing sg_broker_sales_queue pattern).
+-- Return cols prefixed rpt_* to avoid ambiguity with sg_priority_policy.tier column.
+DROP FUNCTION IF EXISTS public.sg_priority_poll_tick(int);
+CREATE OR REPLACE FUNCTION public.sg_priority_poll_tick(p_max_polls int DEFAULT 50)
+RETURNS TABLE (rpt_tier text, rpt_events_polled int, rpt_scope text)
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  r RECORD;
+  v_req bigint;
+  v_now timestamptz := clock_timestamp();
+  v_token text := public.get_app_secret('SEATGEEK_API_TOKEN');
+  v_polled_sales jsonb := '{}'::jsonb;
+  v_polled_listings jsonb := '{}'::jsonb;
+  v_remaining int := p_max_polls;
+  v_tier_name text;
+BEGIN
+  IF v_token IS NULL OR v_token = '' THEN
+    RAISE NOTICE 'sg_priority_poll_tick: SEATGEEK_API_TOKEN missing';
+    RETURN;
+  END IF;
+
+  FOR r IN
+    SELECT s.sg_event_id, s.tier, s.sales_polls_today, p.interval_seconds, p.daily_polls_per_event
+    FROM public.sg_event_priority_state s
+    JOIN public.sg_priority_policy p ON p.tier = s.tier AND p.enabled = true
+    WHERE p.tier <> 'SKIP'
+      AND s.sg_datetime_utc > v_now - interval '2 hours'
+      AND (s.last_polled_sales_at IS NULL
+           OR v_now - s.last_polled_sales_at >= make_interval(secs => p.interval_seconds))
+      AND (p.daily_polls_per_event IS NULL OR s.sales_polls_today < p.daily_polls_per_event)
+    ORDER BY p.sort_order, s.sg_datetime_utc
+    LIMIT v_remaining
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/sales?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+    INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+      VALUES (r.sg_event_id, 'sales', v_req, v_now);
+    UPDATE public.sg_event_priority_state
+      SET last_polled_sales_at = v_now, sales_polls_today = sales_polls_today + 1
+      WHERE sg_event_id = r.sg_event_id;
+    v_polled_sales := v_polled_sales || jsonb_build_object(r.tier, coalesce((v_polled_sales->>r.tier)::int, 0) + 1);
+    v_remaining := v_remaining - 1;
+    EXIT WHEN v_remaining <= 0;
+  END LOOP;
+
+  IF v_remaining > 0 THEN
+    FOR r IN
+      SELECT s.sg_event_id, s.tier, s.listings_polls_today, p.interval_seconds, p.daily_polls_per_event
+      FROM public.sg_event_priority_state s
+      JOIN public.sg_priority_policy p ON p.tier = s.tier AND p.enabled = true
+      WHERE p.tier <> 'SKIP'
+        AND s.sg_datetime_utc > v_now - interval '2 hours'
+        AND (s.last_polled_listings_at IS NULL
+             OR v_now - s.last_polled_listings_at >= make_interval(secs => p.interval_seconds))
+        AND (p.daily_polls_per_event IS NULL OR s.listings_polls_today < p.daily_polls_per_event)
+      ORDER BY p.sort_order, s.sg_datetime_utc
+      LIMIT v_remaining
+    LOOP
+      SELECT net.http_get(
+        url := 'https://brokerdata.seatgeek.com/listings?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+        timeout_milliseconds := 30000
+      ) INTO v_req;
+      INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+        VALUES (r.sg_event_id, 'listings', v_req, v_now);
+      UPDATE public.sg_event_priority_state
+        SET last_polled_listings_at = v_now, listings_polls_today = listings_polls_today + 1
+        WHERE sg_event_id = r.sg_event_id;
+      v_polled_listings := v_polled_listings || jsonb_build_object(r.tier, coalesce((v_polled_listings->>r.tier)::int, 0) + 1);
+      v_remaining := v_remaining - 1;
+      EXIT WHEN v_remaining <= 0;
+    END LOOP;
+  END IF;
+
+  FOR v_tier_name IN SELECT pp.tier FROM public.sg_priority_policy pp WHERE pp.enabled = true AND pp.tier <> 'SKIP'
+  LOOP
+    rpt_tier := v_tier_name;
+    rpt_scope := 'sales';
+    rpt_events_polled := coalesce((v_polled_sales->>v_tier_name)::int, 0);
+    RETURN NEXT;
+    rpt_scope := 'listings';
+    rpt_events_polled := coalesce((v_polled_listings->>v_tier_name)::int, 0);
+    RETURN NEXT;
+  END LOOP;
+END $func$;
+
+COMMENT ON FUNCTION public.sg_priority_poll_tick IS
+  'High-frequency polling driver. Reads sg_event_priority_state, fires HTTP polls for events whose tier interval has elapsed. p_max_polls caps per-fire cost. Sales loop runs first, then listings with remaining budget.';
+
+-- Register the 4 new crons as PAUSED in the snapshot so operator can graduate via cron_resume_with_gate.
+-- We use INSERT into the snapshot (not cron.schedule) so they're recorded but not active.
+INSERT INTO public.cron_pause_state_20260514 (jobid, jobname, schedule, command)
+VALUES
+  (10000260001, 'sg_classify_events_5min', '*/5 * * * *',
+   'SELECT public.sg_classify_events();'),
+  (10000260002, 'sg_priority_poll_tick_1min', '* * * * *',
+   'SELECT * FROM public.sg_priority_poll_tick(50);'),
+  (10000260003, 'sg_priority_sales_process_1min', '* * * * *',
+   'SELECT public.sg_broker_sales_process();'),
+  (10000260004, 'sg_priority_listings_process_1min', '* * * * *',
+   'SELECT public.sg_broker_listings_process();')
+ON CONFLICT (jobid) DO NOTHING;
+
+-- Seed cron_policy rows for the 4 new crons so cron_resume_with_gate works
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+   work_check_sql, daily_max_fires, notes)
+VALUES
+  ('sg_classify_events_5min',
+   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   5, 15, NULL, 288, 'Always-on reclassifier; 5-min cadence captures tier transitions'),
+  ('sg_priority_poll_tick_1min',
+   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   1, 5,
+   'SELECT EXISTS (SELECT 1 FROM public.sg_event_priority_state WHERE tier IN (''HOT'',''WARM'',''COOL'') LIMIT 1)',
+   1440, 'Fires every minute IF there is any HOT/WARM/COOL event; gate work_check_sql short-circuits when nothing imminent'),
+  ('sg_priority_sales_process_1min',
+   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   1, 5,
+   'SELECT EXISTS (SELECT 1 FROM public.sg_broker_pending WHERE scope=''sales'' AND resolved_at IS NULL LIMIT 1)',
+   1440, 'Drains pending sales queue; skip when nothing pending'),
+  ('sg_priority_listings_process_1min',
+   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   1, 5,
+   'SELECT EXISTS (SELECT 1 FROM public.sg_broker_pending WHERE scope=''listings'' AND resolved_at IS NULL LIMIT 1)',
+   1440, 'Drains pending listings queue; skip when nothing pending')
+ON CONFLICT (jobname) DO NOTHING;

--- a/supabase/migrations/20260515270000_sg_classifier_v2_owned_via_tevo_xref.sql
+++ b/supabase/migrations/20260515270000_sg_classifier_v2_owned_via_tevo_xref.sql
@@ -1,0 +1,79 @@
+-- Migration 20260515270000 · level:admin · lane:Audit/Push · writes:sg_classify_events() v2 · pre:20260515260000
+-- The v1 classifier (20260515260000) only counted owned listings via
+-- aq_event_map.sg_event_id linkage, so events not in aq_event_map (Knicks
+-- playoffs, NBA games whose AQ row is SYS-, etc.) classified as OBSERVE.
+-- 157 of our owned events DO have sg_events_canonical.tevo_event_id mapped
+-- directly. v2 uses BOTH join paths so HOT/WARM/COOL/COLD light up.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-14.
+-- Post-apply: HOT=0 (no events <6h right now), WARM=4, COOL=30, COLD=69
+-- = 103 owned events now classified for tiered polling.
+
+CREATE OR REPLACE FUNCTION public.sg_classify_events()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_updated int := 0;
+BEGIN
+  WITH listings_by_tevo AS (
+    SELECT event_id AS tevo_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '7 days' AND event_id IS NOT NULL
+    GROUP BY event_id
+  ),
+  listings_by_aq AS (
+    SELECT aq_short_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '7 days' AND aq_short_event_id IS NOT NULL
+    GROUP BY aq_short_event_id
+  ),
+  event_metrics AS (
+    SELECT
+      c.sg_event_id, c.sg_event_name, c.sg_venue_name, c.sg_datetime_utc,
+      coalesce(a.aq_short_event_id,
+               (SELECT aem.aq_short_event_id FROM public.aq_event_map aem WHERE aem.sg_event_id = c.sg_event_id LIMIT 1)) AS aq_short_event_id,
+      EXTRACT(epoch FROM (c.sg_datetime_utc - v_now)) / 3600 AS hours_to_event,
+      coalesce(lt.owned_cnt,    la.owned_cnt,    0) AS owned_cnt,
+      coalesce(lt.listings_cnt, la.listings_cnt, 0) AS listings_cnt
+    FROM public.sg_events_canonical c
+    LEFT JOIN public.aq_event_map a ON a.sg_event_id = c.sg_event_id
+    LEFT JOIN listings_by_tevo lt ON lt.tevo_event_id = c.tevo_event_id
+    LEFT JOIN listings_by_aq   la ON la.aq_short_event_id = a.aq_short_event_id
+    WHERE c.sg_datetime_utc IS NOT NULL
+      AND c.sg_datetime_utc BETWEEN v_now - interval '6 hours' AND v_now + interval '60 days'
+  ),
+  classified AS (
+    SELECT em.*,
+      (SELECT p.tier FROM public.sg_priority_policy p
+       WHERE p.enabled = true
+         AND em.hours_to_event >= coalesce(p.min_hours_to_event, -999999)
+         AND em.hours_to_event <  coalesce(p.max_hours_to_event, 999999)
+         AND (p.requires_owned = false OR em.owned_cnt > 0)
+       ORDER BY p.sort_order LIMIT 1) AS tier
+    FROM event_metrics em
+  )
+  INSERT INTO public.sg_event_priority_state AS s
+    (sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+     owned_count_last_7d, active_listings_last_7d, tier, hours_to_event, computed_at)
+  SELECT sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+         owned_cnt, listings_cnt, coalesce(tier, 'SKIP'), hours_to_event, v_now
+  FROM classified WHERE sg_event_id IS NOT NULL
+  ON CONFLICT (sg_event_id) DO UPDATE SET
+    sg_event_name=EXCLUDED.sg_event_name, sg_venue_name=EXCLUDED.sg_venue_name,
+    sg_datetime_utc=EXCLUDED.sg_datetime_utc, aq_short_event_id=EXCLUDED.aq_short_event_id,
+    owned_count_last_7d=EXCLUDED.owned_count_last_7d,
+    active_listings_last_7d=EXCLUDED.active_listings_last_7d,
+    tier=EXCLUDED.tier, hours_to_event=EXCLUDED.hours_to_event, computed_at=EXCLUDED.computed_at,
+    sales_polls_today    = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.sales_polls_today END,
+    listings_polls_today = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.listings_polls_today END,
+    budget_day = current_date;
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END $func$;

--- a/supabase/migrations/20260515270100_listings_delta_columns.sql
+++ b/supabase/migrations/20260515270100_listings_delta_columns.sql
@@ -1,0 +1,97 @@
+-- Migration 20260515270100 · level:admin · lane:Audit/Push · writes:listings_snapshots/seatgeek_listings_snapshots prev_* cols + chunked backfill fn + overnight cron · pre:20260515270000
+-- Pattern A change-tracking deltas: store prev_price + prev_qty so analytics
+-- can answer "what changed" without self-join over 8.16M rows.
+-- delta is computed at query time as (current - prev). Avoids GENERATED STORED
+-- which would force a table rewrite (ran out of disk on first attempt).
+--
+-- Overnight backfill: 04:30-04:44 UTC = 12:30-12:44am ET, after listings_aq_backfill window.
+-- Chunked: 100 events per minute with pg_sleep(0.1) yields between events.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-14.
+
+ALTER TABLE public.listings_snapshots
+  ADD COLUMN IF NOT EXISTS prev_retail_price numeric,
+  ADD COLUMN IF NOT EXISTS prev_quantity int;
+
+ALTER TABLE public.seatgeek_listings_snapshots
+  ADD COLUMN IF NOT EXISTS prev_broadcast_price numeric,
+  ADD COLUMN IF NOT EXISTS prev_quantity int;
+
+CREATE INDEX IF NOT EXISTS listings_snapshots_price_change_idx
+  ON public.listings_snapshots (event_id, captured_at)
+  WHERE prev_retail_price IS NOT NULL AND retail_price <> prev_retail_price;
+
+CREATE INDEX IF NOT EXISTS sg_listings_price_change_idx
+  ON public.seatgeek_listings_snapshots (sg_event_id, captured_at)
+  WHERE prev_broadcast_price IS NOT NULL AND broadcast_price <> prev_broadcast_price;
+
+CREATE OR REPLACE FUNCTION public.listings_deltas_backfill_chunked(p_max_events int DEFAULT 100)
+RETURNS TABLE (source_table text, events_processed int, rows_updated int, events_remaining int)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE r RECORD; v_proc int; v_upd int; v_rows int; v_remaining int;
+BEGIN
+  v_proc := 0; v_upd := 0;
+  FOR r IN
+    SELECT DISTINCT event_id FROM public.listings_snapshots
+    WHERE prev_retail_price IS NULL AND event_id IS NOT NULL LIMIT p_max_events
+  LOOP
+    v_proc := v_proc + 1;
+    WITH ranked AS (
+      SELECT id, lag(retail_price) OVER w AS pr_price, lag(quantity) OVER w AS pr_qty
+      FROM public.listings_snapshots
+      WHERE event_id = r.event_id
+      WINDOW w AS (PARTITION BY tevo_ticket_group_id ORDER BY captured_at)
+    )
+    UPDATE public.listings_snapshots ls SET prev_retail_price = ranked.pr_price, prev_quantity = ranked.pr_qty
+    FROM ranked WHERE ls.id = ranked.id AND ranked.pr_price IS NOT NULL;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    v_upd := v_upd + v_rows;
+    PERFORM pg_sleep(0.1);
+  END LOOP;
+  SELECT count(DISTINCT event_id) INTO v_remaining FROM public.listings_snapshots
+    WHERE prev_retail_price IS NULL AND event_id IS NOT NULL;
+  RETURN QUERY SELECT 'listings_snapshots'::text, v_proc, v_upd, v_remaining;
+
+  v_proc := 0; v_upd := 0;
+  FOR r IN
+    SELECT DISTINCT sg_event_id FROM public.seatgeek_listings_snapshots
+    WHERE prev_broadcast_price IS NULL AND sg_event_id IS NOT NULL LIMIT p_max_events
+  LOOP
+    v_proc := v_proc + 1;
+    WITH ranked AS (
+      SELECT id, lag(broadcast_price) OVER w AS pr_price, lag(quantity) OVER w AS pr_qty
+      FROM public.seatgeek_listings_snapshots
+      WHERE sg_event_id = r.sg_event_id
+      WINDOW w AS (PARTITION BY display_id ORDER BY captured_at)
+    )
+    UPDATE public.seatgeek_listings_snapshots sls SET prev_broadcast_price = ranked.pr_price, prev_quantity = ranked.pr_qty
+    FROM ranked WHERE sls.id = ranked.id AND ranked.pr_price IS NOT NULL;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    v_upd := v_upd + v_rows;
+    PERFORM pg_sleep(0.1);
+  END LOOP;
+  SELECT count(DISTINCT sg_event_id) INTO v_remaining FROM public.seatgeek_listings_snapshots
+    WHERE prev_broadcast_price IS NULL AND sg_event_id IS NOT NULL;
+  RETURN QUERY SELECT 'seatgeek_listings_snapshots'::text, v_proc, v_upd, v_remaining;
+END $func$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='listings_deltas_backfill_overnight') THEN
+    PERFORM cron.schedule(
+      'listings_deltas_backfill_overnight',
+      '30-44 4 * * *',
+      $cron$
+        DO $body$
+        DECLARE v_remaining int;
+        BEGIN
+          SELECT max(events_remaining) INTO v_remaining
+          FROM public.listings_deltas_backfill_chunked(100);
+          IF coalesce(v_remaining, 0) = 0 THEN
+            PERFORM cron.unschedule('listings_deltas_backfill_overnight');
+          END IF;
+        END $body$;
+      $cron$
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Operator direction 2026-05-14: \"make AQ Short Event ID the primary key and map to that, also add AQ Short Event ID to our sql table and make it primary key\"

Architecture pivot — \`aq_event_map.aq_short_event_id\` becomes the canonical cross-source event identifier. Every order table now FKs to it. Replaces the earlier idea of bridging through \`events.id\` (TEvo), which suffered from TEvo's ingest-window gap + sg_canonical matcher false-positives (Sky@Lynx misalignment).

## Schema changes

- DROP/RECREATE \`aq_event_map\` with \`aq_short_event_id text\` PK (7-char operator-curated codes like \`OOGGA66\`)
- \`event_id_uuid\` kept as secondary identifier
- 7 indexes (vivid/sg/sh/tm/uuid/date/venue+date)
- \`aq_event_map_ingest(jsonb)\` — idempotent UPSERT, scrubs non-numeric chars from source IDs
- 4 NOT VALID FKs declared then VALIDATED:
  - \`vivid_orders.aq_short_event_id → aq_event_map\`
  - \`tickpick_orders.aq_short_event_id → aq_event_map\`
  - \`seatgeek_orders.aq_short_event_id → aq_event_map\`
  - \`evo_order_items.aq_short_event_id → aq_event_map\`

## Data load + population coverage

| Table | Total | With AQ ID | % | Method |
|---|---|---|---|---|
| vivid_orders | 822 | 564 | **68.6%** | direct: \`raw.productionId = aq.vivid_event_id\` |
| tickpick_orders | 909 | 581 | **63.9%** | venue+date join |
| evo_order_items | 143 | 37 | 25.9% | events → AQ venue+date |
| seatgeek_orders | 400 | 0 | 0% (correct) | all historical 2018-2025; AQ is forward-only |

5,921 rows from kjUntitled spreadsheet.xlsx loaded (238 unclassified rows dropped — they had zero external IDs).

## Already applied to prod

Applied via MCP this session. The migration file replays cleanly on a fresh DB (re-run the xlsx → /rpc/aq_event_map_ingest path to populate aq_event_map, then the UPDATE statements at the end of the migration body backfill the order tables).

## Test plan

- [x] MCP \`SELECT count(*) FROM aq_event_map\` = 5,921
- [x] MCP \`SELECT count(aq_short_event_id) FROM vivid_orders\` = 564
- [x] All 4 FK constraints VALIDATED (convalidated = true)
- [x] release_health_check() reports no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)