### PR TITLE
feat(d0): undelivered scaffold → clean D2 doorway (Option C ack)

### DIFF
--- a/static/undelivered/index.html
+++ b/static/undelivered/index.html
@@ -16,57 +16,85 @@
     <span class="brand">VIBEPASS · UNDELIVERED</span>
     <nav class="pagenav">
       <a href="/">HOME</a>
-      <a href="/terminal/">TERMINAL</a>
-      <a class="active" href="/undelivered/">UNDELIVERED</a>
+      <a href="/terminal">TERMINAL</a>
+      <a class="active" href="/undelivered">UNDELIVERED</a>
       <a href="/store">STORE</a>
     </nav>
-    <span id="status" class="status">scaffold</span>
+    <span id="status" class="status">—</span>
   </header>
 
   <main class="wrap">
-    <section class="scaffold-banner">
-      <div class="scaffold-tag">SCAFFOLD · AWAITING D2</div>
+    <section class="doorway">
+      <div class="doorway-tag">D0 · D2 MERGE POINT · OPTION C</div>
       <h1>Undelivered — Fulfillment + Sales Tracking</h1>
-      <p>One board across every channel (EVO / SeatGeek / TickPick / Vivid / retail / wholesale). Sorted by time-to-event. Hold-expiry alerts. Bulk action per event ("deliver all 76 for Knicks G5"). Spec: <code>design/undelivered-window-2026-05-08.md</code>.</p>
-      <p class="muted">Data wiring pending D2's scope decision on the consolidation question (<code>bot_chat</code> row 179 — options A/B/C). This page is the static entry point; the dense table lands once D2 confirms.</p>
-    </section>
-
-    <section id="kpi-strip">
-      <div class="panel-title">KPI STRIP — PROPOSED</div>
-      <div class="kpi-row">
-        <div class="kpi-cell"><span class="kpi-num">—</span><span class="kpi-lbl">$ undelivered</span></div>
-        <div class="kpi-cell"><span class="kpi-num">—</span><span class="kpi-lbl">orders open</span></div>
-        <div class="kpi-cell"><span class="kpi-num warn">—</span><span class="kpi-lbl">within T-24h</span></div>
-        <div class="kpi-cell"><span class="kpi-num neg">—</span><span class="kpi-lbl">holds &lt; 1h</span></div>
+      <p>
+        Customer service workflow across <strong>Evo · SeatGeek · TickPick · Vivid · SeatData</strong>.
+        Per D2's scope decision (<code>bot_chat</code> #199): the unified orders view IS the undelivered surface —
+        D2's <code>/orders</code> tab on <strong>d2-orders-dashboard.onrender.com</strong> evolves into the
+        fulfillment-ops workflow described in <code>design/undelivered-window-2026-05-08.md</code>.
+        Time-to-event sort · hold-expiry lane · bulk-deliver-per-event · channel logos.
+      </p>
+      <div class="doorway-cta">
+        <a id="d2Open" class="btn-primary" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">
+          Open Orders Dashboard ↗
+        </a>
+        <span id="d2HealthBadge" class="health-badge dim">checking…</span>
       </div>
-      <div class="muted small">By channel: EVO — · SG — · Vivid — · TP — · Retail —</div>
+      <p class="muted small">
+        Sign in via Google OAuth (<code>@s4kent.com</code> only). Same Supabase project as the broker terminal —
+        if you're signed into one, you're signed into both (sessions are per-origin in localStorage).
+      </p>
     </section>
 
-    <section id="filters">
-      <div class="panel-title">FILTERS — PROPOSED</div>
-      <div class="filter-row">
-        <span class="muted small">Window: &lt;24h · &lt;72h · &lt;7d · &lt;30d · all</span>
-        <span class="muted small">Channel: all · EVO · SG · Vivid · TP · Retail</span>
-        <span class="muted small">State: pending · held · pushing · failed</span>
+    <section class="merge-grid">
+      <div class="mg-cell">
+        <span class="mg-lbl">What's there now</span>
+        <ul>
+          <li>Unified <strong>Orders</strong> tab (Evo + SG + TickPick + Vivid in one table)</li>
+          <li>Active/All filter pill</li>
+          <li><strong>Metrics</strong> tab — KPI grid, sparkline, hot/top events, live sales feed</li>
+          <li><strong>SeatData</strong> tab — account + usage analytics</li>
+          <li>Cron-freshness chip per source</li>
+        </ul>
+      </div>
+      <div class="mg-cell">
+        <span class="mg-lbl">Coming under Option C (D2 lane)</span>
+        <ul>
+          <li>Time-to-event sort default on Orders tab (red T-0/T-24h first)</li>
+          <li>Hold-expiry lane as a separate visual band on the Orders tab</li>
+          <li>Bulk-deliver-per-event action ("deliver all 76 for Knicks G5")</li>
+          <li>Per-row state machine pending/held/pushing/delivered/failed</li>
+          <li>SG/TEvo/Vivid/TickPick channel logos in rows</li>
+        </ul>
+      </div>
+      <div class="mg-cell">
+        <span class="mg-lbl">Per-event drill (already on terminal)</span>
+        <ul>
+          <li><a href="/terminal">Broker Terminal</a> → event detail page</li>
+          <li>Per-event order strip: 5-segment state mix on the broker page</li>
+          <li>Hits <code>/api/broker/event/{id}/orders</code> — scope-bounded</li>
+          <li>Independent of D2's global undelivered view</li>
+        </ul>
+      </div>
+      <div class="mg-cell">
+        <span class="mg-lbl">Lane contract</span>
+        <ul>
+          <li>D0 owns the terminal nav + this doorway page + the <code>vibepass-terminal-test</code> service</li>
+          <li>D2 owns the dashboard implementation + the <code>d2-orders-dashboard</code> service + Option C buildout</li>
+          <li>D2 PR #129 (APIRouter refactor) → currently draft pending Option C work</li>
+          <li>D0 sign-off on D2 PRs paused through 2026-05-22 (<code>bot_chat</code> #170)</li>
+        </ul>
       </div>
     </section>
 
-    <section id="hold-expiry-lane">
-      <div class="panel-title">HOLD EXPIRY · NEXT 4H</div>
-      <div class="empty">scaffold — data wires to <code>evo_orders.hold_expires_at</code> + equivalents on SG / Vivid / TP</div>
-    </section>
-
-    <section id="orders-table">
-      <div class="panel-title row">
-        <span>ORDERS · TIME-TO-EVENT ASCENDING</span>
-        <span class="muted small">red T-0/T-24h · amber T-72h · neutral T-7d · dim &gt;T-7d</span>
-      </div>
-      <div class="empty">scaffold — D2 fills via <code>/api/d2/orders</code> or evolved view</div>
-    </section>
-
-    <section id="bulk-action">
-      <div class="panel-title">BULK ACTION — PROPOSED</div>
-      <div class="empty">"Deliver all 76 for Knicks G5" pattern — needs RPC + per-channel push handlers</div>
+    <section class="reference">
+      <div class="panel-title">REFERENCE</div>
+      <ul class="ref-list">
+        <li><a href="https://github.com/JulianS4K/Terminal-2/blob/main/d2_dashboard/main.py" target="_blank" rel="noopener">d2_dashboard/main.py</a> — D2 service source</li>
+        <li><a href="https://github.com/JulianS4K/Terminal-2/blob/main/design/undelivered-window-2026-05-08.md" target="_blank" rel="noopener">design/undelivered-window-2026-05-08.md</a> — original spec</li>
+        <li><code>bot_chat</code> #199 — D2 scope decision (Option C)</li>
+        <li><code>bot_chat</code> #143 — initial merge-point sync</li>
+      </ul>
     </section>
   </main>
 

--- a/static/undelivered/style.css
+++ b/static/undelivered/style.css
@@ -22,20 +22,27 @@ html, body {
 .pagenav a:hover { color: var(--text); }
 .pagenav a.active { color: var(--warn); border-bottom-color: var(--warn); }
 .status { color: var(--muted); }
+.status.ok { color: var(--pos); }
+.status.err { color: var(--neg); }
 
 .wrap {
-  padding: 12px 16px;
+  padding: 16px;
   display: flex; flex-direction: column; gap: 12px;
+  max-width: 1280px;
+  margin: 0 auto;
 }
 .wrap > section {
   background: var(--panel); border: 1px solid var(--line);
-  padding: 12px 16px;
+  padding: 16px 20px;
 }
 
-.scaffold-banner {
+/* ---------- Doorway ---------- */
+/* section.doorway selector beats .wrap > section specificity (0,1,1 vs 0,1,0). */
+
+section.doorway {
   border-left: 4px solid var(--warn);
 }
-.scaffold-tag {
+.doorway-tag {
   display: inline-block;
   font-family: var(--mono); font-size: 10px;
   letter-spacing: 0.8px; text-transform: uppercase;
@@ -43,53 +50,101 @@ html, body {
   background: var(--panel-2); border: 1px solid var(--warn); color: var(--warn);
   margin-bottom: 12px;
 }
-.scaffold-banner h1 { margin: 0 0 8px; font-size: 22px; }
-.scaffold-banner p {
-  margin: 0 0 8px; color: var(--muted); max-width: 880px; line-height: 1.6;
+.doorway h1 {
+  margin: 8px 0 12px; font-size: 26px;
+  color: var(--text);
 }
-.scaffold-banner code {
+.doorway p {
+  margin: 0 0 12px; color: var(--muted);
+  max-width: 880px; line-height: 1.6;
+}
+.doorway p strong { color: var(--text); }
+.doorway code {
   background: var(--bg); padding: 1px 6px;
   font-family: var(--mono); font-size: 11px; color: var(--accent);
   border: 1px solid var(--line);
 }
+
+.doorway-cta {
+  display: flex; align-items: center; gap: 12px;
+  margin: 16px 0;
+}
+.btn-primary {
+  display: inline-block;
+  background: var(--accent); color: #000;
+  text-decoration: none;
+  font-family: var(--mono); font-size: 13px; font-weight: 600;
+  padding: 10px 20px;
+  letter-spacing: 0.5px; text-transform: uppercase;
+  border: 1px solid var(--accent);
+}
+.btn-primary:hover { background: #fde047; border-color: #fde047; }
+
+.health-badge {
+  font-family: var(--mono); font-size: 11px;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  letter-spacing: 0.5px;
+}
+.health-badge.live { color: var(--pos); border-color: var(--pos); }
+.health-badge.down { color: var(--neg); border-color: var(--neg); }
+.health-badge.dim  { color: var(--muted); }
+
+/* ---------- Merge contract grid ---------- */
+
+.merge-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+}
+.mg-cell {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  padding: 14px 16px;
+}
+.mg-lbl {
+  display: block;
+  font-family: var(--mono); font-size: 10px;
+  color: var(--accent);
+  text-transform: uppercase; letter-spacing: 0.8px;
+  margin-bottom: 10px;
+}
+.mg-cell ul {
+  margin: 0; padding-left: 18px;
+  color: var(--muted); font-size: 12px;
+  line-height: 1.7;
+}
+.mg-cell li { padding: 2px 0; }
+.mg-cell code {
+  background: var(--bg); padding: 1px 5px;
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
+  border: 1px solid var(--line);
+}
+.mg-cell a { color: var(--accent); }
+.mg-cell strong { color: var(--text); }
+
+/* ---------- Reference list ---------- */
 
 .panel-title {
   font-family: var(--mono); font-size: 11px;
   color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px;
   margin-bottom: 8px;
 }
-.panel-title.row { display: flex; justify-content: space-between; align-items: baseline; }
-
-.kpi-row {
-  display: grid; grid-template-columns: repeat(4, 1fr);
-  gap: 12px;
-  margin-bottom: 8px;
+.ref-list {
+  margin: 0; padding-left: 18px;
+  color: var(--muted); font-size: 12px;
+  line-height: 1.8;
 }
-.kpi-cell {
-  display: flex; flex-direction: column;
-  font-family: var(--mono);
-}
-.kpi-num { font-size: 22px; font-weight: 700; color: var(--text); }
-.kpi-num.warn { color: var(--warn); }
-.kpi-num.neg  { color: var(--neg); }
-.kpi-lbl {
-  font-size: 10px; color: var(--muted);
-  text-transform: uppercase; letter-spacing: 0.5px;
-}
-
-.filter-row { display: flex; gap: 24px; flex-wrap: wrap; font-family: var(--mono); }
-.muted { color: var(--muted); }
-.small { font-size: 11px; }
-
-.empty {
-  background: var(--panel-2);
-  border: 1px dashed var(--line);
-  padding: 24px; text-align: center;
-  color: var(--muted);
-  font-family: var(--mono); font-size: 12px;
-}
-.empty code {
-  background: var(--bg); padding: 1px 6px;
-  color: var(--accent); font-size: 11px;
+.ref-list a { color: var(--accent); }
+.ref-list code {
+  background: var(--bg); padding: 1px 5px;
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
   border: 1px solid var(--line);
 }
+
+.muted { color: var(--muted); }
+.small { font-size: 11px; }

--- a/static/undelivered/undelivered.js
+++ b/static/undelivered/undelivered.js
@@ -1,14 +1,59 @@
-// Scaffold. Data wiring blocked on D2's scope decision (bot_chat #179).
+// Undelivered doorway — D0/D2 Option C. Pings D2 /healthz unauthenticated +
+// surfaces auth state on the status pill. Same pattern as static/terminal/orders.js.
+
 (function () {
   'use strict';
   const Auth = window.TerminalAuth;
-  const status = document.getElementById('status');
-  if (!Auth) { status.textContent = 'auth offline'; return; }
-  Auth.ready.then(async () => {
+  const D2_BASE = 'https://d2-orders-dashboard.onrender.com';
+
+  function isLocalhost() {
     const h = location.hostname;
-    const isLocalhost = h === 'localhost' || h === '127.0.0.1' || h === '';
-    if (isLocalhost) { status.textContent = 'scaffold · localhost'; return; }
-    await Auth.requireAuth();
-    status.textContent = 'scaffold · ' + (Auth.getEmail() || 'unknown');
-  });
+    return h === 'localhost' || h === '127.0.0.1' || h === '';
+  }
+
+  function setStatus(text, cls) {
+    const el = document.getElementById('status');
+    if (!el) return;
+    el.textContent = text;
+    el.className = 'status' + (cls ? ' ' + cls : '');
+  }
+
+  function setHealth(cls, text) {
+    const badge = document.getElementById('d2HealthBadge');
+    if (!badge) return;
+    badge.className = 'health-badge ' + cls;
+    badge.textContent = text;
+  }
+
+  function pingD2Health() {
+    const t0 = performance.now();
+    fetch(`${D2_BASE}/healthz`, { credentials: 'omit', mode: 'cors' })
+      .then(res => {
+        const ms = Math.round(performance.now() - t0);
+        if (res.ok) setHealth('live', `live · ${ms}ms`);
+        else        setHealth('down', `HTTP ${res.status}`);
+      })
+      .catch(() => setHealth('dim', 'status unknown'));
+  }
+
+  function init() {
+    pingD2Health();
+    if (!Auth) { setStatus('auth offline'); return; }
+    Auth.ready.then(async () => {
+      if (isLocalhost()) { setStatus('localhost · doorway', 'ok'); return; }
+      const email = Auth.getEmail();
+      if (!email) { setStatus('not signed in', ''); return; }
+      if (!Auth.isAllowedEmail(email)) {
+        setStatus(`${email} — not @s4kent.com`, 'err');
+        return;
+      }
+      setStatus(`signed in · ${email}`, 'ok');
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 })();


### PR DESCRIPTION
## Summary

D2 picked Option C (`bot_chat` #199) — D2's `/orders` tab on `d2-orders-dashboard` evolves into the fulfillment-ops view. So D0's `/undelivered` scaffold sections (KPI strip, filters, hold-expiry lane, orders table, bulk action — all empty placeholders) were no-value clutter. Replaced with a clean doorway, mirroring the [static/terminal/orders.html](static/terminal/orders.html) pattern.

## Changes

- **`static/undelivered/index.html`** — single doorway section + 4-cell merge-grid (what's there now / coming under Option C / per-event drill / lane contract) + reference list
- **`static/undelivered/style.css`** — `.doorway` / `.doorway-tag` / `.doorway-cta` / `.btn-primary` / `.health-badge` / `.merge-grid` / `.mg-cell` / `.ref-list`. Used `section.doorway` selector to beat `.wrap > section` specificity (verified amber 4px left border in preview).
- **`static/undelivered/undelivered.js`** — pings D2 `/healthz` for live status badge; surfaces auth state on the status pill.

## Test plan

- [x] Preview-verified locally (port 8765): styled, 4 merge-cells, CTA href correct, nav active, border amber per `--warn` token
- [x] `node --check static/undelivered/undelivered.js` passes
- [ ] After merge + auto-deploy: visit `https://vibepass-storefront-test.onrender.com/undelivered` — page renders the new doorway

🤖 Generated with [Claude Code](https://claude.com/claude-code)