### PR TITLE
fix(admin): pause tickpick crons stuck on 401 vault token

### DIFF
--- a/supabase/migrations/20260515360000_pause_tickpick_broken_crons.sql
+++ b/supabase/migrations/20260515360000_pause_tickpick_broken_crons.sql
@@ -1,0 +1,9 @@
+-- Migration 20260515360000 · admin · pause failing tickpick crons (vault token bad) · pre:20260515350000
+-- 401 from get_app_secret('TICKPICK_API_TOKEN') vs TickPick API. Apps Script ingest
+-- (tickpick_orders_ingest_from_apps_script SECDEF RPC) is the working path — 1001 rows
+-- in last 24h, 92% aq-matched. Cron path = wasted ticks until operator rotates
+-- vault.TICKPICK_API_TOKEN or refactors cron to share Apps Script credential.
+-- No data loss: Apps Script remains primary.
+
+SELECT cron.alter_job(job_id := (SELECT jobid FROM cron.job WHERE jobname='tickpick_orders_queue_30min'),   active := false);
+SELECT cron.alter_job(job_id := (SELECT jobid FROM cron.job WHERE jobname='tickpick_orders_process_30min'), active := false);


### PR DESCRIPTION
## Summary

D2 surfaced 100% silent-success on `tickpick_orders_pending` (55/55 ticks, zero rows). pg_net responses show **401 "[invalid-authorization] Invalid authorization"** from `vault.TICKPICK_API_TOKEN` against TickPick API.

Apps Script direct ingest (`tickpick_orders_ingest_from_apps_script` SECDEF RPC) is the **working path** — 1,001 rows in last 24h, 92% AQ-matched. Cron path was pure wasted ticks.

Pauses both `tickpick_orders_queue_30min` + `tickpick_orders_process_30min`. **No data loss** — Apps Script flow continues.

## Operator follow-up

Rotate `vault.TICKPICK_API_TOKEN` to a working bearer, OR refactor cron path to mirror Apps Script auth. Then re-enable both crons via `cron.alter_job(active:=true)`.

## Test plan

- [x] Migration 20260515360000 applied to prod
- [x] Both crons confirmed `active=false`
- [x] Apps Script flow verified healthy (1,001 rows / 24h, 92% AQ coverage)
- [x] bot_chat 152 resolved with closure 153

🤖 Generated with [Claude Code](https://claude.com/claude-code)