### PR TITLE
fix(admin): align sg_broker backstop schedules at :04/:34

### DIFF
--- a/supabase/migrations/20260516020000_sg_broker_backstops_align_to_4_34.sql
+++ b/supabase/migrations/20260516020000_sg_broker_backstops_align_to_4_34.sql
@@ -1,0 +1,17 @@
+-- Migration 20260516020000 · admin · align sg_broker backstop queue schedules · pre:20260516010000
+-- D2 diagnostic 2026-05-16 surfaced the coupled-polling question: priority tick already
+-- does coupled sales+listings for HOT/WARM/COOL events (sg_priority_poll_tick fires both
+-- endpoints in same minute). The two backstop queues (sg_broker_listings_queue_30min,
+-- sg_broker_sales_queue_30min) are deliberately asymmetric in event SELECTION (listings =
+-- broad firehose by date; sales = priority-weighted by ownership), but their fire MINUTE
+-- was offset for no design reason: listings :04/:34, sales :02/:32.
+--
+-- Aligning sales to :04/:34 gives the 32% overlap subset (~80 events per cycle) co-temporal
+-- sales+listings snapshots, useful for sale-vs-remaining-inventory deltas. Same total API
+-- volume (no event count change), just bursts together. pg_net batch_size=200 absorbs the
+-- 50→100 same-minute calls trivially.
+
+SELECT cron.alter_job(
+  job_id := (SELECT jobid FROM cron.job WHERE jobname='sg_broker_sales_queue_30min'),
+  schedule := '4,34 * * * *'
+);


### PR DESCRIPTION
## Summary

D2 diagnostic surfaced operator's coupled-polling intuition. Priority tick already does coupled sales+listings for HOT/WARM/COOL events. Backstop queues are intentionally asymmetric in **event SELECTION** (listings = broad firehose; sales = priority-weighted) but their fire **MINUTE** was offset for no design reason.

Aligns sales to `:04/:34` to match listings → ~80 overlap events per cycle get co-temporal snapshots.

Applied to prod as `20260516020000`.

## Test plan
- [x] Migration applied
- [ ] T+30min: next `:34` tick fires both queues in the same minute, both succeed
- [ ] Overlap subset events show co-temporal `captured_at` between `seatgeek_listings_snapshots` and `seatgeek_sales_snapshots`

## A1 decision on the 3 options
- A: SHIP (this PR) — free win, zero API delta
- B: HOLD — no demonstrated need; doubles API cost
- C: HOLD — loses priority-asymmetry, larger refactor

Matcher timeout (bot_chat 225) separate next-session work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)