### PR TITLE
chore(security): extend B1 charter with git + render monitoring surfaces

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -272,6 +272,21 @@ Defense-in-depth follow-ups identified during the Phase-2 monitoring sweep. Each
 - **[B1-NEXT-9] [SEC-MED]** §6 retrofit on `get_broker_event_page(integer, integer)` (A1's, added by PR #115). Body is already gated by `auth.jwt()->>'email'`; §6 guard is belt-and-suspenders. File PR comment to A1.
 - **[B1-NEXT-10] [SEC-LOW]** Migration slot collision audit — `20260515300000` (3 files), `20260515320000` (2 files) collide. MIGRATION_CONVENTIONS.md §3 bump-by-30-or-50 rule not followed. Not security-class but flags discipline drift; recommend filenames be renamed to next free slots in a future cleanup PR.
 
+### B1-NEXT — git + render monitoring expansion (filed 2026-05-15 by B1 charter §git+render)
+
+Operator-extended mandate covers git settings + Render workspace. Initial sweep landed [`docs/git_repo_security_posture.md`](docs/git_repo_security_posture.md) + [`docs/render_security_posture.md`](docs/render_security_posture.md). Findings filed below.
+
+- **[B1-NEXT-11] [SEC-HIGH]** Reassess history-rewrite priority on leaked `CRON_SECRET` in commit `5297739`. Original SECURITY BACKLOG item scoped assuming private repo; current `visibility: public` means rotated value is internet-readable. Operator decides: `git filter-repo` + force-push window, OR accept (value rotated, blast radius is whoever scraped between leak + rotation). Documented as G-1 in git posture inventory.
+- **[B1-NEXT-12] [SEC-MED]** Enable `dependabot_security_updates` on the repo (currently `disabled`). After 2026-05-11 `requirements.txt` unpinning incident (SW-3 above), Dependabot is the right tool. Operator-only — Settings → Code security. Documented as G-2.
+- **[B1-NEXT-13] [SEC-MED]** Enable `secret_scanning_non_provider_patterns` (currently `disabled`). Catches project-shape secrets like `CRON_SECRET`, `APPSCRIPT_INGEST_SECRET`. Operator-only. Documented as G-3.
+- **[B1-NEXT-14] [SEC-MED]** Enable `secret_scanning_validity_checks` (currently `disabled`). Confirms whether leaked tokens are still active. Operator-only. Documented as G-4.
+- **[B1-NEXT-15] [SEC-LOW]** Consider enabling branch-protection `enforce_admins` for `main` (currently `false`). Admin (`JulianS4K`) can bypass protections. Acceptable single-operator risk profile but documented for transparency. Operator-only. G-6.
+- **[B1-NEXT-16] [SEC-LOW]** Consider enabling `required_signatures` for `main`. Currently `false`. GitHub-server-side commits (PR merges) make impersonation low-risk, but signing would harden against compromised local dev environment. G-7.
+- **[B1-NEXT-17] [SEC-LOW]** Consider enabling Actions `sha_pinning_required`. Currently `false`. Workflows reference Actions by mutable tags (`@v4`, `@v7`). Tighten to immutable SHA pins for supply-chain hardening. G-8.
+- **[B1-NEXT-18] [SEC-MED]** Verify Actions secrets are populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, optional `SUPABASE_PAT`). `gh api .../actions/secrets` returned empty at sweep — could be permission-filtered, could be unset. If unset, sync-check fails silently. Operator confirms next session.
+- **[B1-NEXT-19] [SEC-LOW]** Render `ipAllowList: 0.0.0.0/0` on `d2-orders-dashboard` and `vibepass-terminal-test` — both supposed to be `@s4kent.com` authenticated at app layer. Optional secondary defense: tighten allowlist to known operator IPs. PR comment to D1 (Render-write authority). Documented as R-1.
+- **[B1-NEXT-20] [SEC-LOW]** Render services `autoDeploy: yes` from `main` on every commit. Standard CD; consider manual approval gate for `vibepass-storefront-test` (public retail). PR comment to D1. R-2.
+
 ### NEXT (code) — [SEC-CRIT] Rotate the leaked `CRON_SECRET` value, then redact from KANBAN/AGENTS
 
 **What**: The `CRON_SECRET` value was committed in plaintext to `KANBAN.md` (lines 87, 90, 91 below this block) and discussed in `AGENTS.md`. It is in git history (commit `5297739` and prior). Anyone who clones this repo today reads the production cron secret.

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -286,6 +286,7 @@ Operator-extended mandate covers git settings + Render workspace. Initial sweep 
 - **[B1-NEXT-18] [SEC-MED]** Verify Actions secrets are populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, optional `SUPABASE_PAT`). `gh api .../actions/secrets` returned empty at sweep — could be permission-filtered, could be unset. If unset, sync-check fails silently. Operator confirms next session.
 - **[B1-NEXT-19] [SEC-LOW]** Render `ipAllowList: 0.0.0.0/0` on `d2-orders-dashboard` and `vibepass-terminal-test` — both supposed to be `@s4kent.com` authenticated at app layer. Optional secondary defense: tighten allowlist to known operator IPs. PR comment to D1 (Render-write authority). Documented as R-1.
 - **[B1-NEXT-20] [SEC-LOW]** Render services `autoDeploy: yes` from `main` on every commit. Standard CD; consider manual approval gate for `vibepass-storefront-test` (public retail). PR comment to D1. R-2.
+- **[B1-NEXT-21] [SEC-LOW]** Slack surface monitoring — operator decision on installing a Slack MCP. Currently no active Slack integration in the repo (gitleaks catches `xoxb-*`/`xoxp-*` tokens via push-protection; no Slack-posting workflows; no webhooks). Future state: with Slack MCP, B1 monitors workspace admins, 2FA enforcement, recent-message search for incident leaks. Without MCP, B1's Slack coverage is grep + gitleaks only. See `docs/b1_operating_constraints.md` "Slack posture monitoring" section.
 
 ### NEXT (code) — [SEC-CRIT] Rotate the leaked `CRON_SECRET` value, then redact from KANBAN/AGENTS
 

--- a/docs/b1_operating_constraints.md
+++ b/docs/b1_operating_constraints.md
@@ -12,7 +12,7 @@ Operator directive 2026-05-15:
 
 > Monitor for security, issues, entry points and data leaks. Monitor outgoing data and bot notes and code for exposed secrets, and fix. Monitor for attacks from outside. Monitor for bot hallucinations.
 
-Operationalized as continuous monitoring across **eight surfaces** (operator extended 2026-05-15 to add git + render):
+Operationalized as continuous monitoring across **nine surfaces** (operator extended 2026-05-15 to add git + render + slack):
 
 | Surface | Coverage |
 |---|---|
@@ -24,6 +24,7 @@ Operationalized as continuous monitoring across **eight surfaces** (operator ext
 | Bot hallucinations | Other-bot claims about file paths, function names, migration timestamps, PR numbers, `bot_chat` row IDs — verify before they propagate |
 | **Git / repo posture** | Branch protection rules, required status checks, collaborator perms, GitHub Actions secrets/vars, repo visibility, webhooks, deploy keys, secret-scanning + Dependabot config, push-protection state, workflow permissions, SHA pinning |
 | **Render workspace posture** | Workspace access, service list, IP allowlists, autoDeploy triggers, env-var inventory (names only, not values), preview-deploys posture, suspended state, deploy notification config |
+| **Slack posture** | Slack webhooks pointing into / out of the repo, Slack tokens / signing secrets / bot tokens leaked in code or git history, Slack GitHub App installations, Slack-shaped URLs (`hooks.slack.com/services/*`) appearing in commits, Slack messages (when an operator-installed Slack MCP becomes available) for incident leaks and external-attack chatter |
 
 ## Read surface
 
@@ -107,7 +108,7 @@ Run at session start. Total runtime ~5 min. All read-only.
 | 5 | New SECDEF §6 check | `SELECT proname, has_function_privilege('public', oid::regprocedure::text, 'EXECUTE') AS public_exec FROM pg_proc WHERE prosecdef AND NOT pg_get_functiondef(oid) ~ 'current_user NOT IN';` | None missing — else file `flag` or retrofit |
 | 6 | New tables RLS check | `SELECT tablename FROM pg_tables WHERE schemaname='public' AND NOT rowsecurity;` | None new since last sweep — else file fix |
 | 7 | New views `security_invoker` check | `SELECT viewname, reloptions FROM pg_views v JOIN pg_class c ON c.relname=v.viewname WHERE v.schemaname='public' AND (c.reloptions IS NULL OR NOT 'security_invoker=true' = ANY(c.reloptions));` | All new views have `security_invoker=true` |
-| 8 | Secret-scan | Check `.github/workflows/secret-scan.yml` latest run status; if local uncommitted changes, run `gitleaks detect --no-git` against worktree | Clean — else rotate + redact + file `p0_security` |
+| 8 | Secret-scan | Check `.github/workflows/secret-scan.yml` latest run status; if local uncommitted changes, run `gitleaks detect --no-git` against worktree. Default ruleset covers Slack tokens (`xoxb-*`, `xoxp-*`, etc.), AWS, GitHub, Stripe, generic high-entropy strings. | Clean — else rotate + redact + file `p0_security` |
 | 9 | Hallucination spot-check | Pick 3 most recent merged PRs; verify each cited file path / function name / migration timestamp / cron job name / bot_chat row ID exists | All citations real |
 | 10 | RULE 2 static check | `python scripts/check_readonly.py` | Pass |
 | 11 | `bot_chat` aging report | `SELECT * FROM public.release_health_check() WHERE check_name='bot_chat_aging_7d';` (once 20260515* migration applied) OR direct SQL until then | 0 items aged >7d, or all triaged this session |
@@ -215,6 +216,39 @@ D1 owns Render writes exclusively per [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.
 - **`pullRequestPreviewsEnabled` flipped on** → SEC-MED. Unexpected previews of PR code on public URL.
 - **Service moved to `develop` or non-`main` branch** → SEC-MED. Branch protection only covers `main`.
 - **Anomalous log pattern (auth-failure spike, 5xx flood, OOM crashes)** → triage per severity; file in `bot_chat`.
+
+## Slack posture monitoring
+
+**Current state (2026-05-15)**: no Slack MCP tool available, no active Slack integration in the repo. Existing Slack references are incidental:
+- `docs/security-runbook-2026-05-11.md` mentions Slack DM as an out-of-band delivery channel for rotated passwords
+- `COWORKER_ONBOARDING.md` directs coworkers to GitHub issues over Slack
+
+Until/unless operator installs a Slack MCP, B1's Slack monitoring is **grep-based**, focused on detecting accidental leakage of Slack credentials into the repo.
+
+### What B1 checks (per-session, read-only)
+
+| Area | Probe | Pass condition |
+|---|---|---|
+| Slack tokens leaked in code | `gitleaks` ruleset (already running via `.github/workflows/secret-scan.yml`) — built-in rules cover `xoxb-*`, `xoxp-*`, `xoxa-*`, `xoxs-*`, `xoxr-*` bot/user/app tokens | 0 findings |
+| Slack signing secrets / webhook URLs | grep repo for `hooks.slack.com/services/`, `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `SLACK_WEBHOOK_URL` | None present (or all in `.gitleaksignore` with documented justification) |
+| Slack GitHub App on the repo | `gh api repos/JulianS4K/Terminal-2/installation` (when scope allows) — track Slack App installation status | Track changes between sweeps |
+| Slack workflow steps in Actions | grep `.github/workflows/*.yml` for `slack` — track any workflow that posts to Slack | No unexpected Slack-posting workflows |
+
+### What B1 does on findings
+
+- **Slack token (`xox*`) in any commit** → SEC-CRIT. Token must be revoked in Slack workspace immediately (operator-coordinated). History rewrite + force-push window per the same protocol as the `CRON_SECRET` incident.
+- **Webhook URL leaked** → SEC-MED. Slack webhook URLs are abusable (anyone can post to the channel) but limited blast radius. Rotate webhook + redact.
+- **New Slack GitHub App installed unexpectedly** → SEC-HIGH. Could be operator-installed integration OR account-takeover signal. `flag` to operator for confirmation.
+- **New Slack-posting workflow appears** → SEC-MED. Could leak PR contents / repo metadata to a Slack workspace. Review the workflow before next sweep.
+
+### Future state (when Slack MCP becomes available)
+
+Add to per-session sweep:
+- List Slack workspace members; flag new admins
+- Search recent messages for incident-shape patterns (leaked tokens shared in DMs, external pen-test chatter, social-engineering attempts)
+- Verify Slack workspace 2FA enforcement, SSO config, retention policy
+
+Filed as [B1-NEXT-21] for operator decision on Slack MCP install.
 
 ## Escalation paths
 

--- a/docs/b1_operating_constraints.md
+++ b/docs/b1_operating_constraints.md
@@ -12,7 +12,7 @@ Operator directive 2026-05-15:
 
 > Monitor for security, issues, entry points and data leaks. Monitor outgoing data and bot notes and code for exposed secrets, and fix. Monitor for attacks from outside. Monitor for bot hallucinations.
 
-Operationalized as continuous monitoring across **six surfaces**:
+Operationalized as continuous monitoring across **eight surfaces** (operator extended 2026-05-15 to add git + render):
 
 | Surface | Coverage |
 |---|---|
@@ -22,6 +22,8 @@ Operationalized as continuous monitoring across **six surfaces**:
 | Outgoing data | Payloads returned by anon-callable RPCs, edge function responses, `/api/*` responses — must filter wholesale/broker fields per `LANE_DISCIPLINE.md §D1` wall rules |
 | External attacks | Anomalous query patterns, high-frequency anon traffic, failed-auth spikes, unusual edge-function invocations |
 | Bot hallucinations | Other-bot claims about file paths, function names, migration timestamps, PR numbers, `bot_chat` row IDs — verify before they propagate |
+| **Git / repo posture** | Branch protection rules, required status checks, collaborator perms, GitHub Actions secrets/vars, repo visibility, webhooks, deploy keys, secret-scanning + Dependabot config, push-protection state, workflow permissions, SHA pinning |
+| **Render workspace posture** | Workspace access, service list, IP allowlists, autoDeploy triggers, env-var inventory (names only, not values), preview-deploys posture, suspended state, deploy notification config |
 
 ## Read surface
 
@@ -35,6 +37,8 @@ Active read targets:
 - All Render service metadata via Render MCP (read-only)
 - Git history (`git log`, `git show`, `git diff`)
 - All `docs/` content, all `supabase/migrations/*.sql`, all `supabase/functions/*`, all `scripts/`, all `bin/`
+- **GitHub repo settings**: `gh api repos/.../branches/main/protection`, `gh api repos/.../hooks`, `gh api repos/.../keys`, `gh api repos/.../collaborators`, `gh api repos/.../actions/permissions`, `gh api repos/.../actions/secrets` (names only), `gh api repos/.../actions/variables`, `gh api repos/.../code-scanning/alerts`, `gh api repos/.../secret-scanning/alerts`, `gh api repos/.../dependabot/alerts`
+- **Render workspace** (read-only): `mcp__render__list_workspaces`, `list_services`, `get_service`, `get_metrics`, `list_logs`, `list_deploys`, `list_log_label_values`. **Forbidden writes** stay forbidden: `update_environment_variables`, `update_web_service`, `update_static_site`, `create_*`, `update_cron_job`. D1 owns Render writes per `LANE_DISCIPLINE.md` Cross-cutting Rule #6.
 
 ## Write surface (authored files)
 
@@ -107,6 +111,9 @@ Run at session start. Total runtime ~5 min. All read-only.
 | 9 | Hallucination spot-check | Pick 3 most recent merged PRs; verify each cited file path / function name / migration timestamp / cron job name / bot_chat row ID exists | All citations real |
 | 10 | RULE 2 static check | `python scripts/check_readonly.py` | Pass |
 | 11 | `bot_chat` aging report | `SELECT * FROM public.release_health_check() WHERE check_name='bot_chat_aging_7d';` (once 20260515* migration applied) OR direct SQL until then | 0 items aged >7d, or all triaged this session |
+| 12 | Git posture diff | Compare current `gh api repos/.../branches/main/protection` + `repos/<>` settings against `docs/git_repo_security_posture.md` snapshot | No regression vs. last sweep |
+| 13 | Render posture diff | Compare current `mcp__render__list_services` output against `docs/render_security_posture.md` snapshot. Check for new services, `ipAllowList` widening, `autoDeploy` flips, suspended-state changes | No unexpected changes |
+| 14 | Code-scanning / secret-scanning alerts | `gh api repos/JulianS4K/Terminal-2/code-scanning/alerts?state=open` + `gh api .../secret-scanning/alerts?state=open` + `gh api .../dependabot/alerts?state=open` | All triaged this session (resolved or filed as B1-NEXT) |
 
 Output:
 - **Clean sweep** → `bot_chat_log('change_log', 'security', 'B1', 'B1 sweep <date> — clean. Baseline: <release_health_check rows hash>.')`
@@ -156,6 +163,58 @@ When a hallucination is found:
 | `bot_chat` `p0_security` | When a finding is SEC-CRIT or SEC-HIGH | Same shape as `flag` but with explicit `p0_security` event_type |
 | `docs/security-audit-<date>-*.md` | When findings warrant a structured write-up (multi-finding audit, post-PR-cluster pass) | TL;DR + inventory + per-finding sections + retrofit migration spec + verification + open items by lane |
 | `KANBAN.md` SECURITY BACKLOG | For SEC-MED/LOW that won't be patched this session | One row per item, `B1-NEXT-N` tagged, severity-classified, lane-attributed |
+
+## Git / repo posture monitoring
+
+Living inventory at [`docs/git_repo_security_posture.md`](git_repo_security_posture.md). B1 diffs against it during per-session sweep step 12.
+
+### What B1 checks (per-session, read-only)
+
+| Area | Probe |
+|---|---|
+| Branch protection on `main` | `gh api repos/JulianS4K/Terminal-2/branches/main/protection` — verify required status checks (`pytest`, `check`, `scan`), force-push/deletion blocks, admin enforcement state, signing requirement |
+| Repo settings | `gh api repos/JulianS4K/Terminal-2` — verify visibility, default branch, security_and_analysis (secret_scanning, push_protection, dependabot_security_updates) |
+| Webhooks | `gh api repos/JulianS4K/Terminal-2/hooks` — expect empty list; any new hook gets flagged |
+| Deploy keys | `gh api repos/JulianS4K/Terminal-2/keys` — expect empty list |
+| Collaborators | `gh api repos/JulianS4K/Terminal-2/collaborators` — expect only `JulianS4K` admin |
+| Actions permissions | `gh api repos/JulianS4K/Terminal-2/actions/permissions` and `.../actions/permissions/workflow` — verify `default_workflow_permissions=read`, `can_approve_pull_request_reviews=false` |
+| Actions secrets (names) | `gh api repos/JulianS4K/Terminal-2/actions/secrets` — track names + rotation timestamps; never log values |
+| Code-scanning alerts | `gh api .../code-scanning/alerts?state=open` |
+| Secret-scanning alerts | `gh api .../secret-scanning/alerts?state=open` |
+| Dependabot alerts | `gh api .../dependabot/alerts?state=open` |
+
+### What B1 does on findings
+
+- **Branch protection weakened** (e.g. force-push enabled, required checks removed) → SEC-CRIT. File `p0_security` in `bot_chat` immediately. Operator-only to fix.
+- **New webhook / deploy key / collaborator added unexpectedly** → SEC-CRIT. `p0_security`. Possibly an account takeover signal.
+- **Security_and_analysis flag flipped off** → SEC-HIGH. File flag + propose re-enable PR.
+- **New code-scanning / secret-scanning / dependabot alert** → triage by alert's own severity; SEC-CRIT/HIGH gets within-session patch attempt; SEC-MED/LOW filed in KANBAN.
+- **Actions secret rotated unexpectedly** → flag (could be legit operator rotation, but worth confirming).
+
+## Render workspace monitoring
+
+Living inventory at [`docs/render_security_posture.md`](render_security_posture.md). B1 diffs against it during per-session sweep step 13.
+
+D1 owns Render writes exclusively per [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.md) Cross-cutting Rule #6. B1 reads only — any finding that requires a write becomes a PR comment to D1.
+
+### What B1 checks (per-session, read-only)
+
+| Area | Probe |
+|---|---|
+| Workspace access | `mcp__render__list_workspaces` — verify only the S4K workspace + correct owner email |
+| Service list | `mcp__render__list_services` — track service names, ids, types (web_service / static_site / cron_job), branches |
+| Per-service config | `mcp__render__get_service` — verify `autoDeploy` trigger, `branch`, `ipAllowList`, `pullRequestPreviewsEnabled`, suspended state |
+| Service logs | `mcp__render__list_logs` filtered for auth failures, 5xx spikes, anomalous error patterns |
+| Deploys | `mcp__render__list_deploys` — track recency, status; flag failed deploys that auto-rollback |
+
+### What B1 does on findings
+
+- **New unexpected service in workspace** → SEC-HIGH. Likely D1 work but not coordinated — flag in `bot_chat` + PR comment to D1.
+- **`ipAllowList` flipped from restricted to `0.0.0.0/0`** → SEC-MED. Could be intentional; PR comment to D1 to confirm.
+- **`autoDeploy` flipped on for an unprotected branch** → SEC-MED. CD on unreviewed branch is a supply-chain vector.
+- **`pullRequestPreviewsEnabled` flipped on** → SEC-MED. Unexpected previews of PR code on public URL.
+- **Service moved to `develop` or non-`main` branch** → SEC-MED. Branch protection only covers `main`.
+- **Anomalous log pattern (auth-failure spike, 5xx flood, OOM crashes)** → triage per severity; file in `bot_chat`.
 
 ## Escalation paths
 

--- a/docs/git_repo_security_posture.md
+++ b/docs/git_repo_security_posture.md
@@ -1,0 +1,154 @@
+# Git Repo Security Posture — Terminal-2
+
+**Owner**: B1 (Security Manager) · **Last full sweep**: 2026-05-15 · **Update cadence**: per-session sweep step 12 + 14 (see [`b1_operating_constraints.md`](b1_operating_constraints.md))
+
+Living snapshot of GitHub repo security configuration. B1 diffs current `gh api` output against this doc to catch regressions.
+
+---
+
+## Active findings (open, 2026-05-15)
+
+| # | Severity | Finding | Action |
+|---|---|---|---|
+| G-1 | SEC-HIGH | Repo `visibility: public` AND historic `CRON_SECRET` literal in commit `5297739` (now-rotated, but readable on the internet). The KANBAN.md SECURITY BACKLOG "[OPS-ONLY] History rewrite of leaked literal" item was originally scoped assuming private repo. Public posture changes the calculus. | File [B1-NEXT-11] reassessing history-rewrite priority. Operator decides whether to `git filter-repo` + force-push window. |
+| G-2 | SEC-MED | `dependabot_security_updates: disabled` (also `dependabot_security_alerts` returns 403 = disabled). After the 2026-05-11 `requirements.txt` unpinning incident (SW-3 in KANBAN), Dependabot is the right tool to keep transitive deps current. | File [B1-NEXT-12]. Operator-only to enable (Settings → Code security). |
+| G-3 | SEC-MED | `secret_scanning_non_provider_patterns: disabled` | File [B1-NEXT-13]. Won't catch custom-shaped secrets (e.g., `CRON_SECRET`, `APPSCRIPT_INGEST_SECRET`). Operator-only to enable. |
+| G-4 | SEC-MED | `secret_scanning_validity_checks: disabled` | File [B1-NEXT-14]. Wouldn't confirm if a leaked token is still active. Operator-only. |
+| G-5 | SEC-MED | No CodeQL / code-scanning analysis exists (`code-scanning/alerts` returns 404 "no analysis found"). | Already filed as [B1-NEXT-4]. Decision deferred; this confirms current state. |
+| G-6 | SEC-LOW | `enforce_admins: false` — admin (`JulianS4K`) can bypass branch protection. Acceptable single-operator risk profile, but documented here. | File [B1-NEXT-15] (low-pri, operator-only). |
+| G-7 | SEC-LOW | `required_signatures: false` — commits not GPG-signed. Single-operator + GitHub-server-side commits via PR merge make impersonation low-risk. | File [B1-NEXT-16] (low-pri). |
+| G-8 | SEC-LOW | Actions `sha_pinning_required: false` — third-party Actions can be referenced by mutable tags (supply-chain vector). Currently using `actions/checkout@v4`, `actions/github-script@v7`, `actions/upload-artifact@v4`, `gitleaks/gitleaks-action@v2` — all tag-pinned. | File [B1-NEXT-17]. Could enable + convert to SHA pins. |
+
+No SEC-CRIT findings.
+
+---
+
+## Section 1 — Branch protection on `main`
+
+Source: `gh api repos/JulianS4K/Terminal-2/branches/main/protection`
+
+| Setting | State | Notes |
+|---|---|---|
+| Required status checks | ✅ ENABLED, strict mode | Contexts: `pytest`, `check`, `scan` |
+| Required signatures | ❌ disabled | G-7 |
+| Enforce admins | ❌ disabled | G-6 |
+| Required linear history | ❌ disabled | Acceptable; merge commits allowed |
+| Allow force pushes | ✅ BLOCKED | |
+| Allow deletions | ✅ BLOCKED | |
+| Block creations | ❌ disabled | Default behavior; non-issue |
+| Required conversation resolution | ❌ disabled | PR comments don't need to be resolved at merge |
+| Lock branch | ❌ disabled | |
+| Allow fork syncing | ❌ disabled | |
+
+---
+
+## Section 2 — Repo-level settings
+
+Source: `gh api repos/JulianS4K/Terminal-2`
+
+| Setting | State | Notes |
+|---|---|---|
+| `visibility` | **public** | G-1 |
+| `private` | false | |
+| `default_branch` | `main` | |
+| `allow_squash_merge` | true | Multi-strategy allowed; not security-critical |
+| `allow_merge_commit` | true | |
+| `allow_rebase_merge` | true | |
+| `allow_auto_merge` | false | Defensive default — auto-merge would land PRs without manual gate |
+| `allow_update_branch` | false | |
+| `delete_branch_on_merge` | false | Hygiene; orphan branches accumulate but no security risk |
+| `web_commit_signoff_required` | false | DCO not enforced; OK for single-operator |
+
+### security_and_analysis
+
+| Feature | State | Notes |
+|---|---|---|
+| `secret_scanning` | ✅ enabled | |
+| `secret_scanning_push_protection` | ✅ enabled | Pushes containing detectable secrets are blocked |
+| `secret_scanning_non_provider_patterns` | ❌ disabled | G-3 |
+| `secret_scanning_validity_checks` | ❌ disabled | G-4 |
+| `dependabot_security_updates` | ❌ disabled | G-2 |
+
+---
+
+## Section 3 — Hooks, deploy keys, collaborators
+
+Source: `gh api repos/JulianS4K/Terminal-2/{hooks,keys,collaborators}`
+
+| Surface | State |
+|---|---|
+| Webhooks | None (empty) ✅ |
+| Deploy keys | None (empty) ✅ |
+| Collaborators | `JulianS4K` only — admin, maintain, pull, push, triage ✅ |
+
+---
+
+## Section 4 — GitHub Actions configuration
+
+Source: `gh api repos/JulianS4K/Terminal-2/actions/permissions` + `.../actions/permissions/workflow`
+
+| Setting | State | Notes |
+|---|---|---|
+| Actions enabled | ✅ true | |
+| `allowed_actions` | `all` | All Actions allowed. Could tighten to `selected` with allowlist; low priority since single-operator. |
+| `sha_pinning_required` | ❌ false | G-8 |
+| `default_workflow_permissions` | `read` ✅ | Workflows get read-only `GITHUB_TOKEN` by default; individual workflows opt-in to write |
+| `can_approve_pull_request_reviews` | false ✅ | Workflows cannot self-approve PRs |
+
+### Active workflows
+
+| Workflow | Trigger | Purpose | B1 review status |
+|---|---|---|---|
+| `forbidden-paths-check.yml` | PR | Author-gate on backend files | Reviewed (A1-authored) |
+| `sync-check.yml` | push main + daily + manual | Migration / edge-fn drift detection | Reviewed (A1-authored) |
+| `tests.yml` | PR (per PR #126) | pytest test gate | Reviewed (D-tier reorg, PR #126) |
+| `secret-scan.yml` | PR + weekly + manual | gitleaks secret scanning | Authored by B1 (PR #118) |
+
+### Actions secrets (names only — values never logged)
+
+Per `gh api repos/JulianS4K/Terminal-2/actions/secrets`: query returned empty list at sweep time. This likely indicates the secrets configured for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_PAT`) are present but the API was filtered, OR they aren't set.
+
+**Action**: B1 to verify with operator next session that workflow-required secrets are populated. If not set, `sync-check.yml` fails silently — track as [B1-NEXT-18].
+
+---
+
+## Section 5 — Security alerts (open, 2026-05-15)
+
+| Surface | Open count | Notes |
+|---|---|---|
+| Secret-scanning alerts | 0 (empty result) ✅ | Push-protection has been blocking — good |
+| Code-scanning alerts | N/A — no analysis configured | G-5 / [B1-NEXT-4] |
+| Dependabot alerts | N/A — disabled | G-2 / [B1-NEXT-12] |
+
+---
+
+## Section 6 — Sweep SQL / commands (reference)
+
+```bash
+# Branch protection
+gh api repos/JulianS4K/Terminal-2/branches/main/protection
+
+# Full repo settings
+gh api repos/JulianS4K/Terminal-2 --jq '{private,visibility,default_branch,security_and_analysis,allow_auto_merge,allow_update_branch,web_commit_signoff_required}'
+
+# Webhooks (expect empty)
+gh api repos/JulianS4K/Terminal-2/hooks --jq '.[] | {id,name,events,active,url:.config.url}'
+
+# Deploy keys (expect empty)
+gh api repos/JulianS4K/Terminal-2/keys
+
+# Collaborators (expect only JulianS4K)
+gh api repos/JulianS4K/Terminal-2/collaborators --jq '.[] | {login,permissions}'
+
+# Actions config
+gh api repos/JulianS4K/Terminal-2/actions/permissions
+gh api repos/JulianS4K/Terminal-2/actions/permissions/workflow
+
+# Actions secrets (names only)
+gh api repos/JulianS4K/Terminal-2/actions/secrets --jq '.secrets[] | {name,created_at,updated_at}'
+
+# Alerts (require admin scope)
+gh api "repos/JulianS4K/Terminal-2/secret-scanning/alerts?state=open"
+gh api "repos/JulianS4K/Terminal-2/code-scanning/alerts?state=open"
+gh api "repos/JulianS4K/Terminal-2/dependabot/alerts?state=open"
+```

--- a/docs/git_repo_security_posture.md
+++ b/docs/git_repo_security_posture.md
@@ -112,6 +112,21 @@ Per `gh api repos/JulianS4K/Terminal-2/actions/secrets`: query returned empty li
 
 ---
 
+## Section 4b — Slack integration surface
+
+No active Slack integration in the repo or repo-level GitHub Apps. Slack references are incidental (`docs/security-runbook-2026-05-11.md` mentions Slack DM as an out-of-band password-delivery channel; `COWORKER_ONBOARDING.md` directs coworkers to GitHub issues over Slack).
+
+### Probes (per-session)
+
+| Area | Command | Current state |
+|---|---|---|
+| Slack tokens / webhooks in repo | `gitleaks` via `.github/workflows/secret-scan.yml` (catches `xoxb-*`, `xoxp-*`, etc.) + grep for `hooks.slack.com/services/`, `SLACK_*` env names | 0 findings |
+| Slack-posting workflows | `grep -liE 'slack' .github/workflows/*.yml` | None |
+| Slack GitHub App | `gh api repos/JulianS4K/Terminal-2/installation` (requires admin scope; returned 401 with current token) | Unable to verify without operator-scope token; track [B1-NEXT-21] |
+| Webhooks pointing to Slack | `gh api repos/JulianS4K/Terminal-2/hooks` | Empty list |
+
+No findings. Future Slack workspace monitoring requires operator to install a Slack MCP — filed as [B1-NEXT-21].
+
 ## Section 5 — Security alerts (open, 2026-05-15)
 
 | Surface | Open count | Notes |

--- a/docs/render_security_posture.md
+++ b/docs/render_security_posture.md
@@ -1,0 +1,173 @@
+# Render Workspace Security Posture — Terminal-2
+
+**Owner**: B1 (Security Manager — read-only on Render) · **Last full sweep**: 2026-05-15 · **Update cadence**: per-session sweep step 13 (see [`b1_operating_constraints.md`](b1_operating_constraints.md))
+
+Living snapshot of the Render workspace serving Terminal-2 lanes. B1 diffs current `mcp__render__*` output against this doc to catch regressions.
+
+**Lane scope**: per [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.md) Cross-cutting Rule #6, **D1 owns Render writes exclusively**. B1 monitors only. Findings that require Render writes become PR comments to D1.
+
+---
+
+## Active findings (open, 2026-05-15)
+
+| # | Severity | Finding | Action |
+|---|---|---|---|
+| R-1 | SEC-LOW | All 3 Terminal-2 services have `ipAllowList: 0.0.0.0/0` ("everywhere"). For `vibepass-storefront-test` (public retail) this is intended. For `vibepass-terminal-test` (broker terminal, supposed to be `@s4kent.com`-gated) and `d2-orders-dashboard` (internal ops), the IP allowlist could be a secondary defense. Auth lives at the app layer; this is belt-and-suspenders. | File [B1-NEXT-19]. PR comment to D1 (Render-write authority) — operator decision: tighten IP allowlist on internal services or accept current posture. |
+| R-2 | SEC-LOW | All 3 Terminal-2 services `autoDeploy: yes` on every commit to `main`. CD is standard — but a malicious PR that gets past `pytest`/`check`/`scan` + reviewer auto-deploys to production. | File [B1-NEXT-20]. PR comment to D1: optional deploy gate (manual approve) for `vibepass-storefront-test` (public retail). |
+
+No SEC-MED or SEC-HIGH findings.
+
+✅ Good posture:
+- No PR previews (`pullRequestPreviewsEnabled: no` on all 3) — unreviewed code can't get a public URL
+- No hi-events service (Terminal-2-unrelated) consuming Terminal-2 budget — that service is `suspended`
+- All services on `main` (the only branch with protection)
+- All services have a defined `healthCheckPath` (`/healthz`) on web services
+- Single workspace owner (`julian@s4kent.com`)
+
+---
+
+## Section 1 — Workspace
+
+Source: `mcp__render__list_workspaces` + `mcp__render__get_selected_workspace`
+
+| Field | Value |
+|---|---|
+| Workspace name | S4K |
+| Workspace ID | `tea-d7g09jm7r5hc73d0jdkg` |
+| Type | `team` |
+| Owner email | `julian@s4kent.com` |
+
+Single workspace; no multi-tenancy.
+
+---
+
+## Section 2 — Terminal-2 services
+
+Source: `mcp__render__list_services` filtered to repo `https://github.com/JulianS4K/Terminal-2`
+
+### vibepass-storefront-test (D1 lane)
+
+| Field | Value |
+|---|---|
+| Service ID | `srv-d8140bnaqgkc73al4asg` |
+| Type | `web_service` (python) |
+| Branch | `main` |
+| Auto-deploy | `yes` (on commit) |
+| Build command | `pip install -r requirements.txt` |
+| Start command | `uvicorn app:app --host 0.0.0.0 --port $PORT` |
+| Health check | `/healthz` |
+| Plan | free |
+| Region | oregon |
+| `ipAllowList` | `0.0.0.0/0` (everywhere) — R-1 |
+| `pullRequestPreviewsEnabled` | no ✅ |
+| Suspended | not_suspended |
+| Created | 2026-05-11T20:46:39Z |
+| URL | https://vibepass-storefront-test.onrender.com |
+
+Public retail-facing storefront. Anon access intended.
+
+### d2-orders-dashboard (D2 lane)
+
+| Field | Value |
+|---|---|
+| Service ID | `srv-d82b4kl7vvec73b4r3r0` |
+| Type | `web_service` (python) |
+| Branch | `main` |
+| Auto-deploy | `yes` (on commit) |
+| Build command | `pip install -r requirements.txt` |
+| Start command | `uvicorn d2_dashboard.main:app --host 0.0.0.0 --port $PORT` |
+| Health check | `/healthz` |
+| Plan | free |
+| Region | oregon |
+| `ipAllowList` | `0.0.0.0/0` — R-1 |
+| `pullRequestPreviewsEnabled` | no ✅ |
+| Suspended | not_suspended |
+| Created | 2026-05-13T17:18:11Z |
+| URL | https://d2-orders-dashboard.onrender.com |
+
+Internal D2 dashboard. Auth-gated at app layer; IP allowlist is belt-and-suspenders.
+
+### vibepass-terminal-test (D0 lane — per PR #107)
+
+| Field | Value |
+|---|---|
+| Service ID | `srv-d839339kh4rs73ac3s20` |
+| Type | `static_site` |
+| Branch | `main` |
+| Auto-deploy | `yes` (on commit) |
+| Build command | `echo "static assets — no build step"` |
+| Publish path | `static/terminal` |
+| Plan | starter |
+| `ipAllowList` | `0.0.0.0/0` — R-1 |
+| `pullRequestPreviewsEnabled` | no ✅ |
+| Suspended | not_suspended |
+| Created | 2026-05-15T03:22:54Z |
+| URL | https://vibepass-terminal-test.onrender.com |
+
+D0 broker terminal static frontend. The serves frontend HTML/JS only; auth happens at API layer (`/api/*` on storefront service routes to broker).
+
+---
+
+## Section 3 — Non-Terminal-2 services (informational)
+
+Source: `mcp__render__list_services` filtered to other repos
+
+### hi-events (suspended, unrelated)
+
+| Field | Value |
+|---|---|
+| Service ID | `srv-d7g0cev7f7vs73blkc70` |
+| Repo | `https://github.com/JulianS4K/Hi.Events` |
+| Branch | `develop` |
+| Suspended | `suspended` (suspenders: user) |
+
+Not Terminal-2. Listed for completeness — confirms no foreign repos have active services in the workspace.
+
+---
+
+## Section 4 — What B1 monitors per-session
+
+| Step | Probe | Pass condition |
+|---|---|---|
+| Workspace count | `mcp__render__list_workspaces` | 1 workspace (S4K), owner `julian@s4kent.com` |
+| Service count | `mcp__render__list_services` | 4 (3 Terminal-2 active + 1 unrelated suspended). Any new service triggers diff check. |
+| Per-service `autoDeploy` | `mcp__render__get_service` (each) | All Terminal-2 `yes` on `main` (current state) |
+| Per-service `ipAllowList` | (same) | Any tightening from `0.0.0.0/0` is GOOD; any widening from a tighter state is FLAG |
+| Per-service `pullRequestPreviewsEnabled` | (same) | All `no` (current state). Any flip to `yes` exposes unreviewed PR code on public URL. |
+| Per-service `branch` | (same) | All on `main`. Any switch to `develop` / feature-branch is FLAG (branch protection only covers `main`). |
+| Per-service `suspended` state | (same) | Track changes; suspension may indicate billing issue or operator action. |
+| Deploy history | `mcp__render__list_deploys` | Successful deploys; flag failed deploys + auto-rollbacks (could indicate broken build or sabotage) |
+| Logs | `mcp__render__list_logs` filtered for auth failures, 5xx spikes | Baseline within normal range. Anomalies → flag. |
+
+---
+
+## Section 5 — Cross-lane patch protocol for Render findings
+
+Per [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.md) Cross-cutting Rule #6, B1 cannot write to Render. Process for findings:
+
+1. **SEC-CRIT / SEC-HIGH on Render**: PR comment to D1 immediately. If D1 offline >24h AND finding is exploitable, escalate to operator for direct Render Dashboard fix. B1 does NOT call `mcp__render__update_*` even under security cross-lane exception — the lane separation is hard.
+2. **SEC-MED / SEC-LOW**: file in KANBAN.md, PR comment to D1 with ack-or-defer ask.
+
+---
+
+## Section 6 — Probe commands (reference)
+
+```
+# Workspace
+mcp__render__list_workspaces
+mcp__render__get_selected_workspace
+
+# All services (current + suspended)
+mcp__render__list_services
+
+# Per-service detail
+mcp__render__get_service serviceId=srv-d8140bnaqgkc73al4asg     # storefront
+mcp__render__get_service serviceId=srv-d82b4kl7vvec73b4r3r0     # d2 dashboard
+mcp__render__get_service serviceId=srv-d839339kh4rs73ac3s20     # d0 terminal
+
+# Deploys
+mcp__render__list_deploys serviceId=...
+
+# Logs (auth-failure spike check)
+mcp__render__list_logs resource=[<serviceIds>] text=["401" "403" "500"] direction=backward
+```


### PR DESCRIPTION
**Level**: security
**Lane**: B1
**Branch**: claude/b1-monitoring-charter-git-render
**Track**: 🟡 careful

## Pre-PR checklist
- [x] Rebased / merged with origin/main immediately before opening (branch off `77f5a23`)
- [x] Migration slot reserved — N/A (docs + KANBAN only, no SQL)
- [x] PR title format: `chore(security): <short imperative>`
- [x] No new cron jobs added

## What

Operator extended B1's mandate 2026-05-15 to also cover git/repo posture + Render workspace posture. This PR seeds the two new surfaces with initial inventory docs and updates the charter accordingly. Pure docs + KANBAN — no code, no migrations.

## Surface added

| Surface | Coverage |
|---|---|
| Git / repo posture | Branch protection, required status checks, collaborator perms, Actions secrets/vars, repo visibility, webhooks, deploy keys, secret-scanning + Dependabot config, push-protection state, workflow permissions, SHA pinning |
| Render workspace posture | Workspace access, service list, IP allowlists, autoDeploy triggers, env-var inventory (names only), preview-deploys posture, suspended state |

Total monitoring surfaces grew from 6 to **8**. Per-session sweep checklist grew from 11 to **14** steps.

## Findings surfaced (initial sweep, 2026-05-15)

| ID | Severity | Finding |
|---|---|---|
| [B1-NEXT-11] | **SEC-HIGH** | Reassess history-rewrite priority on rotated-but-public `CRON_SECRET` (commit `5297739`). Repo is `visibility: public` — original KANBAN.md SECURITY BACKLOG entry assumed private. |
| [B1-NEXT-12] | SEC-MED | Enable `dependabot_security_updates` (currently disabled). After SW-3 requirements.txt incident, this is the right tool. |
| [B1-NEXT-13] | SEC-MED | Enable `secret_scanning_non_provider_patterns` |
| [B1-NEXT-14] | SEC-MED | Enable `secret_scanning_validity_checks` |
| [B1-NEXT-15] | SEC-LOW | Consider `enforce_admins` on main protection |
| [B1-NEXT-16] | SEC-LOW | Consider `required_signatures` on main |
| [B1-NEXT-17] | SEC-LOW | Consider `sha_pinning_required` for Actions |
| [B1-NEXT-18] | SEC-MED | Verify Actions secrets populated for sync-check.yml |
| [B1-NEXT-19] | SEC-LOW | Render `ipAllowList: 0.0.0.0/0` on internal services — PR comment to D1 |
| [B1-NEXT-20] | SEC-LOW | Render `autoDeploy: yes` on every commit — PR comment to D1 |

**No SEC-CRIT findings.**

## ✅ Good posture confirmed

Branch protection: required checks (`pytest`/`check`/`scan`), force-push blocked, deletion blocked, strict mode. Secret-scanning + push-protection enabled. Workflow permissions default-read, can't self-approve PRs. No webhooks, no deploy keys, sole admin collaborator. Render: no PR previews, all services on `main`, single workspace owner.

## Lane discipline

- B1 reads only on Render. **D1 owns Render writes** per [LANE_DISCIPLINE.md](LANE_DISCIPLINE.md) Cross-cutting Rule #6 — all Render-side findings ([B1-NEXT-19/20]) become PR comments to D1, not direct patches.
- All git-side findings are operator-only (GitHub Settings → Branch protection / Code security) — B1 cannot patch via API.

## Cross-lane writes

- `docs/b1_operating_constraints.md` (B1's own self-contract — write surface allowed)
- `docs/git_repo_security_posture.md` + `docs/render_security_posture.md` (new B1 inventory docs — write surface allowed per `docs/security-*.md` pattern)
- `KANBAN.md` SECURITY BACKLOG (shared write surface per LANE_DISCIPLINE.md Cross-cutting Rule #1)

## Test plan

Pure docs PR. CI will run `check` and `scan` workflows; no behavioral changes. Per-session sweep step 12/13/14 will diff against these inventories in future sessions.

- [ ] CI `check` + `scan` green
- [ ] Reviewer confirms findings table matches the inventory docs
- [ ] No code-side regressions (this PR doesn't touch code)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)