### PR TITLE
d2: rewire Undelivered SG source to broker firehose

### DIFF
--- a/d2_dashboard/main.py
+++ b/d2_dashboard/main.py
@@ -533,9 +533,15 @@ def _to_float(v: Any) -> float | None:
 # All 5 sources are mirrored to public.unified_orders by upstream crons (see
 # migration 20260513230100_unified_orders_with_tickpick_vivid). /api/d2/orders
 # is SQL-only — no broker-API calls in the data path.
-_SQL_BACKED_SOURCES = frozenset({"evo", "seatgeek", "seatdata", "tickpick", "vivid"})
+# 2026-05-16 rewire: SG source is now the broker firehose (seatgeek_sales_snapshots)
+# instead of the dormant seller-side (seatgeek_orders, no new rows in 11 months).
+# Live SG signal is the third-party market: ~67k sales/hr captured. The
+# unified_orders view already exposes this as source='seatgeek_sales' with
+# canonical_status hardcoded to 'fulfilled' (terminal) — so Active-pill SG rows
+# will be 0 by construction; All-pill shows the firehose.
+_SQL_BACKED_SOURCES = frozenset({"evo", "seatgeek_sales", "seatdata", "tickpick", "vivid"})
 
-_ALL_SOURCES = ("evo", "seatgeek", "seatdata", "tickpick", "vivid")
+_ALL_SOURCES = ("evo", "seatgeek_sales", "seatdata", "tickpick", "vivid")
 
 
 def _fetch_cron_freshness() -> dict[str, dict]:
@@ -914,7 +920,11 @@ def _fetch_evo(per_page: int, page: int = 1) -> dict:
 
 
 def _fetch_sg(per_page: int, page: int = 1) -> dict:
-    return _fetch_one_source("seatgeek", per_page, page)
+    # SG source on the orders feed is the broker firehose post-2026-05-16
+    # rewire — see _SQL_BACKED_SOURCES comment. Helper is currently
+    # unreferenced; kept for symmetry with the other per-source fetchers in
+    # case the bundled orders feed is ever decomposed.
+    return _fetch_one_source("seatgeek_sales", per_page, page)
 
 
 def _fetch_tickpick(per_page: int, page: int = 1) -> dict:
@@ -1095,7 +1105,7 @@ def orders(
     include_terminal: int = 0,
     _=Depends(require_auth),
 ):
-    """SQL-only orders feed. All 5 sources (evo / seatgeek / seatdata /
+    """SQL-only orders feed. All 5 sources (evo / seatgeek_sales / seatdata /
     tickpick / vivid) are pulled from public.unified_orders, which the
     upstream ingest crons keep populated. No broker-API calls in the data
     path — cron freshness (`/api/d2/cron-freshness`) is the operator's
@@ -1261,8 +1271,12 @@ def _deep_order_evo_sql(sb, order_id: str) -> dict:
     return (res.data or [None])[0] or {}
 
 
-def _deep_order_seatgeek_sql(sb, order_id: str) -> dict:
-    res = sb.table("seatgeek_orders").select("*").eq("sg_order_id", order_id).limit(1).execute()
+def _deep_order_seatgeek_sales_sql(sb, order_id: str) -> dict:
+    # Broker firehose row keyed by sg_sale_id (text). Schema:
+    # sg_sale_id, sg_event_id, broadcast_price, quantity, section, row,
+    # stock_type, delivery_method, in_hand_date, is_instant, seller_notes,
+    # sale_at_utc, aq_short_event_id, venue_short_id, pulled_at, raw.
+    res = sb.table("seatgeek_sales_snapshots").select("*").eq("sg_sale_id", order_id).limit(1).execute()
     return (res.data or [None])[0] or {}
 
 
@@ -1287,11 +1301,11 @@ def _deep_order_gotickets(c, order_id: str) -> dict:
 # Dispatch: SQL sources use the "_sb" sentinel (the Supabase client);
 # gotickets keeps the upstream client factory until SQL backing exists.
 _DEEP_ORDER = {
-    "evo":       ("_sb",               _deep_order_evo_sql),
-    "seatgeek":  ("_sb",               _deep_order_seatgeek_sql),
-    "tickpick":  ("_sb",               _deep_order_tickpick_sql),
-    "vivid":     ("_sb",               _deep_order_vivid_sql),
-    "gotickets": ("_gotickets_client", _deep_order_gotickets),
+    "evo":            ("_sb",               _deep_order_evo_sql),
+    "seatgeek_sales": ("_sb",               _deep_order_seatgeek_sales_sql),
+    "tickpick":       ("_sb",               _deep_order_tickpick_sql),
+    "vivid":          ("_sb",               _deep_order_vivid_sql),
+    "gotickets":      ("_gotickets_client", _deep_order_gotickets),
 }
 
 
@@ -1354,11 +1368,11 @@ def health(_=Depends(require_auth)):
     #    Currently none of our raw tables carry an explicit fulfill-by
     #    timestamp; documenting that here so the operator sees the gap.
     fulfillby_fields = {
-        "evo":      {"in_hand": None, "fulfill_by": None, "notes": "hold_expires_at is auction-hold timer, not fulfill deadline; event_date is implicit"},
-        "seatgeek": {"in_hand": None, "fulfill_by": None, "notes": "reservation_duration_minutes is a relative seller-response clock"},
-        "tickpick": {"in_hand": None, "fulfill_by": None, "notes": "tickpick_orders.raw jsonb may carry more; not surfaced yet"},
-        "vivid":    {"in_hand": None, "fulfill_by": None, "notes": "vivid_orders.raw_xml + raw jsonb; no explicit fulfill-by field in feed"},
-        "seatdata": {"in_hand": None, "fulfill_by": None, "notes": "completed-sales feed — no fulfillment lifecycle"},
+        "evo":            {"in_hand": None, "fulfill_by": None, "notes": "hold_expires_at is auction-hold timer, not fulfill deadline; event_date is implicit"},
+        "seatgeek_sales": {"in_hand": "in_hand_date", "fulfill_by": None, "notes": "broker firehose observation — in_hand_date is the listing's promised drop date; no fulfill-by lifecycle (sales are terminal at observation time)"},
+        "tickpick":       {"in_hand": None, "fulfill_by": None, "notes": "tickpick_orders.raw jsonb may carry more; not surfaced yet"},
+        "vivid":          {"in_hand": None, "fulfill_by": None, "notes": "vivid_orders.raw_xml + raw jsonb; no explicit fulfill-by field in feed"},
+        "seatdata":       {"in_hand": None, "fulfill_by": None, "notes": "completed-sales feed — no fulfillment lifecycle"},
     }
 
     return JSONResponse({
@@ -1374,8 +1388,10 @@ def health(_=Depends(require_auth)):
 def order_detail(source: str, order_id: str, _=Depends(require_auth)):
     """Single-order deep fetch.
 
-    For evo / seatgeek / tickpick / vivid: reads the matching row from the
-    raw `{source}_orders` table in Supabase. No upstream-API call.
+    For evo / tickpick / vivid: reads the matching row from the raw
+    `{source}_orders` table in Supabase. For seatgeek_sales: reads from
+    `seatgeek_sales_snapshots` (broker firehose) keyed by `sg_sale_id`.
+    No upstream-API call.
 
     For gotickets: by-id API call — no SQL backing yet (tracked for future
     ingest cron in the canonical lane).
@@ -1477,8 +1493,9 @@ def metrics(_=Depends(require_auth)):
       - sales gaps (last 24h, >30min)     : d2_metrics_sales_gaps
 
     Windows anchor on America/New_York for "today" so the day boundary
-    matches the operator's clock. Filtered to evo/seatgeek/seatdata/
-    tickpick/vivid; seatgeek_sales (broker market data) excluded."""
+    matches the operator's clock. Post-2026-05-16 rewire: SG source is
+    seatgeek_sales (broker firehose); the dormant seatgeek seller source
+    is excluded from metrics."""
     from datetime import datetime, timedelta, timezone
     import time as _time
     sb = _sb()

--- a/d2_dashboard/static/dashboard.js
+++ b/d2_dashboard/static/dashboard.js
@@ -298,7 +298,7 @@ function renderDashboard(domain) {
           <div class="filter-group">
             <span class="toolbar-meta">Source:</span>
             <label><input type="checkbox" class="flt-source" value="evo"      checked /> evo</label>
-            <label><input type="checkbox" class="flt-source" value="seatgeek" checked /> sg</label>
+            <label><input type="checkbox" class="flt-source" value="seatgeek_sales" checked /> sg market</label>
             <label><input type="checkbox" class="flt-source" value="tickpick" checked /> tickpick</label>
             <label><input type="checkbox" class="flt-source" value="vivid"    checked /> vivid</label>
           </div>
@@ -1361,24 +1361,29 @@ function renderReadableOrder(source, d) {
       opt("Auto-flags",      autoFlags),
       opt("Payment state",   payment.state ? `${payment.state} (${payment.type || "?"})` : null),
     ].join("");
-  } else if (source === "seatgeek") {
-    // SG seller_order/{id} payload: event.name + event.date + event.time
-    // (not event.title / event.datetime_local). Quantity lives under
-    // listing, not at the top level. Combine date+time into ISO for the
-    // formatDate helper.
-    const ev = d.event || {};
-    const listing = d.listing || {};
-    const evDate = ev.date ? `${ev.date}T${ev.time || "00:00:00"}` : (ev.datetime_local || ev.datetime_utc);
+  } else if (source === "seatgeek_sales") {
+    // Broker firehose row (flat shape, read direct from
+    // public.seatgeek_sales_snapshots). Event name/venue are not joined
+    // in the deep fetch; they're already visible in the parent row from
+    // unified_orders. Focus the detail panel on sale-specific fields.
+    const total = (d.broadcast_price != null && d.quantity)
+      ? Number(d.broadcast_price) * Number(d.quantity || 1)
+      : null;
     rows = [
-      row("Order ID",      d.order_id || d.id),
-      row("Event",         ev.name || ev.title || d.event_title),
-      row("Event date",    formatDate(evDate)),
-      row("Venue",         ev.venue),
-      row("Section / Row", listing.section ? `${listing.section} / ${listing.row || "—"}` : null),
-      row("Status",        d.status),
-      row("Quantity",      listing.quantity || d.quantity),
-      row("Total",         d.total),
-      row("Delivery",      d.delivery_method || d.delivery),
+      row("Sale ID",          d.sg_sale_id || d.id),
+      row("SG event ID",      d.sg_event_id),
+      row("AQ event",         d.aq_short_event_id),
+      row("Observed at",      formatDate(d.sale_at_utc || d.pulled_at)),
+      row("Section / Row",    d.section ? `${d.section} / ${d.row || "—"}` : null),
+      row("Quantity",         d.quantity),
+      row("Broadcast price",  d.broadcast_price),
+      opt("Approx. total",    total != null ? total.toFixed(2) : null),
+      opt("Stock type",       d.stock_type),
+      opt("Delivery",         d.delivery_method),
+      opt("In-hand date",     d.in_hand_date),
+      opt("Instant?",         d.is_instant != null ? String(d.is_instant) : null),
+      opt("Seller notes",     d.seller_notes),
+      opt("Venue (short)",    d.venue_short_id),
     ].join("");
   }
   return `<table class="kv">${rows}</table>`;

--- a/supabase/migrations/20260516200000_d2_metrics_swap_sg_to_sg_sales.sql
+++ b/supabase/migrations/20260516200000_d2_metrics_swap_sg_to_sg_sales.sql
@@ -1,0 +1,231 @@
+-- Migration 20260516200000 · lane:D2 · writes:d2_metrics_window(),d2_metrics_hourly_buckets(),d2_metrics_top_events(),d2_metrics_hot_events(),d2_metrics_biggest_sales(),d2_metrics_sales_gaps() · reads:unified_orders · pre:20260515320000,20260515365000 · auth:operator-permitted 2026-05-16
+-- Swap SG source in 6 metrics RPCs from 'seatgeek' (dormant seller-side,
+-- seatgeek_orders, no new rows in 11 months) → 'seatgeek_sales' (broker
+-- firehose, seatgeek_sales_snapshots, +67k rows/hr).
+-- Pairs with d2_dashboard/main.py _ALL_SOURCES swap. All 6 RPCs keep the
+-- same signature/return shape; only the source-IN list changes.
+
+CREATE OR REPLACE FUNCTION public.d2_metrics_window(
+  p_start timestamptz,
+  p_end   timestamptz
+)
+RETURNS TABLE (
+  source           text,
+  orders_count     bigint,
+  fulfilled_count  bigint,
+  gross_total      numeric,
+  fulfilled_gross  numeric,
+  qty_total        bigint,
+  fulfilled_qty    bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    uo.source,
+    count(*)::bigint                                                          AS orders_count,
+    count(*) FILTER (WHERE uo.is_sale_succeeded)::bigint                      AS fulfilled_count,
+    coalesce(sum(uo.gross_value), 0)::numeric                                 AS gross_total,
+    coalesce(sum(uo.gross_value) FILTER (WHERE uo.is_sale_succeeded), 0)::numeric AS fulfilled_gross,
+    coalesce(sum(uo.quantity), 0)::bigint                                     AS qty_total,
+    coalesce(sum(uo.quantity) FILTER (WHERE uo.is_sale_succeeded), 0)::bigint AS fulfilled_qty
+  FROM public.unified_orders uo
+  WHERE uo.created_at >= p_start
+    AND uo.created_at <  p_end
+    AND uo.source IN ('evo', 'seatgeek_sales', 'seatdata', 'tickpick', 'vivid')
+  GROUP BY uo.source;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.d2_metrics_window(timestamptz, timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.d2_metrics_window(timestamptz, timestamptz) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.d2_metrics_hourly_buckets(
+  p_start timestamptz,
+  p_end   timestamptz
+)
+RETURNS TABLE (
+  hour_bucket      timestamptz,
+  source           text,
+  orders_count     bigint,
+  gross            numeric,
+  fulfilled_gross  numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    date_trunc('hour', uo.created_at) AS hour_bucket,
+    uo.source,
+    count(*)::bigint                                                              AS orders_count,
+    coalesce(sum(uo.gross_value), 0)::numeric                                     AS gross,
+    coalesce(sum(uo.gross_value) FILTER (WHERE uo.is_sale_succeeded), 0)::numeric AS fulfilled_gross
+  FROM public.unified_orders uo
+  WHERE uo.created_at >= p_start
+    AND uo.created_at <  p_end
+    AND uo.source IN ('evo', 'seatgeek_sales', 'seatdata', 'tickpick', 'vivid')
+  GROUP BY 1, 2
+  ORDER BY 1 ASC, 2 ASC;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.d2_metrics_hourly_buckets(timestamptz, timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.d2_metrics_hourly_buckets(timestamptz, timestamptz) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.d2_metrics_top_events(
+  p_start timestamptz,
+  p_end   timestamptz,
+  p_limit int DEFAULT 10
+)
+RETURNS TABLE (
+  tevo_event_id   bigint,
+  event_name      text,
+  event_date      timestamptz,
+  total_gross     numeric,
+  total_count     bigint,
+  fulfilled_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    uo.tevo_event_id,
+    max(uo.event_name)             AS event_name,
+    max(uo.event_date)             AS event_date,
+    coalesce(sum(uo.gross_value) FILTER (WHERE uo.is_sale_succeeded), 0)::numeric AS total_gross,
+    count(*)::bigint                                                              AS total_count,
+    count(*) FILTER (WHERE uo.is_sale_succeeded)::bigint                          AS fulfilled_count
+  FROM public.unified_orders uo
+  WHERE uo.created_at >= p_start
+    AND uo.created_at <  p_end
+    AND uo.tevo_event_id IS NOT NULL
+    AND uo.source IN ('evo', 'seatgeek_sales', 'seatdata', 'tickpick', 'vivid')
+  GROUP BY uo.tevo_event_id
+  HAVING coalesce(sum(uo.gross_value) FILTER (WHERE uo.is_sale_succeeded), 0) > 0
+  ORDER BY total_gross DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.d2_metrics_top_events(timestamptz, timestamptz, int) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.d2_metrics_top_events(timestamptz, timestamptz, int) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.d2_metrics_hot_events(
+  p_start timestamptz,
+  p_end   timestamptz,
+  p_limit int DEFAULT 10
+)
+RETURNS TABLE (
+  tevo_event_id   bigint,
+  event_name      text,
+  event_date      timestamptz,
+  recent_count    bigint,
+  recent_gross    numeric,
+  fulfilled_count bigint,
+  last_order_at   timestamptz
+)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public
+AS $$
+  SELECT
+    uo.tevo_event_id,
+    max(uo.event_name) AS event_name,
+    max(uo.event_date) AS event_date,
+    count(*)::bigint AS recent_count,
+    coalesce(sum(uo.gross_value), 0)::numeric AS recent_gross,
+    count(*) FILTER (WHERE uo.is_sale_succeeded)::bigint AS fulfilled_count,
+    max(uo.created_at) AS last_order_at
+  FROM public.unified_orders uo
+  WHERE uo.created_at >= p_start
+    AND uo.created_at <  p_end
+    AND uo.tevo_event_id IS NOT NULL
+    AND uo.source IN ('evo', 'seatgeek_sales', 'seatdata', 'tickpick', 'vivid')
+  GROUP BY uo.tevo_event_id
+  ORDER BY recent_count DESC, recent_gross DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.d2_metrics_hot_events(timestamptz, timestamptz, int) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.d2_metrics_hot_events(timestamptz, timestamptz, int) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.d2_metrics_biggest_sales(
+  p_since timestamptz DEFAULT NULL,
+  p_limit int DEFAULT 10
+)
+RETURNS TABLE (
+  source           text,
+  source_order_id  text,
+  tevo_event_id    bigint,
+  event_name       text,
+  event_date       timestamptz,
+  gross_value      numeric,
+  quantity         bigint,
+  canonical_status text,
+  created_at       timestamptz
+)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public
+AS $$
+  SELECT
+    uo.source,
+    uo.source_order_id,
+    uo.tevo_event_id,
+    uo.event_name,
+    uo.event_date,
+    uo.gross_value,
+    uo.quantity::bigint,
+    uo.canonical_status,
+    uo.created_at
+  FROM public.unified_orders uo
+  WHERE uo.is_sale_succeeded
+    AND uo.created_at >= coalesce(p_since, now() - interval '5 minutes')
+    AND uo.source IN ('evo', 'seatgeek_sales', 'seatdata', 'tickpick', 'vivid')
+  ORDER BY uo.gross_value DESC NULLS LAST
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.d2_metrics_biggest_sales(timestamptz, int) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.d2_metrics_biggest_sales(timestamptz, int) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.d2_metrics_sales_gaps(
+  p_lookback_hours  int DEFAULT 24,
+  p_min_gap_minutes int DEFAULT 30
+)
+RETURNS TABLE (
+  source         text,
+  gap_start      timestamptz,
+  gap_end        timestamptz,
+  gap_minutes    numeric
+)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public
+AS $$
+  WITH recent_sales AS (
+    SELECT
+      uo.source,
+      uo.created_at,
+      lag(uo.created_at) OVER (PARTITION BY uo.source ORDER BY uo.created_at) AS prev_at
+    FROM public.unified_orders uo
+    WHERE uo.is_sale_succeeded
+      AND uo.created_at >= now() - make_interval(hours => p_lookback_hours)
+      AND uo.source IN ('evo', 'seatgeek_sales', 'seatdata', 'tickpick', 'vivid')
+  )
+  SELECT
+    source,
+    prev_at AS gap_start,
+    created_at AS gap_end,
+    round(extract(epoch FROM (created_at - prev_at)) / 60.0, 1) AS gap_minutes
+  FROM recent_sales
+  WHERE prev_at IS NOT NULL
+    AND extract(epoch FROM (created_at - prev_at)) / 60.0 >= p_min_gap_minutes
+  ORDER BY gap_minutes DESC
+  LIMIT 50;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.d2_metrics_sales_gaps(int, int) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.d2_metrics_sales_gaps(int, int) TO service_role;

--- a/supabase/migrations/20260516200100_d2_cron_freshness_swap_sg_to_sg_sales.sql
+++ b/supabase/migrations/20260516200100_d2_cron_freshness_swap_sg_to_sg_sales.sql
@@ -1,0 +1,43 @@
+-- Migration 20260516200100 · lane:D2 · writes:d2_cron_freshness() · reads:cron.job,cron.job_run_details · pre:20260513230300,20260516200000 · auth:operator-permitted 2026-05-16
+-- Swap dashboard SG cron mapping from sg_seller_orders_* (seller-side polling
+-- of dormant account) → sg_broker_sales_* (broker firehose, the live signal).
+-- Source key renamed 'seatgeek' → 'seatgeek_sales' to match unified_orders
+-- branch + d2_metrics_*() RPC source filter post-2026-05-16 rewire.
+
+CREATE OR REPLACE FUNCTION public.d2_cron_freshness()
+RETURNS TABLE(
+  source       text,
+  jobname      text,
+  phase        text,
+  schedule     text,
+  active       boolean,
+  last_run     timestamptz,
+  last_status  text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, cron
+AS $$
+WITH mapping(source, jobname, phase) AS (
+  VALUES
+    ('evo',            'evo_orders_queue_30min',         'queue'),
+    ('evo',            'evo_orders_process_30min',       'process'),
+    ('seatgeek_sales', 'sg_broker_sales_queue_30min',    'queue'),
+    ('seatgeek_sales', 'sg_broker_sales_process_30min',  'process'),
+    ('tickpick',       'tickpick_orders_queue_30min',    'queue'),
+    ('tickpick',       'tickpick_orders_process_30min',  'process')
+)
+SELECT
+  m.source,
+  m.jobname,
+  m.phase,
+  j.schedule,
+  j.active,
+  (SELECT max(d.start_time) FROM cron.job_run_details d WHERE d.jobid = j.jobid) AS last_run,
+  (SELECT d.status FROM cron.job_run_details d WHERE d.jobid = j.jobid ORDER BY d.start_time DESC LIMIT 1) AS last_status
+FROM mapping m
+LEFT JOIN cron.job j ON j.jobname = m.jobname;
+$$;
+
+REVOKE ALL ON FUNCTION public.d2_cron_freshness() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.d2_cron_freshness() TO service_role;

--- a/tests/test_d2_dashboard.py
+++ b/tests/test_d2_dashboard.py
@@ -61,12 +61,17 @@ def _stub_evo(per_page, page=1):
 
 
 def _stub_sg(per_page, page=1):
+    # Post-2026-05-16 rewire: SG source on the orders feed is the broker
+    # firehose (seatgeek_sales_snapshots). Rows are terminal/fulfilled
+    # observations — the dashboard's Active pill filters them out by
+    # construction; the All pill surfaces them.
     return {
-        "source": "seatgeek",
+        "source": "seatgeek_sales",
         "ok": True,
         "rows": [{
-            "source": "seatgeek", "order_id": "SG-9", "event_name": "Hamilton",
-            "event_date": "2026-07-01T20:00:00Z", "qty": 4, "status": "open",
+            "source": "seatgeek_sales", "order_id": "SG-SALE-9", "event_name": "Hamilton",
+            "event_date": "2026-07-01T20:00:00Z", "qty": 4, "status": "sold",
+            "canonical_status": "fulfilled",
             "amount": 1200.5, "currency": "USD", "ordered_at": "2026-05-12T09:00:00Z",
         }],
         "total": 1,
@@ -188,25 +193,27 @@ def test_orders_503_when_supabase_unconfigured(monkeypatch, client):
 
 
 def test_orders_serves_unified_orders_with_per_source_chips(monkeypatch, client):
-    """All 5 sources (evo / seatgeek / seatdata / tickpick / vivid) get
-    origin=sql chips with per-source row counts and `as_of` freshness from
-    `unified_orders.last_seen_at`. No upstream-API leg — the dashboard is
-    SQL-only as of the 2026-05-14 cutover."""
+    """All 5 sources (evo / seatgeek_sales / seatdata / tickpick / vivid)
+    get origin=sql chips with per-source row counts and `as_of` freshness
+    from `unified_orders.last_seen_at`. No upstream-API leg — the dashboard
+    is SQL-only as of the 2026-05-14 cutover. Post-2026-05-16 the SG source
+    is the broker firehose (seatgeek_sales_snapshots), not the dormant
+    seatgeek_orders seller table."""
     monkeypatch.setattr(
         d2_main, "_fetch_unified_orders_page",
         lambda n, p=1, include_terminal=False: {
             "rows": [
-                {"source": "seatgeek", "order_id": "SG-9", "event_name": "Hamilton",
-                 "event_date": "2026-07-01T20:00:00Z", "qty": 4, "status": "open",
-                 "canonical_status": "pending", "amount": 1200.5, "currency": None,
+                {"source": "seatgeek_sales", "order_id": "SG-SALE-9", "event_name": "Hamilton",
+                 "event_date": "2026-07-01T20:00:00Z", "qty": 4, "status": "sold",
+                 "canonical_status": "fulfilled", "amount": 1200.5, "currency": None,
                  "ordered_at": "2026-05-12T09:00:00Z"},
                 {"source": "evo", "order_id": "111", "event_name": "Knicks vs Lakers",
                  "event_date": "2026-06-01T19:30:00Z", "qty": 2, "status": "accepted",
                  "canonical_status": "accepted", "amount": 450.0, "currency": None,
                  "ordered_at": "2026-05-10T12:00:00Z"},
             ],
-            "per_source_count": {"evo": 1, "seatgeek": 1},
-            "per_source_as_of": {"evo": "2026-05-13T20:35:00Z", "seatgeek": "2026-05-09T02:57:00Z"},
+            "per_source_count": {"evo": 1, "seatgeek_sales": 1},
+            "per_source_as_of": {"evo": "2026-05-13T20:35:00Z", "seatgeek_sales": "2026-05-16T16:16:00Z"},
         },
     )
     # Stub the event-window pull (no v_event_base candidates → rows
@@ -215,23 +222,23 @@ def test_orders_serves_unified_orders_with_per_source_chips(monkeypatch, client)
     monkeypatch.setattr(d2_main, "_fetch_cron_freshness", lambda: {})
     body = client.get("/api/d2/orders").json()
     sources = {s["source"]: s for s in body["sources"]}
-    assert set(sources) == {"evo", "seatgeek", "seatdata", "tickpick", "vivid"}
+    assert set(sources) == {"evo", "seatgeek_sales", "seatdata", "tickpick", "vivid"}
     # Every source is SQL-backed now (vivid joined the unified_orders view
     # 2026-05-13; the dashboard was updated 2026-05-14 to stop using the
     # legacy API+match path for it).
-    for src in ("evo", "seatgeek", "seatdata", "tickpick", "vivid"):
+    for src in ("evo", "seatgeek_sales", "seatdata", "tickpick", "vivid"):
         assert sources[src]["origin"] == "sql"
     assert sources["evo"]["ok"] is True
     assert sources["evo"]["as_of"] == "2026-05-13T20:35:00Z"
     assert sources["evo"]["count"] == 1
-    assert sources["seatgeek"]["count"] == 1
+    assert sources["seatgeek_sales"]["count"] == 1
     assert sources["seatdata"]["count"] == 0
     assert sources["seatdata"]["ok"] is True
     assert sources["tickpick"]["count"] == 0
     assert sources["vivid"]["count"] == 0
     # SQL rows: 2 returned, sorted newest-first by ordered_at.
     rows = body["rows"]
-    assert [r["source"] for r in rows] == ["seatgeek", "evo"]
+    assert [r["source"] for r in rows] == ["seatgeek_sales", "evo"]
 
 
 def test_orders_no_longer_carries_cron_blob(monkeypatch, client):
@@ -487,9 +494,9 @@ def test_metrics_bundles_all_windows_buckets_and_top(monkeypatch, client):
             {"source": "evo",      "orders_count": 3, "fulfilled_count": 2,
              "gross_total": 450.0, "fulfilled_gross": 300.0,
              "qty_total": 6, "fulfilled_qty": 4},
-            {"source": "seatgeek", "orders_count": 1, "fulfilled_count": 0,
-             "gross_total": 1200.0, "fulfilled_gross": 0.0,
-             "qty_total": 4, "fulfilled_qty": 0},
+            {"source": "seatgeek_sales", "orders_count": 1, "fulfilled_count": 1,
+             "gross_total": 1200.0, "fulfilled_gross": 1200.0,
+             "qty_total": 4, "fulfilled_qty": 4},
         ]
 
     def _hourly_data(args):
@@ -952,12 +959,15 @@ def test_health_returns_cron_queue_and_sql_blob(monkeypatch, client):
     body = client.get("/api/d2/health").json()
     assert {c["jobname"] for c in body["crons"]} == {"evo_orders_queue_30min", "tickpick_orders_queue_30min"}
     assert set(body["queues"]) == {"tickpick", "vivid"}
-    assert set(body["sql_counts"]) == {"evo", "seatgeek", "seatdata", "tickpick", "vivid"}
-    # fulfillby_fields documents the gap — none of our sources surface an
-    # explicit in-hand / fulfill-by timestamp today.
+    assert set(body["sql_counts"]) == {"evo", "seatgeek_sales", "seatdata", "tickpick", "vivid"}
+    # fulfillby_fields: post-2026-05-16 rewire, seatgeek_sales (broker firehose)
+    # exposes in_hand_date from the listing snapshot. The other four sources
+    # still surface no explicit in-hand / fulfill-by timestamp.
     fb = body["fulfillby_fields"]
-    assert set(fb) == {"evo", "seatgeek", "tickpick", "vivid", "seatdata"}
-    for src in fb:
+    assert set(fb) == {"evo", "seatgeek_sales", "tickpick", "vivid", "seatdata"}
+    assert fb["seatgeek_sales"]["in_hand"] == "in_hand_date"
+    assert fb["seatgeek_sales"]["fulfill_by"] is None
+    for src in ("evo", "tickpick", "vivid", "seatdata"):
         assert fb[src]["in_hand"] is None
         assert fb[src]["fulfill_by"] is None
 


### PR DESCRIPTION
## Summary

Swap the D2 dashboard's SG source from `seatgeek_orders` (dormant
seller-side table — no new rows in ~11 months) to
`seatgeek_sales_snapshots` (broker firehose — ~67k rows/hr, 1-min
freshness). The `unified_orders` view already exposes both sub-sources;
this just flips which one the dashboard reads.

Operator-directed swap per the 2026-05-16 "Replace SG source" decision
in the plan at [d2-bot-continues-here-cheeky-quokka.md](https://github.com/JulianS4K/Terminal-2/blob/main/.claude/plans/d2-bot-continues-here-cheeky-quokka.md) (the same plan whose
coupled-polling Option A was shipped by A1 in #142).

## What changes for users

| Pill | Before | After |
|---|---|---|
| Undelivered (default) | SG: ~0 rows (dormant seller, fulfilled-only) | SG: 0 rows (broker sales are terminal by construction) — same UX |
| All | SG: 400 historical seller orders | SG: ~1M broker firehose observations, +67k/hr |
| Metrics tab | SG: ~$0 fulfilled gross in window | SG: live $/hour visible (e.g. Bruno Mars $4.4M/1h) |

## What stays unchanged

- `seatgeek_orders` table + seller-side ingest crons (63/65) — still
  populated, just no longer surfaced on the dashboard.
- All non-SG sources (evo, seatdata, tickpick, vivid).
- `_CANONICAL_STATUS["seatgeek"]` dict entry — kept for compatibility;
  unused on the orders feed but the samples tab + future seller
  resurfacing may need it.

## Files

| File | Change |
|---|---|
| `d2_dashboard/main.py` | `_SQL_BACKED_SOURCES` / `_ALL_SOURCES` swap; `_deep_order_seatgeek_sales_sql` reads `seatgeek_sales_snapshots`; dispatch + `fulfillby_fields` updated |
| `d2_dashboard/static/dashboard.js` | checkbox label "sg market"; row detail rendered for flat broker shape |
| `tests/test_d2_dashboard.py` | 5 cases updated; 57/57 pass |
| `supabase/migrations/20260516200000_d2_metrics_swap_sg_to_sg_sales.sql` | NEW — 6 metrics RPCs swap source IN list |
| `supabase/migrations/20260516200100_d2_cron_freshness_swap_sg_to_sg_sales.sql` | NEW — cron mapping → `sg_broker_sales_queue_30min` |

## Lane ownership

- D2 authors code + migration drafts.
- A1 applies both migrations to prod (per CLAUDE.md §1 standing rule:
  `apply_migration` needs operator-permitted gate).
- A1 merges PR (sole pusher to main).
- D0 redeploys d2-orders-dashboard service after merge (CLAUDE.md §4 —
  D0 owns Render write authority on D2's service post-reorg).

## Test plan

- [x] `pytest tests/test_d2_dashboard.py` — all 57 pass on fresh main-based branch.
- [ ] After migrations apply: `SELECT * FROM d2_metrics_window(now()-interval '1h', now()) WHERE source='seatgeek_sales'` returns non-zero `gross_total` reflecting live broker market activity.
- [ ] After deploy: `/api/d2/orders?include_terminal=0` → `per_source_count.seatgeek_sales == 0`.
- [ ] After deploy: `/api/d2/orders?include_terminal=1&limit=50` → `per_source_count.seatgeek_sales > 0`.
- [ ] After deploy: `/api/d2/cron-freshness` → `seatgeek_sales` maps to `sg_broker_sales_queue_30min` with recent `last_run`.
- [ ] UI: "sg market" chip renders under All pill with ~1M rows; rows show section/row/price/sale_at; clicking opens broker-shaped detail panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)