### PR TITLE
fix(d2): Auto-refresh = true master pause across all 4 polling timers

### DIFF
--- a/d2_dashboard/static/dashboard.js
+++ b/d2_dashboard/static/dashboard.js
@@ -286,7 +286,7 @@ function renderDashboard(domain) {
           </label>
           <label class="toolbar-toggle">
             <input type="checkbox" id="chk-auto-refresh" checked />
-            <span title="Pauses the 5-min poll while you're working with the table">Auto-refresh</span>
+            <span title="Master pause for ALL auto-polling (orders 5min, cron-freshness 60s, metrics 60s, live sales feed 30s). Manual Refresh + tab-switch first-load still work.">Auto-refresh</span>
           </label>
           <span class="toolbar-meta" id="last-refreshed">last refresh: never</span>
         </div>
@@ -413,6 +413,24 @@ function renderDashboard(domain) {
     });
   });
 
+  // Auto-refresh checkbox is the master pause for all 4 polling timers
+  // (orders 5min, cron-freshness 60s, metrics 60s, sales-feed 30s).
+  // Each timer's setInterval body checks _isAutoRefreshOn() and early-
+  // returns when unchecked. When the operator flips it back ON, fire one
+  // immediate fetch on the active tab so they see fresh data without
+  // waiting up to 5 min for the next orders tick.
+  document.getElementById("chk-auto-refresh")?.addEventListener("change", (e) => {
+    if (!e.target.checked) return;
+    const active = document.querySelector(".tab.active")?.dataset.tab;
+    if (active === "orders") {
+      if (CURRENT_PAGE === 1 && !_DETAIL_OPEN) loadOrders({ silent: true });
+      refreshCronFreshness();
+    } else if (active === "metrics") {
+      loadMetrics();
+      loadSalesFeed();
+    }
+  });
+
   // Re-render (not re-fetch) when the user toggles Hide-Past-12h or any of
   // the in-memory filters. Source / date / amount filters all just re-slice
   // the cached body — no new API call, no new SQL query.
@@ -529,11 +547,17 @@ function activateTab(name) {
   if (name === "health") loadHealth();
 }
 
+// Master pause gate for ALL polling timers (orders 5min, cron-freshness 60s,
+// metrics 60s, sales-feed 30s). Defaults to ON if the checkbox hasn't
+// rendered yet so the boot-time first ticks still fire.
+function _isAutoRefreshOn() {
+  return document.getElementById("chk-auto-refresh")?.checked !== false;
+}
+
 function startOrdersAutoRefresh() {
   if (_ORDERS_REFRESH_TIMER) return;
   _ORDERS_REFRESH_TIMER = setInterval(() => {
-    // Operator paused auto-refresh via the toolbar toggle? Skip silently.
-    if (!document.getElementById("chk-auto-refresh")?.checked) return;
+    if (!_isAutoRefreshOn()) return;
     // Skip a tick while the row-detail panel is open — silently yanking
     // a card the operator is reading would be hostile UX.
     if (_DETAIL_OPEN) return;
@@ -546,10 +570,13 @@ function startOrdersAutoRefresh() {
   }, ORDERS_AUTO_REFRESH_MS);
   // Cron freshness poll — separate from orders. Refresh the chip's "last
   // cron: Xm ago" line every 60s so the operator sees cron health in
-  // near-real-time without dragging the orders feed.
+  // near-real-time without dragging the orders feed. Gated by the same
+  // master pause as the orders bulk poll.
   if (!_CRON_FRESHNESS_TIMER) {
-    refreshCronFreshness();   // immediate first hit
-    _CRON_FRESHNESS_TIMER = setInterval(refreshCronFreshness, CRON_FRESHNESS_POLL_MS);
+    if (_isAutoRefreshOn()) refreshCronFreshness();   // immediate first hit
+    _CRON_FRESHNESS_TIMER = setInterval(() => {
+      if (_isAutoRefreshOn()) refreshCronFreshness();
+    }, CRON_FRESHNESS_POLL_MS);
   }
 }
 
@@ -574,11 +601,18 @@ let _SALES_FEED_REFRESH_TIMER = null;
 let _LAST_SALES_FEED_IDS = new Set();        // for flash-on-new highlighting
 
 function startMetricsAutoRefresh() {
+  // Both metrics timers obey the same master pause (_isAutoRefreshOn) as
+  // the orders bulk poll. When the checkbox is unchecked, ticks fire on
+  // schedule but skip the fetch.
   if (!_METRICS_REFRESH_TIMER) {
-    _METRICS_REFRESH_TIMER = setInterval(loadMetrics, METRICS_AUTO_REFRESH_MS);
+    _METRICS_REFRESH_TIMER = setInterval(() => {
+      if (_isAutoRefreshOn()) loadMetrics();
+    }, METRICS_AUTO_REFRESH_MS);
   }
   if (!_SALES_FEED_REFRESH_TIMER) {
-    _SALES_FEED_REFRESH_TIMER = setInterval(loadSalesFeed, SALES_FEED_REFRESH_MS);
+    _SALES_FEED_REFRESH_TIMER = setInterval(() => {
+      if (_isAutoRefreshOn()) loadSalesFeed();
+    }, SALES_FEED_REFRESH_MS);
   }
 }
 


### PR DESCRIPTION
## Summary

Operator audit caught that the dashboard's "Auto-refresh" checkbox was a UX lie — labeled as universal, gated only 1 of 4 timers.

| Timer | Endpoint | Cadence | Gated before this PR | Gated after |
|---|---|---|---|---|
| `_ORDERS_REFRESH_TIMER` | `/api/d2/orders` | 5 min | ✅ | ✅ |
| `_CRON_FRESHNESS_TIMER` | `/api/d2/cron-freshness` | 60 s | ❌ | ✅ |
| `_METRICS_REFRESH_TIMER` | `/api/d2/metrics` | 60 s | ❌ | ✅ |
| `_SALES_FEED_REFRESH_TIMER` | `/api/d2/sales-feed` | 30 s | ❌ | ✅ |

With Auto-refresh OFF on the Metrics tab, the server still received ~3 hits/min. On free-tier idle windows that silently inflated compute. After this PR: zero auto-polls when unchecked.

## Changes

`d2_dashboard/static/dashboard.js` only (+42 / −8):

- **New helper `_isAutoRefreshOn()`** — single source of truth. Defaults to `true` if the checkbox hasn't rendered yet so boot-time first ticks fire.
- **3 setInterval bodies wrapped** — cron-freshness, metrics, sales-feed each early-return when the checkbox is off. Orders timer had this inline; rewrote to use the helper for consistency.
- **Tooltip rewritten** — "Master pause for ALL auto-polling (orders 5min, cron-freshness 60s, metrics 60s, live sales feed 30s). Manual Refresh + tab-switch first-load still work."
- **Change handler** — flipping OFF→ON fires one immediate fetch on the active tab so the operator sees fresh data right away instead of waiting up to 5 min for the next orders tick.

## Behavior contract

- **Auto-refresh ON**: all 4 timers fire on their normal cadence (no change from today).
- **Auto-refresh OFF**: zero auto-polls. Manual Refresh button + tab-switch first-load + page-boot two-phase still work.
- **Toggle OFF → ON**: one immediate fetch on the active tab, then intervals resume.
- **Toggle ON → OFF**: next tick onward is gated (a fetch already in flight at toggle-time is not cancelled — fine, the gate is for future ticks).

## Test plan

Manual via DevTools Network tab (no JS test harness in the project; the existing `chk-hide-past` toggle has no automated test either):

- [ ] Baseline: ON + Orders tab → `/api/d2/cron-freshness` fires every 60 s.
- [ ] Switch to Metrics → `/api/d2/metrics` (60 s) + `/api/d2/sales-feed` (30 s).
- [ ] Uncheck Auto-refresh, wait 2 min → zero new XHR rows.
- [ ] Manual Refresh button → one explicit fetch fires.
- [ ] Re-check Auto-refresh → one immediate fetch on active tab; subsequent intervals resume.
- [x] `pytest tests/test_d2_dashboard.py` → 57 passed (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)