### PR TITLE
d2: SG broker sales views (section + event) for FE reuse

### DIFF
--- a/supabase/migrations/20260516220000_v_sg_broker_sales_by_section.sql
+++ b/supabase/migrations/20260516220000_v_sg_broker_sales_by_section.sql
@@ -1,0 +1,64 @@
+-- Migration 20260516220000 · lane:A1 (D2-authored) · writes:v_sg_broker_sales_by_section (new view) · reads:seatgeek_sales_snapshots,sg_events_canonical · pre:- · auth:operator-permitted 2026-05-16
+-- Maps the SG broker sales firehose (seatgeek_sales_snapshots) into the
+-- same column shape as the existing seller-side v_sg_sales_by_section view,
+-- so a future frontend can render either source through one renderer + UNION
+-- when seller seller-side activity resumes.
+--
+-- Why a parallel view (not a refactor of v_sg_sales_by_section):
+--   - v_sg_sales_by_section sources seatgeek_orders (seller-side, 400 dormant rows).
+--   - This new view sources seatgeek_sales_snapshots (broker firehose, 900K+ rows,
+--     ~67k sales/hour observed market activity).
+--   - Same FE shape; different population strategies (UPSERT vs observation).
+--
+-- DISTINCT ON (sg_sale_id) is MANDATORY per PROJECT_BIBLE.md §3 — broker
+-- firehose has an 11x duplication factor (sales re-observed across polls).
+-- ORDER BY sg_sale_id, pulled_at DESC picks the latest observation per sale.
+--
+-- Canonical column name mapping (broker → seller-side equivalent):
+--   sg_sale_id        → sale_id (broker uses sg_sale_id; seller uses sg_order_id)
+--   broadcast_price   → sale_price
+--   quantity          → sale_quantity
+--   sale_at_utc       → created_at_sg (when the sale actually transacted)
+--   pulled_at         → last_status_at (when we observed it)
+--   ('sold' constant) → status (broker observations are always terminal)
+-- Plus broker-only fields exposed for FE detail panels:
+--   aq_short_event_id, venue_short_id, is_instant, in_hand_date, seller_notes
+
+CREATE OR REPLACE VIEW public.v_sg_broker_sales_by_section AS
+SELECT DISTINCT ON (s.sg_sale_id)
+  -- Event header (joined from canonical SG event table)
+  s.tevo_event_id,
+  s.sg_event_id,
+  sgc.sg_event_name,
+  sgc.sg_event_date,
+  sgc.sg_venue_name                                                   AS sg_venue,
+  -- Section-level seat info (broker firehose grain)
+  s.section,
+  s."row",
+  s.quantity                                                          AS sale_quantity,
+  s.broadcast_price                                                   AS sale_price,
+  (s.broadcast_price * COALESCE(s.quantity, 1)::numeric)              AS sale_total_estimate,
+  -- Lifecycle: broker sales are observation-time-terminal
+  'sold'::text                                                        AS status,
+  s.sale_at_utc                                                       AS created_at_sg,
+  s.pulled_at                                                         AS last_status_at,
+  -- Delivery facts (shape match with v_sg_sales_by_section)
+  s.delivery_method,
+  s.stock_type,
+  -- Broker-only extras (additive — FE can choose to render or ignore)
+  s.sg_sale_id,
+  s.aq_short_event_id,
+  s.venue_short_id,
+  s.is_instant,
+  s.in_hand_date,
+  s.seller_notes
+FROM public.seatgeek_sales_snapshots s
+LEFT JOIN public.sg_events_canonical sgc ON sgc.sg_event_id = s.sg_event_id
+WHERE s.section IS NOT NULL  -- parity with v_sg_sales_by_section's row filter
+ORDER BY s.sg_sale_id, s.pulled_at DESC;
+
+REVOKE ALL ON public.v_sg_broker_sales_by_section FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public.v_sg_broker_sales_by_section TO service_role;
+
+COMMENT ON VIEW public.v_sg_broker_sales_by_section IS
+  'Section-grain SG broker firehose sales mapped to the v_sg_sales_by_section shape. DISTINCT ON (sg_sale_id) deduplicates the 11x observation factor. Use for FE views that want to UNION seller-side + broker-side SG sales through one renderer.';

--- a/supabase/migrations/20260516220100_v_sg_broker_sales_by_event.sql
+++ b/supabase/migrations/20260516220100_v_sg_broker_sales_by_event.sql
@@ -1,0 +1,50 @@
+-- Migration 20260516220100 · lane:A1 (D2-authored) · writes:v_sg_broker_sales_by_event (new view) · reads:seatgeek_sales_snapshots,sg_events_canonical · pre:20260516220000 · auth:operator-permitted 2026-05-16
+-- Per-event aggregator over the SG broker firehose. Mirrors the existing
+-- seller-side v_sg_sales_by_event shape so a future FE event-index panel
+-- can render either source with the same code path.
+--
+-- The section-grain companion v_sg_broker_sales_by_section (mig 20260516220000)
+-- is the row-level view. This file is the GROUP BY tevo_event_id, sg_event_id
+-- rollup — useful for "is this event heating up?" signals on the dashboard.
+--
+-- Aggregation runs over the DEDUPLICATED set (the section view already does
+-- DISTINCT ON sg_sale_id). Inline the dedup CTE here so this view can be
+-- queried standalone without depending on the section view.
+
+CREATE OR REPLACE VIEW public.v_sg_broker_sales_by_event AS
+WITH dedup AS (
+  SELECT DISTINCT ON (s.sg_sale_id)
+    s.tevo_event_id, s.sg_event_id, s.sg_sale_id,
+    s.quantity, s.broadcast_price, s.section, s.sale_at_utc
+  FROM public.seatgeek_sales_snapshots s
+  WHERE s.section IS NOT NULL
+  ORDER BY s.sg_sale_id, s.pulled_at DESC
+)
+SELECT
+  d.tevo_event_id,
+  d.sg_event_id,
+  max(sgc.sg_event_name)                              AS sg_event_name,
+  max(sgc.sg_event_date)                              AS sg_event_date,
+  max(sgc.sg_venue_name)                              AS sg_venue,
+  count(*)::bigint                                    AS sales_count,
+  sum(d.quantity)::bigint                             AS tickets_sold,
+  sum(d.broadcast_price * COALESCE(d.quantity, 1)::numeric) AS gross_estimate,
+  min(d.broadcast_price)                              AS min_sale_price,
+  round(
+    percentile_cont(0.5)
+      WITHIN GROUP (ORDER BY d.broadcast_price::double precision)::numeric,
+    2
+  )                                                   AS median_sale_price,
+  max(d.broadcast_price)                              AS max_sale_price,
+  count(DISTINCT d.section)::bigint                   AS distinct_sections,
+  string_agg(DISTINCT d.section, ',' ORDER BY d.section) AS sections,
+  max(d.sale_at_utc)                                  AS latest_sale_at
+FROM dedup d
+LEFT JOIN public.sg_events_canonical sgc ON sgc.sg_event_id = d.sg_event_id
+GROUP BY d.tevo_event_id, d.sg_event_id;
+
+REVOKE ALL ON public.v_sg_broker_sales_by_event FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON public.v_sg_broker_sales_by_event TO service_role;
+
+COMMENT ON VIEW public.v_sg_broker_sales_by_event IS
+  'Per-event rollup of SG broker firehose sales. Mirrors v_sg_sales_by_event shape (sales_count, tickets_sold, gross_estimate, min/median/max sale_price, distinct_sections, sections, latest_sale_at). Aggregates over the deduplicated set (DISTINCT ON sg_sale_id, latest by pulled_at). Use for FE event-index "heat" signals.';


### PR DESCRIPTION
## Summary

Maps the SG broker firehose (`seatgeek_sales_snapshots`, +67k sales/hr live) into the same column shape as the existing seller-side `v_sg_sales_by_section` (which sources the dormant 400-row `seatgeek_orders`). Future FE views can UNION both through one renderer without per-source column translation.

Per operator directive 2026-05-16: "for now map the sales columns to others for use later in front end view."

## Column mapping (broker → canonical seller-side names)

| Seller-side name (`v_sg_sales_by_section`) | Broker-side source | Notes |
|---|---|---|
| `sale_quantity` | `seatgeek_sales_snapshots.quantity` | rename only |
| `sale_price` | `broadcast_price` | rename only |
| `status` | `'sold'` (constant) | broker observations are always terminal |
| `created_at_sg` | `sale_at_utc` | when the sale transacted |
| `last_status_at` | `pulled_at` | when we observed it |
| `sg_event_name`, `sg_event_date`, `sg_venue` | joined from `sg_events_canonical` | LEFT JOIN |
| `tevo_event_id`, `sg_event_id`, `section`, `row`, `delivery_method`, `stock_type` | passthrough | match seller-side names already |

Plus 5 broker-only fields exposed at the end of the projection (FE can ignore or surface in a detail panel): `sg_sale_id`, `aq_short_event_id`, `venue_short_id`, `is_instant`, `in_hand_date`, `seller_notes`.

## Correctness — DISTINCT ON is mandatory

PROJECT_BIBLE.md §3 column-landmine note says the broker firehose has an **11× typical duplication factor** (sales re-observed across polls). Verified on Yankees@Mets (today's hot event): **37,234 raw rows → 924 distinct sales = 40× for hot events**. The view uses `DISTINCT ON (sg_sale_id) ... ORDER BY sg_sale_id, pulled_at DESC` to keep the latest observation per sale.

## Test results (read-only smoke test on prod)

5 sample rows from Yankees@Mets (Citi Field, 2026-05-16):

| Section | Row | Qty | Price | Total | Delivery | Stock | In-hand |
|---|---|---|---|---|---|---|---|
| 327 | 6 | 6 | \$175.09 | \$1,050.54 | electronic | mobile | 2026-05-14 |
| 302 | 5 | 4 | \$146.33 | \$585.32 | electronic | mobile | 2026-05-14 |
| 101 | 9 | 2 | \$138.34 | \$276.68 | electronic | mobile | 2026-05-14 |
| 126 | a | 2 | \$383.00 | \$766.00 | electronic | barcode | 2026-05-09 |
| delta sky360 club hh | 2 | 2 | \$1,362.00 | \$2,724.00 | electronic | barcode | 2026-05-09 |

All event-header fields populate from the LEFT JOIN. All 5 have `aq_short_event_id` set. `sale_total_estimate` arithmetic verified.

## Lane / sequencing

- D2 authored the migration.
- **A1 to apply via `apply_migration` once approved** — view creation is a DDL change, gated per CLAUDE.md §1 + PROJECT_BIBLE.md §7.
- Not applied to prod yet; this PR is the apply request.

## What this does NOT change

- `v_sg_sales_by_section` (existing seller-side view) — untouched.
- `seatgeek_sales_snapshots` table — only read.
- D2 dashboard code — view is FE-ready but not wired yet. Operator/D2 wire it when the FE view ships.

## Test plan

- [x] Schema + column names verified against PROJECT_BIBLE.md §3 landmines (`sale_at_utc`, `broadcast_price`, `pulled_at`).
- [x] DISTINCT ON dedup verified (37,234 → 924 on Yankees@Mets).
- [x] LEFT JOIN to `sg_events_canonical` returns event_name/date/venue for all 5 sample rows.
- [ ] (post-apply) `SELECT count(*) FROM v_sg_broker_sales_by_section` should be ~10-50k (all distinct sg_sale_ids across all events).
- [ ] (post-apply) Per-event filter: `SELECT * FROM v_sg_broker_sales_by_section WHERE sg_event_id=17693787 LIMIT 5` returns the rows above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)