### PR TITLE
d1: fix /store search "No events match" race on cold-start

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -274,6 +274,12 @@
     const empty = $("#empty");
 
     let allEvents = [];
+    // loadComplete gates filter() so the user can't trigger a misleading
+    // "No events match" empty state by typing in the search box while the
+    // initial /api/store/home call is still in flight (common on free-tier
+    // cold-start where the round-trip is ~12s). When load resolves below,
+    // any pending user query is re-applied at that point.
+    let loadComplete = false;
 
     function render(events, mode) {
       // mode: "all" (initial load) or "search" (after a query)
@@ -364,6 +370,13 @@
     }
 
     function filter(query) {
+      // Guard against the cold-start race: user typed in the search box
+      // before loadCatalog's /api/store/home round-trip completed. Bailing
+      // out here keeps the "Loading available events…" status pill visible
+      // instead of showing a misleading "No events match" empty state.
+      // The pending query (input.value) is re-applied by loadCatalog when
+      // it resolves — see the .then() handler below.
+      if (!loadComplete) return;
       const q = (query || "").trim().toLowerCase();
       if (!q) return render(allEvents, "all");
       const filtered = allEvents.filter((e) => {
@@ -438,14 +451,28 @@
       status.textContent = "Loading available events…";
       status.style.color = "";
       status.hidden = false;
+      // Reset gate — Retry re-fires this and we want the same race
+      // protection on the second attempt.
+      loadComplete = false;
       api(catalogEndpoint)
         .then((res) => {
           allEvents = res.events || [];
+          loadComplete = true;
           renderCatalogFilterBanner(performerId, venueId, allEvents);
-          render(allEvents, "all");
+          // If user typed during the load window, honor that query now.
+          // Otherwise render the full grid as before.
+          const pendingQuery = (input.value || "").trim();
+          if (pendingQuery) {
+            filter(input.value);
+          } else {
+            render(allEvents, "all");
+          }
           status.hidden = true;
         })
         .catch((err) => {
+          // loadComplete stays false — filter() correctly bails out so a
+          // user typing during error state doesn't see "No events match"
+          // on top of the Retry-button error UI.
           status.replaceChildren();
           status.style.color = "var(--bad)";
           status.hidden = false;


### PR DESCRIPTION
## Summary

@D0 — operator reported `/store` search showing "No events match" for "knicks" despite `/api/store/home?limit=60` returning 60 events including 3+ Knicks playoff games. Root cause is a race condition triggered by free-tier cold-start (still pending the plan flip per [bot_chat 174](https://github.com/JulianS4K/Terminal-2)).

## Root cause

`mountCatalog()` wires `input` + `submit` listeners that call `filter()`. Filter reads `allEvents` which is `[]` until `loadCatalog()`'s `/api/store/home` round-trip resolves. On free-tier cold-start (~12s), the user can easily type or submit before load completes — filter runs against empty array, shows the misleading "No events match" empty state.

Timeline:
- `T=0`: page loads, `allEvents=[]`, status "Loading…"
- `T=200ms`: user types "k" → `filter("k")` on `[]` → `render([], "search")` → empty.hidden=false, "No events match"
- `T=12s`: `/api/store/home` returns, `allEvents = 60 events`, grid renders — but user already saw the misleading message and captured a screenshot.

## Fix

Add `loadComplete` flag. `filter()` bails out when `!loadComplete` so the status pill stays "Loading…" instead of "No events match". When `loadCatalog()` resolves, it re-applies any pending `input.value` so the user's typed search isn't lost.

```js
let allEvents = [];
let loadComplete = false;

function filter(query) {
  if (!loadComplete) return;          // bail during load window
  // ... existing filter logic ...
}

function loadCatalog() {
  // ...
  loadComplete = false;
  api(catalogEndpoint)
    .then((res) => {
      allEvents = res.events || [];
      loadComplete = true;
      // re-apply pending query if user typed during load
      const pendingQuery = (input.value || \"\").trim();
      if (pendingQuery) filter(input.value);
      else render(allEvents, \"all\");
      // ...
    })
    // catch: loadComplete stays false → filter bails out during error UI
}
```

Net: +28 / -1 in [static/store/store.js](static/store/store.js). Pure D1 lane.

## Test plan

- [x] `node --check static/store/store.js` clean
- [x] `pytest tests/test_store_home.py tests/test_store_events.py` 30/30 pass
- [ ] **Manual cold-start repro after merge + deploy** (smoke matrix below)

### Manual repro (post-deploy verification)

```bash
# 1. Wait for storefront-test dyno to sleep (>15min idle)
# 2. Hard-refresh /store
# 3. Within 2s of load, type \"knicks\" in the search box
# 4. Expected: status pill STAYS \"Loading available events…\"
#    NOT \"No events match\"
# 5. Wait ~12s for cold-start to finish
# 6. Expected: grid renders with Knicks playoff games filtered (matches \"knicks\")
```

### Regression guard (warm state)

```bash
# After cold-start completes, refresh /store
# Type \"knicks\" — should filter to Knicks events as user types (existing behavior preserved)
# Click \"×\" clear button — grid restores to full 60-event view (existing behavior preserved)
```

## Underlying issue

This is a defense for the cold-start window. Permanent fix is the operator-side plan flip `free` → `starter` for `vibepass-storefront-test` ([bot_chat 174](https://github.com/JulianS4K/Terminal-2)). Once that lands, cold-start collapses from ~12s to ~50ms and the race window vanishes. This JS guard handles cold-start AND any future slow-network scenarios independent of plan tier.

## Coordination

- Sign-off pause active through 2026-05-22 ([bot_chat 170](https://github.com/JulianS4K/Terminal-2)) → ships under CI gate alone, no D0 review required
- D0 tagged for visibility per [bot_chat 194](https://github.com/JulianS4K/Terminal-2) protocol — your call whether to leave a review comment or let it ride

🤖 Generated with [Claude Code](https://claude.com/claude-code)