### PR TITLE
chore(governance): D-tier reorg — D0 consolidated frontend lane + backend test gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: tests
+
+# Backend test gate (added 2026-05-15 per operator directive).
+# Runs pytest on every PR + push to main. A1 must NOT merge to main
+# until this workflow is green. Render auto-deploy fires on push to main,
+# so a green CI is the implicit gate on deploys.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio
+          # Tolerate missing requirements.txt early in repo lifecycle.
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run pytest
+        env:
+          AUTH_DISABLED: "true"
+          SUPABASE_URL: "https://example.invalid"
+          SUPABASE_SERVICE_ROLE_KEY: "test-key"
+        # `--maxfail=1` short-circuits on first failure to keep CI fast.
+        # `-q` keeps the log lean. Add `tests/` explicit path so a stray
+        # conftest in repo root doesn't surprise us.
+        run: pytest tests/ -q --maxfail=1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,8 @@ jobs:
           AUTH_DISABLED: "true"
           SUPABASE_URL: "https://example.invalid"
           SUPABASE_SERVICE_ROLE_KEY: "test-key"
-        # `--maxfail=1` short-circuits on first failure to keep CI fast.
-        # `-q` keeps the log lean. Add `tests/` explicit path so a stray
-        # conftest in repo root doesn't surprise us.
+          # Repo modules (app.py, broadway_client.py, evo_client.py, etc.) live at
+          # repo root, not a package. Pytest's rootdir auto-discovery doesn't add
+          # them to sys.path; PYTHONPATH=. is the canonical fix.
+          PYTHONPATH: "."
         run: pytest tests/ -q --maxfail=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,12 @@ Read freely: `SELECT`, `information_schema`, `pg_*` views, log inspection, MCP `
 - Supabase **branch** creation (`create_branch` produces a copy-on-write fork — no prod-data mutation)
 - Author migrations as files in `supabase/migrations/` — application to prod is gated separately
 
+**Resolve-protocol semantics (2026-05-15 — C1 / A1 convention):**
+A `bot_chat` reply with `event_type='status'` and `p_in_reply_to` set is the **canonical closure signal** for its parent thread. The `v_bot_chat_unresolved` view (C1-owned, see PR #114 Cluster D-1) auto-excludes any row that has a `status` reply pointing at it via `in_reply_to`. Implications for bot authors:
+- If you are CLOSING a thread (work shipped, question answered), use `event_type='status'`. This will mark the parent as resolved automatically.
+- If you are still working on a thread (acknowledging without fixing), use `event_type='flag'` or `'question'`. These do NOT close the parent — the unresolved view still surfaces it.
+- Premature `status` replies that conflate "I saw this" with "I fixed this" defeat the resolve hygiene. When in doubt, use `flag`.
+
 ### 2. Upstream third-party APIs are read-only
 
 Applies to **every** external API the project integrates with — TEvo, SeatGeek, SeatData, TickPick, Vivid, and any future client (`*_client.py`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,29 +47,26 @@ Lane assignments per `LANE_DISCIPLINE.md`:
 - **C1** — supervisor docs + audit harnesses + lane discipline
 - Operator may explicitly route HTML work to a bot outside its default lane (this is the override path)
 
-### 4. Render workspace — per-service scoped access (2026-05-14)
+### 4. Render workspace — per-service scoped access (2026-05-14, reorg 2026-05-15)
 
-Render MCP tools (`mcp__render__*`) are gated per-bot to their assigned service. Cross-service writes are forbidden without operator approval.
+Render MCP tools (`mcp__render__*`) are gated per-bot. Cross-service writes are forbidden without operator approval.
 
 **A1 (Admin) — exclusive workspace-wide access:**
 - All `mcp__render__*` tools on any service
 - Workspace-level operations: `create_web_service`, `create_postgres`, `create_static_site`, `create_cron_job`, `select_workspace`
 - A1 is the only bot authorized to provision, delete, or change ownership of services
 
-**D1 — scoped to `vibepass-storefront-test` (`srv-d8140bnaqgkc73al4asg`):**
-- Read freely: `list_services`, `get_service`, `list_deploys`, `get_deploy`, `list_logs`, `get_metrics`
-- **Write OK on this service** (no per-call ask): `update_environment_variables`, `update_web_service` (config / branch / build / start commands), restart, redeploy triggers
-- Forbidden: any operation on `d2-orders-dashboard` or `hi-events` or workspace-level resources
+**D0 — consolidated frontend lane (2026-05-15 reorg):**
+- **Write authority on all three frontend services**: `vibepass-terminal-test` (`srv-d839339kh4rs73ac3s20`), `vibepass-storefront-test` (`srv-d8140bnaqgkc73al4asg`), `d2-orders-dashboard` (`srv-d82b4kl7vvec73b4r3r0`)
+- Permitted writes (no per-call ask): `update_environment_variables`, `update_web_service`, restart, redeploy triggers
+- D0 is sign-off authority on D1/D2 subordinate PRs touching their respective surfaces
+- Forbidden: workspace-level operations (A1-only)
 
-**D2 — scoped to `d2-orders-dashboard` (`srv-d82b4kl7vvec73b4r3r0`):**
-- Same as D1 but for its assigned service
-- Write OK on `d2-orders-dashboard` only
-- Forbidden: any operation on `vibepass-storefront-test`, `vibepass-terminal-test`, `hi-events`, or workspace-level resources
-
-**D0 — scoped to `vibepass-terminal-test` (`srv-d839339kh4rs73ac3s20`):**
-- Same as D1/D2 but for its assigned service (static-site type, serves `static/terminal/*`)
-- Write OK on `vibepass-terminal-test` only
-- Forbidden: any operation on other services or workspace-level resources
+**D1, D2 — subordinate coding arm under D0 (2026-05-15 reorg):**
+- D1 still authors `static/store/*`, `app.py /api/store/*`, `render.yaml` (storefront IaC)
+- D2 still authors `d2_dashboard/*`, order client code, `render-d2-dashboard.yaml`
+- Render MCP **read-only** across all services; writes route through D0 approval + A1 merge
+- Cross-service writes (e.g., D1 touching D2's surface) require D0 sign-off in PR comment
 
 **All other bots (B1, C1, D3, D4):**
 - Read-only across all services (monitoring is universal)

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -100,7 +100,13 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 
 **Cadence:** daily checkpoint at 09:00 ET (after overnight backdata processing completes; before US trading-hours peak). One scheduled session per day; ad-hoc sessions if drift gets surfaced by automated alerting between checkpoints.
 
-### D0 — Terminal FE (read-only)
+### D0 — Consolidated Frontend Lane (2026-05-15 reorg)
+
+**Role**: lane owner for all customer + operator frontend surfaces. Reviews + signs off on subordinate (D1, D2) PRs before A1 merges. Owns Render write authority on all three frontend services. Authors `static/terminal/*` directly.
+
+**Subordinates**: D1 (storefront implementer), D2 (dashboard implementer). They write code; D0 reviews; A1 merges after green CI.
+
+### D0 — Terminal FE direct surface
 
 **Writes:**
 - Future `static/terminal/*` UI files (when built)
@@ -117,7 +123,9 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 
 **Reads:** entire data plane (charts, predictive models, possibly Grok integration)
 
-### D1 — Consumer Retail
+### D1 — Consumer Retail (subordinate to D0 as of 2026-05-15)
+
+**Reports to D0.** Authors storefront code; D0 reviews + approves PRs; A1 merges after green CI.
 
 **Writes (source files):**
 - `app.py` `/api/store/*` + `/store/*` routes (coordinate with A1)
@@ -159,7 +167,9 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 - **Render MCP write authority on this service** (no per-call operator ask): `update_environment_variables`, `update_web_service`, redeploy triggers, restart. Cross-service ops (anything touching `d2-orders-dashboard` or workspace-level) remain forbidden without operator approval.
 - D1 does **NOT** own `d2-orders-dashboard` — that surface is D2's (see below).
 
-### D2 — Order Clients
+### D2 — Order Clients (subordinate to D0 as of 2026-05-15)
+
+**Reports to D0.** Authors order-client code + dashboard code; D0 reviews + approves PRs; A1 merges after green CI.
 
 **Writes:**
 - `seatdata_client.py`, `seatgeek_client.py`, `evo_client.py` (order paths only)
@@ -240,22 +250,23 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
    - Explicit `GRANT EXECUTE ... TO service_role`
    - `IF current_user NOT IN ('service_role','postgres','supabase_admin') THEN RAISE EXCEPTION` at body start
 
-6. **Deploy infrastructure ownership** — per-service exclusivity within Render workspace (updated 2026-05-14):
+6. **Deploy infrastructure ownership** — D0 consolidates all frontend services (2026-05-15 reorg):
 
-   | Render service | ID | Owner bot | Source code | Branch | IaC file |
+   | Render service | ID | Lane owner (D0) | Subordinate implementer | Source code | IaC file |
    |---|---|---|---|---|---|
-   | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | **D1** | `app.py`, `static/store/*` | `main` | `render.yaml` |
-   | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | **D2** | `d2_dashboard/*` | `main` | `render-d2-dashboard.yaml` |
-   | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | **D0** | `static/terminal/*` | `main` | `render-d0-terminal.yaml` |
-   | `hi-events` (separate repo) | `srv-d7g0cev7f7vs73blkc70` | n/a (not Terminal-2) | — | `develop` | — |
+   | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | **D0** | D0 | `static/terminal/*` | `render-d0-terminal.yaml` |
+   | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | **D0** | D1 (subord) | `app.py`, `static/store/*` | `render.yaml` |
+   | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | **D0** | D2 (subord) | `d2_dashboard/*` | `render-d2-dashboard.yaml` |
+   | `hi-events` (separate repo) | `srv-d7g0cev7f7vs73blkc70` | n/a (not Terminal-2) | — | — | — |
 
-   - Each owner-bot manages **env vars, deploy config, log monitoring, and IaC blueprint** for their specific service. They do NOT touch the other bot's service.
-   - Per-bot Render access scope (per CLAUDE.md §4, 2026-05-14):
+   - **D0 is the lane owner** across all three frontend services as of 2026-05-15. D0 manages env vars, deploy config, log monitoring, and IaC for every frontend service.
+   - **D1 and D2 are subordinate coding arms.** They still author code in their respective directories (D1 → storefront, D2 → dashboard) but their PRs require **D0 sign-off** in a PR comment before A1 merges. D1/D2 have Render MCP **read-only** access; writes route through D0 + A1.
+   - Per-bot Render access scope (per CLAUDE.md §4, updated 2026-05-15):
      - **A1** — exclusive workspace-wide access: all read + write ops on any service, plus `create_*` / `select_workspace` (only bot authorized to provision or delete services)
-     - **D1** — scoped to `vibepass-storefront-test`: read + write OK on this service (env vars, redeploy, update_web_service); forbidden on other services and workspace-level ops
-     - **D2** — scoped to `d2-orders-dashboard`: read + write OK on this service; forbidden on other services and workspace-level ops
-     - **D0** — scoped to `vibepass-terminal-test`: read + write OK on this service; forbidden on other services and workspace-level ops
+     - **D0** — write authority on all three frontend services; forbidden workspace-level ops (A1-only)
+     - **D1, D2** — read-only on all Render surfaces; writes route through D0 review + A1 merge
      - **B1 / C1 / D3 / D4** — read-only across all services; writes require operator approval
+   - **Deploy gating (2026-05-15)**: backend test workflow (`.github/workflows/tests.yml`) must pass on a PR before A1 merges to `main`. Auto-deploy fires only after green CI lands on `main`. No exceptions.
    - Both services auto-deploy from `main`. A1 (sole pusher to main) merges PRs; each push triggers auto-deploys on both services since both watch `main`. If a PR only touches one service's surface, the other service still redeploys (no-op for it but burns build minutes — acceptable for free tier).
    - **Future split** option if build-time waste becomes painful: each service moves to a bot-specific deploy branch (e.g. `d1/release`, `d2/release`), and A1 fast-forwards each one when their respective code paths change. Deferred until volume justifies the merge-coordination cost.
 

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -82,6 +82,7 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 - `docs/c1-checkpoint-*.md` — daily checkpoint reports
 - `docs/c1_daily_checkpoint_runbook.md` — the runbook itself (canonical)
 - `bot_chat` checkpoint + drift-flag entries
+- `v_bot_chat_unresolved` view migration (resolve-protocol owner, see CLAUDE.md §1 / PR #114 Cluster D-1)
 - PR merge commits (within push-protocol)
 - Stale PR comments (cross-lane coordination, allowed for C1)
 


### PR DESCRIPTION
## Summary

Operator directive 2026-05-15: merge frontend code + Render ownership into D0; D1/D2 become subordinate coding arms; deploys only fire after backend tests pass.

## Changes

| File | Edit |
|---|---|
| `CLAUDE.md` §4 | D0 = write authority on all 3 frontend services. D1/D2 = read-only, route writes through D0 review + A1 merge. |
| `LANE_DISCIPLINE.md` §6 | Deploy ownership table: D0 lane owner for all 3 services; D1/D2 listed as subordinate implementers. New deploy gate clause. |
| `LANE_DISCIPLINE.md` D0/D1/D2 sections | Annotated with "subordinate to D0" headers; existing write surfaces preserved. |
| `.github/workflows/tests.yml` | NEW — pytest on PR + push to main. Green required before A1 merges. |

## Test plan

- [x] CLAUDE.md updated
- [x] LANE_DISCIPLINE.md updated
- [x] tests.yml created with pytest invocation
- [ ] First CI run on this PR — `pytest tests/ -q --maxfail=1` should pass
- [ ] Operator action: add `pytest` to branch protection on main (dashboard)
- [ ] bot_chat announcement posted to D0/D1/D2

🤖 Generated with [Claude Code](https://claude.com/claude-code)