### PR TITLE
d1: reserve quantity cap + api() error context

### DIFF
--- a/app.py
+++ b/app.py
@@ -6322,6 +6322,13 @@ def store_reserve(payload: dict = Body(...), authorization: str | None = Header(
         raise HTTPException(400, "event_id, ticket_group_id and quantity must be integers")
     if not (event_id and ticket_group_id and quantity > 0):
         raise HTTPException(400, "event_id, ticket_group_id and quantity > 0 required")
+    # Upper-bound the requested quantity before we touch inventory. TEvo
+    # ticket groups in practice cap around 8-12 per seat block; 50 is a
+    # generous ceiling that still bounds the request shape so a malformed
+    # client (quantity=999999) gets rejected fast without consulting the
+    # upstream API or the snapshot table.
+    if quantity > 50:
+        raise HTTPException(400, "quantity exceeds maximum allowed per reservation")
 
     if STOREFRONT_SQL_ONLY:
         # SQL-only mode: validate against listings_snapshots' latest capture

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -54,7 +54,12 @@
       // markup shouldn't splatter into the status pill downstream. Mirrors
       // D0's app.js fix from PR #113 commit 34232a1.
       msg = String(msg).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim().slice(0, 80);
-      throw new Error(`${r.status} ${msg}`);
+      // Tag the error with the failing endpoint so the downstream catch
+      // (status pill / alert) tells you *which* call died. Strips the
+      // /api/store/ prefix to keep the message tight — full path stays
+      // available on the network tab when debugging.
+      const tag = String(path).split("?")[0].replace(/^\/api\/store\//, "");
+      throw new Error(`${r.status} ${tag}: ${msg}`);
     }
     return r.json();
   }

--- a/tests/test_store_events.py
+++ b/tests/test_store_events.py
@@ -207,6 +207,50 @@ def test_we_own_always_true_with_office_filter(client, monkeypatch):
     assert all(e["we_own"] is True for e in r.json()["events"])
 
 
+# ---------- /api/store/reserve cap ----------
+
+def test_reserve_rejects_quantity_over_cap(client):
+    """quantity > 50 is rejected at the input-validation gate before any
+    inventory lookup. A malformed/malicious client requesting 999999 must
+    short-circuit with 400; we never want to hit TEvo or the snapshot
+    table with that shape."""
+    r = client.post("/api/store/reserve", json={
+        "event_id": 3346000,
+        "ticket_group_id": 12345,
+        "quantity": 999999,
+    })
+    assert r.status_code == 400, r.text
+    assert "maximum" in r.json()["detail"].lower()
+
+
+def test_reserve_rejects_quantity_just_over_cap(client):
+    """Boundary: quantity == 51 (one over the cap of 50) is rejected."""
+    r = client.post("/api/store/reserve", json={
+        "event_id": 3346000,
+        "ticket_group_id": 12345,
+        "quantity": 51,
+    })
+    assert r.status_code == 400
+
+
+def test_reserve_accepts_quantity_at_cap(client, monkeypatch):
+    """quantity == 50 passes the cap check (and continues to inventory
+    lookup, where our fake returns no match → 404 is expected).
+    Asserting NOT 400-with-cap-message proves the cap check let it
+    through."""
+    class _EmptyTGFake:
+        def get_ticket_groups(self, *_, **__):
+            return {"ticket_groups": []}
+    monkeypatch.setattr(app_module, "client", _EmptyTGFake())
+    r = client.post("/api/store/reserve", json={
+        "event_id": 3346000,
+        "ticket_group_id": 12345,
+        "quantity": 50,
+    })
+    # quantity=50 passes the cap; downstream fails for "no such group" → 404
+    assert r.status_code == 404, r.text
+
+
 def test_503_when_client_unconfigured(client, monkeypatch):
     """When `client` is None at request time, we return 503 — not 500."""
     monkeypatch.setattr(app_module, "client", None)


### PR DESCRIPTION
## Summary
Closes audit findings on `/api/store/reserve` input validation and `api()` error debuggability.

**Backend — `/api/store/reserve` cap**
- New `quantity > 50` short-circuit at the input-validation gate (before any inventory lookup). TEvo ticket-group splits cap around 8-12 in practice; 50 is a generous ceiling. A malformed/malicious client requesting 999999 now returns 400 immediately, without touching TEvo or the snapshot table.

**Frontend — `api()` error context**
- Error message now includes the failing endpoint tag: `"503 movers: <cold-start html>"` instead of `"503 <cold-start html>"`.
- `/api/store/` prefix stripped to keep the message tight; full path stays on the Network tab.
- Existing downstream parsers (e.g. `err.message.includes("410")` at line ~1804) still match — status code is still the first token.

**Tests**
- 3 new tests in `tests/test_store_events.py`: `quantity > 50` → 400 with "maximum" detail; `quantity == 51` (boundary) → 400; `quantity == 50` (cap) → passes cap check, continues to inventory lookup → 404 on no-match.

## Test plan
- [x] `pytest tests/test_store_events.py -q` — 11/11 passing (+3 new)
- [x] `pytest tests/ -q --ignore=test_readonly_guards.py --ignore=test_broadway_client.py` — 98 passed, 9 skipped
- [x] `node --check static/store/store.js` — syntax valid
- [ ] After deploy: `curl -X POST /api/store/reserve -H 'Content-Type: application/json' -d '{"event_id":1,"ticket_group_id":1,"quantity":999}'` → 400
- [ ] Trigger a 502 on any storefront API → confirm error pill shows endpoint tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)