### PR TITLE
feat(admin): resume 3 sg_seller crons at Evo-equivalent cadence

### DIFF
--- a/supabase/migrations/20260515350000_sg_seller_resume_at_evo_cadence.sql
+++ b/supabase/migrations/20260515350000_sg_seller_resume_at_evo_cadence.sql
@@ -1,0 +1,9 @@
+-- Migration 20260515350000 · admin · cron-resume (D2-requested, operator-permitted 2026-05-15) · pre:20260515200000
+-- Resume 3 sg_seller crons paused 2026-05-14. Match Evo cadence: orders queue @30min,
+-- process @30min, listings queue @10min (was 30min, bumped to match collect-listings-0-24h).
+-- Listings slot uses 3-59/10 (NOT */10) to avoid Kong-gateway herd with espn-gameday-10min
+-- at :00 (bot_chat 130 silent-success class). +10min rule does not fire (10 > 5).
+
+SELECT cron.alter_job(job_id := 63, active := true);                              -- sg_seller_orders_queue_30min
+SELECT cron.alter_job(job_id := 65, active := true);                              -- sg_seller_process_30min
+SELECT cron.alter_job(job_id := 64, schedule := '3-59/10 * * * *', active := true); -- sg_seller_listings_queue_30min


### PR DESCRIPTION
## Summary

Resumes 3 sg_seller crons paused 2026-05-14 that have no broker-pipeline replacement (our own SG seller account data: orders + listings). Per D2 plan + operator directive 2026-05-15.

- jobid 63 sg_seller_orders_queue_30min: active=true, schedule unchanged
- jobid 65 sg_seller_process_30min: active=true, schedule unchanged
- jobid 64 sg_seller_listings_queue_30min: active=true, schedule */10 → **3-59/10** to dodge Kong herd at :00 (bot_chat 130 class)

Applied to prod via MCP `20260515350000`.

## Test plan

- [x] cron.alter_job × 3 applied
- [x] Post-apply: all 3 active=true, jobid 64 schedule `3-59/10 * * * *`
- [ ] T+15min: first ticks succeed
- [ ] T+45min: `seatgeek_orders` + `seatgeek_seller_listings` row-count freshness drops below 30min
- [ ] D2 dashboard SG chip flips stale→fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)