### PR TITLE
d1: HEAD support on storefront + movers velocity-freshness gate

### DIFF
--- a/app.py
+++ b/app.py
@@ -5031,7 +5031,7 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     # Velocity windows for the 1h/24h ticket delta + getin pct moves.
     try:
         vw = (db.table("v_event_velocity_windows")
-                .select("tevo_event_id,tevo_tix_now,tevo_tix_d1h,tevo_tix_d24h,"
+                .select("tevo_event_id,tevo_tix_now,tevo_tix_d24h,"
                         "tevo_getin_now,tevo_getin_d24h_pct,tevo_now_at")
                 .in_("tevo_event_id", list(metrics_by_id.keys()))
                 .execute().data) or []
@@ -5044,15 +5044,38 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     perf_ids = [int(p) for p in perf_ids if p]
     perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
 
+    # Freshness gate for velocity signals. v_event_velocity_windows computes
+    # d1h/d24h via subqueries that fall back to the most recent sample <= now-Xh,
+    # so when the collector hasn't fired in the relevant window (known gap
+    # for collect-listings-1-7d + 60d+ per PROJECT_BIBLE.md §9) both subqueries
+    # resolve to the SAME ancient row → d1h == d24h, mis-attributing "N sold
+    # today" when reality is "N sold over multiple days". When the latest TEvo
+    # capture is older than this many hours, treat the velocity row as
+    # suspect and don't surface d24h/d1h numbers. premium (price-based) still
+    # works since it doesn't depend on cadence.
+    _VELOCITY_FRESH_MAX_AGE_SEC = 3 * 3600  # 3 hours
+
+    def _is_velocity_fresh(v: dict) -> bool:
+        ts = v.get("tevo_now_at")
+        if not ts:
+            return False
+        try:
+            captured = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+            age = (datetime.now(timezone.utc) - captured).total_seconds()
+            return 0 <= age <= _VELOCITY_FRESH_MAX_AGE_SEC
+        except (TypeError, ValueError):
+            return False
+
     candidates: list[dict] = []
     for eid, m in metrics_by_id.items():
         if eid in inactive:
             continue
         ev = events_by_id.get(eid) or {}
         v = velocity_by_id.get(eid) or {}
-        tix_d24h = v.get("tevo_tix_d24h")
-        tix_d1h = v.get("tevo_tix_d1h")
-        getin_pct_24h = v.get("tevo_getin_d24h_pct")
+        velocity_fresh = _is_velocity_fresh(v)
+        # Suppress d24h/d1h reads when the underlying velocity row is stale.
+        tix_d24h = v.get("tevo_tix_d24h") if velocity_fresh else None
+        getin_pct_24h = v.get("tevo_getin_d24h_pct") if velocity_fresh else None
         getin_now = v.get("tevo_getin_now")
         from_price = m.get("retail_min") if m.get("retail_min") is not None else getin_now
 
@@ -5098,7 +5121,6 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             "primary_performer_color": (a or {}).get("color_primary"),
             "from_price": from_price,
             "tix_d24h": d24h_val,
-            "tix_d1h": tix_d1h,
             "getin_pct_24h": pct_val,
             "signal": signal,
         })
@@ -6382,12 +6404,12 @@ def store_reserve(payload: dict = Body(...), authorization: str | None = Header(
     }
 
 
-@app.get("/store")
+@app.api_route("/store", methods=["GET", "HEAD"])
 def store_index_page():
     return _render_storefront_page("index.html")
 
 
-@app.get("/store/event/{event_id}")
+@app.api_route("/store/event/{event_id}", methods=["GET", "HEAD"])
 def store_event_page(event_id: int):  # noqa: ARG001 — id read by JS from URL
     return _render_storefront_page("event.html")
 
@@ -6664,14 +6686,14 @@ def store_share_list(
     return {"count": len(shares), "shares": shares}
 
 
-@app.get("/s/{share_id}")
+@app.api_route("/s/{share_id}", methods=["GET", "HEAD"])
 def store_shared_page(share_id: str):  # noqa: ARG001 — id read by JS from URL
     """Serves the same event detail page; JS detects /s/ prefix and resolves
     the share via /api/store/share/{id} instead of using URL filter params."""
     return _render_storefront_page("event.html")
 
 
-@app.get("/store/shares")
+@app.api_route("/store/shares", methods=["GET", "HEAD"])
 def store_shares_page():
     return _render_storefront_page("shares.html")
 

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -710,3 +710,166 @@ def test_movers_cache_failed_compute_doesnt_poison(monkeypatch):
     assert r2.status_code == 200
     assert r2.json()["count"] == 2
     assert app_module._movers_cache, "successful compute writes to cache"
+
+
+# ---------- /api/store/movers velocity-freshness gate ----------
+
+def test_movers_drops_tix_d24h_when_velocity_stale(monkeypatch):
+    """When v_event_velocity_windows.tevo_now_at is older than the
+    freshness threshold (3h), tix_d24h is dropped from the candidate
+    row. This guards against the collector-cadence gap where d1h and
+    d24h subqueries both fall back to the same ancient sample and
+    surface a misleading 'N sold today' badge."""
+    from datetime import datetime, timezone, timedelta
+
+    stale_ts = (datetime.now(timezone.utc) - timedelta(hours=8)).isoformat()
+    fresh_ts = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+
+    # Two events: one with stale velocity, one with fresh velocity.
+    # Both should NOT be classified premium (price < $500) so the only
+    # path to a "selling_fast" signal is via fresh velocity.
+    fake_metrics = [
+        {"event_id": 1001, "owned_tickets_count": 100, "owned_groups_count": 10, "retail_min": 25.0},
+        {"event_id": 1002, "owned_tickets_count": 100, "owned_groups_count": 10, "retail_min": 25.0},
+    ]
+    fake_events = [
+        {"id": 1001, "name": "Stale event", "occurs_at_local": "2026-06-01T19:00:00-04:00",
+         "venue_name": "MSG", "venue_location": "New York, NY",
+         "primary_performer_id": 16303, "primary_performer_name": "Yankees"},
+        {"id": 1002, "name": "Fresh event", "occurs_at_local": "2026-06-02T19:00:00-04:00",
+         "venue_name": "MSG", "venue_location": "New York, NY",
+         "primary_performer_id": 16303, "primary_performer_name": "Yankees"},
+    ]
+    fake_velocity = [
+        {"tevo_event_id": 1001, "tevo_tix_now": 100, "tevo_tix_d24h": -500,
+         "tevo_getin_now": 10.0, "tevo_getin_d24h_pct": -20.0, "tevo_now_at": stale_ts},
+        {"tevo_event_id": 1002, "tevo_tix_now": 100, "tevo_tix_d24h": -500,
+         "tevo_getin_now": 10.0, "tevo_getin_d24h_pct": -20.0, "tevo_now_at": fresh_ts},
+    ]
+    fake_lifecycle = [
+        {"event_id": 1001, "is_active": True},
+        {"event_id": 1002, "is_active": True},
+    ]
+
+    table_map = {
+        "latest_event_metrics": fake_metrics,
+        "events": fake_events,
+        "event_lifecycle": fake_lifecycle,
+        "v_event_velocity_windows": fake_velocity,
+    }
+
+    # Reuse the FakeSupabase pattern from test_store_home — minimal table stub.
+    class _T:
+        def __init__(self, rows): self._rows = rows
+        def select(self, *_, **__): return self
+        def in_(self, _col, _vals): return self
+        def execute(self):
+            class R:
+                def __init__(s, data): s.data = data
+            return R(self._rows)
+        def gt(self, *_, **__): return self
+        def gte(self, *_, **__): return self
+        def lt(self, *_, **__): return self
+        def lte(self, *_, **__): return self
+        def eq(self, *_, **__): return self
+        def is_(self, *_, **__): return self
+        def not_(self, *_, **__): return self
+        def or_(self, *_, **__): return self
+        def order(self, *_, **__): return self
+        def limit(self, *_, **__): return self
+        def neq(self, *_, **__): return self
+
+    class _DB:
+        def table(self, name): return _T(table_map.get(name, []))
+
+    monkeypatch.setattr(app_module, "require_sb", lambda: _DB())
+    monkeypatch.setattr(app_module, "_bulk_performer_assets", lambda *a, **k: {})
+    # Bypass the cache so we hit _compute_movers directly.
+    monkeypatch.setattr(app_module, "_movers_cache", {})
+    monkeypatch.setattr(app_module, "_MOVERS_CACHE_REFRESHING", set())
+
+    client = TestClient(app_module.app)
+    r = client.get("/api/store/movers?city=NYC&days=30&limit=10")
+    assert r.status_code == 200, r.text
+
+    by_id = {e["id"]: e for e in r.json()["events"]}
+
+    # Stale event (1001): velocity-suspect, so tix_d24h must be None and
+    # signal must NOT be selling_fast (no velocity-derived signal allowed).
+    # It also shouldn't make the cut as a candidate (no signal, no
+    # meaningful d24h activity since d24h was dropped).
+    assert 1001 not in by_id, (
+        "stale-velocity event must NOT surface — tix_d24h suppressed and no signal"
+    )
+
+    # Fresh event (1002): velocity trusted; -500 ticket drop fires selling_fast.
+    assert 1002 in by_id, "fresh-velocity event should make the strip"
+    assert by_id[1002]["signal"] == "selling_fast"
+    assert by_id[1002]["tix_d24h"] == -500
+
+
+def test_movers_response_no_longer_includes_tix_d1h(monkeypatch):
+    """tix_d1h was removed from the response (was equal to tix_d24h
+    when collector cadence is the only available sample, misleading).
+    Renderer never read it. Guard against accidental re-introduction."""
+    from datetime import datetime, timezone, timedelta
+    fresh_ts = (datetime.now(timezone.utc) - timedelta(minutes=15)).isoformat()
+
+    fake_metrics = [{"event_id": 2001, "owned_tickets_count": 50, "owned_groups_count": 5, "retail_min": 30.0}]
+    fake_events = [{"id": 2001, "name": "Test", "occurs_at_local": "2026-06-01T19:00:00-04:00",
+                    "venue_name": "MSG", "venue_location": "New York, NY",
+                    "primary_performer_id": 16303, "primary_performer_name": "Yankees"}]
+    fake_velocity = [{"tevo_event_id": 2001, "tevo_tix_now": 50, "tevo_tix_d24h": -80,
+                      "tevo_getin_now": 12.0, "tevo_getin_d24h_pct": -5.0, "tevo_now_at": fresh_ts}]
+    fake_lifecycle = [{"event_id": 2001, "is_active": True}]
+    table_map = {"latest_event_metrics": fake_metrics, "events": fake_events,
+                 "event_lifecycle": fake_lifecycle, "v_event_velocity_windows": fake_velocity}
+
+    class _T:
+        def __init__(self, rows): self._rows = rows
+        def select(self, *_, **__): return self
+        def in_(self, _col, _vals): return self
+        def execute(self):
+            class R:
+                def __init__(s, data): s.data = data
+            return R(self._rows)
+        def gt(self, *_, **__): return self
+        def gte(self, *_, **__): return self
+        def lt(self, *_, **__): return self
+        def lte(self, *_, **__): return self
+        def eq(self, *_, **__): return self
+        def is_(self, *_, **__): return self
+        def not_(self, *_, **__): return self
+        def or_(self, *_, **__): return self
+        def order(self, *_, **__): return self
+        def limit(self, *_, **__): return self
+        def neq(self, *_, **__): return self
+
+    class _DB:
+        def table(self, name): return _T(table_map.get(name, []))
+
+    monkeypatch.setattr(app_module, "require_sb", lambda: _DB())
+    monkeypatch.setattr(app_module, "_bulk_performer_assets", lambda *a, **k: {})
+    monkeypatch.setattr(app_module, "_movers_cache", {})
+    monkeypatch.setattr(app_module, "_MOVERS_CACHE_REFRESHING", set())
+
+    client = TestClient(app_module.app)
+    r = client.get("/api/store/movers?city=NYC&days=30&limit=10")
+    assert r.status_code == 200
+    for ev in r.json()["events"]:
+        assert "tix_d1h" not in ev, (
+            f"tix_d1h must not appear in mover response; got keys: {list(ev.keys())}"
+        )
+
+
+def test_store_html_routes_respond_to_head(monkeypatch):
+    """HEAD requests on the 4 production storefront HTML routes return
+    200 (not 405). Uptime monitors that default to HEAD probes were
+    alerting; PR adds HEAD support via @app.api_route(..., methods=...)."""
+    monkeypatch.setattr(app_module, "_read_storefront_html", lambda name: "<html>ok</html>")
+    client = TestClient(app_module.app)
+    for path in ("/store", "/store/event/123", "/s/test-id", "/store/shares"):
+        r = client.head(path)
+        assert r.status_code == 200, (
+            f"HEAD {path} expected 200, got {r.status_code}"
+        )


### PR DESCRIPTION
## Summary
Two findings from today's audit (post-PR #156):

**E — HEAD method on storefront HTML routes**
- `/store`, `/store/event/{id}`, `/s/{share_id}`, `/store/shares` previously returned 405 on HEAD requests (only GET registered). Some uptime monitors default to HEAD and would alert.
- Swap `@app.get` → `@app.api_route(..., methods=["GET", "HEAD"])` on the 4 production routes. Starlette strips the body on HEAD automatically; no new handler needed. Test pages (`/store/test/*`) unchanged — non-prod.

**A — Movers velocity-freshness gate (collector-cadence honesty)**
- `v_event_velocity_windows` computes `tevo_tix_d1h` / `tevo_tix_d24h` via subqueries that fall back to the most recent sample `<= now-Xh`. When the collector hasn't fired in the relevant window (known gap per [PROJECT_BIBLE.md](PROJECT_BIBLE.md) §9 — `collect-listings-1-7d` + `60d+` 0 firings/7d), **both** subqueries resolve to the **same ancient sample** → `d1h == d24h`. The "N sold today" badge then attributes multi-day movement to a single day.
- Reproduced live: event 3091413 (Yankees 5/18) — captures at `2026-05-16 17:30` and `2026-05-14 16:05` — a 49-hour gap. Both `tevo_tix_1h_ago` and `tevo_tix_24h_ago` fall through to the same 5/14 sample.
- `/api/store/movers` now suppresses `tix_d24h` + `getin_pct_24h` when `tevo_now_at` is older than 3 hours. `premium` signal (price ≥ $500, independent of velocity) still fires for stale events so they keep surfacing.
- **Drops `tix_d1h` from the response entirely.** Was unused by `store.js` (renderer only reads `tix_d24h`) and its value was misleading on the same staleness pattern.

## Test plan
- [x] `pytest tests/test_store_home.py -q` — 32/32 passing (+3 new)
- [x] `pytest tests/ -q --ignore=test_readonly_guards.py --ignore=test_broadway_client.py` — 117 passed, 9 skipped
- [ ] After deploy, smoke matrix:
  - `curl -I /store` → 200 (was 405)
  - `curl /api/store/movers` → no `tix_d1h` key in any event object
  - Cards on `/store` with stale-velocity events (Yankees 5/18 cluster) — no "513 sold today" badge until collector cadence is fixed (B1 lane); cards still appear via `premium` if price ≥ $500

## Companion cleanup
12 merged D1 feature branches deleted from `origin` (`d1-store-*`, `d1-event-a11y`, `d1-render-starter-plan`, etc.). All squash-merged into `main`; the source branches were stale noise in `git branch -r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)