### PR TITLE
feat(d0): provision Render env for D0 broker terminal lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,14 @@ Render MCP tools (`mcp__render__*`) are gated per-bot to their assigned service.
 **D2 — scoped to `d2-orders-dashboard` (`srv-d82b4kl7vvec73b4r3r0`):**
 - Same as D1 but for its assigned service
 - Write OK on `d2-orders-dashboard` only
-- Forbidden: any operation on `vibepass-storefront-test`, `hi-events`, or workspace-level resources
+- Forbidden: any operation on `vibepass-storefront-test`, `vibepass-terminal-test`, `hi-events`, or workspace-level resources
 
-**All other bots (B1, C1, D0, D3, D4):**
+**D0 — scoped to `vibepass-terminal-test` (provisioned 2026-05-15):**
+- Same as D1/D2 but for its assigned service (static-site type, serves `static/terminal/*`)
+- Write OK on `vibepass-terminal-test` only
+- Forbidden: any operation on other services or workspace-level resources
+
+**All other bots (B1, C1, D3, D4):**
 - Read-only across all services (monitoring is universal)
 - All writes require explicit operator approval
 

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -222,15 +222,17 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
    | Render service | ID | Owner bot | Source code | Branch | IaC file |
    |---|---|---|---|---|---|
    | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | **D1** | `app.py`, `static/store/*` | `main` | `render.yaml` |
-   | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | **D2** | `d2_dashboard/*` | `main` | `render-d2-dashboard.yaml` (to be authored) |
+   | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | **D2** | `d2_dashboard/*` | `main` | `render-d2-dashboard.yaml` |
+   | `vibepass-terminal-test` | _(provisioned 2026-05-15)_ | **D0** | `static/terminal/*` | `main` | `render-d0-terminal.yaml` |
    | `hi-events` (separate repo) | `srv-d7g0cev7f7vs73blkc70` | n/a (not Terminal-2) | — | `develop` | — |
 
    - Each owner-bot manages **env vars, deploy config, log monitoring, and IaC blueprint** for their specific service. They do NOT touch the other bot's service.
    - Per-bot Render access scope (per CLAUDE.md §4, 2026-05-14):
      - **A1** — exclusive workspace-wide access: all read + write ops on any service, plus `create_*` / `select_workspace` (only bot authorized to provision or delete services)
-     - **D1** — scoped to `vibepass-storefront-test`: read + write OK on this service (env vars, redeploy, update_web_service); forbidden on `d2-orders-dashboard` and workspace-level ops
-     - **D2** — scoped to `d2-orders-dashboard`: read + write OK on this service; forbidden on `vibepass-storefront-test` and workspace-level ops
-     - **B1 / C1 / D0 / D3 / D4** — read-only across all services; writes require operator approval
+     - **D1** — scoped to `vibepass-storefront-test`: read + write OK on this service (env vars, redeploy, update_web_service); forbidden on other services and workspace-level ops
+     - **D2** — scoped to `d2-orders-dashboard`: read + write OK on this service; forbidden on other services and workspace-level ops
+     - **D0** — scoped to `vibepass-terminal-test`: read + write OK on this service; forbidden on other services and workspace-level ops
+     - **B1 / C1 / D3 / D4** — read-only across all services; writes require operator approval
    - Both services auto-deploy from `main`. A1 (sole pusher to main) merges PRs; each push triggers auto-deploys on both services since both watch `main`. If a PR only touches one service's surface, the other service still redeploys (no-op for it but burns build minutes — acceptable for free tier).
    - **Future split** option if build-time waste becomes painful: each service moves to a bot-specific deploy branch (e.g. `d1/release`, `d2/release`), and A1 fast-forwards each one when their respective code paths change. Deferred until volume justifies the merge-coordination cost.
 

--- a/render-d0-terminal.yaml
+++ b/render-d0-terminal.yaml
@@ -1,0 +1,28 @@
+# Render.com Infrastructure-as-Code blueprint for D0's broker terminal frontend.
+#
+# OWNER: D0 (Terminal FE) — per LANE_DISCIPLINE.md §Cross-cutting Rule #6.
+# Service: vibepass-terminal-test (provisioned 2026-05-15 via A1 + Render MCP)
+# Companion blueprints:
+#   - render.yaml             (D1's vibepass-storefront-test)
+#   - render-d2-dashboard.yaml (D2's d2-orders-dashboard)
+#
+# This is a static-site deploy (pre-built HTML/JS/CSS, served via Render's
+# CDN — no Python runtime). The terminal frontend code lives at
+# static/terminal/*. Currently a placeholder index.html until D0 builds
+# the operational terminal UI.
+
+services:
+  - type: static
+    name: vibepass-terminal-test
+    branch: main
+    autoDeploy: true
+    # No build step — assets are pre-built HTML/CSS/JS committed to the repo.
+    # When D0 introduces a JS framework with a build pipeline, change to
+    # something like `cd static/terminal && npm install && npm run build`
+    # and adjust publishPath accordingly.
+    buildCommand: 'echo "static assets — no build step"'
+    publishPath: static/terminal
+
+    # No env vars needed for static frontend. If D0 wires up
+    # client-side config (Supabase anon key for read-only data fetch),
+    # add them here with `sync: false` so they prompt on provisioning.

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>VibePass Terminal — D0 lane</title>
+  <style>
+    :root { color-scheme: dark light; }
+    html, body {
+      margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+      background: #0b0d10; color: #d7dde4; min-height: 100vh;
+    }
+    main {
+      max-width: 720px; margin: 12vh auto; padding: 0 24px;
+    }
+    h1 { font-size: 28px; font-weight: 600; margin: 0 0 8px; color: #fff; }
+    .tag {
+      display: inline-block; font-size: 11px; letter-spacing: 0.08em;
+      text-transform: uppercase; padding: 3px 8px; border-radius: 4px;
+      background: #1f2530; color: #6e93d6; margin-bottom: 18px;
+    }
+    p { line-height: 1.55; margin: 0 0 14px; color: #aab3bd; }
+    code { background: #1a1f26; padding: 2px 6px; border-radius: 4px; color: #d7dde4; font-size: 13px; }
+    a { color: #6e93d6; }
+    .meta { margin-top: 28px; font-size: 12px; color: #6e7785; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="tag">D0 — Terminal FE</div>
+    <h1>VibePass Terminal — provisioning</h1>
+    <p>This deploy target was provisioned for the D0 lane (broker terminal frontend). The actual terminal UI lives at <code>static/terminal/*</code> and is being built out separately.</p>
+    <p>If you reached this page expecting the operational terminal, you're early — check back after D0 lands their first build, or look at the active services list at <a href="https://dashboard.render.com">dashboard.render.com</a>.</p>
+    <p class="meta">Service: <code>vibepass-terminal-test</code> · Lane: D0 · Region: Oregon · Plan: free · Owner: D0 (per LANE_DISCIPLINE.md §Cross-cutting Rule #6, updated 2026-05-14)</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Operator directive: 'create a render env for d0'. Adds static-site target, placeholder index, IaC blueprint, lane-doc updates. Service provisioning via Render MCP happens after merge.