### PR TITLE
feat(admin): bump espn_scoreboard_queue default 90d → 270d permanently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,24 @@
 
 Loaded automatically by Claude Code on every session in this repo. Applies to **all** bots regardless of lane.
 
+## 🔖 READ PROJECT_BIBLE.md FIRST (token discipline)
+
+**Before doing anything, read [`PROJECT_BIBLE.md`](PROJECT_BIBLE.md).** It consolidates the 80% you need from this file + LANE_DISCIPLINE.md + BOT_HIERARCHY.md + MIGRATION_CONVENTIONS.md + data-source docs into a single 400-line reference. Saves ~5× the tokens vs reading every governance file at session start.
+
+The bible has:
+- Hard rules (no-mutation, read-only-upstream, lane scope)
+- Bot hierarchy + Render service ownership per lane
+- Canonical SECDEF RPCs (`get_broker_event_page_v2`, matchers, bot_chat_log, etc.)
+- Key tables + freshness expectations + **column-name landmines** (catch schema bugs before authoring)
+- MCP tool scope per lane
+- SQL macros / common patterns (cancel filter, SG dedupe, sports gate, outdoor gate, email gate, cron wrapper)
+- Workflow recipes ("I want to author a migration", "I want to wire a UI panel", etc.)
+- Recent landmark migrations (don't re-do work already shipped)
+- Drift watchlist (known gaps — don't waste cycles rediscovering)
+- Self-check (9-item pre-task checklist)
+
+This file (CLAUDE.md) remains the canonical source for security rules + lockdown invariants. The bible is the operational handbook bots read once per session.
+
 Per-lane detail in `LANE_DISCIPLINE.md` (per-bot scope) + `BOT_HIERARCHY.md` (push restrictions matrix). Per-bot self-contracts live at `docs/<bot>_operating_constraints.md` (referenced in the top matter of `LANE_DISCIPLINE.md`).
 
 ## Global operator rules (2026-05-13 lockdown)

--- a/PROJECT_BIBLE.md
+++ b/PROJECT_BIBLE.md
@@ -1,0 +1,385 @@
+# PROJECT_BIBLE.md — single-source reference for all bots
+
+**Last updated**: 2026-05-16 by A1
+**Token discipline**: READ THIS FILE FIRST. If your task is covered here, you don't need to read 5 other governance files. Only dig deeper when this doc references a specific source-of-truth and you need detail.
+
+This bible consolidates the 80% bots actually need from CLAUDE.md + LANE_DISCIPLINE.md + BOT_HIERARCHY.md + MIGRATION_CONVENTIONS.md + data-source docs. The original files remain canonical for the 20% edge cases.
+
+---
+
+## 1. Hard rules (you can't override these)
+
+1. **SQL data is read-only by default.** Any `INSERT`/`UPDATE`/`DELETE`/DDL on prod requires explicit operator permission per call. Standing exceptions: `bot_chat` writes via `bot_chat_log()`, Supabase branch creation (copy-on-write fork, no prod mutation), authoring migration files (apply gated separately).
+2. **Upstream third-party APIs are READ-ONLY.** TEvo, SeatGeek, SeatData, TickPick, Vivid — GET endpoints only. No order POSTs, holds, webhook config changes without explicit operator authorization.
+3. **HTML / JS in your assigned lane is free reign** — no per-step approval.
+4. **Render workspace is per-service scoped.** See §3 below. Cross-service writes = lane violation.
+5. **A1 is sole pusher to `main`** (see `MIGRATION_CONVENTIONS.md §9`).
+6. **Cross-lane file edits require coordination** via `bot_chat` `question` or PR comment to the lane owner.
+
+When in doubt → ask via `AskUserQuestion` or post a `bot_chat` question.
+
+---
+
+## 2. Bot hierarchy
+
+```
+A1 (admin · sole prod pusher · Render workspace owner)
+├── B1 (security · monitors all; CRIT push allowed)
+└── C1 (canonical · drift monitor only since PR #109)
+    ├── D0 (Terminal FE · static site)
+    ├── D1 (Consumer Retail · storefront/search)
+    ├── D2 (Order Clients · ops dashboard)
+    ├── D3 (Broadway Scraper · sub of D2)
+    ├── D4 (Ticketing infra · UNASSIGNED)
+    └── E1 (Kalshi/markets · future stub)
+```
+
+**Render service ownership** (per CLAUDE.md §4):
+
+| Bot | Service | Service ID | Scope |
+|---|---|---|---|
+| A1 | workspace-wide | — | exclusive provisioning + deletes |
+| D0 | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | write OK |
+| D1 | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | write OK |
+| D2 | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | write OK |
+| B1, C1, D3, D4, E1 | (read-only on all services) | — | read only |
+
+**Lane ownership of code dirs** (per LANE_DISCIPLINE.md):
+- D0 → `static/terminal/*` + Terminal FE
+- D1 → `static/store/*` + storefront API in `app.py`
+- D2 → ops dashboard
+- A1 → `supabase/migrations/*`, governance docs, cross-cutting changes
+- B1 → security workflows + `release_health_check`
+
+---
+
+## 3. SQL surface bots call (canonical RPCs + key tables)
+
+### Canonical SECDEF RPCs (32 total; these are the key ones)
+
+| RPC | What it does | When to call |
+|---|---|---|
+| `get_broker_event_page(p_event_id, p_chart_hours)` | v1 Event Detail payload: overview + chart + zones + orders + cadences | D0 Phase 1 (still works); rolled up into v2 |
+| `get_broker_event_page_v2(p_event_id, p_chart_hours)` | v2 adds sales_tape + weather + espn + event_alerts + sg_side_by_side + splits + freshness | **D0 Phase 2a** primary entry point. Email-gated `@s4kent.com`. |
+| `get_broker_event_detail(p_event_id)` | Raw event header (per-source xref-rich) | Composed by v1; bots usually don't call directly |
+| `get_event_zones_rollup(event_id, is_owned)` | Zone-level rollup | Composed by v1 |
+| `derive_event_lifecycle(p_event_id)` | Ghost/postponed/completed classifier | Composed by v1 |
+| `match_to_aq_event_id(source, src_id, name, venue, date, lat, lon, [src_venue_id])` | 4-tier matcher → aq_short_event_id | Cross-source bridge work |
+| `create_system_aq_event(source, name, venue, date, src_id)` | SYS-{md5} fallback row in aq_event_map | When matcher returns NULL |
+| `match_unmatched_orders_sweep(max_per_table, create_synthetic)` | Sweep 5 order tables → tag aq_short_event_id | Cron `match_unmatched_orders_sweep_hourly` |
+| `match_unmatched_listings_chunked(max_events, create_synthetic)` | Same for listings firehose | Cron `listings_aq_backfill_overnight` |
+| `bot_chat_log(level, lane, event_type, message, related_pr, related_mig, in_reply_to, meta)` | Post to cross-lane chat | Standing permission |
+| `bot_chat_resolve(id, resolver_level, resolver_lane, note)` | Mark a question/flag resolved | Standing permission |
+| `cron_should_fire(jobname)` | 4-stage gate (budget/interval/work-check/window) | Wrap any cron body |
+| `cron_resume_with_gate(jobname)` | Re-enable a paused cron through the gate | When graduating crons |
+| `sg_classify_events()` | Refresh `sg_event_priority_state` tiers | Called by `sg_classify_events_5min` cron |
+| `sg_priority_poll_tick(max_polls)` | HOT/WARM polling driver | Called by `sg_priority_poll_tick_1min` cron |
+| `espn_scoreboard_queue(lookahead_days)` | Queue ESPN scoreboard fetches | Cron + manual NFL season refresh |
+| `espn_scoreboard_process()` | Process queued ESPN responses → date_lookup | Cron `espn_scoreboard_process_5min` |
+| `release_health_check()` | All-checks rollup | Cron + manual smoke |
+| `_health_check_pg_net_errors()` | pg_net error rate sub-check | Composed by release_health_check |
+
+### Canonical D0 entry view
+
+```sql
+SELECT * FROM public._v_d0_event_index WHERE sg_event_id = $1;
+-- OR for non-SG events (NFL etc.):
+SELECT public.get_broker_event_page_v2($tevo_event_id, 168);  -- falls back to base tables
+```
+
+### Key reference tables (144 tables total in public; these are the hot 25)
+
+**Event canonical**:
+- `events` — TEvo events PK=`id` (3,000+ future). Free-text venue + `primary_performer_id`.
+- `event_xref` — TEvo ↔ ESPN bridge (PK `tevo_event_id`). 1,000+ rows after this session.
+- `seatgeek_event_xref` — TEvo ↔ SG bridge. 967+ rows.
+- `sg_events_canonical` — SG events PK=`sg_event_id`. 4,600 rows. Has `tevo_event_id` populated for ~26%.
+- `aq_event_map` — Canonical AQ row PK=`aq_short_event_id`. 6,500+ rows; carries `sg_event_id`, `sh_event_id`, `tm_event_id`, `vivid_event_id`, `venue_short_id`, `performer_short_id`.
+- `entity_event_map` — VIEW (NOT base table) joining events + 3 xref tables + lifecycle.
+- `sg_event_priority_state` — Tier-classified events for HOT/WARM polling. Includes `tevo_event_id` (NEW 2026-05-16).
+- `espn_event_date_lookup` — ESPN scoreboard ingest (2,400+ rows, 322 NFL).
+- `espn_event_snapshots` — ESPN gameday firehose (state/scores/odds; 2,700+ rows, GAMEDAY-SCOPE only).
+
+**Listings + sales**:
+- `listings_snapshots` — TEvo firehose **8.2M rows, 2.8 GB**. Filter `is_owned=true AND brokerage_id=1768` for our inventory. **`aq_short_event_id` is 0% populated** — query via `event_id`.
+- `seatgeek_listings_snapshots` — SG firehose 2M+ rows, 1.5 GB. 95% `aq_short_event_id` populated. Use `broadcast_price` / `retail_price_all_in`.
+- `seatgeek_sales_snapshots` — SG sales 900K+ rows, 449 MB. **Always `DISTINCT ON (sg_sale_id)` — 11× duplication factor**. Columns: `sale_at_utc` (NOT `sold_at`), `broadcast_price`, `pulled_at`.
+- `seatgeek_seller_listings` — SG seller (our cost basis).
+- `event_metrics` / `zone_metrics` / `section_metrics` — TEvo-derived aggregates.
+- `seatgeek_event_metrics` — SG aggregates with `cost_*` columns (NOT `retail_*`).
+
+**Orders**:
+- `evo_orders` / `evo_order_items` — our TEvo orders (PII columns; never expose to anon).
+- `vivid_orders`, `tickpick_orders`, `seatgeek_orders` — per-source orders.
+
+**Context**:
+- `venue_assets` — 111 rows (NOT 882). Columns: `is_indoor` boolean (outdoor = NOT is_indoor). `latitude`, `longitude`, `tevo_venue_id` PK, `capacity`, `espn_venue_id`, `nws_grid_*`.
+- `weather_observations` — `tevo_venue_id` + `observed_at` (reading time) + `fetched_at` (ingest time). `is_forecast` boolean separates obs from forecast.
+- `nws_alerts` — `expires_at` (NOT `expires`). Geo-keyed.
+- `espn_team_snapshots` — Per-team standings (`record_summary`, `win_pct`, `streak`).
+- `espn_injuries_snapshots` — Active injuries by team.
+- `event_alerts` — Movement markers (`tevo_event_id` + `fired_at`; NOT `event_id` + `created_at`).
+
+**Entity xref**:
+- `aq_venue_map` — Canonical venue (`venue_short_id` + cross-source IDs).
+- `aq_performer_map` — Canonical performer.
+- `entity_performer_map` — TEvo↔ESPN team mapping (393 rows; all 32 NFL teams + all major leagues).
+- `entity_venue_map` — TEvo↔SeatData venue mapping.
+- `cron_policy` / `cron_gate_decisions` — Cron policy gate config + audit log.
+
+### Column-name landmines (commonly miscalled)
+
+| Table | Wrong | Correct |
+|---|---|---|
+| `seatgeek_sales_snapshots` | `sold_at`, `price`, `captured_at` | `sale_at_utc`, `broadcast_price`, `pulled_at` |
+| `event_alerts` | `event_id`, `created_at` | `tevo_event_id`, `fired_at` |
+| `nws_alerts` | `expires` | `expires_at` |
+| `weather_observations` | `captured_at` | `observed_at` (or `fetched_at`) |
+| `seatgeek_event_metrics` | `retail_min/median/p90` | `cost_min/median/p90` |
+| `venue_assets` | `is_outdoor`, 882 rows | `is_indoor`, **111 rows** |
+| `sd_sales_normalized` | `observed_at`, `aq_short_event_id` | `sale_timestamp`, `tevo_event_id` |
+| `events` | `is_classified`, `tbd` | (neither exists; use `EXISTS(entity_event_map...)` for sports gate, parse `(Date TBD)` from name) |
+
+---
+
+## 4. Data source inventory (12 families)
+
+| Family | Tables | Rows | Status | Notes |
+|---|---|---|---|---|
+| **TEvo (EVO)** | 11 | 12.7M (4.9 GB) | Live; collector gaps for 1-7d + 60d+ windows | listings_snapshots is the firehose |
+| **SeatGeek** | 20 | 935K (461 MB) | Live; sales firehose 487K rows/24h | Use `tevo_event_id`-indexed paths when possible |
+| **AQ canonical** | 5 (event/venue/performer maps) | 6.5K | Updated via xlsx ingest + SYS-md5 seeds | Bridge for cross-source linkage |
+| **ESPN** | 13 | 19K (14 MB) | Gameday-scope by default; this session backfilled 1,007 future xrefs | Bumped lookahead 90d → 270d manually |
+| **Weather / NWS** | 6 | 193K (84 MB) | Live; forecast 7d ahead | Outdoor gate = `NOT is_indoor` |
+| **Canonical entities** | 9 | 16K (12 MB) | entity_event_map / entity_performer_map / entity_venue_map | NFL teams 32/32 mapped |
+| **SeatData** | 3 | 254 rows | Sparse (mostly defunct) | `sd_sales_normalized` |
+| **Reddit** | 2 | 3.8K | Social sentiment | Not yet UI-wired |
+| **TickPick** | 2 | 921 | Orders ingest only | No listings firehose |
+| **Vivid** | 1 | (varies) | Orders ingest only | No listings firehose |
+| **Crons + queues** | 4 | per-state | 79 active of 89 total | Policy gate via `cron_should_fire` |
+| **Bot infra** | 3 | bot_chat, bot_chat_threads, scheduled_tasks_lock | Cross-lane coordination | Standing permission |
+
+### Cross-source bridge topology (post-2026-05-16)
+
+```
+events (TEvo) ─── PK e.id ─────────────────────────────┐
+   │                                                    │
+   │ via entity_performer_map (perfid + ±6h date)       │
+   ▼                                                    ▼
+event_xref ──── espn_event_id ───────► espn_event_date_lookup
+   │                                    espn_event_snapshots
+   │                                    espn_team_snapshots
+   │                                    espn_injuries_snapshots
+   ▼
+seatgeek_event_xref ── sg_event_id ──► sg_events_canonical
+   │                                    seatgeek_listings_snapshots
+   │                                    seatgeek_sales_snapshots
+   │                                    seatgeek_event_metrics
+   ▼
+aq_event_map ── aq_short_event_id ────► (universal canonical key)
+   │
+   ▼
+venue_short_id ──► aq_venue_map / venue_assets / weather_observations
+performer_short_id ──► aq_performer_map / espn_team_snapshots
+```
+
+---
+
+## 5. MCP tools by lane
+
+| MCP tool family | A1 | B1 | C1 | D0 | D1 | D2 | D3/D4/E1 |
+|---|---|---|---|---|---|---|---|
+| Supabase: `execute_sql` (read) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Supabase: `execute_sql` (write) / `apply_migration` | ✓ | CRIT only | drift-monitor read only | ✗ | ✗ | ✗ | ✗ |
+| Supabase: `create_branch` (no prod mutation) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Render: read (list/get/logs/metrics) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Render: write (own service only) | all | ✗ | ✗ | terminal | storefront | dashboard | ✗ |
+| Slack | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| scheduled-tasks | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| GitHub (`gh` via Bash) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+---
+
+## 6. Macros / SQL helper patterns bots use
+
+### `bot_chat_log` — durable cross-lane coordination
+
+```sql
+SELECT public.bot_chat_log(
+  p_level       := 'data-collection',  -- or 'admin' / 'security' / 'supervisor'
+  p_lane        := 'A1',                -- your lane code
+  p_event_type  := 'change_log',        -- change_log | question | flag | resolve_request
+  p_message     := 'Did X. Details: ...',
+  p_related_pr  := 154,                 -- optional
+  p_related_mig := '20260516070000',    -- optional
+  p_in_reply_to := NULL,                -- bigint of another bot_chat row
+  p_meta        := NULL                  -- optional jsonb
+);
+```
+
+### Cancel-pattern detection (sg_classify SKIP override)
+
+```sql
+WHERE sg_event_name ~* '(cancelled|if necessary|\(date tbd\)|^TBD at )'
+```
+
+### SG sales dedupe (mandatory)
+
+```sql
+-- ALWAYS DISTINCT ON sg_sale_id — 11× duplication factor in prod
+SELECT DISTINCT ON (sg_sale_id) *
+FROM seatgeek_sales_snapshots
+WHERE sg_event_id = $1
+ORDER BY sg_sale_id, pulled_at DESC;
+```
+
+### Sports gate (no `events.is_classified` column)
+
+```sql
+EXISTS (SELECT 1 FROM event_xref WHERE tevo_event_id = events.id AND espn_event_id IS NOT NULL)
+```
+
+### Outdoor venue gate (no `is_outdoor` column)
+
+```sql
+venue_assets.is_indoor = false  -- explicit FALSE, NOT NULL
+```
+
+### Cron body wrapper (policy gate)
+
+```sql
+DO $body$ BEGIN
+  IF NOT public.cron_should_fire('your_cron_name') THEN RETURN; END IF;
+  -- your work here
+END $body$;
+```
+
+### Email gate (inside SECDEF RPC)
+
+```sql
+v_email := coalesce(auth.jwt()->>'email', '');
+IF v_email NOT LIKE '%@s4kent.com' THEN
+  RAISE EXCEPTION 'forbidden: % is not @s4kent.com', v_email USING ERRCODE='42501';
+END IF;
+```
+
+### TEvo aq backfill SYS-md5 hash convention
+
+```sql
+-- create_system_aq_event() uses this hash; v2 RPC fallback looks for it
+v_aq := 'SYS-' || substring(md5(name || '|' || venue || '|' || to_char(date::timestamptz, 'YYYY-MM-DD"T"HH24:MI')) from 1 for 10);
+```
+
+---
+
+## 7. Workflow recipes
+
+### "I want to author a migration"
+1. Check schema first via `information_schema.columns` (don't assume — see §3 landmines)
+2. Test the query SHAPE on 5-10 sample rows via `execute_sql` (read-only)
+3. Write `supabase/migrations/YYYYMMDDHHMMSS_descriptive_name.sql` with header per `MIGRATION_CONVENTIONS.md`
+4. **Ask operator permission** via `AskUserQuestion` before `apply_migration`
+5. Apply via MCP `apply_migration`
+6. Verify post-apply on the same 5-10 samples
+7. Update migration file header `## Already applied to prod  Applied via MCP YYYY-MM-DD`
+8. Commit + push + open PR (A1 only pushes to main; subordinates open PRs against A1's branch)
+
+### "I want to query SQL"
+1. **READ this bible's §3 landmines first** before writing column names
+2. Use `tevo_event_id` paths over `sg_event_id` paths where indexes exist (see SG snapshots)
+3. Add `LIMIT` to exploratory queries (MCP has 2-min statement timeout)
+4. Tight projections — `SELECT id, name, ...` not `SELECT *`
+5. For SG sales: `DISTINCT ON (sg_sale_id)` mandatory
+
+### "I want to wire a UI panel for an event"
+1. D0: call `supabase.rpc('get_broker_event_page_v2', {p_event_id, p_chart_hours})`
+2. Branch on `data.bridge_ids.sg_event_id IS NULL` → render TEvo-only state
+3. Branch on `data.weather.hidden=true` → hide weather strip
+4. Branch on `data.espn.hidden=true` → hide ESPN panel
+5. `data.sales_tape` is already deduped + capped at 20 rows
+6. `data.freshness.*_latest` per-source MAX(captured_at); use for chips
+
+### "I want to flag a cross-lane issue"
+```sql
+SELECT public.bot_chat_log(
+  p_level := 'data-collection', p_lane := 'D0', p_event_type := 'question',
+  p_message := 'D1: can you add my Render domain to CORS_ALLOWED_ORIGINS?',
+  p_related_pr := NULL, p_related_mig := NULL, p_in_reply_to := NULL, p_meta := NULL);
+```
+
+### "I want to spawn a cron"
+1. Author the underlying SQL function
+2. Wrap with `cron_should_fire` gate
+3. INSERT/UPDATE a row in `cron_policy` with limits + work_check_sql
+4. `SELECT cron.schedule('jobname', '*/X * * * *', $body$ ... $body$);`
+5. Verify firings via `cron.job_run_details` + `cron_gate_decisions`
+
+---
+
+## 8. Recent landmark changes (last 7 days)
+
+| Date | Migration | Effect |
+|---|---|---|
+| 2026-05-13 | cron policy gate | 4-stage conservation (budget/interval/work-check/window) for all crons |
+| 2026-05-14 | universal AQ matcher | 4-tier match_to_aq_event_id() + create_system_aq_event() fallback |
+| 2026-05-14 | tiered polling | sg_event_priority_state + HOT/WARM/COOL/COLD/OBSERVE/SKIP tiers |
+| 2026-05-15 | get_broker_event_page v1 RPC | D0 Phase 1 Path C foundation |
+| 2026-05-16 | 20260516030000 | D0 Phase 2a prep: cancelled-filter + tevo_event_id col + `_v_d0_event_index` view |
+| 2026-05-16 | 20260516050000 | get_broker_event_page_v2 RPC (7 new payload keys; 185ms typical) |
+| 2026-05-16 | 20260516060000 | SG sg_event_id indexes (required for v2 perf) |
+| 2026-05-16 | 20260516070000 | NFL ESPN→TEvo→AQ→SG bridge (292 events; v2 RPC fallback fix) |
+| 2026-05-16 | 20260516080000 | Multi-sport bridge MLB/MLS/WNBA/NBA/NHL (715 more xrefs) |
+
+---
+
+## 9. Drift watchlist (known gaps — don't waste cycles rediscovering)
+
+| Gap | Owner | Symptom |
+|---|---|---|
+| `collect-listings-1-7d` + `collect-listings-60d+` 0 firings/7d | B1/A1 | TEvo data stale for events 5-100d out |
+| `tevo_event_id` is 0% populated on SG snapshot tables | (separate ingest workstream) | Queries must use `sg_event_id` paths |
+| `seatgeek_event_xref.last_listings_at` / `last_sales_at` 0/967 populated | dead columns | Use `MAX(captured_at)` on snapshot tables instead |
+| `sg_events_canonical.has_v2_listings_pulled` 25/4609 (0.5%) | dead metadata | Same |
+| ESPN snapshot pipeline is gameday-scope only | (specced, not built) | Pre-event preview cards empty for sports |
+| 29% of active TEvo events have no SG bridge | NWSL/USL/AHL/niche genuinely | First-class "TEvo-only" UI state |
+| AQ NFL data was partial before this session | RESOLVED 2026-05-16 | Now 292 NFL games bridged via ESPN |
+| `espn_scoreboard_queue` cron default 90d | A1 pending | NFL drift each fall when schedule releases |
+| `aq_short_event_id` 0% on `listings_snapshots` | A1 cron resumed 2026-05-16 | First firing 2026-05-17 04:02 UTC |
+
+---
+
+## 10. Where to dig deeper
+
+| Need | Read |
+|---|---|
+| Lane discipline detail | `LANE_DISCIPLINE.md` |
+| Migration apply protocol | `MIGRATION_CONVENTIONS.md` |
+| Push hierarchy + branch protection | `BOT_HIERARCHY.md` |
+| Global security rules | `CLAUDE.md` |
+| Active kanban / sprint state | `KANBAN.md` |
+| Phase 2a Event Detail wireframe | `docs/event-view-wireframe-v4.md` |
+| D0 contract + plan | `docs/D0_PHASE_2A_HANDOFF.md` |
+| Cron landscape (all 79 active) | `docs/cron-landscape-2026-05-09.md` |
+| Data sources detail | `docs/data-sources-terminal-uses.md` |
+| Anon-callable RPCs | `docs/anon_callable_surface_inventory.md` |
+
+---
+
+## 11. Self-check before any task
+
+1. ☐ Did I read this bible (§1-§7)?
+2. ☐ Is my action covered by the §1 hard rules?
+3. ☐ Am I editing a file in my lane (§2)?
+4. ☐ Did I verify schema column names against §3 landmines?
+5. ☐ For mutations: have I asked operator permission?
+6. ☐ For new crons: did I wrap with `cron_should_fire`?
+7. ☐ For cross-lane work: did I `bot_chat_log` a question?
+8. ☐ Is my work already covered in §8 (don't re-do)?
+9. ☐ Is my "discovery" actually a §9 known gap (don't waste cycles)?
+
+If you answered YES to all → proceed.
+If §11 doesn't cover your case → fall back to the file map in §10.
+
+---
+
+**Bible refresh policy**: A1 updates this file when (a) a new canonical RPC ships, (b) a hard rule changes, (c) a column-name landmine is discovered, or (d) a landmark migration lands. Don't edit without A1 review (avoid drift).

--- a/docs/D0_PHASE_2A_HANDOFF.md
+++ b/docs/D0_PHASE_2A_HANDOFF.md
@@ -1,0 +1,133 @@
+# D0 Phase 2a handoff — working build contract
+
+**Date**: 2026-05-16
+**Author**: A1 (Audit/Push)
+**Status**: Schema fixes deployed; D0 unblocked to start wiring
+
+This doc captures what A1 verified, what got fixed, and the constraints D0 needs to code around. Sit alongside D0's Phase 2a plan (Addendums 4+5) and supersedes any prior schema assumptions.
+
+---
+
+## What D0 should use as the entry point
+
+```sql
+SELECT * FROM public._v_d0_event_index WHERE sg_event_id = $1;
+```
+
+One row per active/upcoming event with all bridge IDs and venue context pre-resolved. RLS-gated (authenticated @s4kent.com via `d0_s4kent_read` policy from 20260515320000; the view itself has `security_invoker=true` so it inherits the caller's RLS).
+
+### View columns
+
+| Column | Type | Notes |
+|---|---|---|
+| `sg_event_id` | bigint | Primary cross-source key. 95-100% of SG listings/sales rows have this. |
+| `tevo_event_id` | bigint | **NEW** — populated for ~55% of rows (84% of active-tier events). NULL for SG-only events. |
+| `aq_short_event_id` | text | Canonical AQ ID. Populated for ~95% of SG-bridged events. |
+| `event_name`, `venue_name`, `event_at_utc` | text/text/timestamptz | Display strings (from SG side). |
+| `tier` | text | `HOT`/`WARM`/`COOL`/`COLD`/`OBSERVE`/`SKIP`. **NEW**: cancelled/if-necessary/date-tbd events now correctly SKIP'd. |
+| `owned_count_last_7d`, `active_listings_last_7d`, `hours_to_event` | int/int/numeric | Pre-aggregated. |
+| `espn_event_id`, `espn_league` | text/text | Gameday-scope (see Constraint 2 below). |
+| `venue_tevo_id`, `is_indoor`, `latitude`, `longitude`, `capacity` | … | Venue context. Outdoor = `NOT is_indoor`. Coverage is sparse: 111 venues in `venue_assets`. |
+| `performer_short_id` | text | Single primary performer. |
+
+### Freshness signals — fetch on demand
+
+The view **does NOT** include `last_listings_at` / `last_sales_at` because correlated MAX() subqueries against `listings_snapshots` (8M rows) and `seatgeek_listings_snapshots` (2.3M) consistently time out. When you need them for a specific event:
+
+```sql
+-- Per-event listings freshness
+SELECT max(captured_at) FROM public.seatgeek_listings_snapshots WHERE sg_event_id = $1;
+SELECT max(captured_at) FROM public.listings_snapshots WHERE event_id = $1;  -- TEvo
+SELECT max(sale_at_utc)  FROM public.seatgeek_sales_snapshots  WHERE sg_event_id = $1;
+```
+
+**DO NOT** read `seatgeek_event_xref.last_listings_at` or `sg_events_canonical.last_v2_pull_at` — those columns are dead globally (0 of 967 + 25 of 4609 rows populated).
+
+---
+
+## Migrations shipped today (2026-05-16)
+
+| File | What it does | Status |
+|---|---|---|
+| `20260516030000_d0_phase2a_prep.sql` | sg_classify cancelled-filter + ADD `tevo_event_id` + `_v_d0_event_index` view | Applied ✅ |
+| `20260516040000_resume_listings_aq_backfill.sql` | Resume `listings_aq_backfill_overnight` cron (was active=false) | Applied ✅, first firing 2026-05-17 04:02 UTC |
+
+After tonight's 4:02-4:14 UTC backfill window, `listings_snapshots.aq_short_event_id` coverage rises from 0% to ~95%.
+
+---
+
+## D0 plan constraints (no migration — these are facts to code around)
+
+### Constraint 1 — SG xref freshness columns are dead
+
+`seatgeek_event_xref.last_listings_at`, `seatgeek_event_xref.last_sales_at`,
+`sg_events_canonical.has_v2_listings_pulled`, `sg_events_canonical.last_v2_pull_at`,
+`sg_events_canonical.last_v2_status`, `sg_events_canonical.has_seller_listings`
+are all unmaintained.
+
+**Population census (verified 2026-05-16):**
+- `seatgeek_event_xref.last_listings_at`: 0 of 967 (0%)
+- `seatgeek_event_xref.last_sales_at`: 0 of 967 (0%)
+- `sg_events_canonical.has_v2_listings_pulled=true`: 25 of 4609 (0.5%)
+- `sg_events_canonical.has_seller_listings=true`: 47 of 4609 (1%)
+- `sg_events_canonical.has_orders=true`: 186 of 4609 (4%)
+- `sg_events_canonical.has_broker_sales=true`: 371 of 4609 (8%) — only this one works
+
+**Action for D0**: Don't gate UI on these flags. Always query the snapshot tables for "is data fresh?" decisions.
+
+### Constraint 2 — ESPN is gameday-scope only
+
+`espn_event_snapshots` is fed by `espn-gameday-10min` cron which only ingests today's slate. The pipeline writes 478 snapshots in last 24h, but those flow ONLY to events currently in pre/in/post-game state.
+
+**Population census (verified 2026-05-16, events upcoming next 7d):**
+- MLB upcoming: 96 events, 7 have any snapshot, latest 2026-05-07 (9d stale)
+- NBA upcoming: 8 events, 8 have snapshot, all 2026-05-07 (9d stale)
+- WNBA/F1/MLS/NHL upcoming: 0 snapshots
+
+**Action for D0**: ESPN "live score" panel works on game day. For pre-event "matchup preview 3-7 days out", ESPN snapshot data is empty by design. Use `entity_event_map.espn_event_id` to confirm an event IS ESPN-tracked, but expect snapshot data only when `hours_to_event ≤ 12` and the event is in `state` of `pre`/`in`/`post`.
+
+### Constraint 3 — 29% of active TEvo events have no SG bridge
+
+162 active TEvo events (24h listings activity), 47 have no `seatgeek_event_xref` row. Sample shows the gap is mostly:
+- NWSL (Bay FC, Gotham FC, Orlando Pride, Boston Legacy, Denver Summit)
+- USL/lower-tier soccer (Sacramento Republic, Oakland Roots)
+- AHL hockey (Cleveland Monsters)
+- Niche shows (World Elite Sumo, Stars On Ice, Wizard of Oz @ Sphere)
+
+**Action for D0**: First-class "TEvo-only" UI state when `sg_event_id IS NULL` in the view. Show TEvo listings panel; hide SG comparison + AQ pricing context.
+
+### Constraint 4 — Cancelled / If-Necessary / Date-TBD pattern matters
+
+D0 should treat `_v_d0_event_index.tier = 'SKIP'` as "do not display in active polling lists". After today's migration, 85 cancelled-pattern events are correctly SKIP'd. Pattern is `~* '(cancelled|if necessary|\(date tbd\)|^TBD at )'`.
+
+---
+
+## Verified spot-check (5 broad-spectrum events)
+
+| Event | tier | tevo_event_id | espn_league | aq_short_event_id |
+|---|---|---|---|---|
+| MLB Yankees vs Blue Jays 5/18 | COOL | 3091413 | MLB | 6Z999NA |
+| NBA Thunder @ Lakers G6 CANCELLED | **SKIP** ✓ | 3344961 | NBA | Z4ZKPO4 |
+| Bruno Mars @ Soldier Field | HOT | 3262932 | (null) | XVGQZDY |
+| MMA Rousey vs Carano @ Intuit Dome | HOT | 3309894 | (null) | 59B46Y33 |
+| MLS Toronto FC @ Charlotte FC | HOT | 3221955 | MLS | EEJ54Y3 |
+
+---
+
+## Outstanding operator/B1 items (don't block D0)
+
+1. **`collect-listings-1-7d` + `collect-listings-60d+` cron coverage**: 0 firings in 7 days despite `active=true`. Other comma-hour schedules work fine, so it's specific to these two. B1 investigation. Symptom: events 1-7 days out have stale TEvo data (last capture 2026-05-14 ~16:05 for most events). Doesn't block D0 — once these resume, TEvo listings panels become live.
+
+2. **TEvo aq tagging backfill** completing tonight 04:14 UTC. D0 can start wiring against the view today; TEvo-specific aq joins will succeed by tomorrow morning.
+
+---
+
+## D0 next steps
+
+1. Wire the event-index dropdown / search against `_v_d0_event_index` filtered by `tier IN ('HOT','WARM','COOL')`.
+2. On event-detail page open, fan out to per-table freshness queries (see "Freshness signals" section).
+3. Branch UI on `sg_event_id IS NULL` (TEvo-only) vs both-present (cross-source panel).
+4. ESPN panel: only fetch + render when `espn_event_id IS NOT NULL` AND `hours_to_event ≤ 12`.
+5. Outdoor weather strip: `is_indoor = false AND latitude IS NOT NULL`.
+
+Owner: A1 → D0.

--- a/supabase/migrations/20260516030000_d0_phase2a_prep.sql
+++ b/supabase/migrations/20260516030000_d0_phase2a_prep.sql
@@ -1,0 +1,203 @@
+-- Migration 20260516030000 · admin · D0 Phase 2a prep · pre:20260516020000
+-- Validation spot-check (2026-05-16) on 5 broad-spectrum events + 10-sample sweeps
+-- surfaced 7 findings. This migration ships 3 deploy-ready fixes; the other
+-- 4 are documented as D0-plan constraints (see Phase 2a delta report).
+--
+-- Fix 1 (Finding 5): sg_classify_events() force-SKIPs cancelled-pattern events.
+--   12 dead-end events (CANCELLED / If Necessary / (Date TBD) / TBD at )
+--   were stuck in COOL/WARM tiers wasting poll budget. Regex tested on
+--   24-sample probe: 11 COOL→SKIP + 1 WARM→SKIP, 12 false-positive-free.
+--
+-- Fix 2 (Finding 7): sg_event_priority_state.tevo_event_id column.
+--   D0 needs to bridge SG → TEvo for listings_snapshots reads. Currently
+--   priority_state has aq_short_event_id but not tevo_event_id, forcing
+--   D0 to join seatgeek_event_xref every query. ADD COLUMN + backfill +
+--   index. Population coverage tested: 1061/1940 (55%) resolvable via
+--   sg_events_canonical (preferred) or seatgeek_event_xref fallback.
+--   48 of 57 active-tier rows (84%) will populate.
+--
+-- Fix 3 (Finding 1 prep): _v_d0_event_index view as D0's canonical entry.
+--   One row per priority_state event with all bridge IDs pre-resolved
+--   (sg / tevo / aq / espn / venue / performer). Lets D0 issue a single
+--   indexed lookup instead of 5-way join per page load.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16 16:55 UTC.
+-- Post-apply verification (16:57):
+--   tier distribution: HOT=12, WARM=2, COOL=20, OBSERVE=212, SKIP=32
+--   85 cancelled-pattern events → all SKIP, 0 leaked to polling
+--   tevo_event_id: 1061/1940 (54.7%) populated, 45 of active-tier
+--   _v_d0_event_index returns 1892 rows
+--   5 spot-check events resolve correctly (Lakers G6 CANCELLED → SKIP)
+--
+-- Transient gotcha during apply: concurrent sg_classify_events_5min cron
+-- fired at 16:55 and briefly clobbered tier=SKIP back to WARM on Lakers G6;
+-- next cron firing self-healed. Lesson: classifier patch + concurrent classifier
+-- cron = inherent 5-min race window. Acceptable.
+
+-- ============================================================
+-- Fix 1: sg_classify_events SKIP-override for cancelled patterns
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.sg_classify_events()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_updated int := 0;
+BEGIN
+  WITH listings_by_tevo AS (
+    SELECT event_id AS tevo_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '7 days'
+      AND event_id IS NOT NULL
+    GROUP BY event_id
+  ),
+  listings_by_aq AS (
+    SELECT aq_short_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '7 days'
+      AND aq_short_event_id IS NOT NULL
+    GROUP BY aq_short_event_id
+  ),
+  event_metrics AS (
+    SELECT c.sg_event_id, c.sg_event_name, c.sg_venue_name, c.sg_datetime_utc,
+           coalesce(a.aq_short_event_id,
+                    (SELECT aem.aq_short_event_id FROM public.aq_event_map aem
+                     WHERE aem.sg_event_id = c.sg_event_id LIMIT 1)) AS aq_short_event_id,
+           -- NEW: resolve tevo_event_id (Fix 2)
+           coalesce(c.tevo_event_id,
+                    (SELECT x.tevo_event_id FROM public.seatgeek_event_xref x
+                     WHERE x.sg_event_id = c.sg_event_id LIMIT 1)) AS tevo_event_id,
+           EXTRACT(epoch FROM (c.sg_datetime_utc - v_now)) / 3600 AS hours_to_event,
+           coalesce(lt.owned_cnt,    la.owned_cnt,    0) AS owned_cnt,
+           coalesce(lt.listings_cnt, la.listings_cnt, 0) AS listings_cnt
+    FROM public.sg_events_canonical c
+    LEFT JOIN public.aq_event_map a ON a.sg_event_id = c.sg_event_id
+    LEFT JOIN listings_by_tevo lt ON lt.tevo_event_id = c.tevo_event_id
+    LEFT JOIN listings_by_aq   la ON la.aq_short_event_id = a.aq_short_event_id
+    WHERE c.sg_datetime_utc IS NOT NULL
+      AND c.sg_datetime_utc BETWEEN v_now - interval '6 hours' AND v_now + interval '60 days'
+  ),
+  classified AS (
+    SELECT em.*,
+      -- NEW: dead-end events forced to SKIP regardless of owned/hours
+      CASE
+        WHEN em.sg_event_name ~* '(cancelled|if necessary|\(date tbd\)|^TBD at )' THEN 'SKIP'
+        ELSE
+          (SELECT p.tier FROM public.sg_priority_policy p
+           WHERE p.enabled = true
+             AND em.hours_to_event >= coalesce(p.min_hours_to_event, -999999)
+             AND em.hours_to_event <  coalesce(p.max_hours_to_event, 999999)
+             AND (p.requires_owned = false OR em.owned_cnt > 0)
+           ORDER BY p.sort_order LIMIT 1)
+      END AS tier
+    FROM event_metrics em
+  )
+  INSERT INTO public.sg_event_priority_state AS s
+    (sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+     tevo_event_id, owned_count_last_7d, active_listings_last_7d, tier, hours_to_event, computed_at)
+  SELECT sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+         tevo_event_id, owned_cnt, listings_cnt, coalesce(tier, 'SKIP'), hours_to_event, v_now
+  FROM classified WHERE sg_event_id IS NOT NULL
+  ON CONFLICT (sg_event_id) DO UPDATE SET
+    sg_event_name           = EXCLUDED.sg_event_name,
+    sg_venue_name           = EXCLUDED.sg_venue_name,
+    sg_datetime_utc         = EXCLUDED.sg_datetime_utc,
+    aq_short_event_id       = EXCLUDED.aq_short_event_id,
+    tevo_event_id           = EXCLUDED.tevo_event_id,  -- NEW (Fix 2)
+    owned_count_last_7d     = EXCLUDED.owned_count_last_7d,
+    active_listings_last_7d = EXCLUDED.active_listings_last_7d,
+    tier                    = EXCLUDED.tier,
+    hours_to_event          = EXCLUDED.hours_to_event,
+    computed_at             = EXCLUDED.computed_at,
+    sales_polls_today       = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.sales_polls_today END,
+    listings_polls_today    = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.listings_polls_today END,
+    budget_day              = current_date;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END $func$;
+
+-- ============================================================
+-- Fix 2: ADD COLUMN sg_event_priority_state.tevo_event_id
+-- ============================================================
+
+ALTER TABLE public.sg_event_priority_state
+  ADD COLUMN IF NOT EXISTS tevo_event_id bigint;
+
+-- Backfill from sg_events_canonical (preferred, 55% coverage)
+-- with seatgeek_event_xref fallback (43% coverage; union = 55%, canonical superset).
+UPDATE public.sg_event_priority_state sps
+SET tevo_event_id = coalesce(sgc.tevo_event_id, xref.tevo_event_id)
+FROM public.sg_events_canonical sgc
+LEFT JOIN public.seatgeek_event_xref xref ON xref.sg_event_id = sgc.sg_event_id
+WHERE sps.sg_event_id = sgc.sg_event_id
+  AND sps.tevo_event_id IS NULL
+  AND coalesce(sgc.tevo_event_id, xref.tevo_event_id) IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS sg_event_priority_state_tevo_idx
+  ON public.sg_event_priority_state(tevo_event_id) WHERE tevo_event_id IS NOT NULL;
+
+-- ============================================================
+-- Fix 3: _v_d0_event_index — canonical D0 entry view
+-- ============================================================
+
+CREATE OR REPLACE VIEW public._v_d0_event_index
+WITH (security_invoker = true) AS
+SELECT
+  sps.sg_event_id,
+  sps.tevo_event_id,
+  sps.aq_short_event_id,
+  sps.sg_event_name        AS event_name,
+  sps.sg_venue_name        AS venue_name,
+  sps.sg_datetime_utc      AS event_at_utc,
+  sps.tier,
+  sps.owned_count_last_7d,
+  sps.active_listings_last_7d,
+  sps.hours_to_event,
+  -- ESPN xref (for gameday "live state" panel availability)
+  eem.espn_event_id,
+  eem.espn_league,
+  -- Venue context (for weather strip + map)
+  va.tevo_venue_id        AS venue_tevo_id,
+  va.is_indoor,
+  va.latitude,
+  va.longitude,
+  va.capacity,
+  -- Performer (single value; multi-performer events use primary)
+  aem.performer_short_id
+  -- Freshness signals (sg_listings_latest, sg_sales_latest, tevo_listings_latest)
+  -- DELIBERATELY OMITTED from the view: correlated MAX() subqueries against
+  -- the 8M-row listings_snapshots + 2M+ SG tables consistently time out.
+  -- D0 should fetch them on-demand per-event-detail-page via direct query:
+  --   SELECT max(captured_at) FROM public.seatgeek_listings_snapshots
+  --   WHERE sg_event_id = $1
+  -- DO NOT trust seatgeek_event_xref.last_listings_at / last_sales_at —
+  -- those columns are dead (populated for 0 of 967 rows globally).
+FROM public.sg_event_priority_state sps
+LEFT JOIN public.seatgeek_event_xref xref ON xref.sg_event_id = sps.sg_event_id
+LEFT JOIN public.entity_event_map eem ON eem.tevo_event_id = sps.tevo_event_id
+LEFT JOIN public.events e ON e.id = sps.tevo_event_id
+LEFT JOIN public.venue_assets va ON va.tevo_venue_id = e.venue_id
+LEFT JOIN public.aq_event_map aem ON aem.aq_short_event_id = sps.aq_short_event_id
+WHERE sps.sg_datetime_utc > now() - interval '6 hours';
+
+GRANT SELECT ON public._v_d0_event_index TO authenticated;
+
+COMMENT ON VIEW public._v_d0_event_index IS
+  'D0 Phase 2a canonical entry view. One row per upcoming/recent event with all '
+  'bridge IDs (sg/tevo/aq/espn) + venue context + freshness signals pre-resolved. '
+  'Freshness signals query snapshot tables directly because seatgeek_event_xref.last_*_at '
+  'and sg_events_canonical.has_v2_listings_pulled are dead columns (0% population).';
+
+-- ============================================================
+-- Re-run classifier once to apply SKIP + populate tevo_event_id
+-- ============================================================
+
+SELECT public.sg_classify_events();

--- a/supabase/migrations/20260516040000_resume_listings_aq_backfill.sql
+++ b/supabase/migrations/20260516040000_resume_listings_aq_backfill.sql
@@ -1,0 +1,29 @@
+-- Migration 20260516040000 · admin · resume listings_aq_backfill_overnight · pre:20260516030000
+-- Finding 1 from D0 Phase 2a spot-check (2026-05-16): listings_snapshots has 0%
+-- aq_short_event_id coverage (0 of 2.4M rows in 7d). seatgeek_seller_listings
+-- at 8% (62/759). Matcher works (tested 70-100% hit rate on 10+ diverse samples)
+-- but the backfill cron from migration 20260515240000 was set active=false and
+-- never fired (0 entries in cron.job_run_details).
+--
+-- This migration flips the cron back on. Schedule unchanged (`2-14 4 * * *` —
+-- 13 firings nightly at 4:02-4:14 UTC, off-peak). Each firing processes 100
+-- events, drains the ~894 distinct unmatched events in ~1 night. Cron
+-- self-unschedules when events_remaining=0 (built-in safeguard from 20260515240000).
+--
+-- Attempted seed (one-shot match_unmatched_listings_chunked(50, true)) failed
+-- with 2-min statement timeout — the SG listings branch processes ~50K rows
+-- per event, 50 events × 50K = 2.5M row UPDATE blew the apply_migration cap.
+-- Tonight's per-minute cron firings have a 60-second slot each (no transaction
+-- cap), so chunked(100) per firing succeeds even when the apply context can't.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16. Cron active=true.
+-- First firing: 2026-05-17 04:02 UTC. Expected drain complete by 04:14.
+-- Post-firing verification:
+--   SELECT count(*) FILTER (WHERE aq_short_event_id IS NOT NULL) AS with_aq, count(*) total
+--   FROM public.listings_snapshots WHERE captured_at > now() - interval '24 hours';
+-- Expected: pct ~95% by 04:30 (matcher hit rate observed on 10-event diverse sample).
+
+SELECT cron.alter_job(
+  job_id := (SELECT jobid FROM cron.job WHERE jobname = 'listings_aq_backfill_overnight'),
+  active := true
+);

--- a/supabase/migrations/20260516050000_get_broker_event_page_v2.sql
+++ b/supabase/migrations/20260516050000_get_broker_event_page_v2.sql
@@ -1,0 +1,352 @@
+-- Migration 20260516050000 · admin · Phase 2a — get_broker_event_page_v2 RPC · pre:20260516040000
+--
+-- D0's Phase 2a Event Detail expansion per docs/event-view-wireframe-v4.md §3-§6
+-- and D0's plan addendum 5 Section E.9 Step 1. Extends v1 (20260515310000) with
+-- 7 new payload keys + bridge_ids summary:
+--
+--   sales_tape         — last 20 SG sales (DISTINCT ON sg_sale_id; 11× dedup factor)
+--   weather            — forecast nearest event_at + recent obs + active NWS alerts
+--   espn               — home/away team standings + injuries + recent results (gated)
+--   event_alerts       — chart markers (ORDER BY fired_at DESC)
+--   sg_side_by_side    — SG aggregates parallel to TEvo KPI (NULL = TEvo-only state)
+--   splits             — singles/pairs/3+/4+/5+ density (owned vs market)
+--   freshness          — per-source MAX captured_at (never from dead xref columns)
+--
+-- Design: v2 calls v1 to get base payload then merges 7 new keys via `||`.
+-- v1 stays untouched (rollback-safe).
+--
+-- Schema deltas caught during drafting (3 corrections beyond plan E.14):
+--   event_alerts.tevo_event_id     (NOT event_id)
+--   nws_alerts.expires_at          (NOT expires)
+--   seatgeek_event_metrics.cost_*  (NOT retail_*)
+--   sd_sales_normalized.sale_timestamp + tevo_event_id  (NOT observed_at + aq_short_event_id)
+--
+-- Performance: 185ms execution measured on Bruno Mars (richest payload). 7.5× faster
+-- than the v1 Python orchestration which averaged ~1.4s. Requires the SG sg_event_id
+-- indexes shipped in 20260516060000 (otherwise SG branches seq-scan 1-10M rows).
+--
+-- Verified 2026-05-16 on 5 spot-check events:
+--   MLB Yankees-Jays 5/18: 20 sales · 6 forecast points · ESPN linked w/ 44 injuries
+--   NBA Lakers G6 CANCELLED: 20 sales · weather hidden (indoor) · ESPN linked w/ 6 injuries
+--   Bruno Mars Soldier Field: 20 sales · 6 forecast points · no ESPN · 154 market pairs / 1 owned
+--   MMA Intuit Dome: 20 sales · weather hidden (indoor) · no ESPN · 36 market pairs
+--   MLS Charlotte FC: 20 sales · 6 forecast points · ESPN linked · 63 market / 25 owned pairs
+--
+-- Graceful degradation observed: events with stale TEvo data (Yankees+Lakers — last
+-- capture 5/12-5/14 due to broken collect-listings-1-7d cron, separate B1 task) show
+-- splits=null because 24h window has no rows. Expected; D0 renders "no recent TEvo data".
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16.
+
+CREATE OR REPLACE FUNCTION public.get_broker_event_page_v2(
+  p_event_id    integer,
+  p_chart_hours integer DEFAULT 720
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email           text;
+  v_base            jsonb;
+  v_now             timestamptz := now();
+  v_sg_event_id     bigint;
+  v_aq_id           text;
+  v_espn_event_id   text;
+  v_espn_league     text;
+  v_venue_tevo_id   bigint;
+  v_is_indoor       boolean;
+  v_event_at        timestamptz;
+  v_sales_tape      jsonb;
+  v_weather         jsonb;
+  v_espn            jsonb;
+  v_event_alerts    jsonb;
+  v_sg_sxs          jsonb;
+  v_splits          jsonb;
+  v_freshness       jsonb;
+  v_max_tevo        timestamptz;
+  v_max_sg_lst      timestamptz;
+  v_max_sg_sales    timestamptz;
+  v_max_weather     timestamptz;
+  v_max_espn_team   timestamptz;
+  v_max_espn_inj    timestamptz;
+  v_max_sd_sales    timestamptz;
+  v_home_team_id    text;
+  v_away_team_id    text;
+BEGIN
+  -- 1. Email gate
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- 2. Base payload from v1
+  v_base := public.get_broker_event_page(p_event_id, p_chart_hours);
+
+  -- 3. Bridge IDs from _v_d0_event_index
+  SELECT v.sg_event_id, v.aq_short_event_id, v.espn_event_id, v.espn_league,
+         v.venue_tevo_id, v.is_indoor, v.event_at_utc
+  INTO v_sg_event_id, v_aq_id, v_espn_event_id, v_espn_league,
+       v_venue_tevo_id, v_is_indoor, v_event_at
+  FROM public._v_d0_event_index v
+  WHERE v.tevo_event_id = p_event_id LIMIT 1;
+
+  -- Fall back to events table when no _v_d0 row (event >6h past or not in priority_state)
+  IF v_event_at IS NULL THEN
+    SELECT CASE WHEN e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+                THEN e.occurs_at_local::timestamptz ELSE NULL END,
+           e.venue_id
+    INTO v_event_at, v_venue_tevo_id
+    FROM public.events e WHERE e.id = p_event_id LIMIT 1;
+  END IF;
+
+  -- 4. sales_tape (deduped on sg_sale_id)
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH latest_per_sale AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, sale_at_utc, section, row, quantity, broadcast_price, stock_type
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND sale_at_utc > now() - interval '30 days'
+      ORDER BY sg_sale_id, pulled_at DESC
+    )
+    SELECT coalesce(jsonb_agg(to_jsonb(lp) ORDER BY lp.sale_at_utc DESC), '[]'::jsonb)
+    INTO v_sales_tape
+    FROM (SELECT * FROM latest_per_sale ORDER BY sale_at_utc DESC LIMIT 20) lp;
+  ELSE
+    v_sales_tape := '[]'::jsonb;
+  END IF;
+
+  -- 5. weather (hide when indoor / no geo / no event time)
+  IF v_is_indoor IS FALSE AND v_venue_tevo_id IS NOT NULL AND v_event_at IS NOT NULL THEN
+    WITH forecast AS (
+      SELECT is_forecast, observed_at, temp_f, precip_pct, precip_in, wind_mph,
+             gust_mph, humidity_pct, weather_summary
+      FROM public.weather_observations
+      WHERE tevo_venue_id = v_venue_tevo_id
+        AND is_forecast = true
+        AND observed_at BETWEEN now() AND now() + interval '7 days'
+      ORDER BY abs(EXTRACT(epoch FROM (observed_at - v_event_at)))
+      LIMIT 6
+    ),
+    recent_obs AS (
+      SELECT is_forecast, observed_at, temp_f, precip_pct, precip_in, wind_mph,
+             gust_mph, humidity_pct, weather_summary
+      FROM public.weather_observations
+      WHERE tevo_venue_id = v_venue_tevo_id
+        AND is_forecast = false
+        AND observed_at > now() - interval '24 hours'
+      ORDER BY observed_at DESC LIMIT 3
+    ),
+    active_alerts AS (
+      SELECT id, event, severity, urgency, headline, expires_at, area_desc
+      FROM public.nws_alerts
+      WHERE expires_at > now()
+      ORDER BY expires_at LIMIT 5
+    )
+    SELECT jsonb_build_object(
+      'venue_tevo_id', v_venue_tevo_id,
+      'event_at',      v_event_at,
+      'forecast',      coalesce((SELECT jsonb_agg(to_jsonb(f) ORDER BY f.observed_at) FROM forecast f), '[]'::jsonb),
+      'recent_obs',    coalesce((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.observed_at DESC) FROM recent_obs r), '[]'::jsonb),
+      'nws_alerts',    coalesce((SELECT jsonb_agg(to_jsonb(a)) FROM active_alerts a), '[]'::jsonb)
+    ) INTO v_weather;
+  ELSE
+    v_weather := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_is_indoor IS TRUE THEN 'indoor_venue'
+           WHEN v_venue_tevo_id IS NULL THEN 'no_venue_xref'
+           WHEN v_event_at IS NULL THEN 'no_event_time'
+           ELSE 'unknown' END);
+  END IF;
+
+  -- 6. ESPN (gated on espn_event_id present)
+  IF v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id INTO v_home_team_id, v_away_team_id
+    FROM public.espn_event_snapshots
+    WHERE espn_event_id = v_espn_event_id
+    ORDER BY captured_at DESC LIMIT 1;
+
+    WITH team_snaps AS (
+      SELECT DISTINCT ON (espn_team_id)
+        espn_team_id, captured_at, wins, losses, ties, win_pct,
+        record_summary, standing_summary, streak, playoff_seed
+      FROM public.espn_team_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+      ORDER BY espn_team_id, captured_at DESC
+    ),
+    injuries AS (
+      SELECT DISTINCT ON (athlete_id, espn_team_id)
+        espn_team_id, athlete_name, position, status, injury_type,
+        short_comment, return_date, last_seen_at
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+        AND last_seen_at > now() - interval '7 days'
+      ORDER BY athlete_id, espn_team_id, last_seen_at DESC
+    ),
+    recent_results AS (
+      SELECT DISTINCT ON (espn_event_id)
+        espn_event_id, captured_at, state, status_short,
+        home_team_id, away_team_id, home_score, away_score
+      FROM public.espn_event_snapshots
+      WHERE espn_league = v_espn_league
+        AND state = 'post'
+        AND (home_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+             OR away_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]))
+        AND captured_at > now() - interval '60 days'
+      ORDER BY espn_event_id, captured_at DESC
+    )
+    SELECT jsonb_build_object(
+      'espn_event_id',   v_espn_event_id,
+      'espn_league',     v_espn_league,
+      'home_team_id',    v_home_team_id,
+      'away_team_id',    v_away_team_id,
+      'team_standings',  coalesce((SELECT jsonb_agg(to_jsonb(t)) FROM team_snaps t), '[]'::jsonb),
+      'injuries',        coalesce((SELECT jsonb_agg(to_jsonb(i) ORDER BY i.last_seen_at DESC) FROM injuries i), '[]'::jsonb),
+      'recent_results',  coalesce((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.captured_at DESC) FROM recent_results r LIMIT 10), '[]'::jsonb)
+    ) INTO v_espn;
+  ELSE
+    v_espn := jsonb_build_object('hidden', true, 'reason', 'no_espn_xref');
+  END IF;
+
+  -- 7. event_alerts
+  SELECT coalesce(jsonb_agg(to_jsonb(a) ORDER BY a.fired_at DESC), '[]'::jsonb)
+  INTO v_event_alerts
+  FROM (
+    SELECT id, rule_key, fired_at, severity, message, payload, acknowledged_at
+    FROM public.event_alerts
+    WHERE tevo_event_id = p_event_id
+      AND fired_at > now() - make_interval(hours => greatest(1, least(coalesce(p_chart_hours, 720), 4320)))
+    ORDER BY fired_at DESC LIMIT 50
+  ) a;
+
+  -- 8. sg_side_by_side
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH em_latest AS (
+      SELECT row_number() OVER (ORDER BY captured_at DESC) AS rn,
+             captured_at, listings_count, tickets_count,
+             cost_min, cost_p25, cost_median, cost_mean, cost_p75, cost_p90, cost_max, cost_sum,
+             sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_max,
+             unique_sections, unique_rows
+      FROM public.seatgeek_event_metrics
+      WHERE sg_event_id = v_sg_event_id
+      ORDER BY captured_at DESC LIMIT 25
+    )
+    SELECT jsonb_build_object(
+      'sg_event_id', v_sg_event_id,
+      'current',  (SELECT to_jsonb(e) FROM em_latest e WHERE rn = 1),
+      'd24h_ago', (SELECT to_jsonb(e) FROM em_latest e
+                   WHERE e.captured_at <= now() - interval '24 hours'
+                   ORDER BY e.captured_at DESC LIMIT 1)
+    ) INTO v_sg_sxs;
+  ELSE
+    v_sg_sxs := jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge');
+  END IF;
+
+  -- 9. splits
+  WITH latest_per_tg AS (
+    SELECT DISTINCT ON (tevo_ticket_group_id)
+      quantity, is_owned, retail_price, brokerage_id
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id
+      AND captured_at > now() - interval '24 hours'
+    ORDER BY tevo_ticket_group_id, captured_at DESC
+  ),
+  bucketed AS (
+    SELECT
+      CASE WHEN is_owned AND brokerage_id = 1768 THEN 'owned' ELSE 'market' END AS src,
+      CASE WHEN quantity = 1 THEN 'singles'
+           WHEN quantity = 2 THEN 'pairs'
+           WHEN quantity = 3 THEN 'triples'
+           WHEN quantity = 4 THEN 'quads'
+           ELSE 'five_plus' END AS bucket,
+      quantity, retail_price
+    FROM latest_per_tg
+  )
+  SELECT coalesce(jsonb_object_agg(src, bucket_data), jsonb_build_object('owned','{}'::jsonb, 'market','{}'::jsonb))
+  INTO v_splits
+  FROM (
+    SELECT src, jsonb_object_agg(bucket, jsonb_build_object(
+      'tg_count', tg_count, 'tix_count', tix_count,
+      'min_px', round(min_px::numeric, 2), 'avg_px', round(avg_px::numeric, 2), 'max_px', round(max_px::numeric, 2)
+    )) AS bucket_data
+    FROM (
+      SELECT src, bucket, count(*) AS tg_count, sum(quantity) AS tix_count,
+             min(retail_price) AS min_px, avg(retail_price) AS avg_px, max(retail_price) AS max_px
+      FROM bucketed GROUP BY src, bucket
+    ) ia GROUP BY src
+  ) oa;
+
+  IF v_splits IS NULL THEN v_splits := jsonb_build_object('owned','{}'::jsonb, 'market','{}'::jsonb); END IF;
+
+  -- 10. Freshness
+  SELECT max(captured_at) INTO v_max_tevo
+  FROM public.listings_snapshots WHERE event_id = p_event_id;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT max(captured_at) INTO v_max_sg_lst
+    FROM public.seatgeek_listings_snapshots WHERE sg_event_id = v_sg_event_id;
+    SELECT max(sale_at_utc) INTO v_max_sg_sales
+    FROM public.seatgeek_sales_snapshots WHERE sg_event_id = v_sg_event_id;
+  END IF;
+
+  IF v_venue_tevo_id IS NOT NULL THEN
+    SELECT max(observed_at) INTO v_max_weather
+    FROM public.weather_observations
+    WHERE tevo_venue_id = v_venue_tevo_id AND is_forecast = false;
+  END IF;
+
+  IF v_espn_event_id IS NOT NULL THEN
+    SELECT max(captured_at) INTO v_max_espn_team
+    FROM public.espn_team_snapshots
+    WHERE espn_league = v_espn_league
+      AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]);
+    SELECT max(last_seen_at) INTO v_max_espn_inj
+    FROM public.espn_injuries_snapshots
+    WHERE espn_league = v_espn_league
+      AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]);
+  END IF;
+
+  SELECT max(sale_timestamp) INTO v_max_sd_sales
+  FROM public.sd_sales_normalized WHERE tevo_event_id = p_event_id;
+
+  v_freshness := jsonb_build_object(
+    'tevo_listings_latest', v_max_tevo,
+    'sg_listings_latest',   v_max_sg_lst,
+    'sg_sales_latest',      v_max_sg_sales,
+    'weather_latest',       v_max_weather,
+    'espn_team_latest',     v_max_espn_team,
+    'espn_inj_latest',      v_max_espn_inj,
+    'sd_sales_latest',      v_max_sd_sales,
+    'computed_at',          v_now
+  );
+
+  -- 11. Merge new keys onto v1 base
+  RETURN v_base || jsonb_build_object(
+    'v', 'v2',
+    'bridge_ids', jsonb_build_object(
+      'tevo_event_id', p_event_id,
+      'sg_event_id', v_sg_event_id,
+      'aq_short_event_id', v_aq_id,
+      'espn_event_id', v_espn_event_id,
+      'espn_league', v_espn_league,
+      'venue_tevo_id', v_venue_tevo_id
+    ),
+    'sales_tape',      v_sales_tape,
+    'weather',         v_weather,
+    'espn',            v_espn,
+    'event_alerts',    v_event_alerts,
+    'sg_side_by_side', v_sg_sxs,
+    'splits',          v_splits,
+    'freshness',       v_freshness
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_broker_event_page_v2(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_broker_event_page_v2(integer, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_broker_event_page_v2(integer, integer) IS
+  'D0 Phase 2a Event Detail RPC. Extends v1 with sales_tape (SG, deduped on sg_sale_id), weather (forecast+obs+NWS, hidden when indoor), espn (standings+injuries+recent_results, gated on espn xref), event_alerts (chart markers), sg_side_by_side (NULL when no SG bridge), splits (owned vs market density), freshness (per-source MAX captured_at). Email-gated to @s4kent.com. 185ms typical execution.';

--- a/supabase/migrations/20260516060000_sg_event_id_indexes.sql
+++ b/supabase/migrations/20260516060000_sg_event_id_indexes.sql
@@ -1,0 +1,29 @@
+-- Migration 20260516060000 · admin · SG sg_event_id indexes for v2 RPC · pre:20260516050000
+--
+-- Index gap discovered while validating get_broker_event_page_v2 (20260516050000):
+-- SG snapshot tables have unindexed sg_event_id (their actual FK from the SG API side).
+-- The pre-existing (tevo_event_id, time_col) indexes are partial WHERE tevo_event_id
+-- IS NOT NULL, but tevo_event_id is **0% populated** on these tables (ingest writes
+-- sg_event_id only; the bridge backfill never ran).
+--
+-- Effect without these indexes: every v2 RPC call seq-scans 1-10M-row tables for
+-- SG payload keys (sales_tape, sg_side_by_side, freshness). Function consistently
+-- times out at 2 min on first call.
+--
+-- After indexes: v2 RPC completes in ~185ms typical (verified on Bruno Mars event
+-- 3262932 with richest payload — sales tape + 6-point forecast + ESPN standings +
+-- splits + freshness).
+--
+-- Note: not addressing the underlying tevo_event_id backfill gap here — that's a
+-- separate ingest workstream. These indexes match the actual data shape today.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16.
+
+CREATE INDEX IF NOT EXISTS idx_sg_sales_sg_event_id_time
+  ON public.seatgeek_sales_snapshots (sg_event_id, sale_at_utc DESC NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS idx_sg_listings_sg_event_id_time
+  ON public.seatgeek_listings_snapshots (sg_event_id, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sg_event_metrics_sg_event_id_time
+  ON public.seatgeek_event_metrics (sg_event_id, captured_at DESC);

--- a/supabase/migrations/20260516070000_espn_nfl_bridge_backfill.sql
+++ b/supabase/migrations/20260516070000_espn_nfl_bridge_backfill.sql
@@ -1,0 +1,497 @@
+-- Migration 20260516070000 · admin · ESPN→TEvo→AQ→SG NFL bridge backfill · pre:20260516060000
+--
+-- Operator directive 2026-05-16: "NFL schedule just got released ... use ESPN game
+-- data to search for event in TEvo and then map that event to aq event and use aq
+-- number to map to sg."
+--
+-- 100-event sync census earlier this session surfaced: 0% of sampled NFL events had
+-- cross-source bridges (SG / ESPN / AQ). Root cause: NFL schedule was JUST released;
+-- AQ + ESPN ingests hadn't yet picked up the regular season.
+--
+-- This migration:
+-- 1. Triggers ESPN scoreboard ingest with 270-day lookahead (cron default is 90d —
+--    enough for preseason but misses regular season Oct-Jan). 322 NFL games landed
+--    in espn_event_date_lookup spanning 2026-08-07 to 2027-01-31.
+-- 2. Bridges ESPN→TEvo via entity_performer_map (32 NFL teams, all mapped). Matches
+--    on home_team_id + ±6h date window. Result: 292/322 (91%) ESPN games matched
+--    to live TEvo events.
+-- 3. Populates event_xref (the table backing entity_event_map view's ESPN side) for
+--    the 292 matched events. match_method='a1_espn_nfl_perfid_date_2026_05_16'.
+-- 4. Creates AQ rows for the 292 events via existing create_system_aq_event fn
+--    (SYS-{md5(name|venue|date)[:10]} convention). category='espn_nfl_derived'.
+-- 5. Attempts AQ→SG match via venue+date probe of sg_events_canonical. Found 3
+--    SG NFL games (Lions@Bills TNF 9/17, Cowboys@Giants SNF 9/13, Bears@Lions 11/26
+--    Thanksgiving — all primetime). Updates aq_event_map.sg_event_id + inserts
+--    seatgeek_event_xref rows for those 3.
+--
+-- Idempotent: re-runs are no-ops via ON CONFLICT clauses.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16.
+
+-- ============================================================
+-- Step 1: Trigger ESPN scoreboard ingest with full-season lookahead
+-- ============================================================
+SELECT public.espn_scoreboard_queue(270);
+
+-- Step 2: Wait for pg_net to fetch (typical ~10-15s for 7 scoreboard requests)
+SELECT pg_sleep(15);
+
+-- Step 3: Process the responses into espn_event_date_lookup
+SELECT public.espn_scoreboard_process();
+
+-- ============================================================
+-- Step 4: Populate event_xref with ESPN→TEvo NFL bridges
+-- ============================================================
+WITH matched AS (
+  SELECT DISTINCT ON (e.id)
+    e.id AS tevo_event_id,
+    eg.espn_event_id,
+    'NFL'::text AS espn_league,
+    abs(EXTRACT(epoch FROM (e.occurs_at_local::timestamptz - eg.game_at_utc))) AS time_delta
+  FROM public.espn_event_date_lookup eg
+  JOIN public.entity_performer_map pm_home
+    ON pm_home.espn_team_id = eg.home_team_id AND pm_home.espn_league = 'NFL'
+  JOIN public.events e
+    ON e.primary_performer_id = pm_home.tevo_performer_id
+    AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+    AND abs(EXTRACT(epoch FROM (e.occurs_at_local::timestamptz - eg.game_at_utc))) < 21600
+  WHERE eg.espn_league = 'NFL' AND eg.game_at_utc > now()
+  ORDER BY e.id, abs(EXTRACT(epoch FROM (e.occurs_at_local::timestamptz - eg.game_at_utc)))
+)
+INSERT INTO public.event_xref AS m
+  (tevo_event_id, espn_event_id, espn_league, espn_slug, matched_at, match_method, meta)
+SELECT
+  tevo_event_id, espn_event_id, espn_league,
+  'nfl-' || espn_event_id,
+  now(),
+  'a1_espn_nfl_perfid_date_2026_05_16',
+  jsonb_build_object('time_delta_sec', time_delta)
+FROM matched
+ON CONFLICT (tevo_event_id) DO UPDATE SET
+  espn_event_id = EXCLUDED.espn_event_id,
+  espn_league   = EXCLUDED.espn_league,
+  espn_slug     = EXCLUDED.espn_slug,
+  matched_at    = now(),
+  match_method  = EXCLUDED.match_method;
+
+-- ============================================================
+-- Step 5: Create AQ rows for matched events (via existing helper)
+-- ============================================================
+DO $$
+DECLARE
+  r RECORD;
+  v_count int := 0;
+BEGIN
+  FOR r IN
+    SELECT e.name, e.venue_name, e.occurs_at_local
+    FROM public.event_xref ex
+    JOIN public.events e ON e.id = ex.tevo_event_id
+    WHERE ex.espn_league = 'NFL'
+      AND ex.match_method = 'a1_espn_nfl_perfid_date_2026_05_16'
+      AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+  LOOP
+    PERFORM public.create_system_aq_event(
+      'espn_nfl_derived', r.name, r.venue_name, r.occurs_at_local::timestamptz);
+    v_count := v_count + 1;
+  END LOOP;
+  RAISE NOTICE 'NFL AQ rows created/upserted: %', v_count;
+END $$;
+
+-- ============================================================
+-- Step 6: AQ→SG match via venue+date (matcher tier 2 equivalent)
+-- ============================================================
+WITH our_nfl AS (
+  SELECT
+    e.id AS tevo_event_id, e.name AS tevo_name, e.venue_name AS tevo_venue,
+    e.occurs_at_local::timestamptz AS event_at,
+    aem.aq_short_event_id
+  FROM public.event_xref ex
+  JOIN public.events e ON e.id = ex.tevo_event_id
+  JOIN public.aq_event_map aem
+    ON aem.aq_short_event_id = 'SYS-' || substring(
+       md5(coalesce(e.name,'') || '|' || coalesce(e.venue_name,'') || '|' ||
+           coalesce(to_char(e.occurs_at_local::timestamptz, 'YYYY-MM-DD"T"HH24:MI'),''))
+       from 1 for 10)
+  WHERE ex.espn_league = 'NFL'
+    AND ex.match_method = 'a1_espn_nfl_perfid_date_2026_05_16'
+    AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+),
+sg_matched AS (
+  SELECT DISTINCT ON (n.tevo_event_id)
+    n.tevo_event_id, n.aq_short_event_id, c.sg_event_id, c.sg_event_name,
+    c.sg_venue_name, c.sg_datetime_utc
+  FROM our_nfl n
+  JOIN public.sg_events_canonical c
+    ON lower(trim(c.sg_venue_name)) = lower(trim(n.tevo_venue))
+    AND abs(EXTRACT(epoch FROM (c.sg_datetime_utc - n.event_at))) < 21600
+  ORDER BY n.tevo_event_id, abs(EXTRACT(epoch FROM (c.sg_datetime_utc - n.event_at)))
+),
+upd_aq AS (
+  UPDATE public.aq_event_map aem
+  SET sg_event_id = sm.sg_event_id
+  FROM sg_matched sm
+  WHERE aem.aq_short_event_id = sm.aq_short_event_id
+    AND aem.sg_event_id IS NULL
+  RETURNING aem.aq_short_event_id
+)
+INSERT INTO public.seatgeek_event_xref AS x
+  (tevo_event_id, sg_event_id, sg_event_name, sg_event_location, sg_start_data,
+   matched_at, match_method, match_confidence)
+SELECT
+  tevo_event_id, sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc,
+  now(), 'a1_espn_nfl_perfid_bridge_2026_05_16', 0.95
+FROM sg_matched
+ON CONFLICT (tevo_event_id) DO UPDATE SET
+  sg_event_id   = EXCLUDED.sg_event_id,
+  sg_event_name = EXCLUDED.sg_event_name,
+  matched_at    = now(),
+  match_method  = EXCLUDED.match_method;
+
+-- ============================================================
+-- Step 7: v2 RPC fallback bridge fix
+-- ============================================================
+-- Earlier v2 RPC anchored bridge lookups on _v_d0_event_index which only contains
+-- SG-tracked events (anchored on sg_event_priority_state). NFL events lacking SG
+-- presence fell through silently with all bridge_ids = NULL.
+--
+-- Fix: when view returns no row, fall back to base tables (events + venue_assets +
+-- event_xref + seatgeek_event_xref + aq_event_map). For aq_short_event_id lookup,
+-- also try the SYS-{md5(name|venue|date)[:10]} convention used by create_system_aq_event.
+
+CREATE OR REPLACE FUNCTION public.get_broker_event_page_v2(
+  p_event_id    integer,
+  p_chart_hours integer DEFAULT 720
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email           text;
+  v_base            jsonb;
+  v_now             timestamptz := now();
+  v_sg_event_id     bigint;
+  v_aq_id           text;
+  v_espn_event_id   text;
+  v_espn_league     text;
+  v_venue_tevo_id   bigint;
+  v_is_indoor       boolean;
+  v_event_at        timestamptz;
+  v_sales_tape      jsonb;
+  v_weather         jsonb;
+  v_espn            jsonb;
+  v_event_alerts    jsonb;
+  v_sg_sxs          jsonb;
+  v_splits          jsonb;
+  v_freshness       jsonb;
+  v_max_tevo        timestamptz;
+  v_max_sg_lst      timestamptz;
+  v_max_sg_sales    timestamptz;
+  v_max_weather     timestamptz;
+  v_max_espn_team   timestamptz;
+  v_max_espn_inj    timestamptz;
+  v_max_sd_sales    timestamptz;
+  v_home_team_id    text;
+  v_away_team_id    text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_base := public.get_broker_event_page(p_event_id, p_chart_hours);
+
+  -- Primary: bridge IDs from _v_d0_event_index (anchored on sg_event_priority_state)
+  SELECT v.sg_event_id, v.aq_short_event_id, v.espn_event_id, v.espn_league,
+         v.venue_tevo_id, v.is_indoor, v.event_at_utc
+  INTO v_sg_event_id, v_aq_id, v_espn_event_id, v_espn_league,
+       v_venue_tevo_id, v_is_indoor, v_event_at
+  FROM public._v_d0_event_index v
+  WHERE v.tevo_event_id = p_event_id LIMIT 1;
+
+  -- Fallback for non-SG events (NFL, NWSL, niche): read from base tables
+  IF v_event_at IS NULL THEN
+    SELECT
+      CASE WHEN e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+           THEN e.occurs_at_local::timestamptz ELSE NULL END,
+      e.venue_id, va.is_indoor
+    INTO v_event_at, v_venue_tevo_id, v_is_indoor
+    FROM public.events e
+    LEFT JOIN public.venue_assets va ON va.tevo_venue_id = e.venue_id
+    WHERE e.id = p_event_id LIMIT 1;
+  END IF;
+
+  IF v_espn_event_id IS NULL THEN
+    SELECT ex.espn_event_id, ex.espn_league
+    INTO v_espn_event_id, v_espn_league
+    FROM public.event_xref ex WHERE ex.tevo_event_id = p_event_id LIMIT 1;
+  END IF;
+
+  IF v_sg_event_id IS NULL THEN
+    SELECT sgx.sg_event_id INTO v_sg_event_id
+    FROM public.seatgeek_event_xref sgx WHERE sgx.tevo_event_id = p_event_id LIMIT 1;
+  END IF;
+
+  IF v_aq_id IS NULL THEN
+    IF v_sg_event_id IS NOT NULL THEN
+      SELECT aem.aq_short_event_id INTO v_aq_id
+      FROM public.aq_event_map aem WHERE aem.sg_event_id = v_sg_event_id LIMIT 1;
+    END IF;
+    IF v_aq_id IS NULL THEN
+      -- SYS-{md5} convention (created via create_system_aq_event)
+      SELECT aem.aq_short_event_id INTO v_aq_id
+      FROM public.events e
+      JOIN public.aq_event_map aem
+        ON aem.aq_short_event_id = 'SYS-' || substring(
+             md5(coalesce(e.name,'') || '|' || coalesce(e.venue_name,'') || '|' ||
+                 coalesce(to_char(e.occurs_at_local::timestamptz, 'YYYY-MM-DD"T"HH24:MI'),''))
+             from 1 for 10)
+      WHERE e.id = p_event_id
+        AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+      LIMIT 1;
+    END IF;
+  END IF;
+
+  -- sales_tape
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH latest_per_sale AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, sale_at_utc, section, row, quantity, broadcast_price, stock_type
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND sale_at_utc > now() - interval '30 days'
+      ORDER BY sg_sale_id, pulled_at DESC
+    )
+    SELECT coalesce(jsonb_agg(to_jsonb(lp) ORDER BY lp.sale_at_utc DESC), '[]'::jsonb)
+    INTO v_sales_tape
+    FROM (SELECT * FROM latest_per_sale ORDER BY sale_at_utc DESC LIMIT 20) lp;
+  ELSE
+    v_sales_tape := '[]'::jsonb;
+  END IF;
+
+  -- weather
+  IF v_is_indoor IS FALSE AND v_venue_tevo_id IS NOT NULL AND v_event_at IS NOT NULL THEN
+    WITH forecast AS (
+      SELECT is_forecast, observed_at, temp_f, precip_pct, precip_in, wind_mph,
+             gust_mph, humidity_pct, weather_summary
+      FROM public.weather_observations
+      WHERE tevo_venue_id = v_venue_tevo_id
+        AND is_forecast = true
+        AND observed_at BETWEEN now() AND now() + interval '7 days'
+      ORDER BY abs(EXTRACT(epoch FROM (observed_at - v_event_at)))
+      LIMIT 6
+    ),
+    recent_obs AS (
+      SELECT is_forecast, observed_at, temp_f, precip_pct, precip_in, wind_mph,
+             gust_mph, humidity_pct, weather_summary
+      FROM public.weather_observations
+      WHERE tevo_venue_id = v_venue_tevo_id
+        AND is_forecast = false
+        AND observed_at > now() - interval '24 hours'
+      ORDER BY observed_at DESC LIMIT 3
+    ),
+    active_alerts AS (
+      SELECT id, event, severity, urgency, headline, expires_at, area_desc
+      FROM public.nws_alerts WHERE expires_at > now() ORDER BY expires_at LIMIT 5
+    )
+    SELECT jsonb_build_object(
+      'venue_tevo_id', v_venue_tevo_id,
+      'event_at',      v_event_at,
+      'forecast',      coalesce((SELECT jsonb_agg(to_jsonb(f) ORDER BY f.observed_at) FROM forecast f), '[]'::jsonb),
+      'recent_obs',    coalesce((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.observed_at DESC) FROM recent_obs r), '[]'::jsonb),
+      'nws_alerts',    coalesce((SELECT jsonb_agg(to_jsonb(a)) FROM active_alerts a), '[]'::jsonb)
+    ) INTO v_weather;
+  ELSE
+    v_weather := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_is_indoor IS TRUE THEN 'indoor_venue'
+           WHEN v_venue_tevo_id IS NULL THEN 'no_venue_xref'
+           WHEN v_event_at IS NULL THEN 'no_event_time'
+           ELSE 'unknown' END);
+  END IF;
+
+  -- ESPN (gated on espn xref; falls back to date_lookup for events without snapshots yet)
+  IF v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id INTO v_home_team_id, v_away_team_id
+    FROM public.espn_event_snapshots
+    WHERE espn_event_id = v_espn_event_id
+    ORDER BY captured_at DESC LIMIT 1;
+
+    IF v_home_team_id IS NULL THEN
+      SELECT home_team_id, away_team_id INTO v_home_team_id, v_away_team_id
+      FROM public.espn_event_date_lookup
+      WHERE espn_event_id = v_espn_event_id LIMIT 1;
+    END IF;
+
+    WITH team_snaps AS (
+      SELECT DISTINCT ON (espn_team_id)
+        espn_team_id, captured_at, wins, losses, ties, win_pct,
+        record_summary, standing_summary, streak, playoff_seed
+      FROM public.espn_team_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+      ORDER BY espn_team_id, captured_at DESC
+    ),
+    injuries AS (
+      SELECT DISTINCT ON (athlete_id, espn_team_id)
+        espn_team_id, athlete_name, position, status, injury_type,
+        short_comment, return_date, last_seen_at
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+        AND last_seen_at > now() - interval '7 days'
+      ORDER BY athlete_id, espn_team_id, last_seen_at DESC
+    ),
+    recent_results AS (
+      SELECT DISTINCT ON (espn_event_id)
+        espn_event_id, captured_at, state, status_short,
+        home_team_id, away_team_id, home_score, away_score
+      FROM public.espn_event_snapshots
+      WHERE espn_league = v_espn_league
+        AND state = 'post'
+        AND (home_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+             OR away_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]))
+        AND captured_at > now() - interval '60 days'
+      ORDER BY espn_event_id, captured_at DESC
+    )
+    SELECT jsonb_build_object(
+      'espn_event_id',   v_espn_event_id,
+      'espn_league',     v_espn_league,
+      'home_team_id',    v_home_team_id,
+      'away_team_id',    v_away_team_id,
+      'team_standings',  coalesce((SELECT jsonb_agg(to_jsonb(t)) FROM team_snaps t), '[]'::jsonb),
+      'injuries',        coalesce((SELECT jsonb_agg(to_jsonb(i) ORDER BY i.last_seen_at DESC) FROM injuries i), '[]'::jsonb),
+      'recent_results',  coalesce((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.captured_at DESC) FROM recent_results r LIMIT 10), '[]'::jsonb)
+    ) INTO v_espn;
+  ELSE
+    v_espn := jsonb_build_object('hidden', true, 'reason', 'no_espn_xref');
+  END IF;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(a) ORDER BY a.fired_at DESC), '[]'::jsonb)
+  INTO v_event_alerts
+  FROM (
+    SELECT id, rule_key, fired_at, severity, message, payload, acknowledged_at
+    FROM public.event_alerts
+    WHERE tevo_event_id = p_event_id
+      AND fired_at > now() - make_interval(hours => greatest(1, least(coalesce(p_chart_hours, 720), 4320)))
+    ORDER BY fired_at DESC LIMIT 50
+  ) a;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH em_latest AS (
+      SELECT row_number() OVER (ORDER BY captured_at DESC) AS rn,
+             captured_at, listings_count, tickets_count,
+             cost_min, cost_p25, cost_median, cost_mean, cost_p75, cost_p90, cost_max, cost_sum,
+             sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_max,
+             unique_sections, unique_rows
+      FROM public.seatgeek_event_metrics
+      WHERE sg_event_id = v_sg_event_id
+      ORDER BY captured_at DESC LIMIT 25
+    )
+    SELECT jsonb_build_object(
+      'sg_event_id', v_sg_event_id,
+      'current',  (SELECT to_jsonb(e) FROM em_latest e WHERE rn = 1),
+      'd24h_ago', (SELECT to_jsonb(e) FROM em_latest e
+                   WHERE e.captured_at <= now() - interval '24 hours'
+                   ORDER BY e.captured_at DESC LIMIT 1)
+    ) INTO v_sg_sxs;
+  ELSE
+    v_sg_sxs := jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge');
+  END IF;
+
+  WITH latest_per_tg AS (
+    SELECT DISTINCT ON (tevo_ticket_group_id)
+      quantity, is_owned, retail_price, brokerage_id
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id AND captured_at > now() - interval '24 hours'
+    ORDER BY tevo_ticket_group_id, captured_at DESC
+  ),
+  bucketed AS (
+    SELECT
+      CASE WHEN is_owned AND brokerage_id = 1768 THEN 'owned' ELSE 'market' END AS src,
+      CASE WHEN quantity = 1 THEN 'singles' WHEN quantity = 2 THEN 'pairs'
+           WHEN quantity = 3 THEN 'triples' WHEN quantity = 4 THEN 'quads'
+           ELSE 'five_plus' END AS bucket,
+      quantity, retail_price
+    FROM latest_per_tg
+  )
+  SELECT coalesce(jsonb_object_agg(src, bucket_data), jsonb_build_object('owned','{}'::jsonb, 'market','{}'::jsonb))
+  INTO v_splits
+  FROM (
+    SELECT src, jsonb_object_agg(bucket, jsonb_build_object(
+      'tg_count', tg_count, 'tix_count', tix_count,
+      'min_px', round(min_px::numeric, 2), 'avg_px', round(avg_px::numeric, 2), 'max_px', round(max_px::numeric, 2)
+    )) AS bucket_data
+    FROM (
+      SELECT src, bucket, count(*) AS tg_count, sum(quantity) AS tix_count,
+             min(retail_price) AS min_px, avg(retail_price) AS avg_px, max(retail_price) AS max_px
+      FROM bucketed GROUP BY src, bucket
+    ) ia GROUP BY src
+  ) oa;
+
+  IF v_splits IS NULL THEN v_splits := jsonb_build_object('owned','{}'::jsonb, 'market','{}'::jsonb); END IF;
+
+  SELECT max(captured_at) INTO v_max_tevo
+  FROM public.listings_snapshots WHERE event_id = p_event_id;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT max(captured_at) INTO v_max_sg_lst
+    FROM public.seatgeek_listings_snapshots WHERE sg_event_id = v_sg_event_id;
+    SELECT max(sale_at_utc) INTO v_max_sg_sales
+    FROM public.seatgeek_sales_snapshots WHERE sg_event_id = v_sg_event_id;
+  END IF;
+
+  IF v_venue_tevo_id IS NOT NULL THEN
+    SELECT max(observed_at) INTO v_max_weather
+    FROM public.weather_observations
+    WHERE tevo_venue_id = v_venue_tevo_id AND is_forecast = false;
+  END IF;
+
+  IF v_espn_event_id IS NOT NULL THEN
+    SELECT max(captured_at) INTO v_max_espn_team
+    FROM public.espn_team_snapshots
+    WHERE espn_league = v_espn_league
+      AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]);
+    SELECT max(last_seen_at) INTO v_max_espn_inj
+    FROM public.espn_injuries_snapshots
+    WHERE espn_league = v_espn_league
+      AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]);
+  END IF;
+
+  SELECT max(sale_timestamp) INTO v_max_sd_sales
+  FROM public.sd_sales_normalized WHERE tevo_event_id = p_event_id;
+
+  v_freshness := jsonb_build_object(
+    'tevo_listings_latest', v_max_tevo,
+    'sg_listings_latest',   v_max_sg_lst,
+    'sg_sales_latest',      v_max_sg_sales,
+    'weather_latest',       v_max_weather,
+    'espn_team_latest',     v_max_espn_team,
+    'espn_inj_latest',      v_max_espn_inj,
+    'sd_sales_latest',      v_max_sd_sales,
+    'computed_at',          v_now
+  );
+
+  RETURN v_base || jsonb_build_object(
+    'v', 'v2',
+    'bridge_ids', jsonb_build_object(
+      'tevo_event_id', p_event_id,
+      'sg_event_id', v_sg_event_id,
+      'aq_short_event_id', v_aq_id,
+      'espn_event_id', v_espn_event_id,
+      'espn_league', v_espn_league,
+      'venue_tevo_id', v_venue_tevo_id
+    ),
+    'sales_tape',      v_sales_tape,
+    'weather',         v_weather,
+    'espn',            v_espn,
+    'event_alerts',    v_event_alerts,
+    'sg_side_by_side', v_sg_sxs,
+    'splits',          v_splits,
+    'freshness',       v_freshness
+  );
+END $func$;
+
+COMMENT ON FUNCTION public.get_broker_event_page_v2(integer, integer) IS
+  'D0 Phase 2a Event Detail RPC. Reads bridge IDs from _v_d0_event_index first; falls back to event_xref + seatgeek_event_xref + aq_event_map (SYS-md5 convention) for events not in sg_event_priority_state. 7 new payload keys beyond v1: sales_tape, weather, espn, event_alerts, sg_side_by_side, splits, freshness. Email-gated to @s4kent.com.';

--- a/supabase/migrations/20260516080000_espn_multi_sport_bridge.sql
+++ b/supabase/migrations/20260516080000_espn_multi_sport_bridge.sql
@@ -1,0 +1,132 @@
+-- Migration 20260516080000 · admin · ESPN→TEvo→AQ→SG multi-sport bridge · pre:20260516070000
+--
+-- Extends the NFL bridge (20260516070000) to MLB / MLS / WNBA / NBA / NHL using the
+-- same ESPN→TEvo→AQ→SG pattern. Coverage census 2026-05-16 found 819 ESPN games
+-- matchable via entity_performer_map but not yet bridged in event_xref:
+--   MLB: 759 candidates (471 already xref'd; gap = matcher just hasn't kept up)
+--   MLS: 41   candidates (7 already xref'd)
+--   WNBA: 12  candidates (18 already xref'd)
+--   NBA: 6    candidates (4 already xref'd)
+--   NHL: 1    candidate  (1 already xref'd)
+--
+-- This migration:
+-- 1. INSERT into event_xref for ESPN games NOT yet bridged (filtered out via
+--    LEFT JOIN existence check). match_method='a1_espn_multi_perfid_date_2026_05_16'.
+-- 2. Conditionally create SYS- AQ rows ONLY for events without any existing AQ match
+--    (probed via match_to_aq_event_id which uses all 4 matcher tiers). Avoids
+--    duplicate SYS- entries when aq_curated rows already exist (mostly MLB).
+-- 3. AQ→SG match probe + INSERT for events where SG has the game.
+--
+-- Idempotent via ON CONFLICT clauses + WHERE NOT EXISTS guards.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16.
+-- Result counts:
+--   event_xref:       MLB 654 + MLS 42 + WNBA 12 + NBA 6 + NHL 1 = 715 new bridges
+--   aq_event_map:     470 SYS- rows (excluding 245 events with existing AQ matches)
+--   seatgeek_xref:    MLB 347 + MLS 10 + NFL 3 + WNBA 2 = 362 new SG bridges
+-- Combined with 20260516070000 NFL: 1,007 ESPN xrefs + 470 AQ rows + 365 SG xrefs
+
+-- ============================================================
+-- Step 1: ESPN→TEvo bridge for ALL non-NFL leagues
+-- ============================================================
+WITH matched AS (
+  SELECT DISTINCT ON (e.id)
+    e.id AS tevo_event_id,
+    eg.espn_event_id,
+    eg.espn_league,
+    abs(EXTRACT(epoch FROM (e.occurs_at_local::timestamptz - eg.game_at_utc))) AS time_delta
+  FROM public.espn_event_date_lookup eg
+  JOIN public.entity_performer_map pm_home
+    ON pm_home.espn_team_id = eg.home_team_id AND pm_home.espn_league = eg.espn_league
+  JOIN public.events e
+    ON e.primary_performer_id = pm_home.tevo_performer_id
+    AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+    AND abs(EXTRACT(epoch FROM (e.occurs_at_local::timestamptz - eg.game_at_utc))) < 21600
+  LEFT JOIN public.event_xref ex_existing
+    ON ex_existing.tevo_event_id = e.id
+  WHERE eg.game_at_utc > now()
+    AND eg.espn_league IN ('MLB','MLS','WNBA','NBA','NHL')
+    AND ex_existing.tevo_event_id IS NULL
+  ORDER BY e.id, abs(EXTRACT(epoch FROM (e.occurs_at_local::timestamptz - eg.game_at_utc)))
+)
+INSERT INTO public.event_xref AS m
+  (tevo_event_id, espn_event_id, espn_league, espn_slug, matched_at, match_method, meta)
+SELECT
+  tevo_event_id, espn_event_id, espn_league,
+  lower(espn_league) || '-' || espn_event_id,
+  now(),
+  'a1_espn_multi_perfid_date_2026_05_16',
+  jsonb_build_object('time_delta_sec', time_delta)
+FROM matched;
+
+-- ============================================================
+-- Step 2: Conditional AQ row creation (skip when existing AQ match)
+-- ============================================================
+DO $$
+DECLARE
+  r RECORD;
+  v_existing text;
+  v_created int := 0;
+  v_skipped int := 0;
+BEGIN
+  FOR r IN
+    SELECT e.id, e.name, e.venue_name, e.occurs_at_local, ex.espn_league
+    FROM public.event_xref ex
+    JOIN public.events e ON e.id = ex.tevo_event_id
+    WHERE ex.match_method = 'a1_espn_multi_perfid_date_2026_05_16'
+      AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+  LOOP
+    SELECT aq_short_event_id INTO v_existing
+    FROM public.match_to_aq_event_id(
+      'evo', NULL, r.name, r.venue_name, r.occurs_at_local::timestamptz, NULL, NULL, NULL)
+    LIMIT 1;
+
+    IF v_existing IS NULL THEN
+      PERFORM public.create_system_aq_event(
+        'espn_' || lower(r.espn_league) || '_derived',
+        r.name, r.venue_name, r.occurs_at_local::timestamptz);
+      v_created := v_created + 1;
+    ELSE
+      v_skipped := v_skipped + 1;
+    END IF;
+  END LOOP;
+  RAISE NOTICE 'multi-sport AQ rows: % created, % skipped (already had AQ)', v_created, v_skipped;
+END $$;
+
+-- ============================================================
+-- Step 3: AQ→SG match across all newly-bridged events
+-- ============================================================
+WITH our_bridged AS (
+  SELECT e.id AS tevo_event_id, e.name, e.venue_name,
+         e.occurs_at_local::timestamptz AS event_at, ex.espn_league
+  FROM public.event_xref ex
+  JOIN public.events e ON e.id = ex.tevo_event_id
+  WHERE ex.match_method IN ('a1_espn_nfl_perfid_date_2026_05_16',
+                             'a1_espn_multi_perfid_date_2026_05_16')
+    AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+),
+sg_matched AS (
+  SELECT DISTINCT ON (n.tevo_event_id)
+    n.tevo_event_id, n.espn_league,
+    c.sg_event_id, c.sg_event_name, c.sg_venue_name, c.sg_datetime_utc
+  FROM our_bridged n
+  JOIN public.sg_events_canonical c
+    ON lower(trim(c.sg_venue_name)) = lower(trim(n.venue_name))
+    AND abs(EXTRACT(epoch FROM (c.sg_datetime_utc - n.event_at))) < 21600
+  LEFT JOIN public.seatgeek_event_xref sgx_existing
+    ON sgx_existing.tevo_event_id = n.tevo_event_id
+  WHERE sgx_existing.tevo_event_id IS NULL
+  ORDER BY n.tevo_event_id, abs(EXTRACT(epoch FROM (c.sg_datetime_utc - n.event_at)))
+)
+INSERT INTO public.seatgeek_event_xref AS x
+  (tevo_event_id, sg_event_id, sg_event_name, sg_event_location, sg_start_data,
+   matched_at, match_method, match_confidence)
+SELECT
+  tevo_event_id, sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc,
+  now(), 'a1_espn_multi_bridge_2026_05_16', 0.95
+FROM sg_matched
+ON CONFLICT (tevo_event_id) DO UPDATE SET
+  sg_event_id   = EXCLUDED.sg_event_id,
+  sg_event_name = EXCLUDED.sg_event_name,
+  matched_at    = now(),
+  match_method  = EXCLUDED.match_method;

--- a/supabase/migrations/20260516090000_espn_scoreboard_queue_lookahead_270d.sql
+++ b/supabase/migrations/20260516090000_espn_scoreboard_queue_lookahead_270d.sql
@@ -1,0 +1,58 @@
+-- Migration 20260516090000 · admin · bump espn_scoreboard_queue default 90d → 270d · pre:20260516080000
+--
+-- This session surfaced: the espn_scoreboard_queue_4h cron passes no args, so
+-- defaults to 90d lookahead. That captured NFL preseason (Aug) but missed the
+-- full regular season Oct-Jan when the NFL released the 2026 schedule.
+--
+-- Bumping the default to 270d means the daily cron auto-captures the full NFL
+-- season (~22 weeks) + MLB Aug-Apr + NBA Oct-June without future operator
+-- intervention each fall.
+--
+-- Cost impact: minimal. Each league makes 1 HTTP call per cron firing regardless
+-- of lookahead (the ESPN scoreboard endpoint accepts a date range param). 7 leagues
+-- × 1 call/day = 7 ESPN calls/day, unchanged. The processed payload is bigger
+-- (more events per call) but ESPN's limit=1000 cap handles it.
+--
+-- Verified manually 2026-05-16: espn_scoreboard_queue(270) returned 322 NFL games
+-- in single call (compared to 8 with 90d). 1,403 future MLB games, 308 WNBA, 323 MLS.
+--
+-- MLB still uses two-call split (past 30 + next 30, then next 30 to far) per
+-- existing logic — that split is unchanged because MLB events span the full year
+-- and ESPN's limit=1000 needs 2 fetches to cover.
+--
+-- ## Already applied to prod  Applied via MCP 2026-05-16.
+
+CREATE OR REPLACE FUNCTION public.espn_scoreboard_queue(p_lookahead_days integer DEFAULT 270)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  cfg RECORD; v_req bigint; v_count int := 0;
+  v_back text   := to_char(current_date - 30, 'YYYYMMDD');
+  v_mid  text   := to_char(current_date + 30, 'YYYYMMDD');
+  v_far  text   := to_char(current_date + p_lookahead_days, 'YYYYMMDD');
+BEGIN
+  FOR cfg IN
+    SELECT * FROM (VALUES
+      ('basketball','nba','NBA',          v_back || '-' || v_far),
+      ('football','nfl','NFL',            v_back || '-' || v_far),
+      ('baseball','mlb','MLB',            v_back || '-' || v_mid),  -- past 30 + next 30
+      ('baseball','mlb','MLB',            v_mid  || '-' || v_far),  -- next 30 to far
+      ('hockey','nhl','NHL',              v_back || '-' || v_far),
+      ('basketball','wnba','WNBA',        v_back || '-' || v_far),
+      ('soccer','usa.1','MLS',            v_back || '-' || v_far)
+    ) AS x(sport, league_path, league_label, date_range)
+  LOOP
+    SELECT net.http_get(
+      url := 'https://site.api.espn.com/apis/site/v2/sports/' || cfg.sport || '/' || cfg.league_path || '/scoreboard',
+      params := jsonb_build_object('dates', cfg.date_range, 'limit', '1000'),
+      headers := jsonb_build_object('Accept','application/json','User-Agent','terminal-2-broker (julian@s4kent.com)'),
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+    INSERT INTO espn_scoreboard_pending(espn_league, request_id) VALUES (cfg.league_label, v_req);
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.5);
+  END LOOP;
+  RETURN v_count;
+END $function$;


### PR DESCRIPTION
## Summary

NFL released 2026 schedule on 2026-05-16. Existing 90d cron lookahead only captured preseason (Aug) — missed Oct-Jan regular season. PR #154 manually triggered espn_scoreboard_queue(270) to backfill 322 NFL games + bridge them. This PR makes the bigger lookahead permanent so future schedule releases don't require manual intervention.

**Already applied to prod via MCP** — this PR codifies what landed.

## Effect

- `espn_scoreboard_queue_4h` cron (04:00 UTC daily) now passes no args → defaults to 270d → auto-fetches full NFL season + MLB 1-year forward + NBA Oct-June + WNBA + MLS + NHL future schedules
- Same 7 HTTP calls/day to ESPN (1 per league); just bigger payloads per call (well under ESPN's limit=1000 cap)
- MLB's existing two-call split (past 30 + next 30, then next 30 to far) preserved — handles MLB's ~1,400 future games

## Verified post-session

After applying + running `cross_source_match_tick()` once:

| League | ESPN bridged | + SG bridged | Coverage |
|---|---|---|---|
| MLB | 654 | 641 | **98%** ⬆ from 53% |
| WNBA | 12 | 12 | **100%** |
| NBA | 6 | 6 | **100%** |
| MLS | 42 | 30 | **71%** ⬆ |
| NFL | 292 | 9 | 3% (SG doesn't widely carry NFL) |
| NHL | 1 | 0 | 0% |

669 new TEvo↔SG matches landed in single matcher firing — auto-matcher catches up as cron continues to fire every 30 min.

## Carry-forward (none)

All 3 carry-forward items from PR #154 now resolved:
- ✅ B1: collect-listings crons 0-firings — FALSE ALARM (all 4 firing correctly post-resume; were just freshly scheduled at audit time)
- ✅ A1: ESPN scoreboard lookahead 90d → 270d (this PR)
- ✅ NFL events auto-bridge as SG ingests — `cross_source_match_tick_30min` cron picks them up

🤖 Generated with [Claude Code](https://claude.com/claude-code)