### PR TITLE
fix(d0): terminal-test CDN rewrite + Slack directive doc points to #187 (supersedes #131)

### DIFF
--- a/docs/d0_frontend_consolidation_plan.md
+++ b/docs/d0_frontend_consolidation_plan.md
@@ -63,14 +63,14 @@ Nice-to-haves, no commitments:
 
 ## Governance going forward
 
-### D0 sign-off on D1/D2 PRs (Slack-channel-driven per `bot_chat` #175)
+### D0 sign-off on D1/D2 PRs (per canonical Slack directive `bot_chat` #187)
 
-Flow (lands when PR #126 merges; paused 7 days from 2026-05-15 per operator row #170):
+Flow (locks when PR #126 merges; paused 7 days from 2026-05-15 per row #170):
 1. D1/D2 author PR
-2. Post sign-off request to `#terminal-2-d0` (private; D0+D1+D2)
-3. D0 approves in-channel
+2. Post sign-off request to `#terminal-2-d0`
+3. D0 approves in-channel ("approved" or "hold — see PR comment")
 4. A1 merges after CI green + visible D0 approval
-5. Merge mirrors to `#terminal-2-alerts` automatically
+5. Auto-mirror to `#terminal-2-alerts` on merge
 
 D0 sign-off template (posted to `#terminal-2-d0`):
 
@@ -82,10 +82,10 @@ CI: pytest / scan / check status
 Notes: <≤2 lines>
 ```
 
-- D0 reviews within 24h of channel post (business hours). After 24h, A1 can merge urgent fixes; D0 re-ups in-channel post-fact.
+- 24h SLA business hours. After 24h, A1 may merge urgent fixes; D0 re-ups in-channel post-fact.
 - Override: B1 can sign-off for security-critical fixes if D0 unavailable.
-- D0 own PRs don't need self-sign-off; A1 reviews per standard pusher protocol.
-- Slack ≠ canonical. Decisions also surface in `bot_chat` (`change_log` event after merge) — the durable audit trail.
+- D0 own PRs don't need self-sign-off; A1 reviews per pusher protocol.
+- Slack ≠ canonical. Decisions also land in `bot_chat` (`change_log` after merge).
 
 ### Friday checkpoint cadence
 

--- a/docs/d0_operating_constraints.md
+++ b/docs/d0_operating_constraints.md
@@ -72,15 +72,16 @@ D0 does **not** write any Supabase table. Standing exception per [CLAUDE.md](../
 - **Render env var change** on any of 3 services: D0 records via `bot_chat` `change_log` with service ID + var name (never the value).
 - **Supabase Auth Redirect URL** changes: operator dashboard action; D0 surfaces via `bot_chat` `question` and confirms post-apply.
 
-## Slack channels (per `bot_chat` #175 — fast-twitch surfaces, not canonical)
+## Slack channels (canonical directive: `bot_chat` #187)
 
-| Channel | ID | Audience | D0 use |
-|---|---|---|---|
-| `#terminal-2-alerts` | `C0B3PR8MJ07` | public, all bots read | Watch for cross-cutting auto-alerts; do not post directly |
-| `#terminal-2-d0` | `C0B420N237F` | private, D0+D1+D2 | D0 sign-off on D1/D2 PRs; cross-FE conventions; daily ops |
-| `#terminal-2-admin` | `C0B3PU1DGVD` | private, A1/B1/C1 only | D0 does not post here; receives admin-tier escalations only via mention |
+D0 reads + posts only in `#terminal-2-d0` (`C0B420N237F`) for sign-offs + cross-FE coord. Never `#terminal-2-alerts` (scheduled-tasks-only) or `#terminal-2-admin` (A1/B1/C1 private). `bot_chat` remains canonical.
 
-`bot_chat` remains the canonical durable record. Slack channels are the realtime correlate for when next-session bot_chat polling is too slow. Every decision must have a `bot_chat` trail.
+**Triggering Slack visibility from `bot_chat`** (hourly aging sweep — pages on unresolved >2h):
+- `event_type='p0_security'` → Slack page
+- `event_type='flag'` + `meta={"severity":"high"}` → Slack page
+- Routine `flag` / `question` → bot_chat queue only
+
+**Loop prevention**: replies to Slack posts originating from scheduled tasks go via `bot_chat` `status` with `in_reply_to=<originating_id>`, not via Slack reply.
 
 ## Verification gate
 

--- a/render-d0-terminal.yaml
+++ b/render-d0-terminal.yaml
@@ -24,6 +24,16 @@ services:
     buildCommand: 'echo "static assets — no build step"'
     publishPath: static/terminal
 
+    # Path rewrites — the HTML in static/terminal/*.html references assets
+    # by their canonical app.py path (e.g. /static/terminal/style.css), but
+    # publishPath strips the static/terminal/ prefix on the CDN. Rewrite the
+    # /static/terminal/* requests to the unprefixed CDN root so the same
+    # HTML works on the CDN, on storefront-test, and on localhost.
+    routes:
+      - type: rewrite
+        source: /static/terminal/*
+        destination: /:splat
+
     # No env vars needed for static frontend. If D0 wires up
     # client-side config (Supabase anon key for read-only data fetch),
     # add them here with `sync: false` so they prompt on provisioning.


### PR DESCRIPTION
## Summary

Supersedes [#131](https://github.com/JulianS4K/Terminal-2/pull/131), which got tangled in a squash-merge rebase loop. Same 2 changes, clean history off `main`.

1. **`render-d0-terminal.yaml`** — adds `routes: rewrite` mapping `/static/terminal/* → /:splat` so the CDN-stripped `publishPath: static/terminal` doesn't 404 every asset reference. Same fix described in #131.
2. **`docs/d0_operating_constraints.md` + `docs/d0_frontend_consolidation_plan.md`** — point at `bot_chat` #187 as the canonical Slack directive (replaces the inline summaries of rows 171+175).

## Test plan

After merge + auto-deploy:
- [ ] `curl https://vibepass-terminal-test.onrender.com/static/terminal/style.css` → 200
- [ ] `curl https://vibepass-terminal-test.onrender.com/static/terminal/app.js` → 200
- [ ] Browser-load `/event.html?event=3345925` → renders with full styling

Closes #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)