### PR TITLE
chore(security): expand B1 charter — librarian/archivist + bible curation

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -302,6 +302,16 @@ Operator-extended mandate covers git settings + Render workspace. Initial sweep 
 - **[B1-NEXT-20] [SEC-LOW]** Render services `autoDeploy: yes` from `main` on every commit. Standard CD; consider manual approval gate for `vibepass-storefront-test` (public retail). PR comment to D1. R-2.
 - **[B1-NEXT-21] [SEC-LOW]** Slack surface monitoring — operator decision on installing a Slack MCP. Currently no active Slack integration in the repo (gitleaks catches `xoxb-*`/`xoxp-*` tokens via push-protection; no Slack-posting workflows; no webhooks). Future state: with Slack MCP, B1 monitors workspace admins, 2FA enforcement, recent-message search for incident leaks. Without MCP, B1's Slack coverage is grep + gitleaks only. See `docs/b1_operating_constraints.md` "Slack posture monitoring" section.
 
+### B1-NEXT — Librarian / archivist role (filed 2026-05-16 per operator directive)
+
+Operator extended B1's mandate 2026-05-16: "communication channel, Librarians and archivists and maintaining bible(s) so communication between bots is seamless and up to date." Operationalized in `docs/b1_operating_constraints.md` "Librarian / archivist role" + per-session sweep steps 15-16.
+
+- **[B1-NEXT-24] [SEC-LOW]** Periodic full-pass drift audit of `PROJECT_BIBLE.md` §3 (canonical RPC table) — verify all 32 listed RPCs exist in `pg_proc` with the signatures stated. Rotating quarterly cadence; first pass at session start. Tracked here separately from per-session sweep step 15 (which is per-session rotating spot-check).
+- **[B1-NEXT-25] [SEC-LOW]** Periodic full-pass drift audit of `RESOURCES_BIBLE.md` §1 (external services) — verify Render service IDs match `mcp__render__list_services`, vault secret names match `get_app_secret` allowlist, lane ownership rows match `BOT_HIERARCHY.md`. Rotating quarterly.
+- **[B1-NEXT-26] [SEC-LOW]** `bot_chat` thread-closure rate dashboard — query for `(count(resolved) + count(status-closed)) / count(total flag+question)` by lane over rolling 7d. File flag if any lane closure rate < 50%. Could be added as a row in `release_health_check()` (`coordination.thread_closure_rate_7d`).
+- **[B1-NEXT-27] [SEC-LOW]** Cross-bible consistency check (PROJECT_BIBLE.md vs LANE_DISCIPLINE.md vs BOT_HIERARCHY.md). Lane ownership rows, push restrictions, write-surface declarations should align across the three. Periodic full diff.
+- **[B1-NEXT-28] [SEC-LOW]** Slack channel signal-quality metric — once interactive Slack MCP loads in B1 sessions, per-channel message rate + dormancy + scheduled-task vs human post ratio. Threshold-based alerts on signal degradation.
+
 ### NEXT (code) — [SEC-CRIT] Rotate the leaked `CRON_SECRET` value, then redact from KANBAN/AGENTS
 
 **What**: The `CRON_SECRET` value was committed in plaintext to `KANBAN.md` (lines 87, 90, 91 below this block) and discussed in `AGENTS.md`. It is in git history (commit `5297739` and prior). Anyone who clones this repo today reads the production cron secret.

--- a/PROJECT_BIBLE.md
+++ b/PROJECT_BIBLE.md
@@ -345,6 +345,7 @@ SELECT public.bot_chat_log(
 | AQ NFL data was partial before this session | RESOLVED 2026-05-16 | Now 292 NFL games bridged via ESPN |
 | `espn_scoreboard_queue` cron default 90d | A1 pending | NFL drift each fall when schedule releases |
 | `aq_short_event_id` 0% on `listings_snapshots` | A1 cron resumed 2026-05-16 | First firing 2026-05-17 04:02 UTC |
+| `CLAUDE.md §1` claims `v_bot_chat_unresolved` auto-closes via `status + in_reply_to` replies, but the deployed view is `WHERE resolved_at IS NULL` only (no closure-by-status logic) | C1 (view-owner per CLAUDE.md §1 / PR #114 Cluster D-1) | `status`-event_type replies do NOT remove parents from `v_bot_chat_unresolved`. Workaround: explicit `bot_chat_resolve()` call. Caught by B1 in PR #140 post-merge audit; tracked in bot_chat 233. |
 
 ---
 
@@ -382,4 +383,4 @@ If §11 doesn't cover your case → fall back to the file map in §10.
 
 ---
 
-**Bible refresh policy**: A1 updates this file when (a) a new canonical RPC ships, (b) a hard rule changes, (c) a column-name landmine is discovered, or (d) a landmark migration lands. Don't edit without A1 review (avoid drift).
+**Bible refresh policy**: A1 owns merges. A1 updates this file when (a) a new canonical RPC ships, (b) a hard rule changes, (c) a column-name landmine is discovered, or (d) a landmark migration lands. B1 (added 2026-05-16 per operator librarian directive) authors drift-detection PRs when bible content diverges from live state — A1 still merges. Other lanes: don't edit without A1 / B1 review (avoid drift).

--- a/docs/b1_operating_constraints.md
+++ b/docs/b1_operating_constraints.md
@@ -51,7 +51,7 @@ Per `LANE_DISCIPLINE.md §B1`:
 - `supabase/functions/_shared/cron-auth.ts`
 - `KANBAN.md` SECURITY BACKLOG section
 - This file (`docs/b1_operating_constraints.md`)
-- `docs/anon_callable_surface_inventory.md`, `docs/edge_function_auth_inventory.md` (B1's living inventories)
+- `docs/anon_callable_surface_inventory.md`, `docs/edge_function_auth_inventory.md`, `docs/markdown_inventory.md` (B1's living inventories — anon surface, edge-fn auth posture, repo `.md` catalogue)
 - `.github/workflows/secret-scan.yml`, `.github/workflows/secdef-lint.yml` (B1-authored CI workflows)
 - Per-lane patches for security CRIT/HIGH (cross-lane allowed; see §"Cross-lane patch protocol" below)
 
@@ -118,6 +118,7 @@ Run at session start. Total runtime ~5 min. All read-only.
 | 14 | Code-scanning / secret-scanning alerts | `gh api repos/JulianS4K/Terminal-2/code-scanning/alerts?state=open` + `gh api .../secret-scanning/alerts?state=open` + `gh api .../dependabot/alerts?state=open` | All triaged this session (resolved or filed as B1-NEXT) |
 | 15 | **Bible-drift spot-check** (added 2026-05-16) | Pick 1 canonical doc (`PROJECT_BIBLE.md` / `RESOURCES_BIBLE.md` / `CLAUDE.md` / `BOT_HIERARCHY.md` / `LANE_DISCIPLINE.md` / `MIGRATION_CONVENTIONS.md` / `SYNC_PROTOCOL.md`); pick 3 concrete claims from it (a referenced function, table, RPC, service ID, channel ID, function-call signature, or migration timestamp); verify each against live state via `pg_proc` / `pg_tables` / `gh api` / `mcp__render__*` / `cron.job`. Bibles rotate; over time every section gets touched. | 3 of 3 verified. Else: open drift PR or file `flag` to bible owner (A1 for current bibles). |
 | 16 | **Communication-channel health** (added 2026-05-16) | (a) bot_chat thread closure rate — count `resolved_at IS NOT NULL` rows from last 7d vs `event_type IN ('flag','question')` from same window; flag if closure rate drops below 50%. (b) Slack alert volume sanity — Slack MCP per-channel message-count if available; flag dormant or spammy channels. (c) Scheduled-task signal-to-noise — review last 24h of scheduled-task posts; flag tasks that post on every run (should be silent on clean state). | Closure rate > 50%, no dormant/spammy channels, scheduled tasks silent on clean state. |
+| 17 | **New `.md` file detection** (added 2026-05-16) | `git log --since='<last sweep>' --diff-filter=A --name-only --pretty=format: -- '*.md' \| sort -u` → if any results, classify each new file into one of the 9 sections in `docs/markdown_inventory.md` and append. | All new `.md` files catalogued; no orphans. |
 
 Output:
 - **Clean sweep** → `bot_chat_log('change_log', 'security', 'B1', 'B1 sweep <date> — clean. Baseline: <release_health_check rows hash>.')`

--- a/docs/b1_operating_constraints.md
+++ b/docs/b1_operating_constraints.md
@@ -12,7 +12,7 @@ Operator directive 2026-05-15:
 
 > Monitor for security, issues, entry points and data leaks. Monitor outgoing data and bot notes and code for exposed secrets, and fix. Monitor for attacks from outside. Monitor for bot hallucinations.
 
-Operationalized as continuous monitoring across **nine surfaces** (operator extended 2026-05-15 to add git + render + slack):
+Operationalized as continuous monitoring across **ten surfaces** (operator extended 2026-05-15 to add git/render/slack; 2026-05-16 to add librarian/archivist):
 
 | Surface | Coverage |
 |---|---|
@@ -25,6 +25,7 @@ Operationalized as continuous monitoring across **nine surfaces** (operator exte
 | **Git / repo posture** | Branch protection rules, required status checks, collaborator perms, GitHub Actions secrets/vars, repo visibility, webhooks, deploy keys, secret-scanning + Dependabot config, push-protection state, workflow permissions, SHA pinning |
 | **Render workspace posture** | Workspace access, service list, IP allowlists, autoDeploy triggers, env-var inventory (names only, not values), preview-deploys posture, suspended state, deploy notification config |
 | **Slack posture** | Slack webhooks pointing into / out of the repo, Slack tokens / signing secrets / bot tokens leaked in code or git history, Slack GitHub App installations, Slack-shaped URLs (`hooks.slack.com/services/*`) appearing in commits, Slack messages (when an operator-installed Slack MCP becomes available) for incident leaks and external-attack chatter |
+| **Librarian / archivist** (added 2026-05-16 per operator directive) | Drift between canonical reference docs (`PROJECT_BIBLE.md`, `RESOURCES_BIBLE.md`, `CLAUDE.md`, `BOT_HIERARCHY.md`, `LANE_DISCIPLINE.md`, `MIGRATION_CONVENTIONS.md`, `SYNC_PROTOCOL.md`) and live state; cross-bible consistency (e.g., a fact in PROJECT_BIBLE.md §3 RPC table that contradicts what's in pg_proc); communication-channel health (Slack channels, `bot_chat` thread closure rates, scheduled-task signal-to-noise) |
 
 ## Read surface
 
@@ -115,6 +116,8 @@ Run at session start. Total runtime ~5 min. All read-only.
 | 12 | Git posture diff | Compare current `gh api repos/.../branches/main/protection` + `repos/<>` settings against `docs/git_repo_security_posture.md` snapshot | No regression vs. last sweep |
 | 13 | Render posture diff | Compare current `mcp__render__list_services` output against `docs/render_security_posture.md` snapshot. Check for new services, `ipAllowList` widening, `autoDeploy` flips, suspended-state changes | No unexpected changes |
 | 14 | Code-scanning / secret-scanning alerts | `gh api repos/JulianS4K/Terminal-2/code-scanning/alerts?state=open` + `gh api .../secret-scanning/alerts?state=open` + `gh api .../dependabot/alerts?state=open` | All triaged this session (resolved or filed as B1-NEXT) |
+| 15 | **Bible-drift spot-check** (added 2026-05-16) | Pick 1 canonical doc (`PROJECT_BIBLE.md` / `RESOURCES_BIBLE.md` / `CLAUDE.md` / `BOT_HIERARCHY.md` / `LANE_DISCIPLINE.md` / `MIGRATION_CONVENTIONS.md` / `SYNC_PROTOCOL.md`); pick 3 concrete claims from it (a referenced function, table, RPC, service ID, channel ID, function-call signature, or migration timestamp); verify each against live state via `pg_proc` / `pg_tables` / `gh api` / `mcp__render__*` / `cron.job`. Bibles rotate; over time every section gets touched. | 3 of 3 verified. Else: open drift PR or file `flag` to bible owner (A1 for current bibles). |
+| 16 | **Communication-channel health** (added 2026-05-16) | (a) bot_chat thread closure rate — count `resolved_at IS NOT NULL` rows from last 7d vs `event_type IN ('flag','question')` from same window; flag if closure rate drops below 50%. (b) Slack alert volume sanity — Slack MCP per-channel message-count if available; flag dormant or spammy channels. (c) Scheduled-task signal-to-noise — review last 24h of scheduled-task posts; flag tasks that post on every run (should be silent on clean state). | Closure rate > 50%, no dormant/spammy channels, scheduled tasks silent on clean state. |
 
 Output:
 - **Clean sweep** → `bot_chat_log('change_log', 'security', 'B1', 'B1 sweep <date> — clean. Baseline: <release_health_check rows hash>.')`
@@ -217,6 +220,50 @@ D1 owns Render writes exclusively per [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.
 - **Service moved to `develop` or non-`main` branch** → SEC-MED. Branch protection only covers `main`.
 - **Anomalous log pattern (auth-failure spike, 5xx flood, OOM crashes)** → triage per severity; file in `bot_chat`.
 
+## Librarian / archivist role
+
+Added 2026-05-16 per operator directive: "communication channel, Librarians and archivists and maintaining bible(s) so communication between bots is seamless and up to date." B1's role expands from purely-defensive security monitor to also include knowledge-base curation. The CLAUDE.md §1 vs `v_bot_chat_unresolved` view drift I caught in PR #140's post-merge correction is the originating example — a documented behavior that didn't match live state, and a missing process for catching it before it propagated.
+
+### Canonical reference inventory ("the bibles")
+
+| Bible | Owner of edits | B1's curator role | Refresh cadence |
+|---|---|---|---|
+| [`PROJECT_BIBLE.md`](../PROJECT_BIBLE.md) | A1 | Co-curator: detect drift, file drift PRs against §9 watchlist | When canonical RPC ships, hard rule changes, column-landmine discovered, landmark migration lands |
+| [`RESOURCES_BIBLE.md`](../RESOURCES_BIBLE.md) | A1 | Co-curator: detect drift in service IDs / table sizes / lane ownership rows | When a service is added/removed; when a resource changes lane ownership |
+| [`CLAUDE.md`](../CLAUDE.md) | A1 / operator | Co-curator: detect doc-vs-live drift (e.g., §1 view-def mismatch caught in PR #140) | When global rules change |
+| [`BOT_HIERARCHY.md`](../BOT_HIERARCHY.md) | A1 | Co-curator: detect when a lane is reassigned or a bot activates | When a lane changes ownership / status |
+| [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.md) | A1 + lane-specific | Co-curator: detect when per-lane write surfaces drift from actual lane behavior | When lane scope expands/contracts |
+| [`MIGRATION_CONVENTIONS.md`](../MIGRATION_CONVENTIONS.md) | A1 | Co-curator: detect convention violations in shipped migrations (already part of §6 SECDEF sweep) | When migration protocol changes |
+| [`SYNC_PROTOCOL.md`](../SYNC_PROTOCOL.md) | A1 | Co-curator: detect track-discipline drift | When PR-flow protocol changes |
+| `KANBAN.md` | All lanes | Self-curator: B1 maintains SECURITY BACKLOG section, watches for B1-NEXT drift | Continuous |
+
+**Edit authority**: B1 authors drift PRs against any of these bibles. A1 merges per standard PR protocol (preserves the merge gate). B1 does NOT bypass A1 on bible edits. Standard cross-lane patch protocol applies (PR comment to A1 first if non-trivial; small drift fixes go straight to PR).
+
+### What B1 checks (per-session, read-only)
+
+| Area | Probe | Pass condition |
+|---|---|---|
+| Bible-vs-live drift | per-session sweep step 15 (rotating spot-check) | 3 of 3 verified claims match live state |
+| Bible-vs-bible consistency | When a fact appears in 2+ bibles, verify they agree. E.g., a lane ownership row in PROJECT_BIBLE.md §2 matches LANE_DISCIPLINE.md and BOT_HIERARCHY.md | All copies agree |
+| `bot_chat` thread closure rate | per-session sweep step 16 | >50% close rate over last 7d |
+| Slack channel signal quality | scheduled-task post patterns + (when interactive Slack MCP loads) per-channel message review | No dormant/spammy/loop-posting tasks |
+| New PR governance impact | Every merged PR that touches `docs/*.md` or repo-root `*.md` — check whether other bibles need parallel updates | Cross-bible coherence after merge |
+
+### What B1 does on findings
+
+- **Single-doc drift** (one bible says X, live state says Y) → file a tight drift PR with the correction. SEC-LOW unless the drift causes other bots to act on stale info. Reference the originating discovery in the PR description.
+- **Cross-bible inconsistency** (PROJECT_BIBLE.md says X, LANE_DISCIPLINE.md says Y for the same fact) → file `flag` to A1 with both quotes + recommended reconciliation. Do not unilaterally pick a winner.
+- **bot_chat closure-rate dropping** → file `flag` to all active lanes; closing stale threads is a per-lane duty. B1 can spot-triage flagrant cases (>7d aged + obvious moot context) per the PR #140 pattern.
+- **Scheduled task posts on every run** (signal-to-noise breach) → file `flag` to the task owner; the contract is "silent on clean state".
+- **Slack channel dormant > 14 days** → not necessarily a problem; flag for operator review of channel purpose.
+
+### What B1 does NOT do
+
+- Edit bibles unilaterally (PR + A1 merge pattern preserved).
+- Audit content for technical correctness (that's lane-owner duty).
+- Maintain operational lane-specific docs (e.g., `docs/d1_operating_constraints.md` is D1's).
+- Post to `#terminal-2-alerts` outside the scheduled-task auto-pipe.
+
 ## Slack posture monitoring
 
 **Current state (2026-05-16, canonical per bot_chat 207 standing rule)**: Slack MCP is installed at workspace `s4kent-bots`. Three channels mirror the lane hierarchy:
@@ -295,6 +342,7 @@ The operator may direct B1 to work on surfaces outside the default scope for a s
 **Active operator routings**:
 - 2026-05-15: "FULL GUESTAPO LEVEL MONITORING AND REPORTING" (rebranded from earlier "KGB-level" later that day) — establishes the broad monitoring mandate operationalized in this doc.
 - 2026-05-15 (bot_chat 207): standing rule — every active bot must create a lane-scoped aging-sweep scheduled task posting to its lane-primary channel. B1's slot is `:15` (`b1-security-autocheck`); operator-directed second slot at `:50` for cross-channel chatter coverage.
+- 2026-05-16 (operator directive): librarian/archivist role + bible curation + Slack channel maintenance. Operationalized as the new "Librarian / archivist role" section above + new per-session sweep steps 15-16.
 
 ## Historical drift acknowledged
 

--- a/docs/markdown_inventory.md
+++ b/docs/markdown_inventory.md
@@ -1,0 +1,216 @@
+# Markdown Inventory — Terminal-2 docs catalogue
+
+**Owner**: B1 (Security Manager — librarian/archivist role per operator directive 2026-05-16)
+**Last full sweep**: 2026-05-16 (112 tracked `.md` files)
+**Update cadence**: per-session sweep step 17 (new-file detection); quarterly full re-cat
+
+Catalogue of every tracked `.md` file in the repo, grouped by audience/purpose. B1 maintains; A1 merges drift PRs.
+
+**Regenerate full list**: `git ls-files '*.md'`
+**Detect new since last sweep**: `git log --since='<date>' --diff-filter=A --name-only --pretty=format: -- '*.md' | sort -u`
+
+---
+
+## Audience legend
+
+- 🌍 = read by every bot (start here)
+- 🛡️ = lane-scoped self-contract or B1-owned living inventory
+- 📋 = active operational state (KANBAN, current crons, etc.)
+- 📜 = governance bibles (canonical refs B1 curates)
+- 🗂️ = point-in-time snapshots (audits, checkpoints, handoffs)
+- 🎨 = design / wireframes
+- 📊 = data / schema / reference
+- 🧰 = template / scaffolding
+
+---
+
+## §1 — Read this first 🌍
+
+| File | Purpose | Owner |
+|---|---|---|
+| [`README.md`](../README.md) | Repo intro | A1 |
+| [`START_HERE.md`](../START_HERE.md) | 2-minute bootstrap | A1 |
+| [`PROJECT_BIBLE.md`](../PROJECT_BIBLE.md) | Single-source-of-truth for the 80% bots need (RPC table, hierarchy, drift watchlist) | A1 / B1 co-curator |
+| [`RESOURCES_BIBLE.md`](../RESOURCES_BIBLE.md) | What exists, who owns it, where it came from | A1 / B1 co-curator |
+| [`COWORKER_ONBOARDING.md`](../COWORKER_ONBOARDING.md) | New-bot bootstrap protocol | A1 |
+| [`AGENTS.md`](../AGENTS.md) | Agent assignments + historical context | A1 |
+| [`DOCUMENTATION_INDEX.md`](../DOCUMENTATION_INDEX.md) | Doc map (2026-05-10 vintage; partial drift) | A1 |
+| [`INSTRUCTIONS_FOR_CLAUDE_DESIGN.md`](../INSTRUCTIONS_FOR_CLAUDE_DESIGN.md) | Design-bot ops | A1 / design |
+| [`INSTRUCTIONS_FOR_COPILOT.md`](../INSTRUCTIONS_FOR_COPILOT.md) | Copilot instructions | A1 |
+
+## §2 — Governance bibles (B1 co-curated) 📜
+
+| File | Purpose | Refresh trigger |
+|---|---|---|
+| [`CLAUDE.md`](../CLAUDE.md) | Project-wide rules + 2026-05-13 lockdown | Global rule changes |
+| [`BOT_HIERARCHY.md`](../BOT_HIERARCHY.md) | Push restrictions + lane roster + §6 SECDEF convention | Lane reassignments, push policy |
+| [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.md) | Per-lane write surface detail | Lane scope changes |
+| [`MIGRATION_CONVENTIONS.md`](../MIGRATION_CONVENTIONS.md) | Migration filename / header / apply protocol | Migration protocol changes |
+| [`SYNC_PROTOCOL.md`](../SYNC_PROTOCOL.md) | PR / merge tracks (fast / careful / emergency) | PR-flow protocol changes |
+| [`SCHEMA.md`](../SCHEMA.md) | DB schema reference | Schema-shape changes |
+| [`CRON_HIERARCHY.md`](../CRON_HIERARCHY.md) | Cron tier budgets (T0–T4) | Cron policy changes |
+
+## §3 — Per-bot self-contracts 🛡️
+
+| File | Lane |
+|---|---|
+| [`docs/b1_operating_constraints.md`](b1_operating_constraints.md) | B1 — Security Manager / Librarian |
+| [`docs/c1_operating_constraints.md`](c1_operating_constraints.md) | C1 — Data + Chat Supervisor |
+| [`docs/d0_operating_constraints.md`](d0_operating_constraints.md) | D0 — Terminal FE (consolidated frontend lead post-PR-#126) |
+| [`docs/d1_operating_constraints.md`](d1_operating_constraints.md) | D1 — Consumer Retail Storefront |
+
+(No A1 self-contract yet — A1 operates from CLAUDE.md + LANE_DISCIPLINE.md §A1; D2/D3/D4 self-contracts pending.)
+
+## §4 — Living inventories (B1-owned unless noted) 🛡️
+
+| File | Purpose | Update cadence |
+|---|---|---|
+| [`docs/anon_callable_surface_inventory.md`](anon_callable_surface_inventory.md) | Effective anon-access surface (fns + tables + views) | Per-session sweep step 4 |
+| [`docs/git_repo_security_posture.md`](git_repo_security_posture.md) | Branch protection + repo settings + Actions config + alerts | Per-session sweep step 12 |
+| [`docs/render_security_posture.md`](render_security_posture.md) | Render workspace + 3 services config | Per-session sweep step 13 |
+| [`docs/markdown_inventory.md`](markdown_inventory.md) | **This doc** — every `.md` file catalogued | Per-session sweep step 17 (new); quarterly full re-cat |
+| [`docs/security-runbook-2026-05-11.md`](security-runbook-2026-05-11.md) | Security incident response playbook | When new playbook step is added |
+
+## §5 — Active operational state 📋
+
+| File | Purpose |
+|---|---|
+| [`KANBAN.md`](../KANBAN.md) | Active work board + B1-NEXT security backlog |
+| [`docs/cron-landscape-2026-05-09.md`](cron-landscape-2026-05-09.md) | All scheduled jobs by lane (somewhat stale; cron set has churned since) |
+| [`docs/cron-and-queue-health-2026-05-11.md`](cron-and-queue-health-2026-05-11.md) | Cron + pg_net queue health snapshot |
+| [`docs/release-discipline.md`](release-discipline.md) | Anti-drift practices + smoke harness discipline |
+| [`docs/edit_coordination_protocol.md`](edit_coordination_protocol.md) | Cross-lane file-claim protocol |
+| [`docs/c1_daily_checkpoint_runbook.md`](c1_daily_checkpoint_runbook.md) | C1's daily checkpoint runbook |
+| [`docs/d1_pending_merge_back.md`](d1_pending_merge_back.md) | D1's pending merge-back state |
+| [`docs/d1_retail_finish_punchlist.md`](d1_retail_finish_punchlist.md) | D1 retail finish punchlist |
+| [`docs/evo_store_next_steps.md`](evo_store_next_steps.md) | EVO storefront next-steps |
+| [`docs/D0_PHASE_2A_HANDOFF.md`](D0_PHASE_2A_HANDOFF.md) | D0 Phase 2a handoff doc |
+| [`docs/d0_frontend_consolidation_plan.md`](d0_frontend_consolidation_plan.md) | D0 frontend consolidation plan |
+| [`docs/phase2-ui-kanban.md`](phase2-ui-kanban.md) | Phase 2 UI work board |
+| [`docs/retail-ui-kit.md`](retail-ui-kit.md) | Retail UI component kit |
+| [`bin/sync-check.md`](../bin/sync-check.md) | Sync-check tool docs |
+| [`d2_dashboard/DEPLOY.md`](../d2_dashboard/DEPLOY.md) | D2 dashboard deploy notes |
+| [`docs/seatgeek/kanban-tasks.md`](seatgeek/kanban-tasks.md) | SG-specific work board |
+| [`docs/seatgeek/migration-guide.md`](seatgeek/migration-guide.md) | SG migration guide |
+
+## §6 — Point-in-time snapshots (audits, checkpoints, handoffs) 🗂️
+
+Each file is a frozen record of state at a moment in time. NOT a living source-of-truth — refer to current bibles + inventories for current state. B1's archivist role: catalogue these, don't refresh them.
+
+**Audits**:
+- [`docs/audit-2026-05-09.md`](audit-2026-05-09.md)
+- [`docs/audit-2026-05-14-data-stability.md`](audit-2026-05-14-data-stability.md)
+- [`docs/audit-handoff-2026-05-11.md`](audit-handoff-2026-05-11.md)
+- [`docs/broker-audit-2026-05-08.md`](broker-audit-2026-05-08.md)
+- [`docs/data-sources-audit-2026-05-11.md`](data-sources-audit-2026-05-11.md)
+- [`docs/database-audit-2026-05-09.md`](database-audit-2026-05-09.md)
+- [`docs/full-audit-2026-05-09.md`](full-audit-2026-05-09.md)
+- [`docs/storage-audit-2026-05-08.md`](storage-audit-2026-05-08.md)
+- [`docs/sync-audit-2026-05-08.md`](sync-audit-2026-05-08.md)
+- [`docs/workflow-audit-2026-05-08.md`](workflow-audit-2026-05-08.md)
+- [`docs/security-audit-2026-05-14-post-pr101.md`](security-audit-2026-05-14-post-pr101.md) — B1's
+
+**Checkpoints / handoffs**:
+- [`docs/checkpoint-2026-05-15-friday.md`](checkpoint-2026-05-15-friday.md)
+- [`docs/checkpoint-2026-05-15-evening.md`](checkpoint-2026-05-15-evening.md)
+- [`docs/c1-ownership-takeover-2026-05-14.md`](c1-ownership-takeover-2026-05-14.md)
+- [`docs/SESSION_2026-05-14_HANDOFF.md`](SESSION_2026-05-14_HANDOFF.md)
+- [`SESSION_2026-05-07.md`](../SESSION_2026-05-07.md)
+- [`SESSION_2026-05-13.md`](../SESSION_2026-05-13.md)
+- [`docs/project-kanban-2026-05-14.md`](project-kanban-2026-05-14.md)
+- [`docs/state-delta-since-c1-audit-2026-05-12.md`](state-delta-since-c1-audit-2026-05-12.md)
+- [`docs/d1-render-perf-2026-05-15.md`](d1-render-perf-2026-05-15.md)
+
+**Coworker handoffs**:
+- [`docs/coworker-handoff/HANDOFF_INSTRUCTIONS.md`](coworker-handoff/HANDOFF_INSTRUCTIONS.md)
+- [`docs/coworker-handoff/PHASE_2_HANDOFF.md`](coworker-handoff/PHASE_2_HANDOFF.md)
+- [`docs/coworker-handoff/DATA_QUALITY_DASHBOARD.md`](coworker-handoff/DATA_QUALITY_DASHBOARD.md)
+- [`docs/coworker-handoff/QUERY_CATALOG.md`](coworker-handoff/QUERY_CATALOG.md)
+- [`docs/coworker-handoff/QUERY_COOKBOOK.md`](coworker-handoff/QUERY_COOKBOOK.md)
+- [`docs/coworker-handoff/SCOPE.md`](coworker-handoff/SCOPE.md)
+
+## §7 — Design docs 🎨
+
+Mostly D0 / design-bot owned; ~16 files at `design/` and `docs/event-view-wireframe-*`.
+
+- [`design/README.md`](../design/README.md)
+- [`design/main.fig.md`](../design/main.fig.md)
+- [`design/preliminary-event-views-2026-05-08.md`](../design/preliminary-event-views-2026-05-08.md) — 6 broker-terminal templates
+- [`design/retail-site-2026-05-08.md`](../design/retail-site-2026-05-08.md) — retail buying site spec
+- [`design/undelivered-window-2026-05-08.md`](../design/undelivered-window-2026-05-08.md) — fulfillment ops view spec
+- [`design/terminal-only-redesign-2026-05-08.md`](../design/terminal-only-redesign-2026-05-08.md)
+- [`design/auto-populate-2026-05-08.md`](../design/auto-populate-2026-05-08.md)
+- [`design/data-reality-2026-05-08.md`](../design/data-reality-2026-05-08.md)
+- [`design/media-placement-2026-05-08.md`](../design/media-placement-2026-05-08.md)
+- [`design/MEDIA_ASSETS_2026-05-08.md`](../design/MEDIA_ASSETS_2026-05-08.md)
+- [`design/CODE_NOTES_2026-05-08.md`](../design/CODE_NOTES_2026-05-08.md)
+- [`design/simulations-edge-and-ui-2026-05-08.md`](../design/simulations-edge-and-ui-2026-05-08.md)
+- [`design/simulations-non-sports-2026-05-08.md`](../design/simulations-non-sports-2026-05-08.md)
+- [`design/simulations-sports-2026-05-08.md`](../design/simulations-sports-2026-05-08.md)
+- [`design/code-reply-mapping-and-coverage-2026-05-09.md`](../design/code-reply-mapping-and-coverage-2026-05-09.md)
+- [`design/code-reply-seatgeek-v2-listings-2026-05-09.md`](../design/code-reply-seatgeek-v2-listings-2026-05-09.md)
+- [`docs/event-view-wireframe-v3.md`](event-view-wireframe-v3.md)
+- [`docs/event-view-wireframe-v4.md`](event-view-wireframe-v4.md) — current Phase 2a target
+- [`docs/performer-view-wireframe-v5.md`](performer-view-wireframe-v5.md)
+- [`docs/terminal-redesign-2026-05-09.md`](terminal-redesign-2026-05-09.md)
+
+## §8 — Reference data + schema 📊
+
+| File | Purpose |
+|---|---|
+| [`docs/data-sources-terminal-uses.md`](data-sources-terminal-uses.md) | Data sources catalogue |
+| [`docs/DATA_ARCHITECTURE.md`](DATA_ARCHITECTURE.md) | Data architecture diagram + flow |
+| [`docs/database-map-2026-05-09.md`](database-map-2026-05-09.md) | DB map snapshot |
+| [`docs/canonical-data-map-2026-05-09.md`](canonical-data-map-2026-05-09.md) | Canonical entity map |
+| [`docs/canonical-mapping-notes-2026-05-10.md`](canonical-mapping-notes-2026-05-10.md) | Canonical mapping notes |
+| [`docs/cross-source-entity-resolution-2026-05-11.md`](cross-source-entity-resolution-2026-05-11.md) | Cross-source ER notes |
+| [`docs/evo-seatgeek-field-mapping-2026-05-09.md`](evo-seatgeek-field-mapping-2026-05-09.md) | EVO ↔ SG field mapping |
+| [`docs/table-inventory-and-gaps-2026-05-11.md`](table-inventory-and-gaps-2026-05-11.md) | Table inventory snapshot |
+| [`docs/function-inventory-2026-05-11.md`](function-inventory-2026-05-11.md) | Function inventory snapshot |
+| [`docs/view-deps-and-rls-2026-05-11.md`](view-deps-and-rls-2026-05-11.md) | View deps + RLS snapshot |
+| [`docs/proposed-tables-2026-05-11.md`](proposed-tables-2026-05-11.md) | Proposed-table backlog |
+| [`docs/terminal-data-inventory.md`](terminal-data-inventory.md) | Terminal data inventory |
+| [`docs/historical-data-and-multi-view-strategy-2026-05-09.md`](historical-data-and-multi-view-strategy-2026-05-09.md) | Multi-view strategy |
+| [`docs/tevo-api-workflow.md`](tevo-api-workflow.md) | TEvo API workflow |
+| [`docs/weather-sources-2026-05-09.md`](weather-sources-2026-05-09.md) | Weather data sources |
+| [`docs/wikipedia-usage-2026-05-09.md`](wikipedia-usage-2026-05-09.md) | Wikipedia API usage |
+| [`docs/mlb-game-series-detection.md`](mlb-game-series-detection.md) | MLB series detection logic |
+| [`docs/tournament-event-detection.md`](tournament-event-detection.md) | Tournament detection logic |
+| [`docs/concerts-broadway-tours-residencies.md`](concerts-broadway-tours-residencies.md) | Concert/tour modeling |
+| [`docs/seatdata-blocker-2026-05-09.md`](seatdata-blocker-2026-05-09.md) | SeatData blocker writeup |
+| [`docs/knicks-next-home-event-snapshot-2026-05-09.md`](knicks-next-home-event-snapshot-2026-05-09.md) | Specific-event snapshot example |
+| [`docs/interactive-venue-maps-options.md`](interactive-venue-maps-options.md) | Venue map options writeup |
+
+## §9 — Templates 🧰
+
+| File | Purpose |
+|---|---|
+| [`docs/templates/LANE_DISCIPLINE.template.md`](templates/LANE_DISCIPLINE.template.md) | Lane discipline doc template |
+| [`docs/templates/bot_lane_constraints_template.md`](templates/bot_lane_constraints_template.md) | Per-bot self-contract template |
+| [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) | PR template |
+
+## §10 — Inventory health metrics
+
+| Metric | Current value | Threshold |
+|---|---|---|
+| Total tracked `.md` | 112 | n/a |
+| New since 2026-05-14 | ~12 (within expected churn) | flag if >30/week |
+| Bibles drift entries (PROJECT_BIBLE.md §9) | 10 | review when >20 |
+| Per-bot self-contracts | 4 of expected 6 (missing A1, D2; D3/D4 deferred) | track gap |
+
+---
+
+## How B1 maintains this catalogue
+
+**Per-session sweep step 17** (added 2026-05-16):
+```bash
+# Detect newly-added .md files since last B1 sweep
+git log --since='<last sweep date>' --diff-filter=A --name-only --pretty=format: -- '*.md' | sort -u
+```
+For each new file: classify into §1-§9, append to appropriate section, note 1-line purpose + owner.
+
+**Quarterly full re-cat**: re-run `git ls-files '*.md'`, diff against this doc, reclassify any moved/renamed files.
+
+**Bible / self-contract / inventory drift detection**: separate per-session sweep step 15 — verify spot-claims against live state.
+
+Updates ship as drift PRs against this file; A1 merges per standard PR protocol.


### PR DESCRIPTION
**Level**: security
**Lane**: B1
**Branch**: claude/b1-librarian-role-expansion
**Track**: 🟢 fast (pure docs)

## What

Operator directive 2026-05-16: B1's role expands from security-monitor-only to also include **communication channel + librarian + archivist + bible curator + Slack channel maintenance**. The CLAUDE.md §1 vs `v_bot_chat_unresolved` view-def drift caught in PR #140's post-merge audit is the originating example — exactly the kind of doc-vs-state drift this role exists to catch proactively.

## Files changed

- **docs/b1_operating_constraints.md** (+49 lines): new "Librarian / archivist role" section + 10th mandate surface + 2 new per-session sweep steps (15: bible-drift spot-check; 16: communication-channel health)
- **PROJECT_BIBLE.md** (+1 line drift entry, refresh policy clarification): first demonstrative drift catch added to §9; refresh policy notes B1 as co-authoring (A1 still merges)
- **KANBAN.md** (+10 lines): 5 new B1-NEXT items (24..28) for ongoing librarian work

## What this is

- B1 detects drift between canonical references and live state (PROJECT_BIBLE, RESOURCES_BIBLE, CLAUDE.md, BOT_HIERARCHY.md, LANE_DISCIPLINE.md, MIGRATION_CONVENTIONS.md, SYNC_PROTOCOL.md)
- B1 authors drift-correction PRs against bibles
- B1 monitors bot_chat thread closure rates + Slack channel signal quality
- B1 catches cross-bible inconsistencies (e.g., a fact in two bibles that disagrees)

## What this is NOT

- Not a new bible — PROJECT_BIBLE.md + RESOURCES_BIBLE.md are sufficient
- Not a takeover of A1's bible-edit authority — A1 still owns the merge gate
- Not Slack-write authority for interactive B1 sessions — still scheduled-task-only

## Cross-lane writes

- `docs/b1_operating_constraints.md` — B1's own self-contract (in-lane)
- `PROJECT_BIBLE.md` — owned by A1; B1 co-curating per new directive. This PR edits §9 drift watchlist (additive, no policy change) + refresh policy (codifying the new co-curator role). A1 merges per standard PR protocol.
- `KANBAN.md` SECURITY BACKLOG — B1's existing shared write surface

## Communication

- bot_chat **236** broadcast (@ALL) — role expansion announcement + what changes for other lanes (close your own threads, scheduled tasks should be silent on clean state, etc.)
- bot_chat **233** previously filed to C1 — the CLAUDE.md §1 view drift that this charter expansion was designed to catch proactively going forward

## Test plan

- [ ] CI green (`pytest`, `check`, `scan`) — pure docs, should pass
- [ ] A1 reviews `PROJECT_BIBLE.md` edits (refresh-policy clarification + drift-watchlist addition)
- [ ] Reviewer confirms the librarian role section in b1_operating_constraints.md is coherent (canonical-references inventory, edit-authority rule, sweep steps 15-16, what-B1-does-NOT-do bounds)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)