### PR TITLE
d1: delegated Reserve click handlers (renderListings memory-leak fix)

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -829,6 +829,12 @@
     const resetBtn = $("#resetFilters");
 
     let allListings = [];
+    // Shared listing lookup — keyed by string(listing.id). renderListings()
+    // and renderParkingTab() write into this; the single delegated Reserve
+    // click handler reads from it. Replaces the prior per-row
+    // `btn.addEventListener` pattern, which accumulated handlers on every
+    // re-render (filter change, refetch) without ever removing them.
+    const listingsByIdMap = new Map();
     // Section universe — server tells us every section present in the
     // unfiltered owned set (`sections_available`). We cache it so the
     // section chip group keeps showing every section even after the user
@@ -908,10 +914,24 @@
       }
     }
 
+    // One-time delegated click handler for Reserve buttons. Resolves the
+    // listing via `data-listing-id` against `listingsByIdMap`. Prevents
+    // the previous leak where every re-render attached fresh per-row
+    // listeners with no cleanup.
+    function onReserveDelegatedClick(e) {
+      const btn = e.target.closest("button[data-action='reserve']");
+      if (!btn) return;
+      const id = btn.dataset.listingId;
+      if (!id) return;
+      const listing = listingsByIdMap.get(id);
+      if (listing) openModal(listing);
+    }
+    listEl.addEventListener("click", onReserveDelegatedClick);
+
     // ---- Listings rendering (server already filtered) ----
     function renderListings() {
       listCount.textContent = `${allListings.length}`;
-      listEl.innerHTML = "";
+      listEl.replaceChildren();
       if (!allListings.length) {
         noListings.hidden = false;
         return;
@@ -960,7 +980,12 @@
         const btn = document.createElement("button");
         btn.className = "btn";
         btn.textContent = "Reserve";
-        btn.addEventListener("click", () => openModal(l));
+        btn.dataset.action = "reserve";
+        if (l.id != null) {
+          const key = String(l.id);
+          btn.dataset.listingId = key;
+          listingsByIdMap.set(key, l);
+        }
 
         li.append(seat, qbox, pbox, btn);
 
@@ -1047,7 +1072,12 @@
         const btn = document.createElement("button");
         btn.className = "btn";
         btn.textContent = "Reserve";
-        btn.addEventListener("click", () => openModal(l));
+        btn.dataset.action = "reserve";
+        if (l.id != null) {
+          const key = String(l.id);
+          btn.dataset.listingId = key;
+          listingsByIdMap.set(key, l);
+        }
 
         li.append(seat, qbox, pbox, btn);
         if (l.public_notes) {
@@ -1057,6 +1087,15 @@
           li.append(notes);
         }
         parkUl.append(li);
+      }
+
+      // One-time delegated click handler on parkUl. Shares the same
+      // resolution path as the seats list — looks up the listing via
+      // `data-listing-id` in `listingsByIdMap`. Gated by `dataset.wired`
+      // so we don't stack handlers across renderParkingTab() calls.
+      if (!parkUl.dataset.wired) {
+        parkUl.dataset.wired = "1";
+        parkUl.addEventListener("click", onReserveDelegatedClick);
       }
 
       // Wire tab toggle once; idempotent — first click handler win.


### PR DESCRIPTION
## Summary
- `renderListings()` and `renderParkingTab()` previously attached a fresh `addEventListener("click", () => openModal(l))` to every Reserve button on every render. Filter changes / refetches stacked handlers on each re-render with no cleanup.
- Replaces both per-row attachments with a single delegated click handler on each parent UL (`#listings`, `#parkingListings`). Listings are pushed into a shared `listingsByIdMap`; the delegated handler resolves `event.target → data-listing-id → Map`.
- `parkUl`'s delegated listener is gated by `dataset.wired` so re-rendering parking doesn't re-attach.

Caught by C1 in the project audit.

## Test plan
- [x] `node --check static/store/store.js` — syntax valid
- [x] `pytest tests/test_store_home.py -q` — 22/22 passing (no Python regressions)
- [ ] Live `/store/event/<id>` after deploy: click Reserve → modal opens; close; click another → modal opens; repeat 10× → only one handler fires per click
- [ ] Filter chip change → cards re-render → click Reserve → still one handler per click (no stacking)
- [ ] Parking tab: switch to Parking → click Reserve → modal opens; back to seats → click Reserve → still works

Smoke matrix after merge per [docs/d1_operating_constraints.md:124](docs/d1_operating_constraints.md:124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)