### PR TITLE
docs: Friday checkpoint 2026-05-15 + downstream bot handoff notes

### DIFF
--- a/docs/checkpoint-2026-05-15-friday.md
+++ b/docs/checkpoint-2026-05-15-friday.md
@@ -1,0 +1,160 @@
+# Friday Checkpoint — 2026-05-15
+
+**Author**: A1 (drafted on operator request; C1 to sign off for the formal daily-checkpoint record).
+**Cadence**: end-of-week summary + handoff notes for downstream bots.
+
+---
+
+## Headline
+
+Big day. Eight PRs merged (admin + D1 + D2). One reorg in flight (PR #126). Two real production bugs root-caused and fixed in-session (listings_deltas `id`-column, SG seller `status=` CSV). Backend test gate + branch protection on `main` shipped. D-tier hierarchy flattened: D0 consolidated frontend lane, D1/D2 demoted to subordinate coding arms.
+
+## Drift status
+
+| Surface | State |
+|---|---|
+| `migration_drift_check()` | 100 rows (no genuine drift; auto-version artifact — file timestamps differ from schema_migrations.version per the MCP `apply_migration` mechanism C1 flagged) |
+| `release_health_check()` | 2 fail / 1 warn / 7 ok (see Health below) |
+| Open PRs awaiting merge | 3 (#113 D0 auth, #114 C1 checkpoint, #126 D-tier reorg awaiting CI) |
+| bot_chat unresolved | 102 total, 31 from today, **0 older than 7 days** (C1 swept stale tail earlier) |
+
+## Health check (2 fail / 1 warn / 7 ok)
+
+| Class | Check | Status | Note |
+|---|---|---|---|
+| cron | `failed_jobs_90min` | **fail** | 3 distinct: `orphan_event_backfill_queue/process_15min`, `midnight-catchup-sweep` — Cluster B-2 (queued for tomorrow's A1 cycle) |
+| cron | `subhourly_jobs_silent_90min` | **fail** | Includes `listings_deltas_backfill_overnight`, `sg_canonical_link_overnight` (registered post-cron-resume after window passed; harmless until next 04:30 UTC) and the same orphan_* pair |
+| fks | `not_valid_fks` | warn | 57 NOT VALID FKs; unchanged from yesterday |
+| data_freshness | * | ok | All ingest tables fresh |
+| queues | * | ok | 0 pending |
+| pg_net | `error_rate_60min` | warn | **38% error rate** — Kong 429s persist (bot_chat 130, edge-fn fan-out problem, operator territory) |
+
+## PRs landed today (8)
+
+| # | Title | Lane | Effect |
+|---|---|---|---|
+| 112 | `cron_resume_with_gate` trailing-semi fix | A1 | 4 broken crons re-resumed |
+| 115 | D0 `get_broker_event_page` RPC + Tier-1 RLS + pg_net check | A1 | D0 Path C unblocked; 10 reference tables PostgREST-readable |
+| 117/118/119 | D1 storefront SQL homepage + perf + plan bump | D1 | 1.4s → 50ms first paint; cache-bust shipped |
+| 120 | `listings_deltas_backfill_chunked` `id`-column bug | A1 | 905-event drain running, ~600 remain |
+| 122 | SG seller crons resumed at Evo cadence (`3-59/10` stagger) | A1 | Kong herd avoided |
+| 123 | TickPick crons paused (vault token bad) | A1 | Apps Script flow remains primary, no data loss |
+| 124 | D1 `Cache-Control: no-cache` on /store HTML | D1 | Customers never see stale shell |
+| 125 | SG seller `status=` per-status loop + D2 metrics apply | A1+D2 | SG seller orders flowing (200+200 fulfilled+confirmed first tick); D2 Metrics tab unblocked |
+
+## PRs awaiting action
+
+| # | Title | Age | Blocker |
+|---|---|---|---|
+| 113 | D0 terminal MVP (Event Detail + Home + Movers + Performer + Orders + auth) | 13h | Operator: add 2 Supabase Auth redirect URLs (bot_chat 145) |
+| 114 | C1 daily checkpoint 2026-05-15 + consolidation plan | 13h | A1 review (mostly done via bot_chat 138; remaining: bundle decisions tracked) |
+| 126 | D-tier reorg (D0 consolidated, D1/D2 subordinate, test gate) | <1h | CI: pytest re-running after PYTHONPATH fix |
+
+## Wins (in-session, beyond the PR list)
+
+- **Branch protection on `main` LIVE** — pytest + check + scan required; force-push/delete blocked
+- **Apply batch** through MCP: 7 migrations shipped (310000 / 320000 / 330000 / 340000 / 350000 / 360000 / 365000 / 370000)
+- **Two structural finds**: (1) MCP `apply_migration` auto-versions (filename ≠ schema_migrations.version), (2) seatgeek_orders 346-day stale via `created_at_sg` was actually a status-filter bug not silent ingest
+
+## Open follow-ups
+
+### Operator action items (only the operator can do these)
+
+1. **Rotate `vault.TICKPICK_API_TOKEN`** — re-enables paused tickpick crons. Currently Apps Script ingest covers TickPick (939 rows / 24h) so this is non-urgent.
+2. **Rotate `rnd_WPA69TmT4vTttGvYa07GdMIqzfXz`** — Render API key was screenshotted; treat as compromised.
+3. **Flip D1 + D2 service plans free → starter** ($14/mo total) on Render dashboard — kills cold-starts.
+4. **Add 2 Supabase Auth redirect URLs** for D0 auth (bot_chat 145):
+   - `https://vibepass-terminal-test.onrender.com/static/terminal/login.html`
+   - `http://localhost:8000/static/terminal/login.html`
+
+### A1 lane (next session)
+
+1. **Cluster B-2**: fix the 3 failing crons (orphan_event_backfill FK + no-destination + midnight-catchup timeout)
+2. **SG seller orders pagination**: 507k upstream tail. Author chunked backfill function + overnight drain cron.
+3. **Edge fn fan-out**: investigate `collect-listings` edge fn source for Kong 429 cause (bot_chat 130, requires operator/lane-owner GH access to supabase/functions/)
+4. **`ALTER SYSTEM SET track_functions='pl'`** attempt for next week's real-data sprawl audit
+
+### B1 lane
+
+- PR #110 SECDEF retrofit (still open) — finish the 11-function pass + RLS gap fix on aq_venue_map + aq_performer_map
+
+### D0 lane (now consolidated)
+
+- After PR #126 merges + Supabase Auth redirect URLs added: PR #113 D0 terminal MVP can be functionally smoke-tested
+- D1/D2 PRs going forward: D0 reviews + signs off in PR comment before A1 merges
+
+### C1 lane
+
+- Tomorrow's 09:00 ET formal checkpoint: incorporate this draft + verify drift state vs current
+- Cluster D-1 view migration for `event_type='status'` = closure semantics (PR #114 action item)
+- 12-deliverable omnibus in PR #114 — landing recommendations from A1 review (bot_chat 138)
+
+## Notes for downstream bots
+
+### @D0 — promoted to consolidated frontend lane (effective when PR #126 merges)
+
+You now own all 3 frontend services at the Render layer:
+- `vibepass-terminal-test` (your existing)
+- `vibepass-storefront-test` (was D1's)
+- `d2-orders-dashboard` (was D2's)
+
+Plus: Render MCP write authority on all 3 (no per-call ask), and sign-off authority on D1/D2 subordinate PRs before A1 merges them.
+
+Operationally:
+- D1, D2 still author code in their existing directories
+- They open PRs against `main` as before
+- Before A1 merges, look for a D0 sign-off comment in the PR (any clear "approved" or "ship" works)
+- If a D1/D2 PR conflicts with your roadmap or needs adjustment, leave a review comment — A1 will hold the merge
+
+For your own work:
+- PR #113 still open, blocked on operator adding Supabase Auth redirect URLs (bot_chat 145)
+- `get_broker_event_page` RPC live in prod; Tier-1 RLS grants live on 10 reference tables (per PR #115)
+- Auth flow shipped to PR #113 (commit `fefa08c`) — once operator adds the redirect URLs, magic-link + Google OAuth round-trip works
+
+### @D1 — subordinate coding arm under D0
+
+Your code surfaces (`static/store/*`, `app.py /api/store/*`, `render.yaml`) and write authority for source files are unchanged. What changes:
+- Render MCP access drops to **read-only** (was write OK on `vibepass-storefront-test`)
+- Your PRs require a **D0 sign-off comment** before A1 merges
+- All your shipped work today (PRs #117/118/119/124) lands; no rework needed
+
+If you have time, the open follow-up from your own audit is:
+- F3 `HEAD /store` 405 — low priority cosmetic
+- Sprint 3 (legal/trust pages) — pre-req for any future payment flow
+
+### @D2 — subordinate coding arm under D0
+
+Same shape as D1. Your code surfaces (`d2_dashboard/*`, order client `.py` files) are unchanged. Render access drops to read-only.
+
+Note that the SG seller orders silent-success you root-caused (bot_chat 154) is now fixed (PR #125, per-status loop). Your Metrics tab also unblocked via the same PR (6 d2_metrics_* functions live).
+
+Pagination of the 507k SG seller fulfilled tail is A1 lane — I'll author a chunked backfill function in the next session.
+
+### @B1
+
+Branch protection now enforces `secret-scan` workflow you shipped earlier today. Your PR #110 SECDEF retrofit can ship next; coordinate with A1 (me) on bundling the SECDEF body assertions + RLS gap on aq_venue_map / aq_performer_map.
+
+### @C1
+
+This doc supersedes/feeds into your formal `c1-checkpoint-2026-05-15.md`. Differences vs your PR #114:
+- Headline section + downstream-bot notes section added
+- Audit + Consolidation Plan items resolved (per bot_chat 138)
+- D-tier reorg shipped — update `LANE_DISCIPLINE.md` references in your own runbook if relevant
+
+For tomorrow's 09:00 ET cycle, the watch list is:
+1. Overnight backfill window (04:30 UTC `listings_deltas`, 04:46 UTC `sg_canonical_link`) — both should now succeed cleanly after PR #120 fix
+2. SG seller cron first 24h: confirm rows accumulate properly across the 4-status loop
+3. Cluster B-2 crons (orphan + midnight-catchup) still failing — assigned to A1 tomorrow
+4. listings drain cron should have self-unscheduled by morning
+
+## Tomorrow's watch items
+
+- Drain cron `listings_deltas_backfill_drain_now` should have self-unscheduled (events_remaining=0)
+- Overnight backfill cycle quality (post-PR-#120 first clean run)
+- SG seller orders steady-state ingest rate (was 0/24h, target dozens/day)
+- Cluster B-2 follow-through (3 cron fixes)
+- Operator-action-item triage: any of the 4 items rotated/configured
+
+---
+
+*Drafted by A1 on operator request 2026-05-15. C1 to formalize into the canonical `c1-checkpoint-YYYY-MM-DD.md` series in tomorrow's 09:00 ET cycle, integrating any overnight signal.*


### PR DESCRIPTION
## Summary

A1-drafted Friday checkpoint at operator request. Captures the day's wins (8 merged PRs, branch protection live, 2 prod bugs root-caused + fixed) plus per-bot handoff notes for D0 (now consolidated frontend lane), D1/D2 (subordinate), B1, and C1.

C1 to formalize into the canonical \`c1-checkpoint-YYYY-MM-DD.md\` series in tomorrow's 09:00 ET cycle.

## Test plan
- [x] Doc written
- [x] Reflects current health check + bot_chat counts (read via MCP)
- [x] Open follow-ups split by lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)