### PR TITLE
chore(governance): per-service Render edit access for D1+D2; A1 workspace-wide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,34 @@ Lane assignments per `LANE_DISCIPLINE.md`:
 - **C1** — supervisor docs + audit harnesses + lane discipline
 - Operator may explicitly route HTML work to a bot outside its default lane (this is the override path)
 
+### 4. Render workspace — per-service scoped access (2026-05-14)
+
+Render MCP tools (`mcp__render__*`) are gated per-bot to their assigned service. Cross-service writes are forbidden without operator approval.
+
+**A1 (Admin) — exclusive workspace-wide access:**
+- All `mcp__render__*` tools on any service
+- Workspace-level operations: `create_web_service`, `create_postgres`, `create_static_site`, `create_cron_job`, `select_workspace`
+- A1 is the only bot authorized to provision, delete, or change ownership of services
+
+**D1 — scoped to `vibepass-storefront-test` (`srv-d8140bnaqgkc73al4asg`):**
+- Read freely: `list_services`, `get_service`, `list_deploys`, `get_deploy`, `list_logs`, `get_metrics`
+- **Write OK on this service** (no per-call ask): `update_environment_variables`, `update_web_service` (config / branch / build / start commands), restart, redeploy triggers
+- Forbidden: any operation on `d2-orders-dashboard` or `hi-events` or workspace-level resources
+
+**D2 — scoped to `d2-orders-dashboard` (`srv-d82b4kl7vvec73b4r3r0`):**
+- Same as D1 but for its assigned service
+- Write OK on `d2-orders-dashboard` only
+- Forbidden: any operation on `vibepass-storefront-test`, `hi-events`, or workspace-level resources
+
+**All other bots (B1, C1, D0, D3, D4):**
+- Read-only across all services (monitoring is universal)
+- All writes require explicit operator approval
+
+**Standing rules across all bots:**
+- Read ops always OK (no per-call ask)
+- Service Tokens are the preferred mechanism for enforcement when feasible (Render's Member-role token can't perform writes by API constraint, providing hard isolation beyond policy). Until tokens are scoped per-bot, the scoping is policy-level and audited via Render's audit log.
+- Cross-service writes (D1 touching D2's service or vice versa) = lane violation, surfaces as `flag` in `bot_chat` per existing cross-lane rules
+
 ## Cross-lane writes
 
 If your work needs to touch another lane's surface:

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -133,6 +133,7 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 
 **Owns deploy infra:**
 - **Render service: `vibepass-storefront-test`** (`srv-d8140bnaqgkc73al4asg`). D1 manages env vars, deploy config, log monitoring, and `render.yaml` IaC for this service exclusively. Auto-deploys from `main` branch.
+- **Render MCP write authority on this service** (no per-call operator ask): `update_environment_variables`, `update_web_service`, redeploy triggers, restart. Cross-service ops (anything touching `d2-orders-dashboard` or workspace-level) remain forbidden without operator approval.
 - D1 does **NOT** own `d2-orders-dashboard` — that surface is D2's (see below).
 
 ### D2 — Order Clients
@@ -157,7 +158,8 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 **Reads:** events, performer / venue context for join purposes, A1's listings tables for cross-validation
 
 **Owns deploy infra:**
-- **Render service: `d2-orders-dashboard`** (`srv-d82b4kl7vvec73b4r3r0`). D2 manages env vars, deploy config, log monitoring, and (when created) `render-d2-dashboard.yaml` IaC for this service exclusively. Auto-deploys from `main` branch; D2's order-related PRs that affect `d2_dashboard/` trigger auto-redeploys on merge.
+- **Render service: `d2-orders-dashboard`** (`srv-d82b4kl7vvec73b4r3r0`). D2 manages env vars, deploy config, log monitoring, and `render-d2-dashboard.yaml` IaC for this service exclusively. Auto-deploys from `main` branch; D2's order-related PRs that affect `d2_dashboard/` trigger auto-redeploys on merge.
+- **Render MCP write authority on this service** (no per-call operator ask): `update_environment_variables`, `update_web_service`, redeploy triggers, restart. Cross-service ops (anything touching `vibepass-storefront-test` or workspace-level) remain forbidden without operator approval.
 - D2 does **NOT** own `vibepass-storefront-test` — that surface is D1's.
 
 ### Undelivered FE (sub of D2)
@@ -224,7 +226,11 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
    | `hi-events` (separate repo) | `srv-d7g0cev7f7vs73blkc70` | n/a (not Terminal-2) | — | `develop` | — |
 
    - Each owner-bot manages **env vars, deploy config, log monitoring, and IaC blueprint** for their specific service. They do NOT touch the other bot's service.
-   - Render MCP tools (`mcp__render__*`) — **read** ops (`list_services`, `get_service`, `list_deploys`, `list_logs`, `get_metrics`) are available to both D1 and D2 (scoped by service-id in arguments). **Write** ops (`update_environment_variables`, `update_web_service`, `create_*`) require operator approval per the standard "Render is read-only by default" rule in `CLAUDE.md §4`.
+   - Per-bot Render access scope (per CLAUDE.md §4, 2026-05-14):
+     - **A1** — exclusive workspace-wide access: all read + write ops on any service, plus `create_*` / `select_workspace` (only bot authorized to provision or delete services)
+     - **D1** — scoped to `vibepass-storefront-test`: read + write OK on this service (env vars, redeploy, update_web_service); forbidden on `d2-orders-dashboard` and workspace-level ops
+     - **D2** — scoped to `d2-orders-dashboard`: read + write OK on this service; forbidden on `vibepass-storefront-test` and workspace-level ops
+     - **B1 / C1 / D0 / D3 / D4** — read-only across all services; writes require operator approval
    - Both services auto-deploy from `main`. A1 (sole pusher to main) merges PRs; each push triggers auto-deploys on both services since both watch `main`. If a PR only touches one service's surface, the other service still redeploys (no-op for it but burns build minutes — acceptable for free tier).
    - **Future split** option if build-time waste becomes painful: each service moves to a bot-specific deploy branch (e.g. `d1/release`, `d2/release`), and A1 fast-forwards each one when their respective code paths change. Deferred until volume justifies the merge-coordination cost.
 


### PR DESCRIPTION
Refines PR #104 (ownership-only) to grant D1+D2 explicit write authority on their assigned services. A1 retains exclusive workspace-wide access for create/delete/provision. Other bots stay read-only.

Operator directive: 'allow them read access to monitor and edit those respective renders. d1 is assigned vibepass-storefront-test. A1 has exclusive entire render workspace access'.

Files: CLAUDE.md (new §4), LANE_DISCIPLINE.md (§Rule #6 + per-bot sections).