### PR TITLE
d1: a11y — labels, roles, aria-labels on storefront inputs

### DIFF
--- a/static/store/event.html
+++ b/static/store/event.html
@@ -89,19 +89,19 @@
              curated zones in performer_zones. Filters apply only to Seats. -->
         <div id="filterBar" class="filter-bar">
           <div id="zoneRow" class="filter-row" hidden>
-            <span class="filter-label">Zone</span>
-            <div class="chip-group" id="zoneChips"></div>
+            <span id="zoneLabel" class="filter-label">Zone</span>
+            <div class="chip-group" id="zoneChips" role="group" aria-labelledby="zoneLabel"></div>
           </div>
           <div id="sectionRow" class="filter-row" hidden>
-            <span class="filter-label">Section</span>
-            <div class="chip-group" id="sectionChips"></div>
+            <span id="sectionLabel" class="filter-label">Section</span>
+            <div class="chip-group" id="sectionChips" role="group" aria-labelledby="sectionLabel"></div>
           </div>
           <div class="filter-row inline">
-            <span class="filter-label">Price</span>
-            <input id="minPrice" type="number" min="0" step="10" placeholder="min $" />
-            <input id="maxPrice" type="number" min="0" step="10" placeholder="max $" />
-            <span class="filter-label" style="margin-left:16px">Min qty</span>
-            <select id="minQty">
+            <label for="minPrice" class="filter-label">Price</label>
+            <input id="minPrice" type="number" min="0" step="10" placeholder="min $" aria-label="Minimum price" />
+            <input id="maxPrice" type="number" min="0" step="10" placeholder="max $" aria-label="Maximum price" />
+            <label for="minQty" class="filter-label" style="margin-left:16px">Min qty</label>
+            <select id="minQty" aria-label="Minimum ticket quantity">
               <option value="">any</option>
               <option value="2">2+</option>
               <option value="3">3+</option>

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -19,13 +19,15 @@
     <section class="hero">
       <h1>Find tickets to anything we have.</h1>
       <p class="sub">Direct inventory, transparent pricing.</p>
-      <form id="searchForm" class="search">
+      <form id="searchForm" class="search" role="search">
+        <label for="q" class="sr-only">Search events, performers, or venues</label>
         <input
           id="q"
           type="search"
           placeholder="artist · team · venue · city"
           autocomplete="off"
           autofocus
+          aria-label="Search events, performers, or venues"
           aria-autocomplete="list"
           aria-controls="searchSuggest"
         />

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -24,6 +24,21 @@ body {
 }
 a { color: inherit; }
 
+/* Screen-reader-only label utility. Visually hidden but exposed to
+   assistive tech. Standard inert-block pattern (1×1 clip + non-wrap)
+   to avoid layout impact. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ----- Topbar ----- */
 .topbar {
   display: flex;


### PR DESCRIPTION
## Summary
Closes the C1-audit a11y findings on the public storefront.

**event.html**
- Zone / Section chip groups: `role="group"` + `aria-labelledby` against existing label spans → SR announces "Zone, group, … chip selected" instead of two stray strings.
- Price inputs: convert decorative `<span>` filter labels into real `<label for=>` elements; add `aria-label` to `minPrice` / `maxPrice` / `minQty` so the announced name matches the placeholder semantics.

**index.html**
- Search form gets `role="search"` (landmark).
- `#q` search input gets a visually-hidden `<label for="q">` + `aria-label`; previously was placeholder-only and effectively unlabeled to AT.

**style.css**
- New `.sr-only` utility (standard 1×1 clip + non-wrap pattern). Single use site today.

No visual change. No JS change. Pure semantic additions.

## Test plan
- [x] `pytest tests/test_store_home.py -q` — 27/27 passing
- [x] HTML parses (Python `HTMLParser.feed` on both pages)
- [ ] Screen-reader smoke (VoiceOver/NVDA): the search field announces with name "Search events, performers, or venues"; zone chips announce as a labeled group; price inputs announce as "Minimum price" / "Maximum price".
- [ ] Visual regression: `.sr-only` label is invisible in browser; layout unchanged on `/store` and `/store/event/:id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)