### PR TITLE
feat(d0): Phase 2a Event Detail — v2 RPC + 6 new panels

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -17,9 +17,9 @@
     <span id="status" class="status">Loading…</span>
   </header>
 
-  <main class="wrap">
+  <main class="wrap event">
     <section id="hero">
-      <div>
+      <div class="hero-main">
         <h1 class="title" id="evTitle">—</h1>
         <p class="meta">
           <span id="evVenue">—</span>
@@ -27,6 +27,8 @@
           <span id="evDate">—</span>
         </p>
         <div class="badges" id="evBadges"></div>
+      </div>
+      <div class="hero-side">
         <div class="coverage" id="coverage">
           <span class="lbl">COVERAGE</span>
           <span class="light" data-src="tevo"     title="TEvo"></span>
@@ -34,25 +36,81 @@
           <span class="light" data-src="seatdata" title="SeatData"></span>
           <span class="light" data-src="espn"     title="ESPN"></span>
         </div>
+        <div class="freshness" id="freshness">
+          <span class="fr-chip" data-src="tevo">TEvo —</span>
+          <span class="fr-chip" data-src="sg-lst">SG L —</span>
+          <span class="fr-chip" data-src="sg-sales">SG S —</span>
+          <span class="fr-chip" data-src="weather">Wx —</span>
+          <span class="fr-chip" data-src="espn">ESPN —</span>
+        </div>
+        <div class="event-mode" id="eventMode"></div>
       </div>
     </section>
 
-    <section id="kpi">
-      <div class="kpi-label">OWNED PREMIUM PCT</div>
-      <div class="kpi-value" id="kpiVal">—</div>
-      <div class="kpi-sub"   id="kpiSub">our asks vs market not us</div>
+    <section id="kpi-grid">
+      <div class="kpi-cell" id="kpiOwnedPremium">
+        <span class="kpi-lbl">OWNED PREMIUM %</span>
+        <span class="kpi-val" id="kpiOwnedPremiumVal">—</span>
+        <span class="kpi-sub" id="kpiOwnedPremiumSub">our asks vs market</span>
+      </div>
+      <div class="kpi-cell" id="kpiRetailMedian">
+        <span class="kpi-lbl">RETAIL MEDIAN</span>
+        <span class="kpi-val" id="kpiRetailMedianVal">—</span>
+        <span class="kpi-sg"  id="kpiRetailMedianSG"></span>
+      </div>
+      <div class="kpi-cell" id="kpiQtyAvailable">
+        <span class="kpi-lbl">QTY AVAILABLE</span>
+        <span class="kpi-val" id="kpiQtyAvailableVal">—</span>
+        <span class="kpi-sg"  id="kpiQtyAvailableSG"></span>
+      </div>
+      <div class="kpi-cell" id="kpiQtyOwned">
+        <span class="kpi-lbl">QTY OWNED</span>
+        <span class="kpi-val" id="kpiQtyOwnedVal">—</span>
+        <span class="kpi-sub" id="kpiQtyOwnedSub"></span>
+      </div>
+      <div class="kpi-cell" id="kpiGetin">
+        <span class="kpi-lbl">GET-IN</span>
+        <span class="kpi-val" id="kpiGetinVal">—</span>
+        <span class="kpi-sg"  id="kpiGetinSG"></span>
+      </div>
+      <div class="kpi-cell" id="kpiOwnedMedian">
+        <span class="kpi-lbl">OWNED MEDIAN</span>
+        <span class="kpi-val" id="kpiOwnedMedianVal">—</span>
+        <span class="kpi-sub">our retail</span>
+      </div>
+      <div class="kpi-cell" id="kpiNonownedMedian">
+        <span class="kpi-lbl">NON-OWNED MEDIAN</span>
+        <span class="kpi-val" id="kpiNonownedMedianVal">—</span>
+        <span class="kpi-sub">market without us</span>
+      </div>
+      <div class="kpi-cell" id="kpiOwnedShare">
+        <span class="kpi-lbl">OWNED SHARE</span>
+        <span class="kpi-val" id="kpiOwnedShareVal">—</span>
+        <span class="kpi-sub" id="kpiOwnedShareSub"></span>
+      </div>
     </section>
 
     <section id="chart">
       <div class="chart-title">
-        <span>PRICE &amp; INVENTORY · 7D</span>
-        <span class="legend">
-          <span><i style="background:var(--accent)"></i> Owned median</span>
-          <span><i style="background:var(--muted)"></i> Market median</span>
-          <span><i style="background:var(--info)"></i> Owned qty</span>
-        </span>
+        <span>PRICE &amp; INVENTORY · <span id="chartRangeLabel">7d</span></span>
+        <div class="chart-controls">
+          <span class="legend" id="chartLegend"></span>
+          <select id="chartRange" class="range-select">
+            <option value="6">6h</option>
+            <option value="24">24h</option>
+            <option value="72">3d</option>
+            <option value="168" selected>7d</option>
+            <option value="720">30d</option>
+            <option value="4320">ALL</option>
+          </select>
+        </div>
       </div>
       <div id="chartHost"></div>
+    </section>
+
+    <section id="splits">
+      <div class="panel-title">SPLITS — DENSITY · LAST 24H</div>
+      <div id="splitsBody"></div>
     </section>
 
     <section id="zones">
@@ -60,9 +118,38 @@
       <div id="zonesBody"></div>
     </section>
 
+    <section id="sales-tape">
+      <div class="panel-title">SALES TAPE — SEATGEEK · LAST 20</div>
+      <div id="salesTapeBody"></div>
+    </section>
+
+    <section id="espn">
+      <div class="panel-title row">
+        <span>ESPN — STANDINGS · INJURIES · RECENT</span>
+        <span class="muted small" id="espnSubtitle"></span>
+      </div>
+      <div id="espnBody"></div>
+    </section>
+
+    <section id="weather">
+      <div class="panel-title row">
+        <span>WEATHER — VENUE + FORECAST</span>
+        <span class="muted small" id="weatherSubtitle"></span>
+      </div>
+      <div id="weatherBody"></div>
+    </section>
+
     <section id="order-strip">
       <div class="panel-title">ORDERS — STATE MIX</div>
       <div id="ordersBody"></div>
+    </section>
+
+    <section id="alerts">
+      <div class="panel-title row">
+        <span>EVENT ALERTS — LAST <span id="alertsWindow">7d</span></span>
+        <span class="muted small" id="alertsCount"></span>
+      </div>
+      <div id="alertsBody"></div>
     </section>
   </main>
 

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -1,14 +1,19 @@
-// D0 Terminal — Event Detail page.
-// Path C: ONE call to supabase.rpc('get_broker_event_page', {p_event_id})
-// returns a flattened JSONB with overview / chart_data / zones / orders /
-// cadences. The RPC is SECDEF + email-gated to @s4kent.com (raises 42501
-// for non-matching JWTs). Migration 20260515310000 — see PR #115.
+// D0 Terminal — Event Detail page · Phase 2a.
+// ONE call to supabase.rpc('get_broker_event_page_v2', {p_event_id, p_chart_hours}).
+// v2 extends v1 with 7 payload keys + bridge_ids:
+//   sales_tape / weather / espn / event_alerts / sg_side_by_side / splits / freshness
+// Path A fallback (legacy /api/broker/*) kept for localhost AUTH_DISABLED dev only;
+// the fallback fills v1 keys but the v2 panels render their empty/hidden states.
+// Migration 20260516050000 — PR #150. Contract: PROJECT_BIBLE.md §3 + §7.
 
 (function () {
   'use strict';
 
   const T = window.Terminal;
-  const CHART_HOURS = 168; // 7d window (RPC clamps to [1, 4320])
+  const DEFAULT_HOURS = 168;
+  let CHART_HOURS = DEFAULT_HOURS;
+  let _chartInstance = null;
+  let _lastPayload = null;
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
@@ -17,36 +22,14 @@
       T.setStatus('No event id — pass ?event=<id>', 'err');
       return;
     }
-
-    // Pre-flight email check (cheap defense-in-depth — A1 flagged that the
-    // RPC raises 42501 for non-@s4kent.com instead of returning empty rows
-    // like the RLS policies do).
     const Auth = window.TerminalAuth;
-    if (Auth && !Auth.isAllowedEmail(Auth.getEmail()) && !isLocalhost()) {
+    if (Auth && !isLocalhost() && !Auth.isAllowedEmail(Auth.getEmail())) {
       T.setStatus(`Not signed in with @s4kent.com — sign in first`, 'err');
       return;
     }
 
-    T.setStatus(`Loading event ${eventId}…`);
-
-    try {
-      const data = await fetchPayload(eventId);
-      T.setStatus(`Loaded event ${eventId}`, 'ok');
-      const overview = adaptOverview(data.overview);
-      const chart    = adaptChart(data.chart_data);
-      const zones    = data.zones || {};
-      const orders   = adaptOrders(data.orders, eventId);
-      const cadences = adaptCadences(data.cadences);
-
-      try { renderHero(overview); } catch (e) { console.error('hero', e); }
-      try { renderKPI(chart);      } catch (e) { console.error('kpi', e); }
-      try { renderChart(chart);    } catch (e) { console.error('chart', e); }
-      try { renderZones(zones);    } catch (e) { console.error('zones', e); }
-      try { renderOrders(orders);  } catch (e) { console.error('orders', e); }
-      try { renderCoverage(cadences, overview); } catch (e) { console.error('coverage', e); }
-    } catch (e) {
-      handleRpcError(e);
-    }
+    wireRangeSelector(eventId);
+    await loadAndRender(eventId);
   }
 
   function isLocalhost() {
@@ -54,34 +37,80 @@
     return h === 'localhost' || h === '127.0.0.1' || h === '';
   }
 
-  // ---------- Fetch via Path C (Supabase RPC) with Path A fallback ----------
+  async function loadAndRender(eventId) {
+    T.setStatus(`Loading event ${eventId}…`);
+    try {
+      const data = await fetchPayload(eventId);
+      _lastPayload = data;
+      T.setStatus(`Loaded event ${eventId}`, 'ok');
+
+      const bridge = data.bridge_ids || {};
+      const overview = adaptOverview(data.overview);
+      const chart    = adaptChart(data.chart_data);
+      const zones    = data.zones || {};
+      const orders   = adaptOrders(data.orders, eventId);
+      const cadences = adaptCadences(data.cadences);
+
+      safe('hero',       () => renderHero(overview, bridge));
+      safe('eventMode',  () => renderEventMode(bridge, data));
+      safe('kpiGrid',    () => renderKPIGrid(chart, data.sg_side_by_side));
+      safe('chart',      () => renderChart(chart, data.event_alerts));
+      safe('chartLegend',() => renderChartLegend());
+      safe('splits',     () => renderSplits(data.splits));
+      safe('zones',      () => renderZones(zones));
+      safe('salesTape',  () => renderSalesTape(data.sales_tape, bridge));
+      safe('espn',       () => renderEspn(data.espn));
+      safe('weather',    () => renderWeather(data.weather));
+      safe('orders',     () => renderOrders(orders));
+      safe('coverage',   () => renderCoverage(cadences, overview, data.freshness, bridge));
+      safe('freshness',  () => renderFreshness(data.freshness));
+      safe('alerts',     () => renderAlerts(data.event_alerts));
+    } catch (e) {
+      handleRpcError(e);
+    }
+  }
+
+  function safe(label, fn) {
+    try { fn(); } catch (e) { console.error('[' + label + ']', e); }
+  }
+
+  function wireRangeSelector(eventId) {
+    const sel = document.getElementById('chartRange');
+    if (!sel) return;
+    sel.addEventListener('change', async () => {
+      CHART_HOURS = parseInt(sel.value, 10) || DEFAULT_HOURS;
+      const lbl = document.getElementById('chartRangeLabel');
+      if (lbl) lbl.textContent = sel.options[sel.selectedIndex].textContent;
+      const aw = document.getElementById('alertsWindow');
+      if (aw) aw.textContent = sel.options[sel.selectedIndex].textContent;
+      await loadAndRender(eventId);
+    });
+  }
+
+  // ---------- Fetch (Path C primary, Path A fallback) ----------
 
   async function fetchPayload(eventId) {
     const Auth = window.TerminalAuth;
     if (Auth && Auth.client && Auth.getAccessToken()) {
       const { data, error } = await Auth.client
-        .rpc('get_broker_event_page', { p_event_id: eventId, p_chart_hours: CHART_HOURS });
+        .rpc('get_broker_event_page_v2', { p_event_id: eventId, p_chart_hours: CHART_HOURS });
       if (error) {
         const err = new Error(error.message || 'RPC error');
-        err.code = error.code;
-        err.details = error.details;
-        err.hint = error.hint;
+        err.code = error.code; err.details = error.details; err.hint = error.hint;
         throw err;
       }
       return data;
     }
-
-    // Path A fallback — localhost dev with AUTH_DISABLED, or pre-OAuth-setup.
-    // Reconstructs the RPC shape from the 5 legacy endpoints.
-    const eventIdStr = String(eventId);
+    // Path A fallback (localhost dev only). Returns v1 shape; v2 panels render empty states.
+    const idStr = String(eventId);
     const [overview, chartData, zones, orders, cadences] = await Promise.all([
-      T.api(`/api/broker/event/${eventIdStr}/overview`),
-      T.api(`/api/broker/event/${eventIdStr}/chart-data?hours=${CHART_HOURS}`),
-      T.api(`/api/broker/event/${eventIdStr}/zones`),
-      T.api(`/api/broker/event/${eventIdStr}/orders`),
-      T.api(`/api/broker/event/${eventIdStr}/cadences`),
+      T.api(`/api/broker/event/${idStr}/overview`),
+      T.api(`/api/broker/event/${idStr}/chart-data?hours=${CHART_HOURS}`),
+      T.api(`/api/broker/event/${idStr}/zones`),
+      T.api(`/api/broker/event/${idStr}/orders`),
+      T.api(`/api/broker/event/${idStr}/cadences`),
     ]);
-    return legacyToRpcShape(overview, chartData, zones, orders, cadences);
+    return legacyToV2Shape(overview, chartData, zones, orders, cadences, eventId);
   }
 
   function handleRpcError(e) {
@@ -97,24 +126,20 @@
     console.error(e);
   }
 
-  // ---------- Shape adapters: RPC JSONB → existing renderer expectations ----------
+  // ---------- Shape adapters (v1 base) ----------
 
   function adaptOverview(o) {
-    if (!o) return { event: {}, lifecycle: null, cadence_seconds: null };
+    if (!o) return { event: {}, lifecycle: null };
     return {
       event: o.event || {},
       lifecycle: o.lifecycle || null,
       cadence_seconds: o.cadence_seconds || null,
       last_pull_at: o.last_pull_at || null,
-      _metrics_current: o.metrics_current || null,
-      _metrics_prev: o.metrics_prev || null,
     };
   }
 
-  // Slice the event_metrics_series rows into the named time-series the chart
-  // + KPI renderers consume. Legacy /chart-data did this on the server.
   function adaptChart(c) {
-    if (!c) return { prices_owned: [], prices_market: [], prices_nonowned: [], counts_owned: [] };
+    if (!c) return { prices_owned: [], prices_market: [], prices_nonowned: [], counts_owned: [], counts_market: [] };
     const rows = c.event_metrics_series || [];
     const slice = (col) => rows.map(r => ({ t: r.captured_at, v: r[col] == null ? null : Number(r[col]) }));
     return {
@@ -127,16 +152,13 @@
     };
   }
 
-  // Compute the order summary client-side (the RPC returns raw items + orders).
   function adaptOrders(o, eventId) {
     if (!o) return { event_id: eventId, items: [], orders: [], summary: null };
     const items = o.items || [];
     const orders = o.orders || [];
     if (!items.length) return { event_id: eventId, items, orders, summary: null };
     const stateById = new Map(orders.map(x => [x.evo_order_id, x.state || 'unknown']));
-    const byState = {};
-    let ticketsSold = 0, grossSold = 0;
-    let lastUpdate = null;
+    const byState = {}; let ticketsSold = 0, grossSold = 0; let lastUpdate = null;
     items.forEach(it => {
       const st = stateById.get(it.evo_order_id) || 'unknown';
       byState[st] = (byState[st] || 0) + 1;
@@ -149,13 +171,10 @@
       if (o.evo_updated_at && (!lastUpdate || o.evo_updated_at > lastUpdate)) lastUpdate = o.evo_updated_at;
     });
     return {
-      event_id: eventId,
-      items, orders,
+      event_id: eventId, items, orders,
       summary: {
-        total_items: items.length,
-        by_state: byState,
-        tickets_sold: ticketsSold,
-        gross_sold: Math.round(grossSold * 100) / 100,
+        total_items: items.length, by_state: byState,
+        tickets_sold: ticketsSold, gross_sold: Math.round(grossSold * 100) / 100,
         last_update_at: lastUpdate,
       },
     };
@@ -166,33 +185,29 @@
     return { sections: c };
   }
 
-  // Path-A → Path-C shape converter for the fallback path. Best effort —
-  // legacy /overview already has computed `metrics: {key: {v, delta}}` so
-  // we don't have metrics_current/_prev raw; renderers don't actually read
-  // those today, so leaving null is fine.
-  function legacyToRpcShape(overview, chartData, zones, orders, cadences) {
+  function legacyToV2Shape(overview, chartData, zones, orders, cadences, eventId) {
     return {
+      v: 'v1-fallback',
+      bridge_ids: { tevo_event_id: eventId, sg_event_id: null, espn_event_id: null,
+                    aq_short_event_id: null, espn_league: null, venue_tevo_id: null },
       overview: overview ? {
-        event: overview.event,
-        lifecycle: overview.lifecycle,
-        cadence_seconds: overview.cadence_seconds,
-        last_pull_at: overview.last_pull_at,
-        metrics_current: null,
-        metrics_prev: null,
-        zones: overview.zones,
+        event: overview.event, lifecycle: overview.lifecycle,
+        cadence_seconds: overview.cadence_seconds, last_pull_at: overview.last_pull_at,
       } : null,
-      chart_data: chartData ? {
-        event_metrics_series: buildSeriesFromLegacy(chartData),
-        zone_metrics_series: [],
-        range: null,
-      } : null,
+      chart_data: chartData ? { event_metrics_series: buildSeriesFromLegacy(chartData) } : null,
       zones: zones || null,
       orders: orders || null,
       cadences: cadences && cadences.sections ? cadences.sections : (cadences || {}),
+      sales_tape: [],
+      weather:    { hidden: true, reason: 'path_a_fallback' },
+      espn:       { hidden: true, reason: 'path_a_fallback' },
+      event_alerts:    [],
+      sg_side_by_side: { hidden: true, reason: 'path_a_fallback' },
+      splits:     { owned: {}, market: {} },
+      freshness:  {},
     };
   }
 
-  // Reverse the slice — turn legacy {prices_owned:[{t,v}], ...} into rows.
   function buildSeriesFromLegacy(c) {
     const byT = new Map();
     const pull = (series, col) => (series || []).forEach(p => {
@@ -210,8 +225,8 @@
 
   // ---------- Hero ----------
 
-  function renderHero(overview) {
-    if (!overview || overview.__err) return;
+  function renderHero(overview, bridge) {
+    if (!overview) return;
     const ev = overview.event || {};
     document.getElementById('evTitle').textContent = ev.name || `Event ${ev.id || ''}`;
     document.getElementById('evVenue').textContent = ev.venue_name || ev.venue || '—';
@@ -227,7 +242,6 @@
       b.textContent = days <= 0 ? 'TODAY' : days === 1 ? 'TOMORROW' : `T-${days}d`;
       badges.appendChild(b);
     }
-
     const lc = overview.lifecycle;
     if (lc) {
       const status = lc.status || lc.classification;
@@ -242,44 +256,112 @@
         badges.appendChild(b);
       }
     }
-
     if (overview.cadence_seconds) {
       const b = document.createElement('span');
       b.className = 'badge';
-      const m = Math.round(overview.cadence_seconds / 60);
-      b.textContent = `POLL ${m}m`;
+      b.textContent = `POLL ${Math.round(overview.cadence_seconds / 60)}m`;
+      badges.appendChild(b);
+    }
+    if (bridge && bridge.espn_league) {
+      const b = document.createElement('span');
+      b.className = 'badge';
+      b.textContent = String(bridge.espn_league).toUpperCase();
       badges.appendChild(b);
     }
   }
 
-  // ---------- KPI: owned_premium_pct (computed client-side) ----------
-
-  function renderKPI(chart) {
-    const valEl = document.getElementById('kpiVal');
-    const subEl = document.getElementById('kpiSub');
-    if (!chart || chart.__err) {
-      valEl.textContent = '—';
-      subEl.textContent = chart && chart.__err ? 'chart-data unavailable' : '';
-      return;
+  function renderEventMode(bridge, data) {
+    const el = document.getElementById('eventMode');
+    if (!el) return;
+    el.innerHTML = '';
+    if (!bridge) return;
+    if (bridge.sg_event_id == null) {
+      el.innerHTML = '<span class="mode-chip warn">TEvo-only · no SG bridge</span>';
+    } else if (data && data.v === 'v1-fallback') {
+      el.innerHTML = '<span class="mode-chip dim">v1 fallback (localhost)</span>';
     }
-    const owned    = T.latestNonNull(chart.prices_owned);
-    const nonowned = T.latestNonNull(chart.prices_nonowned);
-
-    if (!owned || !nonowned) {
-      valEl.textContent = 'n/a';
-      valEl.className = 'kpi-value';
-      subEl.textContent = !nonowned
-        ? 'no nonowned median yet (we\'re alone in event)'
-        : 'no owned median yet';
-      return;
-    }
-    const pct = (owned / nonowned - 1) * 100;
-    valEl.textContent = T.fmtPct(pct, 1);
-    valEl.className = 'kpi-value ' + colorBucket(pct);
-    subEl.textContent = `our $${T.fmtNum(owned, { max: 0 })} vs market $${T.fmtNum(nonowned, { max: 0 })}`;
   }
 
-  // Sweet spot ±15 green, ±15-30 amber, beyond red.
+  // ---------- KPI grid (8 cells, TEvo + SG side-by-side where applicable) ----------
+
+  function renderKPIGrid(chart, sgSxs) {
+    // Owned Premium %
+    const owned    = T.latestNonNull(chart.prices_owned);
+    const nonowned = T.latestNonNull(chart.prices_nonowned);
+    const market   = T.latestNonNull(chart.prices_market);
+    const qtyMkt   = T.latestNonNull(chart.counts_market);
+    const qtyOwn   = T.latestNonNull(chart.counts_owned);
+
+    const opVal = document.getElementById('kpiOwnedPremiumVal');
+    const opSub = document.getElementById('kpiOwnedPremiumSub');
+    if (owned && nonowned) {
+      const pct = (owned / nonowned - 1) * 100;
+      opVal.textContent = T.fmtPct(pct, 1);
+      opVal.className = 'kpi-val ' + colorBucket(pct);
+      opSub.textContent = `our $${T.fmtNum(owned, { max: 0 })} vs $${T.fmtNum(nonowned, { max: 0 })}`;
+    } else {
+      opVal.textContent = 'n/a';
+      opSub.textContent = !nonowned ? 'no market without us' : 'no owned median';
+    }
+
+    // SG side-by-side: pull current snapshot (cost_* columns)
+    const sg = (sgSxs && !sgSxs.hidden && sgSxs.current) ? sgSxs.current : null;
+    const sgPrev = (sgSxs && !sgSxs.hidden && sgSxs.d24h_ago) ? sgSxs.d24h_ago : null;
+    const sgHidden = !sgSxs || sgSxs.hidden;
+
+    // Retail Median  (TEvo retail_median + SG cost_median)
+    setKpi('kpiRetailMedianVal', market != null ? '$' + T.fmtNum(market, { max: 0 }) : '—');
+    setKpiSg('kpiRetailMedianSG', sg && sg.cost_median, sgPrev && sgPrev.cost_median, '$', 0, sgHidden);
+
+    // Qty Available  (TEvo counts_market + SG listings_count)
+    setKpi('kpiQtyAvailableVal', qtyMkt != null ? T.fmtNum(qtyMkt) : '—');
+    setKpiSg('kpiQtyAvailableSG', sg && sg.tickets_count, sgPrev && sgPrev.tickets_count, '', 0, sgHidden);
+
+    // Qty Owned  (counts_owned + share)
+    setKpi('kpiQtyOwnedVal', qtyOwn != null ? T.fmtNum(qtyOwn) : '—');
+    const share = (qtyOwn && qtyMkt && qtyMkt > 0) ? (qtyOwn / qtyMkt * 100) : null;
+    setKpiSub('kpiQtyOwnedSub', share != null ? `${share.toFixed(1)}% of market` : '');
+
+    // Get-in  (TEvo nothing direct; SG cost_min)
+    const tevoGetin = market != null ? null : null;  // v1 chart_data lacks min; SG side carries it
+    setKpi('kpiGetinVal', sg && sg.cost_min != null ? '$' + T.fmtNum(sg.cost_min, { max: 0 }) : (tevoGetin != null ? '$' + T.fmtNum(tevoGetin) : '—'));
+    setKpiSg('kpiGetinSG', null, null, '', 0, true);  // suppress SG row (already primary)
+
+    // Owned Median (our retail)
+    setKpi('kpiOwnedMedianVal', owned != null ? '$' + T.fmtNum(owned, { max: 0 }) : '—');
+
+    // Non-owned Median
+    setKpi('kpiNonownedMedianVal', nonowned != null ? '$' + T.fmtNum(nonowned, { max: 0 }) : '—');
+
+    // Owned Share (qty %)
+    document.getElementById('kpiOwnedShareVal').textContent = share != null ? share.toFixed(1) + '%' : '—';
+    document.getElementById('kpiOwnedShareSub').textContent = (qtyOwn != null && qtyMkt != null)
+      ? `${T.fmtNum(qtyOwn)} of ${T.fmtNum(qtyMkt)}` : '';
+  }
+
+  function setKpi(id, value) {
+    const el = document.getElementById(id); if (!el) return;
+    el.textContent = value;
+  }
+  function setKpiSub(id, value) {
+    const el = document.getElementById(id); if (!el) return;
+    el.textContent = value;
+  }
+  function setKpiSg(id, val, prevVal, prefix, max, hidden) {
+    const el = document.getElementById(id); if (!el) return;
+    if (hidden || val == null) { el.textContent = ''; el.className = 'kpi-sg'; return; }
+    const v = `${prefix}${T.fmtNum(val, { max })}`;
+    let delta = '';
+    if (prevVal != null && prevVal !== 0) {
+      const pct = (val / prevVal - 1) * 100;
+      delta = ` (${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%)`;
+      el.className = 'kpi-sg ' + (pct >= 0 ? 'pos' : 'neg');
+    } else {
+      el.className = 'kpi-sg';
+    }
+    el.textContent = `SG ${v}${delta}`;
+  }
+
   function colorBucket(pct) {
     const a = Math.abs(pct);
     if (a <= 15) return 'pos';
@@ -287,76 +369,193 @@
     return 'neg';
   }
 
-  // ---------- Chart (uPlot) ----------
+  // ---------- Chart (8 series + event_alerts markers) ----------
 
-  function renderChart(chart) {
+  function renderChart(chart, alerts) {
     const host = document.getElementById('chartHost');
     host.innerHTML = '';
-    if (!chart || chart.__err || !window.uPlot) return;
+    if (!chart || !window.uPlot) return;
 
-    // Build a unified time axis from the union of timestamps across the
-    // three series we care about. event_metrics rows are usually aligned
-    // (they come from the same captured_at), so the union typically equals
-    // any individual series.
-    const series = [chart.prices_owned, chart.prices_market, chart.counts_owned];
-    const tset = new Set();
-    series.forEach(s => (s || []).forEach(p => tset.add(p.t)));
-    const ts = [...tset].sort();
-    const idx = new Map(ts.map((t, i) => [t, i]));
-
-    function project(s) {
-      const arr = new Array(ts.length).fill(null);
-      (s || []).forEach(p => { arr[idx.get(p.t)] = p.v; });
-      return arr;
-    }
-    const xs = ts.map(t => Math.round(new Date(t).getTime() / 1000));
-    const data = [
-      xs,
-      project(chart.prices_owned),
-      project(chart.prices_market),
-      project(chart.counts_owned),
+    const seriesSpecs = [
+      { key: 'prices_owned',    label: 'Owned median',    color: '#fbbf24', scale: 'y',   width: 2,   dash: null },
+      { key: 'prices_market',   label: 'Market median',   color: '#737373', scale: 'y',   width: 1.5, dash: [4, 4] },
+      { key: 'prices_nonowned', label: 'Non-owned median',color: '#a78bfa', scale: 'y',   width: 1.5, dash: [6, 3] },
+      { key: 'counts_owned',    label: 'Owned qty',       color: '#60a5fa', scale: 'qty', width: 1,   dash: null, fill: 'rgba(96,165,250,0.08)' },
+      { key: 'counts_market',   label: 'Market qty',      color: '#94a3b8', scale: 'qty', width: 1,   dash: [2, 2] },
     ];
 
+    // Build unified time axis
+    const tset = new Set();
+    seriesSpecs.forEach(s => (chart[s.key] || []).forEach(p => tset.add(p.t)));
+    const ts = [...tset].sort();
+    const xs = ts.map(t => Math.round(new Date(t).getTime() / 1000));
+    const idx = new Map(ts.map((t, i) => [t, i]));
+    const project = (s) => {
+      const arr = new Array(ts.length).fill(null);
+      (s || []).forEach(p => { const i = idx.get(p.t); if (i != null) arr[i] = p.v; });
+      return arr;
+    };
+
+    const data = [xs, ...seriesSpecs.map(s => project(chart[s.key]))];
+
+    // Pick a tick-friendly width (re-render on resize)
     const rect = host.getBoundingClientRect();
+    const w = Math.max(800, rect.width || host.clientWidth || 1200);
+    const h = Math.max(280, (rect.height || 320) - 20);
+
     const opts = {
-      width: Math.max(800, rect.width || host.clientWidth || 1200),
-      height: Math.max(280, (rect.height || 320) - 20),
+      width: w, height: h,
       cursor: { drag: { x: true, y: false } },
-      scales: {
-        x: { time: true },
-        y: {},
-        qty: {},
-      },
+      scales: { x: { time: true }, y: {}, qty: {} },
       axes: [
         { stroke: 'var(--muted)', grid: { stroke: 'var(--line-2)', width: 1 } },
         { scale: 'y',   stroke: 'var(--muted)', grid: { stroke: 'var(--line-2)', width: 1 },
-          values: (u, v) => v.map(x => '$' + (x === null ? '' : Math.round(x))) },
+          values: (u, v) => v.map(x => x === null ? '' : '$' + Math.round(x)) },
         { scale: 'qty', side: 1, stroke: 'var(--muted)', grid: { show: false },
           values: (u, v) => v.map(x => x === null ? '' : Math.round(x)) },
       ],
       series: [
         { label: 'time' },
-        { label: 'Owned median', stroke: '#fbbf24', width: 2,   scale: 'y',   spanGaps: true },
-        { label: 'Market median', stroke: '#737373', width: 1.5, scale: 'y',   spanGaps: true, dash: [4, 4] },
-        { label: 'Owned qty',     stroke: '#60a5fa', width: 1,   scale: 'qty', spanGaps: true, fill: 'rgba(96,165,250,0.08)' },
+        ...seriesSpecs.map(s => ({
+          label: s.label, stroke: s.color, width: s.width, scale: s.scale,
+          spanGaps: true, dash: s.dash || undefined, fill: s.fill || undefined,
+        })),
       ],
+      hooks: {
+        draw: [
+          (u) => drawAlertsMarkers(u, alerts || []),
+        ],
+      },
     };
 
-    new window.uPlot(opts, data, host);
+    _chartInstance = new window.uPlot(opts, data, host);
 
-    // Resize on window resize.
     if (!host.__resizeWired) {
       host.__resizeWired = true;
-      window.addEventListener('resize', () => renderChart(chart));
+      let resizeTimer;
+      window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => renderChart(chart, alerts), 200);
+      });
     }
   }
 
-  // ---------- Zones table ----------
+  function drawAlertsMarkers(u, alerts) {
+    if (!alerts || !alerts.length) return;
+    const ctx = u.ctx;
+    if (!ctx) return;
+    ctx.save();
+    alerts.forEach(a => {
+      if (!a.fired_at) return;
+      const tSec = Math.round(new Date(a.fired_at).getTime() / 1000);
+      const x = u.valToPos(tSec, 'x', true);
+      if (x < u.bbox.left || x > u.bbox.left + u.bbox.width) return;
+      const top = u.bbox.top + 4;
+      const bot = u.bbox.top + u.bbox.height - 4;
+      // vertical line
+      ctx.strokeStyle = severityColor(a.severity);
+      ctx.globalAlpha = 0.35;
+      ctx.beginPath(); ctx.moveTo(x, top); ctx.lineTo(x, bot); ctx.stroke();
+      // triangle marker at top
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = severityColor(a.severity);
+      ctx.beginPath();
+      ctx.moveTo(x, top); ctx.lineTo(x - 4, top - 6); ctx.lineTo(x + 4, top - 6); ctx.closePath();
+      ctx.fill();
+    });
+    ctx.restore();
+  }
+
+  function severityColor(sev) {
+    if (sev === 'critical' || sev === 'high') return '#ef4444';
+    if (sev === 'medium' || sev === 'warn')   return '#f59e0b';
+    return '#60a5fa';
+  }
+
+  function renderChartLegend() {
+    const el = document.getElementById('chartLegend');
+    if (!el) return;
+    const items = [
+      ['#fbbf24', 'Owned'],
+      ['#737373', 'Market'],
+      ['#a78bfa', 'Non-owned'],
+      ['#60a5fa', 'Owned qty'],
+      ['#94a3b8', 'Mkt qty'],
+    ];
+    el.innerHTML = items.map(([c, l]) =>
+      `<span><i style="background:${c}"></i> ${l}</span>`).join('');
+  }
+
+  // ---------- Splits ----------
+
+  function renderSplits(splits) {
+    const body = document.getElementById('splitsBody');
+    body.innerHTML = '';
+    if (!splits) {
+      body.innerHTML = '<div class="empty">no splits data</div>';
+      return;
+    }
+    const owned = splits.owned || {};
+    const market = splits.market || {};
+    const buckets = ['singles', 'pairs', 'triples', 'quads', 'five_plus'];
+    const totalOwnedTg = sumTg(owned);
+    const totalMarketTg = sumTg(market);
+
+    if (totalOwnedTg === 0 && totalMarketTg === 0) {
+      body.innerHTML = '<div class="empty">no recent TEvo listings (last 24h) — possibly stale collector</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.className = 'splits-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Split</th>
+        <th class="num">Ours TG</th>
+        <th class="num">Ours tix</th>
+        <th class="num">Ours avg $</th>
+        <th class="num">Mkt TG</th>
+        <th class="num">Mkt tix</th>
+        <th class="num">Mkt avg $</th>
+      </tr></thead>
+      <tbody></tbody>
+    `;
+    const tb = tbl.querySelector('tbody');
+    buckets.forEach(b => {
+      const ob = owned[b] || {};
+      const mb = market[b] || {};
+      if (!ob.tg_count && !mb.tg_count) return;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="split-name">${labelForBucket(b)}</td>
+        <td class="num ours">${fmtIntCell(ob.tg_count)}</td>
+        <td class="num ours">${fmtIntCell(ob.tix_count)}</td>
+        <td class="num ours">${fmtPxCell(ob.avg_px)}</td>
+        <td class="num">${fmtIntCell(mb.tg_count)}</td>
+        <td class="num">${fmtIntCell(mb.tix_count)}</td>
+        <td class="num">${fmtPxCell(mb.avg_px)}</td>
+      `;
+      tb.appendChild(tr);
+    });
+    body.appendChild(tbl);
+  }
+
+  function labelForBucket(b) {
+    return { singles: 'singles (1)', pairs: 'pairs (2)', triples: 'triples (3)',
+             quads: 'quads (4)', five_plus: '5+ pack' }[b] || b;
+  }
+  function sumTg(o) {
+    return Object.values(o || {}).reduce((s, b) => s + (b && b.tg_count || 0), 0);
+  }
+  function fmtIntCell(n) { return (n === null || n === undefined) ? '—' : T.fmtNum(n); }
+  function fmtPxCell(n)  { return (n === null || n === undefined) ? '—' : '$' + T.fmtNum(n, { max: 0 }); }
+
+  // ---------- Zones (carried from v1) ----------
 
   function renderZones(zones) {
     const body = document.getElementById('zonesBody');
     body.innerHTML = '';
-    if (!zones || zones.__err) {
+    if (!zones) {
       body.innerHTML = '<div class="empty">zones unavailable</div>';
       return;
     }
@@ -365,7 +564,6 @@
       body.innerHTML = '<div class="empty">no zone data</div>';
       return;
     }
-
     const tbl = document.createElement('table');
     tbl.innerHTML = `
       <thead><tr>
@@ -374,9 +572,7 @@
         <th class="num">Median</th>
         <th class="num">Ours qty</th>
         <th class="num">Ours %</th>
-      </tr></thead>
-      <tbody></tbody>
-    `;
+      </tr></thead><tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
     rows.slice(0, 30).forEach(r => {
       const tr = document.createElement('tr');
@@ -387,20 +583,206 @@
         <td class="num">${T.fmtNum(r.tickets_count)}</td>
         <td class="num">$${T.fmtNum(r.retail_median, { max: 0 })}</td>
         <td class="num ours">${T.fmtNum(r.owned_tickets_count)}</td>
-        <td class="num ours">${ourPct}</td>
-      `;
+        <td class="num ours">${ourPct}</td>`;
       tb.appendChild(tr);
     });
     body.appendChild(tbl);
+  }
 
-    if (zones.source) {
-      const note = document.createElement('div');
-      note.className = 'panel-title';
-      note.style.marginTop = '8px';
-      note.style.color = 'var(--dim)';
-      note.textContent = `source: ${zones.source}` + (zones.parking_hidden ? ` · ${zones.parking_hidden} parking hidden` : '');
-      body.appendChild(note);
+  // ---------- Sales tape (SG, deduped already by RPC) ----------
+
+  function renderSalesTape(rows, bridge) {
+    const body = document.getElementById('salesTapeBody');
+    body.innerHTML = '';
+    if (!rows || !rows.length) {
+      const reason = bridge && bridge.sg_event_id == null
+        ? 'no SG bridge for this event'
+        : 'no recent SG sales';
+      body.innerHTML = `<div class="empty">${reason}</div>`;
+      return;
     }
+    const tbl = document.createElement('table');
+    tbl.className = 'sales-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Sold at</th>
+        <th>Section</th>
+        <th>Row</th>
+        <th class="num">Lot qty</th>
+        <th class="num">Px / tix</th>
+        <th>Stock</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${T.fmtDate(r.sale_at_utc)}</td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${r.quantity != null ? T.fmtNum(r.quantity) : '—'}</td>
+        <td class="num">${r.broadcast_price != null ? '$' + T.fmtNum(r.broadcast_price, { max: 2 }) : '—'}</td>
+        <td class="muted">${escapeHtml(r.stock_type || '')}</td>`;
+      tb.appendChild(tr);
+    });
+    body.appendChild(tbl);
+  }
+
+  // ---------- ESPN ----------
+
+  function renderEspn(espn) {
+    const section = document.getElementById('espn');
+    const body = document.getElementById('espnBody');
+    const subtitle = document.getElementById('espnSubtitle');
+    if (!body) return;
+    if (!espn || espn.hidden) {
+      section.style.display = 'none';
+      return;
+    }
+    section.style.display = '';
+    if (subtitle) {
+      const lg = espn.espn_league ? String(espn.espn_league).toUpperCase() : '';
+      subtitle.textContent = `${lg} · ${espn.home_team_id || '?'} vs ${espn.away_team_id || '?'}`;
+    }
+    body.innerHTML = '';
+
+    const teams = espn.team_standings || [];
+    const injuries = espn.injuries || [];
+    const recents = espn.recent_results || [];
+
+    const grid = document.createElement('div');
+    grid.className = 'espn-grid';
+    // Standings cards
+    teams.forEach(t => {
+      const card = document.createElement('div');
+      card.className = 'espn-card';
+      const rec = t.record_summary || `${t.wins || 0}-${t.losses || 0}${t.ties ? '-' + t.ties : ''}`;
+      card.innerHTML = `
+        <div class="espn-card-hd">${escapeHtml(t.espn_team_id || '')}</div>
+        <div class="espn-card-row"><span class="lbl">record</span><span class="val">${rec}</span></div>
+        <div class="espn-card-row"><span class="lbl">win %</span><span class="val">${t.win_pct != null ? (t.win_pct * 100).toFixed(1) + '%' : '—'}</span></div>
+        <div class="espn-card-row"><span class="lbl">streak</span><span class="val">${escapeHtml(t.streak || '—')}</span></div>
+        <div class="espn-card-row"><span class="lbl">seed</span><span class="val">${t.playoff_seed || '—'}</span></div>
+        <div class="espn-card-foot">${escapeHtml(t.standing_summary || '')}</div>
+      `;
+      grid.appendChild(card);
+    });
+    body.appendChild(grid);
+
+    // Injuries
+    if (injuries.length) {
+      const inj = document.createElement('div');
+      inj.className = 'espn-injuries';
+      inj.innerHTML = '<div class="espn-sublabel">ACTIVE INJURIES (' + injuries.length + ')</div>';
+      const ul = document.createElement('ul');
+      injuries.slice(0, 12).forEach(i => {
+        const li = document.createElement('li');
+        const sev = (i.status || '').toLowerCase();
+        const dot = sev === 'out' || sev === 'ir' ? '◯' : sev === 'questionable' || sev === 'q' ? '▲' : '●';
+        li.innerHTML = `<span class="inj-dot ${injuryClass(sev)}">${dot}</span> <strong>${escapeHtml(i.athlete_name || '')}</strong> <span class="inj-pos">${escapeHtml(i.position || '')}</span> <span class="inj-status">${escapeHtml(i.status || '')}</span> <span class="muted">${escapeHtml(i.injury_type || '')}</span>`;
+        ul.appendChild(li);
+      });
+      inj.appendChild(ul);
+      body.appendChild(inj);
+    }
+
+    // Recent results
+    if (recents.length) {
+      const rr = document.createElement('div');
+      rr.className = 'espn-recent';
+      rr.innerHTML = '<div class="espn-sublabel">RECENT RESULTS (' + recents.length + ')</div>';
+      const ul = document.createElement('ul');
+      recents.slice(0, 5).forEach(r => {
+        const li = document.createElement('li');
+        li.innerHTML = `<span class="muted">${T.fmtDate(r.captured_at)}</span> ${escapeHtml(r.away_team_id || '?')} ${r.away_score != null ? r.away_score : '—'} @ ${escapeHtml(r.home_team_id || '?')} ${r.home_score != null ? r.home_score : '—'}`;
+        ul.appendChild(li);
+      });
+      rr.appendChild(ul);
+      body.appendChild(rr);
+    }
+  }
+
+  function injuryClass(sev) {
+    if (sev === 'out' || sev === 'ir') return 'inj-out';
+    if (sev === 'questionable' || sev === 'q') return 'inj-q';
+    return 'inj-p';
+  }
+
+  // ---------- Weather ----------
+
+  function renderWeather(w) {
+    const section = document.getElementById('weather');
+    const body = document.getElementById('weatherBody');
+    const subtitle = document.getElementById('weatherSubtitle');
+    if (!body) return;
+    if (!w || w.hidden) {
+      section.style.display = 'none';
+      return;
+    }
+    section.style.display = '';
+    body.innerHTML = '';
+    if (subtitle) subtitle.textContent = w.event_at ? `event ${T.fmtDate(w.event_at)}` : '';
+
+    const fc = w.forecast || [];
+    const obs = w.recent_obs || [];
+    const alerts = w.nws_alerts || [];
+
+    if (fc.length) {
+      const fcWrap = document.createElement('div');
+      fcWrap.className = 'wx-forecast';
+      fcWrap.innerHTML = '<div class="wx-sublabel">FORECAST · NEAREST TO EVENT TIME</div>';
+      const row = document.createElement('div');
+      row.className = 'wx-row';
+      fc.forEach(f => {
+        const cell = document.createElement('div');
+        cell.className = 'wx-cell';
+        cell.innerHTML = `
+          <div class="wx-time">${shortHour(f.observed_at)}</div>
+          <div class="wx-temp">${f.temp_f != null ? Math.round(f.temp_f) + '°' : '—'}</div>
+          <div class="wx-precip">${f.precip_pct != null ? Math.round(f.precip_pct) + '%' : '—'} ${f.precip_in != null ? `· ${f.precip_in.toFixed(2)}"` : ''}</div>
+          <div class="wx-wind">${f.wind_mph != null ? Math.round(f.wind_mph) + ' mph' : '—'}${f.gust_mph != null ? ` · g${Math.round(f.gust_mph)}` : ''}</div>
+          <div class="wx-summary">${escapeHtml(f.weather_summary || '')}</div>
+        `;
+        row.appendChild(cell);
+      });
+      fcWrap.appendChild(row);
+      body.appendChild(fcWrap);
+    }
+
+    if (obs.length) {
+      const obsWrap = document.createElement('div');
+      obsWrap.className = 'wx-obs';
+      obsWrap.innerHTML = `<div class="wx-sublabel">RECENT OBSERVATIONS (${obs.length})</div>`;
+      const ul = document.createElement('ul');
+      obs.forEach(o => {
+        const li = document.createElement('li');
+        li.innerHTML = `<span class="muted">${T.fmtDate(o.observed_at)}</span> ${o.temp_f != null ? Math.round(o.temp_f) + '°F' : '—'} · ${o.precip_pct != null ? o.precip_pct + '% precip' : '—'} · ${escapeHtml(o.weather_summary || '')}`;
+        ul.appendChild(li);
+      });
+      obsWrap.appendChild(ul);
+      body.appendChild(obsWrap);
+    }
+
+    if (alerts.length) {
+      const aw = document.createElement('div');
+      aw.className = 'wx-alerts';
+      aw.innerHTML = `<div class="wx-sublabel">NWS ALERTS (${alerts.length})</div>`;
+      const ul = document.createElement('ul');
+      alerts.forEach(a => {
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>${escapeHtml(a.event || '')}</strong> <span class="muted">${escapeHtml(a.severity || '')} · expires ${T.fmtDate(a.expires_at)}</span> — ${escapeHtml(a.headline || '')}`;
+        ul.appendChild(li);
+      });
+      aw.appendChild(ul);
+      body.appendChild(aw);
+    }
+  }
+
+  function shortHour(iso) {
+    if (!iso) return '—';
+    try {
+      const d = new Date(iso);
+      return d.toLocaleString(undefined, { weekday: 'short', hour: 'numeric' });
+    } catch (_) { return iso; }
   }
 
   // ---------- Orders strip ----------
@@ -408,7 +790,7 @@
   function renderOrders(orders) {
     const body = document.getElementById('ordersBody');
     body.innerHTML = '';
-    if (!orders || orders.__err) {
+    if (!orders) {
       body.innerHTML = '<div class="empty">orders unavailable</div>';
       return;
     }
@@ -416,9 +798,7 @@
       body.innerHTML = '<div class="empty">no orders for this event</div>';
       return;
     }
-
     const byState = orders.summary.by_state || {};
-    const total = orders.summary.total_items || 1;
     const stateOrder = ['pending', 'accepted', 'completed', 'rejected', 'pending_sub', 'unknown'];
 
     const bar = document.createElement('div');
@@ -458,27 +838,31 @@
     body.appendChild(summary);
   }
 
-  // ---------- Coverage 4-light badge ----------
+  // ---------- Coverage + freshness ----------
 
-  function renderCoverage(cadences, overview) {
-    if (!cadences || cadences.__err) return;
+  function renderCoverage(cadences, overview, freshness, bridge) {
+    if (!cadences) return;
     const sections = cadences.sections || {};
-    const lights = document.querySelectorAll('#coverage .light');
-    const tevoFresh = isFresh(sections.overview);
-    const espnFresh = isFresh(sections.espn_team) || isFresh(sections.espn_injuries);
+    const tevoFresh = isFreshFromTs(freshness && freshness.tevo_listings_latest, 3 * 3600);
+    const sgFresh   = bridge && bridge.sg_event_id != null
+      ? isFreshFromTs(freshness && (freshness.sg_listings_latest || freshness.sg_sales_latest), 6 * 3600)
+      : null;
+    const sdFresh   = isFreshFromTs(freshness && freshness.sd_sales_latest, 7 * 24 * 3600);
+    const espnFresh = isFresh(sections.espn_team) || isFresh(sections.espn_injuries)
+      || isFreshFromTs(freshness && (freshness.espn_team_latest || freshness.espn_inj_latest), 24 * 3600);
 
-    lights.forEach(el => {
-      const src = el.dataset.src;
-      el.classList.remove('lit', 'stale');
-      if (src === 'tevo') {
-        if (tevoFresh === true)  el.classList.add('lit');
-        else if (tevoFresh === false) el.classList.add('stale');
-      } else if (src === 'espn') {
-        if (espnFresh === true)  el.classList.add('lit');
-        else if (espnFresh === false) el.classList.add('stale');
-      }
-      // seatgeek + seatdata stay dim — Phase 2.
-    });
+    setLight('tevo',     tevoFresh);
+    setLight('seatgeek', sgFresh);
+    setLight('seatdata', sdFresh);
+    setLight('espn',     espnFresh);
+  }
+
+  function setLight(src, fresh) {
+    const el = document.querySelector(`#coverage .light[data-src="${src}"]`);
+    if (!el) return;
+    el.classList.remove('lit', 'stale');
+    if (fresh === true) el.classList.add('lit');
+    else if (fresh === false) el.classList.add('stale');
   }
 
   function isFresh(section) {
@@ -487,6 +871,77 @@
     if (!Number.isFinite(ageSec)) return null;
     const limit = (section.cadence_seconds || 3600) * 3;
     return ageSec <= limit;
+  }
+  function isFreshFromTs(iso, limitSec) {
+    if (!iso) return null;
+    const age = (Date.now() - new Date(iso).getTime()) / 1000;
+    if (!Number.isFinite(age)) return null;
+    return age <= limitSec;
+  }
+
+  function renderFreshness(fr) {
+    if (!fr) return;
+    const map = {
+      'tevo':     fr.tevo_listings_latest,
+      'sg-lst':   fr.sg_listings_latest,
+      'sg-sales': fr.sg_sales_latest,
+      'weather':  fr.weather_latest,
+      'espn':     fr.espn_team_latest || fr.espn_inj_latest,
+    };
+    Object.entries(map).forEach(([src, ts]) => {
+      const el = document.querySelector(`.fr-chip[data-src="${src}"]`);
+      if (!el) return;
+      const label = chipLabel(src);
+      el.classList.remove('fresh', 'stale', 'dim');
+      if (!ts) {
+        el.textContent = `${label} —`;
+        el.classList.add('dim');
+        return;
+      }
+      const ageMin = Math.round((Date.now() - new Date(ts).getTime()) / 60000);
+      el.textContent = `${label} ${formatAge(ageMin)}`;
+      const stale = ageMin > staleLimit(src);
+      el.classList.add(stale ? 'stale' : 'fresh');
+      el.title = `${label}: ${T.fmtDate(ts)}`;
+    });
+  }
+  function chipLabel(src) {
+    return { tevo: 'TEvo', 'sg-lst': 'SG L', 'sg-sales': 'SG S', weather: 'Wx', espn: 'ESPN' }[src] || src;
+  }
+  function staleLimit(src) {
+    return { tevo: 180, 'sg-lst': 60, 'sg-sales': 30, weather: 360, espn: 1440 }[src] || 360;
+  }
+  function formatAge(min) {
+    if (min < 1)   return 'now';
+    if (min < 60)  return `${min}m`;
+    if (min < 1440) return `${Math.round(min / 60)}h`;
+    return `${Math.round(min / 1440)}d`;
+  }
+
+  // ---------- Event alerts list ----------
+
+  function renderAlerts(alerts) {
+    const body = document.getElementById('alertsBody');
+    const count = document.getElementById('alertsCount');
+    body.innerHTML = '';
+    if (!alerts || !alerts.length) {
+      body.innerHTML = '<div class="empty">no event alerts in window</div>';
+      if (count) count.textContent = '0 alerts';
+      return;
+    }
+    if (count) count.textContent = `${alerts.length} alert${alerts.length === 1 ? '' : 's'}`;
+    const ul = document.createElement('ul');
+    ul.className = 'alerts-list';
+    alerts.slice(0, 20).forEach(a => {
+      const li = document.createElement('li');
+      li.className = 'alert-row sev-' + (a.severity || 'info');
+      li.innerHTML = `
+        <span class="al-time muted">${T.fmtDate(a.fired_at)}</span>
+        <span class="al-rule">${escapeHtml(a.rule_key || '')}</span>
+        <span class="al-msg">${escapeHtml(a.message || '')}</span>`;
+      ul.appendChild(li);
+    });
+    body.appendChild(ul);
   }
 
   // ---------- Util ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -512,6 +512,257 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 }
 .auth-ctrl .auth-signout:hover { color: var(--neg); border-color: var(--neg); }
 
+/* ---------- EVENT page (Phase 2a expansion) ---------- */
+
+.wrap.event {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 12px;
+}
+.wrap.event > section {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 12px 16px;
+}
+.wrap.event > #hero          { grid-column: 1 / -1; }
+.wrap.event > #kpi-grid      { grid-column: 1 / -1; padding: 12px 16px; }
+.wrap.event > #chart         { grid-column: 1 / -1; padding: 12px 8px; }
+.wrap.event > #splits        { grid-column: 1 / 7; }
+.wrap.event > #zones         { grid-column: 7 / 13; }
+.wrap.event > #sales-tape    { grid-column: 1 / -1; }
+.wrap.event > #espn          { grid-column: 1 / -1; }
+.wrap.event > #weather       { grid-column: 1 / -1; }
+.wrap.event > #order-strip   { grid-column: 1 / -1; }
+.wrap.event > #alerts        { grid-column: 1 / -1; }
+
+/* Hero band — main info left, status side panel right */
+.wrap.event > #hero {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: start;
+}
+.hero-main .title { font-size: 22px; font-weight: 600; margin: 0 0 4px; color: var(--text); }
+.hero-main .meta  { color: var(--muted); font-family: var(--mono); font-size: 12px; margin: 0 0 8px; }
+.hero-main .meta .dot { margin: 0 8px; color: var(--dim); }
+.hero-main .badges { display: flex; gap: 6px; flex-wrap: wrap; }
+.hero-side {
+  display: flex; flex-direction: column; gap: 8px;
+  align-items: flex-end;
+  min-width: 280px;
+}
+
+/* Freshness chips (per-source last-cron heartbeat) */
+.freshness {
+  display: flex; gap: 4px; flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.fr-chip {
+  display: inline-block;
+  font-family: var(--mono); font-size: 10px;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--muted);
+  letter-spacing: 0.3px;
+}
+.fr-chip.fresh { color: var(--pos); border-color: rgba(74, 222, 128, 0.4); }
+.fr-chip.stale { color: var(--warn); border-color: rgba(245, 158, 11, 0.4); }
+.fr-chip.dim   { color: var(--dim); }
+
+/* TEvo-only / fallback mode chip */
+.event-mode { display: flex; gap: 4px; }
+.mode-chip {
+  font-family: var(--mono); font-size: 10px;
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--muted);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+.mode-chip.warn { color: var(--warn); border-color: var(--warn); }
+.mode-chip.dim  { color: var(--dim); border-color: var(--line); }
+
+/* KPI grid (8 cells, 4-col 2-row) */
+#kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--line);
+}
+.kpi-cell {
+  background: var(--panel);
+  padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 4px;
+  font-family: var(--mono);
+  min-height: 88px;
+}
+.kpi-cell .kpi-lbl {
+  font-size: 10px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.kpi-cell .kpi-val {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.1;
+}
+.kpi-cell .kpi-val.pos  { color: var(--pos); }
+.kpi-cell .kpi-val.warn { color: var(--warn); }
+.kpi-cell .kpi-val.neg  { color: var(--neg); }
+.kpi-cell .kpi-sub {
+  font-size: 11px;
+  color: var(--muted);
+}
+.kpi-cell .kpi-sg {
+  font-size: 11px;
+  color: var(--info);
+  letter-spacing: 0.2px;
+}
+.kpi-cell .kpi-sg.pos { color: var(--pos); }
+.kpi-cell .kpi-sg.neg { color: var(--neg); }
+
+/* Chart controls */
+#chart .chart-controls {
+  display: flex; gap: 12px; align-items: center;
+}
+.range-select {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  color: var(--text);
+  font-family: var(--mono); font-size: 11px;
+  padding: 3px 8px;
+}
+.range-select:focus { outline: none; border-color: var(--accent); }
+
+/* Splits panel */
+#splits .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+.splits-tbl { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 12px; }
+.splits-tbl th { text-align: left; color: var(--muted); padding: 4px 8px; border-bottom: 1px solid var(--line); font-weight: 500; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.splits-tbl th.num, .splits-tbl td.num { text-align: right; }
+.splits-tbl td { padding: 4px 8px; border-bottom: 1px solid var(--line-2); color: var(--text); }
+.splits-tbl tr:hover td { background: var(--panel-2); }
+.splits-tbl .split-name { color: var(--text); }
+.splits-tbl td.ours { color: var(--accent); }
+
+/* Sales tape */
+#sales-tape .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+.sales-tbl { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 12px; }
+.sales-tbl th { text-align: left; color: var(--muted); padding: 4px 8px; border-bottom: 1px solid var(--line); font-weight: 500; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.sales-tbl th.num, .sales-tbl td.num { text-align: right; }
+.sales-tbl td { padding: 4px 8px; border-bottom: 1px solid var(--line-2); color: var(--text); }
+.sales-tbl tr:hover td { background: var(--panel-2); }
+
+/* ESPN panel */
+#espn .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+#espn .panel-title .muted { color: var(--dim); font-size: 10px; font-weight: normal; text-transform: none; letter-spacing: 0; }
+.espn-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.espn-card {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  padding: 10px 12px;
+  font-family: var(--mono); font-size: 12px;
+}
+.espn-card-hd {
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+.espn-card-row {
+  display: flex; justify-content: space-between;
+  padding: 2px 0;
+  border-bottom: 1px solid var(--line-2);
+}
+.espn-card-row:last-of-type { border-bottom: 0; }
+.espn-card-row .lbl { color: var(--muted); }
+.espn-card-row .val { color: var(--text); }
+.espn-card-foot { margin-top: 6px; color: var(--dim); font-size: 10px; }
+.espn-sublabel {
+  color: var(--muted); font-family: var(--mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.5px;
+  margin: 12px 0 6px;
+}
+.espn-injuries ul, .espn-recent ul {
+  margin: 0; padding: 0; list-style: none;
+  font-family: var(--mono); font-size: 12px;
+}
+.espn-injuries li, .espn-recent li {
+  padding: 3px 0;
+  border-bottom: 1px solid var(--line-2);
+}
+.espn-injuries .inj-dot { display: inline-block; width: 16px; text-align: center; }
+.espn-injuries .inj-dot.inj-out { color: var(--neg); }
+.espn-injuries .inj-dot.inj-q   { color: var(--warn); }
+.espn-injuries .inj-dot.inj-p   { color: var(--info); }
+.espn-injuries .inj-pos { color: var(--muted); font-size: 10px; margin: 0 4px; }
+.espn-injuries .inj-status { color: var(--accent); font-size: 11px; }
+
+/* Weather strip */
+#weather .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+#weather .panel-title .muted { color: var(--dim); font-size: 10px; font-weight: normal; text-transform: none; letter-spacing: 0; }
+.wx-sublabel {
+  color: var(--muted); font-family: var(--mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.5px;
+  margin: 0 0 6px;
+}
+.wx-forecast { margin-bottom: 12px; }
+.wx-row {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--line);
+}
+.wx-cell {
+  background: var(--panel-2);
+  padding: 8px 10px;
+  font-family: var(--mono); font-size: 11px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.wx-cell .wx-time { color: var(--muted); font-size: 10px; text-transform: uppercase; }
+.wx-cell .wx-temp { color: var(--accent); font-size: 16px; font-weight: 700; }
+.wx-cell .wx-precip { color: var(--info); font-size: 10px; }
+.wx-cell .wx-wind { color: var(--muted); font-size: 10px; }
+.wx-cell .wx-summary { color: var(--text); font-size: 10px; margin-top: 2px; }
+.wx-obs ul, .wx-alerts ul {
+  margin: 0; padding: 0; list-style: none;
+  font-family: var(--mono); font-size: 12px;
+}
+.wx-obs li, .wx-alerts li {
+  padding: 3px 0;
+  border-bottom: 1px solid var(--line-2);
+}
+.wx-alerts li strong { color: var(--warn); }
+
+/* Event alerts */
+#alerts .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+#alerts .panel-title .muted { color: var(--dim); font-size: 10px; font-weight: normal; text-transform: none; letter-spacing: 0; }
+.alerts-list {
+  margin: 0; padding: 0; list-style: none;
+  font-family: var(--mono); font-size: 12px;
+}
+.alerts-list .alert-row {
+  display: grid;
+  grid-template-columns: 140px 180px 1fr;
+  gap: 12px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--line-2);
+}
+.alerts-list .alert-row .al-rule { color: var(--accent); font-size: 11px; }
+.alerts-list .alert-row .al-msg { color: var(--text); }
+.alerts-list .alert-row.sev-critical .al-msg { color: var(--neg); }
+.alerts-list .alert-row.sev-high .al-msg { color: var(--neg); }
+.alerts-list .alert-row.sev-medium .al-msg { color: var(--warn); }
+
 /* ---------- LOGIN page ---------- */
 
 body[data-page="login"] {


### PR DESCRIPTION
## Summary

Wires `static/terminal/event.{html,js,css}` against `get_broker_event_page_v2` (migration `20260516050000`, [PR #150](https://github.com/JulianS4K/Terminal-2/pull/150)). One RPC call returns the v1 base payload plus 7 new keys: `sales_tape` / `weather` / `espn` / `event_alerts` / `sg_side_by_side` / `splits` / `freshness` plus a `bridge_ids` summary.

D0's first wire-up of the v2 contract — Phase 2a MVP per plan E.13 wireframe.

## What renders now

- **8-cell KPI grid** — owned premium %, retail median (TEvo + SG side-by-side), qty available (TEvo + SG), qty owned + share, get-in, owned median, non-owned median, owned share %. SG columns show 24h delta colored.
- **Expanded chart** — 5 series (owned/market/non-owned median + owned + market qty) with `event_alerts` drawn as severity-colored vertical markers + triangle dots. Range selector (6h / 24h / 3d / 7d / 30d / ALL) re-fires the RPC.
- **Splits panel** — owned vs market density across singles / pairs / triples / quads / 5+ buckets.
- **Sales tape** — last 20 SG transactions, dedupe already handled in the RPC (`DISTINCT ON sg_sale_id`).
- **Weather strip** — 6 forecast cells around event time + 3 recent observations + NWS alerts. Auto-hides when payload is `{hidden: true, reason: 'indoor_venue' | 'no_venue_xref' | ...}`.
- **ESPN panel** — home/away standings cards + injury list (12 max, severity-dot coded) + recent results (5 max). Auto-hides when `{hidden: true, reason: 'no_espn_xref'}`.
- **Event alerts list** — bottom panel showing time / rule_key / message with severity color.
- **Per-source freshness chips** in hero side panel — TEvo / SG L / SG S / Wx / ESPN with age formatting (now / Xm / Xh / Xd) + green/amber stale gate per source.
- **Coverage 4-light** now driven by freshness payload + v1 cadences sections.
- **TEvo-only first-class state** — when `bridge_ids.sg_event_id` is null, mode chip surfaces "TEvo-only · no SG bridge", SG KPI columns collapse, sales tape shows "no SG bridge for this event" instead of crashing.

## Verification

Stubbed v2 payload via `preview_eval` against the localhost static server. Confirmed both states:

**Full payload (Bruno Mars-shaped)**:
- `kpiOwnedPremium: +19.7%` (computed from 425/355−1 — sweet-spot green bucket... actually amber at >15%)
- `kpiRetailSG: SG $365 (-1.9%)` (24h delta math correct)
- `splitsRows: 3`, `salesRows: 3`, `weatherCells: 3`, `alertsRows: 2`
- `chartCanvas: 1` (uPlot rendered with 5 series + 2 alert markers)
- `weatherDisplay: block`, `espnDisplay: none` (hidden:true respected)

**TEvo-only payload (no SG bridge)**:
- Mode chip: `"TEvo-only · no SG bridge"`
- `kpiRetailSG: ""` (collapsed)
- `salesEmpty: "no SG bridge for this event"`
- `weatherDisplay: none`, `espnDisplay: none`
- Splits still render (TEvo data path)

Direct call to live Supabase v2 RPC confirmed CSP allows + auth layer fires (`42501` forbidden for non-`@s4kent.com` session, as expected).

Path A fallback preserved for localhost `AUTH_DISABLED` dev — returns `v1-fallback` shape that lets v2 panels render their empty states.

## Out of scope (for separate work)

- Real `@s4kent.com` Google OAuth smoke test on prod (`vibepass-terminal-test.onrender.com`) — needs operator-side Supabase Auth Redirect URLs (`bot_chat #145`).
- Phase 2b (Performer expansion + Venue net-new) — needs A1 to author `get_broker_performer_page` + `get_broker_venue_page` RPCs.
- Phase 2c (Home market-wide + Blind-spots + Movers expansion) — needs A1 RPC asks.

## Test plan

- [ ] After CI green + auto-deploy to `vibepass-terminal-test`, operator opens `https://vibepass-terminal-test.onrender.com/static/terminal/event.html?event=3262932` (Bruno Mars — A1's verification target)
- [ ] Confirm all 8 KPI cells populate including SG side-by-side
- [ ] Confirm chart shows 5 series with event_alerts triangles
- [ ] Test outdoor venue (Bruno Mars / Yankees outdoor) → weather strip visible with forecast
- [ ] Test indoor venue (NBA / MMA Intuit Dome) → weather hidden cleanly
- [ ] Test ESPN-linked sports event (NBA / NFL) → standings + injuries + recent results populate
- [ ] Test non-sports event (Bruno Mars) → ESPN panel hidden
- [ ] Test TEvo-only event (NWSL / niche) → mode chip + collapsed SG cols
- [ ] Test range selector dropdown re-fires RPC
- [ ] Confirm per-source freshness chips show realistic ages

🤖 Generated with [Claude Code](https://claude.com/claude-code)