### PR TITLE
chore(d0): patch lane docs with provisioned service ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Render MCP tools (`mcp__render__*`) are gated per-bot to their assigned service.
 - Write OK on `d2-orders-dashboard` only
 - Forbidden: any operation on `vibepass-storefront-test`, `vibepass-terminal-test`, `hi-events`, or workspace-level resources
 
-**D0 — scoped to `vibepass-terminal-test` (provisioned 2026-05-15):**
+**D0 — scoped to `vibepass-terminal-test` (`srv-d839339kh4rs73ac3s20`):**
 - Same as D1/D2 but for its assigned service (static-site type, serves `static/terminal/*`)
 - Write OK on `vibepass-terminal-test` only
 - Forbidden: any operation on other services or workspace-level resources

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -223,7 +223,7 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
    |---|---|---|---|---|---|
    | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | **D1** | `app.py`, `static/store/*` | `main` | `render.yaml` |
    | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | **D2** | `d2_dashboard/*` | `main` | `render-d2-dashboard.yaml` |
-   | `vibepass-terminal-test` | _(provisioned 2026-05-15)_ | **D0** | `static/terminal/*` | `main` | `render-d0-terminal.yaml` |
+   | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | **D0** | `static/terminal/*` | `main` | `render-d0-terminal.yaml` |
    | `hi-events` (separate repo) | `srv-d7g0cev7f7vs73blkc70` | n/a (not Terminal-2) | — | `develop` | — |
 
    - Each owner-bot manages **env vars, deploy config, log monitoring, and IaC blueprint** for their specific service. They do NOT touch the other bot's service.

--- a/render-d0-terminal.yaml
+++ b/render-d0-terminal.yaml
@@ -1,7 +1,8 @@
 # Render.com Infrastructure-as-Code blueprint for D0's broker terminal frontend.
 #
 # OWNER: D0 (Terminal FE) — per LANE_DISCIPLINE.md §Cross-cutting Rule #6.
-# Service: vibepass-terminal-test (provisioned 2026-05-15 via A1 + Render MCP)
+# Service: vibepass-terminal-test (srv-d839339kh4rs73ac3s20, provisioned 2026-05-15)
+# URL:     https://vibepass-terminal-test.onrender.com
 # Companion blueprints:
 #   - render.yaml             (D1's vibepass-storefront-test)
 #   - render-d2-dashboard.yaml (D2's d2-orders-dashboard)


### PR DESCRIPTION
Follow-up to #107: replaces 'provisioned 2026-05-15' placeholder with the actual srv-d839339kh4rs73ac3s20 across LANE_DISCIPLINE.md, CLAUDE.md, and render-d0-terminal.yaml.