### PR TITLE
d1: Cache-Control: no-cache on /store HTML shells (bootstrap-safety)

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,6 +97,29 @@ def _read_storefront_html(name: str) -> str:
     return html
 
 
+def _render_storefront_page(name: str) -> HTMLResponse:
+    """Return an HTMLResponse for a static/store/*.html shell with
+    Cache-Control: no-cache, must-revalidate so browsers always
+    revalidate the HTML on every page load.
+
+    The asset URLs inside the HTML are cache-busted via
+    _read_storefront_html()'s `?v=<sha>` rewrite — those keep their
+    long-cache friendliness. Only the HTML shell itself needs the
+    revalidate header so operators (and returning customers) never
+    get trapped on stale HTML pointing at un-versioned asset URLs
+    after a deploy. See Round 5 of docs/d1-bot-continues-here-rustling
+    -sunrise.md for the bootstrap-trap scenario this prevents.
+
+    Cost: every page load adds one conditional GET (304 Not Modified
+    when unchanged — ~1 KB request, ~50 ms latency, no body transfer).
+    Trivial.
+    """
+    return HTMLResponse(
+        content=_read_storefront_html(name),
+        headers={"Cache-Control": "no-cache, must-revalidate"},
+    )
+
+
 # ---------- Bootstrap ----------
 
 SUPABASE_URL = os.environ.get("SUPABASE_URL")
@@ -6261,12 +6284,12 @@ def store_reserve(payload: dict = Body(...), authorization: str | None = Header(
 
 @app.get("/store")
 def store_index_page():
-    return HTMLResponse(_read_storefront_html("index.html"))
+    return _render_storefront_page("index.html")
 
 
 @app.get("/store/event/{event_id}")
 def store_event_page(event_id: int):  # noqa: ARG001 — id read by JS from URL
-    return HTMLResponse(_read_storefront_html("event.html"))
+    return _render_storefront_page("event.html")
 
 
 # ---------- Share links (revocable, trackable) ----------
@@ -6513,12 +6536,12 @@ def store_share_list(
 def store_shared_page(share_id: str):  # noqa: ARG001 — id read by JS from URL
     """Serves the same event detail page; JS detects /s/ prefix and resolves
     the share via /api/store/share/{id} instead of using URL filter params."""
-    return HTMLResponse(_read_storefront_html("event.html"))
+    return _render_storefront_page("event.html")
 
 
 @app.get("/store/shares")
 def store_shares_page():
-    return HTMLResponse(_read_storefront_html("shares.html"))
+    return _render_storefront_page("shares.html")
 
 
 def _require_non_prod():

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -529,3 +529,41 @@ def test_build_storefront_version_dev_when_unset(monkeypatch):
     monkeypatch.delenv("RENDER_GIT_COMMIT", raising=False)
     monkeypatch.delenv("GIT_COMMIT", raising=False)
     assert app_module._build_storefront_version() == "dev"
+
+
+def test_store_html_response_has_no_cache_header(store_home_client):
+    """Bootstrap-safety: /store HTML must include Cache-Control: no-cache
+    so browsers revalidate on every page load and never get trapped on
+    stale HTML pointing at un-versioned asset URLs.
+
+    Without this header, a browser that cached /store before a cache-bust
+    shipped would keep loading the old JS via the un-versioned URL until
+    its heuristic cache expires (could be hours/days). The `?v=<sha>`
+    query string on the asset URLs in PR #121 only helps once the BROWSER
+    re-fetches /store and sees the new HTML — this header forces that
+    re-fetch on every request.
+    """
+    r = store_home_client.get("/store")
+    assert r.status_code == 200
+    cc = r.headers.get("cache-control", "")
+    assert "no-cache" in cc.lower(), (
+        f"Cache-Control must include no-cache; got: {cc!r}"
+    )
+
+
+def test_all_storefront_html_routes_revalidate(store_home_client):
+    """Every served /store/* HTML shell — index, event, share, shares —
+    must carry the no-cache header. Catches a regression where someone
+    swaps one route back to FileResponse or raw HTMLResponse without
+    realizing the helper enforces revalidate.
+    """
+    # /store/event/{id} works without DB because the route only reads the
+    # static HTML shell — the event_id is consumed by JS at runtime.
+    paths = ["/store", "/store/event/3346000", "/s/test-id", "/store/shares"]
+    for path in paths:
+        r = store_home_client.get(path)
+        assert r.status_code == 200, f"{path} → {r.status_code}"
+        cc = r.headers.get("cache-control", "")
+        assert "no-cache" in cc.lower(), (
+            f"{path}: Cache-Control missing no-cache; got: {cc!r}"
+        )


### PR DESCRIPTION
## Summary

Defensive follow-up to [PR #121](https://github.com/JulianS4K/Terminal-2/pull/121)'s `?v=<sha>` static-asset cache-bust. Eliminates the **bootstrap trap** the operator just hit: a browser that cached `/store` HTML before PR #121 deployed still references the un-versioned `/static/store/store.js`, gets a cache-hit, and runs the old buggy JS until its cache expires.

### Problem

PR #121 made every deploy invalidate the browser cache for `store.js` + `style.css` via `?v=<sha>` query strings inside the served HTML. Steady-state correct. But:

1. Browser cached `/store` HTML before PR #121 deployed (no `Cache-Control` was set → heuristic caching could last hours/days).
2. Cached HTML contains `<script src=\"/static/store/store.js\">` (un-versioned).
3. Browser cache-hits on the un-versioned URL → serves old JS.
4. Old JS runs the 2-phase loader bug → cards never paint.

Hard-refresh fixes any one browser. But every returning visitor / new operator hits the same trap.

### Fix

Add `Cache-Control: no-cache, must-revalidate` to every `/store` HTML response so browsers always send a conditional GET. ~99% serve as `304 Not Modified` (no body transfer, ~50 ms). Static asset URLs keep their long-cache via `?v=<sha>` — only the HTML shell revalidates.

### Implementation

[app.py](app.py):
- New helper `_render_storefront_page(name)` next to `_read_storefront_html`. Wraps the existing HTML helper in an `HTMLResponse` with `Cache-Control: no-cache, must-revalidate`.
- 4 production HTML routes flip from `HTMLResponse(_read_storefront_html(\"...html\"))` to `_render_storefront_page(\"...html\")`:

| Route | File |
|---|---|
| `/store` | `index.html` |
| `/store/event/{event_id}` | `event.html` |
| `/s/{share_id}` | `event.html` |
| `/store/shares` | `shares.html` |

`/store/test/*` routes (non-prod) unchanged — `FileResponse` is fine.

**Net diff**: +31 / -4 in `app.py`, +38 in tests. No new imports, no frontend changes, no migrations.

### Note on `no-cache` vs `no-store`

- **`no-cache`** = always revalidate before serving (304-friendly). What we want.
- **`no-store`** = never cache at all (forbids even the conditional check). Wasteful.

The HTML rarely changes between deploys; 304s dominate.

## Test plan

**30/30 tests pass** locally (16 home + 4 cache-bust + 2 cache-control + 8 events).

Two new tests in [tests/test_store_home.py](tests/test_store_home.py):
- `test_store_html_response_has_no_cache_header` — asserts `/store` response includes `no-cache` in `Cache-Control`.
- `test_all_storefront_html_routes_revalidate` — same assertion across all 4 production routes (catches a regression where someone swaps one back to raw `HTMLResponse`).

### Smoke after merge

```bash
# Cache-Control header is present on all 4 HTML shells:
for path in /store /store/event/3346000 /s/test-id /store/shares; do
  echo \"=== \$path ===\"
  curl -sS -I \"https://vibepass-storefront-test.onrender.com\$path\" | grep -i 'cache-control'
done
# expect: cache-control: no-cache, must-revalidate

# Static asset cache-bust still works (unchanged from PR #121):
curl https://vibepass-storefront-test.onrender.com/store | grep -o '/static/store/store.js?v=[a-f0-9]*'
# expect: /static/store/store.js?v=<short-sha>
```

### Risk + revert

Risk: trivial. Every page load adds one conditional GET (~50 ms, ~99% as 304).

Revert: drop the `headers=...` arg from `_render_storefront_page`. HTML routes continue serving without the header — same behavior as before PR #121.

### Coordination

Single-purpose D1 PR. No A1 dependencies. Per A1's bot_chat 2026-05-15: \"ship when ready, I'll merge per push protocol.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)