### PR TITLE
d1: polish bundle — offset clamp + seat-map placeholder + aria-live

### DIFF
--- a/app.py
+++ b/app.py
@@ -4237,7 +4237,11 @@ def store_events(
     cap = min(max(limit, 1), 500)
     # offset → TEvo page index. TEvo paginates 1-based.
     per_page = min(cap, 100)
-    offset = max(offset, 0)
+    # Cap offset to prevent absurd values from triggering a 502 on impossible
+    # page lookups (TEvo doesn't paginate beyond what its catalog holds —
+    # office-filtered catalog is ~3-4k events at peak, so 5000 is a safe
+    # upper bound that catches malicious/bug values like ?offset=999999).
+    offset = min(max(offset, 0), 5000)
     start_page = (offset // per_page) + 1
     # When offset is NOT a multiple of per_page, we land mid-page and have to
     # slice the leading rows off the first fetched page. Account for that in

--- a/static/store/event.html
+++ b/static/store/event.html
@@ -18,7 +18,7 @@
   <main class="wrap">
     <a class="back" href="/store">← back to events</a>
 
-    <div id="status" class="status">Loading event…</div>
+    <div id="status" class="status" aria-live="polite">Loading event…</div>
 
     <section id="header" class="event-head" hidden>
       <!-- Venue hero image — subtle background banner, populated when
@@ -59,7 +59,12 @@
 
     <section id="body" class="event-body" hidden>
       <aside class="map">
-        <img id="seatMap" alt="seating chart" />
+        <!-- 1x1 transparent placeholder so the browser doesn't flash a
+             broken-image icon between page-load and JS setting img.src
+             from the configurations API. JS replaces the src attribute
+             once the seat-map URL is known. -->
+        <img id="seatMap" alt="seating chart"
+             src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />
       </aside>
 
       <div class="listings">

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -50,7 +50,7 @@
         <h2 class="movers-title">Moving fast in NYC · next 3 weeks</h2>
         <div id="moversRow" class="movers-row"></div>
       </section>
-      <div id="status" class="status">Loading available events…</div>
+      <div id="status" class="status" aria-live="polite">Loading available events…</div>
       <div id="grid" class="grid" hidden></div>
       <div id="empty" class="empty" hidden>
         No events match. Try a broader search, or clear the box to see all.


### PR DESCRIPTION
## Summary

Three small defensive fixes surfaced during a read-only audit pass while [PR #141](https://github.com/JulianS4K/Terminal-2/pull/141) (search race) awaits A1 merge. Bundling because they're independent + all single-line edits.

| # | Fix | File | Lines |
|---|---|---|---|
| 1 | `/api/store/events` `offset` clamp at 5000 (limit was already clamped) | `app.py:4240` | -1 / +5 |
| 2 | Seat-map 1x1 transparent placeholder src (no broken-image flash) | `static/store/event.html:62` | -1 / +7 |
| 3 | `aria-live=\"polite\"` on `<div id=\"status\">` on both pages (a11y) | `static/store/index.html:53`, `event.html:21` | +2 |

### 1. Offset clamp on `/api/store/events`

Audit edge case: `GET /api/store/events?limit=999999&offset=999999` returns 502 \"events fetch failed\". `limit` is already capped at 500 (line 4237). `offset` was only floor-clamped at ≥0. Pathological large offset propagates to TEvo as `page=10000+` → upstream error → our 502 catch fires.

```diff
- offset = max(offset, 0)
+ offset = min(max(offset, 0), 5000)
```

5000 is a safe upper bound: TEvo's office-filtered catalog is ~3-4k events at peak.

### 2. Seat-map placeholder

`<img id=\"seatMap\">` had no src attribute. Browsers showed broken-image icon between page-load and JS setting img.src from the configurations API (in store.js `mountEvent`). Adding 1x1 transparent GIF data URI as initial src means no flash; JS replacement still works identically.

### 3. `aria-live=\"polite\"` on status divs

Screen readers don't announce loading-state text updates without `aria-live`. Both pages have the same `\"Loading…\"` → `\"No events match\"` / `\"Couldn't load events\"` status pill pattern. `polite` (not `assertive`) is the right tone — updates aren't urgent enough to interrupt the user's reading flow.

## Test plan

- [x] `py -m py_compile app.py` clean
- [x] `py -m pytest tests/test_store_home.py tests/test_store_events.py` → 30/30 pass
- [x] `node --check` not needed (HTML-only on JS surfaces; placeholders are data URIs)
- [ ] **After merge + deploy**:
  ```bash
  # Offset clamp:
  curl -sS 'https://vibepass-storefront-test.onrender.com/api/store/events?limit=999999&offset=999999' -w '\nhttp=%{http_code}\n' | head -c 200
  # expect: 200 (clamped to limit=500 offset=5000, returns empty or last-page events)

  # Seat-map placeholder (DevTools Network tab):
  # Load /store/event/3346000 — no broken-image flash before configurations API resolves

  # aria-live (DevTools Inspector):
  # /store and /store/event/{id} both have <div id=\"status\" aria-live=\"polite\">
  ```

## Live homescreen population times (measured during audit, warm-state)

For operator awareness — context for the audit and the timing question:

| Asset | Mean | Range | Bytes |
|---|---|---|---|
| `/store` HTML | 285 ms | 203-410 | 2,935 |
| `style.css` | 313 ms | 178-514 | 29,193 |
| `store.js` | 300 ms | 257-382 | 81,555 |
| `/api/store/home?limit=60` | 768 ms | 678-824 | 43,093 |
| **`/api/store/movers?city=NYC`** | **1003 ms** | 974-1055 | 3,344 |
| `/api/store/search` first call | 1170 ms | (cold cache miss) | ~2.5 KB |
| `/api/store/search` cached | 250 ms | 180-330 | ~2.5 KB |

**Warm TTI to first cards visible**: ~1.1s (HTML + parallel assets + home fetch). Movers strip lights up ~1s after. **First search-suggest has 1.2s penalty per unique query** until the in-process LRU primes (200 entries, 60s TTL — per `_search_cache` in app.py).

Movers is the slowest endpoint on the homescreen at ~1s; that's the TEvo `searches/suggestions` + LEM join cost.

## Coordination

- Sign-off pause active through 2026-05-22 ([bot_chat 170](https://github.com/JulianS4K/Terminal-2)) — ships under CI gate alone
- Companion to [PR #141](https://github.com/JulianS4K/Terminal-2/pull/141) (search race) — separate concerns, both queued for A1 merge
- D0 tagged for visibility per [bot_chat 194](https://github.com/JulianS4K/Terminal-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)