### PR TITLE
fix(d0): Phase 2a polish — UX fixes + relative asset paths (live Render routing)

### DIFF
--- a/static/terminal/auth.js
+++ b/static/terminal/auth.js
@@ -7,8 +7,8 @@
 //
 // Operator one-time setup (per d2_dashboard/DEPLOY.md):
 //   Supabase Auth → URL Configuration → Redirect URLs, add:
-//     https://vibepass-terminal-test.onrender.com/static/terminal/login.html
-//     http://localhost:8000/static/terminal/login.html  (for dev)
+//     https://vibepass-terminal-test.onrender.com/login.html         (Render publishPath=static/terminal serves at root)
+//     http://localhost:8000/static/terminal/login.html                (localhost uvicorn serves under /static prefix)
 //
 // Public anon key — safe to embed in static-site JS (RLS gates access).
 
@@ -67,7 +67,9 @@
 
   function loginUrl(returnUrl) {
     const here = returnUrl || (location.pathname + location.search);
-    return '/static/terminal/login.html?return=' + encodeURIComponent(here);
+    // Relative path — browser resolves relative to current page, so works
+    // under both /static/terminal/ (localhost uvicorn) and / (Render CDN).
+    return 'login.html?return=' + encodeURIComponent(here);
   }
 
   async function requireAuth() {
@@ -91,7 +93,11 @@
 
   async function signInWithGoogle(returnUrl) {
     const here = returnUrl || (location.pathname + location.search);
-    const redirectTo = location.origin + '/static/terminal/login.html?return=' + encodeURIComponent(here);
+    // Absolute URL required by Supabase OAuth (must match an allow-listed
+    // redirect URL exactly). Use new URL() to resolve login.html relative to
+    // current page — yields /static/terminal/login.html on localhost or
+    // /login.html on Render where publishPath=static/terminal serves at root.
+    const redirectTo = new URL('login.html?return=' + encodeURIComponent(here), location.href).toString();
     const { error } = await client.auth.signInWithOAuth({
       provider: 'google',
       options: {
@@ -104,7 +110,7 @@
 
   async function signOut() {
     try { await client.auth.signOut(); } catch (e) { console.warn('signOut error', e); }
-    window.location.href = '/static/terminal/login.html';
+    window.location.href = 'login.html';
   }
 
   function getAccessToken() {

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -7,8 +7,8 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Event</title>
-  <link rel="stylesheet" href="/static/terminal/lib/uplot.min.css" />
-  <link rel="stylesheet" href="/static/terminal/style.css" />
+  <link rel="stylesheet" href="lib/uplot.min.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="event">
 
@@ -153,11 +153,11 @@
     </section>
   </main>
 
-  <script src="/static/terminal/lib/supabase.js"></script>
-  <script src="/static/terminal/lib/uplot.iife.min.js"></script>
-  <script src="/static/terminal/auth.js"></script>
-  <script src="/static/terminal/app.js"></script>
-  <script src="/static/terminal/nav.js"></script>
-  <script src="/static/terminal/event.js"></script>
+  <script src="lib/supabase.js"></script>
+  <script src="lib/uplot.iife.min.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="event.js"></script>
 </body>
 </html>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -322,10 +322,24 @@
     const share = (qtyOwn && qtyMkt && qtyMkt > 0) ? (qtyOwn / qtyMkt * 100) : null;
     setKpiSub('kpiQtyOwnedSub', share != null ? `${share.toFixed(1)}% of market` : '');
 
-    // Get-in  (TEvo nothing direct; SG cost_min)
-    const tevoGetin = market != null ? null : null;  // v1 chart_data lacks min; SG side carries it
-    setKpi('kpiGetinVal', sg && sg.cost_min != null ? '$' + T.fmtNum(sg.cost_min, { max: 0 }) : (tevoGetin != null ? '$' + T.fmtNum(tevoGetin) : '—'));
-    setKpiSg('kpiGetinSG', null, null, '', 0, true);  // suppress SG row (already primary)
+    // Get-in (cheapest available ticket): prefer SG cost_min, fall back to TEvo
+    // splits.market.singles.min_px (smallest 1-tix market lot). Keeps the cell
+    // populated for TEvo-only events instead of "—".
+    let getinVal = sg && sg.cost_min != null ? sg.cost_min : null;
+    let getinSrc = sg && sg.cost_min != null ? 'SG' : null;
+    if (getinVal == null && _lastPayload && _lastPayload.splits) {
+      const marketSingles = _lastPayload.splits.market && _lastPayload.splits.market.singles;
+      if (marketSingles && marketSingles.min_px != null) {
+        getinVal = marketSingles.min_px;
+        getinSrc = 'TEvo';
+      }
+    }
+    setKpi('kpiGetinVal', getinVal != null ? '$' + T.fmtNum(getinVal, { max: 0 }) : '—');
+    const getinSub = document.getElementById('kpiGetinSG');
+    if (getinSub) {
+      getinSub.textContent = getinSrc ? getinSrc.toLowerCase() === 'sg' ? '' : 'src: TEvo singles' : '';
+      getinSub.className = 'kpi-sg';
+    }
 
     // Owned Median (our retail)
     setKpi('kpiOwnedMedianVal', owned != null ? '$' + T.fmtNum(owned, { max: 0 }) : '—');
@@ -881,12 +895,19 @@
 
   function renderFreshness(fr) {
     if (!fr) return;
+    // Weather: prefer obs latest, fall back to most-recent forecast time so
+    // outdoor events with forecast-only data don't render a misleading dim chip.
+    const weatherTs = fr.weather_latest || latestForecastTs();
+    // ESPN: max of team + injuries timestamps (NOT first non-null — team
+    // snapshots are gameday-batched and often 3d stale even when injuries
+    // ingested 6 min ago).
+    const espnTs = maxTs(fr.espn_team_latest, fr.espn_inj_latest);
     const map = {
       'tevo':     fr.tevo_listings_latest,
       'sg-lst':   fr.sg_listings_latest,
       'sg-sales': fr.sg_sales_latest,
-      'weather':  fr.weather_latest,
-      'espn':     fr.espn_team_latest || fr.espn_inj_latest,
+      'weather':  weatherTs,
+      'espn':     espnTs,
     };
     Object.entries(map).forEach(([src, ts]) => {
       const el = document.querySelector(`.fr-chip[data-src="${src}"]`);
@@ -904,6 +925,21 @@
       el.classList.add(stale ? 'stale' : 'fresh');
       el.title = `${label}: ${T.fmtDate(ts)}`;
     });
+  }
+  function maxTs(...tss) {
+    let best = null;
+    for (const t of tss) {
+      if (!t) continue;
+      if (best == null || new Date(t).getTime() > new Date(best).getTime()) best = t;
+    }
+    return best;
+  }
+  function latestForecastTs() {
+    const w = _lastPayload && _lastPayload.weather;
+    if (!w || w.hidden) return null;
+    const fc = w.forecast || [];
+    if (!fc.length) return null;
+    return fc.reduce((acc, f) => maxTs(acc, f.observed_at), null);
   }
   function chipLabel(src) {
     return { tevo: 'TEvo', 'sg-lst': 'SG L', 'sg-sales': 'SG S', weather: 'Wx', espn: 'ESPN' }[src] || src;

--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -103,7 +103,7 @@
       const dpct = +r.delta_owned_pct;
       const card = document.createElement('a');
       card.className = 'mover-card ' + c.sign;
-      card.href = '/static/terminal/event.html?event=' + r.event_id;
+      card.href = 'event.html?event=' + r.event_id;
       card.innerHTML = `
         <div class="mc-name">${escapeHtml(r.event_name || ('Event ' + r.event_id))}</div>
         <div class="mc-meta">${escapeHtml(r.performer_name || '')}${r.venue_name ? ' · ' + escapeHtml(r.venue_name) : ''}</div>
@@ -169,7 +169,7 @@
       const dvalTxt = !Number.isFinite(dval) ? '—' : (dval >= 0 ? '+' : '−') + '$' + T.fmtNum(Math.round(Math.abs(dval)));
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td><a href="/static/terminal/event.html?event=${r.event_id}">${escapeHtml(r.event_name || ('Event ' + r.event_id))}</a></td>
+        <td><a href="event.html?event=${r.event_id}">${escapeHtml(r.event_name || ('Event ' + r.event_id))}</a></td>
         <td>${escapeHtml(r.performer_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
         <td class="num">${T.fmtNum(ot)}</td>

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Home</title>
-  <link rel="stylesheet" href="/static/terminal/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="home">
 
@@ -40,7 +40,7 @@
     <section id="movers-strip">
       <div class="panel-title row">
         <span>TOP MOVERS · 24H · OUR BOOK MARK-TO-MARKET</span>
-        <a href="/static/terminal/movers.html" class="more-link">all movers →</a>
+        <a href="movers.html" class="more-link">all movers →</a>
       </div>
       <div class="movers-grid" id="moversGrid">
         <div class="empty">loading…</div>
@@ -61,10 +61,10 @@
     </section>
   </main>
 
-  <script src="/static/terminal/lib/supabase.js"></script>
-  <script src="/static/terminal/auth.js"></script>
-  <script src="/static/terminal/app.js"></script>
-  <script src="/static/terminal/nav.js"></script>
-  <script src="/static/terminal/home.js"></script>
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="home.js"></script>
 </body>
 </html>

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Sign in</title>
-  <link rel="stylesheet" href="/static/terminal/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="login">
 
@@ -35,8 +35,8 @@
     </div>
   </main>
 
-  <script src="/static/terminal/lib/supabase.js"></script>
-  <script src="/static/terminal/auth.js"></script>
-  <script src="/static/terminal/login.js"></script>
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="login.js"></script>
 </body>
 </html>

--- a/static/terminal/login.js
+++ b/static/terminal/login.js
@@ -15,7 +15,10 @@
   }
 
   const params = new URLSearchParams(location.search);
-  const returnUrl = params.get('return') || '/static/terminal/';
+  // Default return: the directory containing login.html — yields
+  // /static/terminal/ on localhost uvicorn and / on Render static-site CDN.
+  const defaultReturn = location.pathname.replace(/login\.html.*$/, '');
+  const returnUrl = params.get('return') || defaultReturn;
   const errParam = params.get('error');
 
   const errEl = document.getElementById('loginErr');
@@ -58,7 +61,7 @@
     }
     // Valid session — bounce to where we came from.
     // Defensive: only bounce to same-origin URLs to avoid open-redirect.
-    const safe = isSafeReturn(returnUrl) ? returnUrl : '/static/terminal/';
+    const safe = isSafeReturn(returnUrl) ? returnUrl : defaultReturn;
     window.location.replace(safe);
   });
 

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Movers</title>
-  <link rel="stylesheet" href="/static/terminal/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="movers">
 
@@ -45,10 +45,10 @@
     </section>
   </main>
 
-  <script src="/static/terminal/lib/supabase.js"></script>
-  <script src="/static/terminal/auth.js"></script>
-  <script src="/static/terminal/app.js"></script>
-  <script src="/static/terminal/nav.js"></script>
-  <script src="/static/terminal/movers.js"></script>
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="movers.js"></script>
 </body>
 </html>

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -133,7 +133,7 @@
       const tr = document.createElement('tr');
       tr.classList.add('clickable');
       tr.addEventListener('click', () => {
-        window.location.href = '/static/terminal/event.html?event=' + r.event_id;
+        window.location.href = 'event.html?event=' + r.event_id;
       });
       const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
       const mDPct = +r.delta_market_pct;
@@ -141,7 +141,7 @@
       const mDVal = +r.delta_market_val;
       const oDVal = +r.delta_owned_val;
       tr.innerHTML = `
-        <td><a href="/static/terminal/event.html?event=${r.event_id}" onclick="event.stopPropagation()">${escapeHtml(r.event_name || ('Event ' + r.event_id))}</a></td>
+        <td><a href="event.html?event=${r.event_id}" onclick="event.stopPropagation()">${escapeHtml(r.event_name || ('Event ' + r.event_id))}</a></td>
         <td>${escapeHtml(r.performer_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
         <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -4,12 +4,16 @@
 (function () {
   'use strict';
 
+  // Relative hrefs so the same nav works under both deploy targets:
+  // (a) localhost uvicorn at /static/terminal/, (b) Render static-site CDN
+  // at root (publishPath strips static/terminal/). Each link is resolved
+  // relative to the current page URL by the browser.
   const PAGES = [
-    { id: 'home',      label: 'HOME',      href: '/static/terminal/' },
-    { id: 'event',     label: 'EVENT',     href: '/static/terminal/event.html' },
-    { id: 'movers',    label: 'MOVERS',    href: '/static/terminal/movers.html' },
-    { id: 'performer', label: 'PERFORMER', href: '/static/terminal/performer.html' },
-    { id: 'orders',    label: 'ORDERS',    href: '/static/terminal/orders.html' },
+    { id: 'home',      label: 'HOME',      href: './' },
+    { id: 'event',     label: 'EVENT',     href: 'event.html' },
+    { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
+    { id: 'performer', label: 'PERFORMER', href: 'performer.html' },
+    { id: 'orders',    label: 'ORDERS',    href: 'orders.html' },
   ];
 
   function inject() {

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
-  <link rel="stylesheet" href="/static/terminal/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="orders">
 
@@ -105,10 +105,10 @@
     </section>
   </main>
 
-  <script src="/static/terminal/lib/supabase.js"></script>
-  <script src="/static/terminal/auth.js"></script>
-  <script src="/static/terminal/app.js"></script>
-  <script src="/static/terminal/nav.js"></script>
-  <script src="/static/terminal/orders.js"></script>
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="orders.js"></script>
 </body>
 </html>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Performer</title>
-  <link rel="stylesheet" href="/static/terminal/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body data-page="performer">
 
@@ -59,10 +59,10 @@
     </section>
   </main>
 
-  <script src="/static/terminal/lib/supabase.js"></script>
-  <script src="/static/terminal/auth.js"></script>
-  <script src="/static/terminal/app.js"></script>
-  <script src="/static/terminal/nav.js"></script>
-  <script src="/static/terminal/performer.js"></script>
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="performer.js"></script>
 </body>
 </html>

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -131,7 +131,7 @@
       const ownedShare = e.owned_share != null ? T.fmtPct(e.owned_share * 100, 0) : '—';
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td><a href="/static/terminal/event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a></td>
+        <td><a href="event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a></td>
         <td>${escapeHtml(e.venue_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
         <td class="num">${T.fmtNum(e.tickets_count || 0)}</td>

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -542,7 +542,13 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
   gap: 24px;
   align-items: start;
 }
-.hero-main .title { font-size: 22px; font-weight: 600; margin: 0 0 4px; color: var(--text); }
+.hero-main { min-width: 0; }  /* allow long titles to wrap instead of pushing hero-side off-grid */
+.hero-main .title {
+  font-size: 22px; font-weight: 600; margin: 0 0 4px; color: var(--text);
+  line-height: 1.15;
+  /* Wrap on any whitespace; never overflow the grid column. */
+  overflow-wrap: anywhere;
+}
 .hero-main .meta  { color: var(--muted); font-family: var(--mono); font-size: 12px; margin: 0 0 8px; }
 .hero-main .meta .dot { margin: 0 8px; color: var(--dim); }
 .hero-main .badges { display: flex; gap: 6px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary

Two follow-ups to the merged Phase 2a scaffold ([apps#160](https://github.com/JulianS4K/Terminal-2/pull/160)):

### Commit 1 — UX fixes verified against 5 prod payloads

Smoke-tested the merged Event Detail scaffold against 5 diverse v2 payloads pulled live from prod (`get_broker_event_page_v2`). 4 issues found + fixed:

1. **ESPN freshness chip** used first-non-null of `(team_latest, inj_latest)` — a 3d-stale team snapshot always beat fresh 6-min injuries ingest. Now `max()` of both. Yankees: `ESPN 3d stale` → `ESPN 15m fresh`.
2. **Weather freshness chip** stayed dim despite 6 forecast cells visible. RPC's `weather_latest` only reads `MAX(observed_at WHERE is_forecast=false)`; all 5 prod samples had `weather_latest=null` because venues have forecast-only weather. FE fallback derives chip time from `forecast[].observed_at` when null.
3. **Get-in cell** rendered `—` on TEvo-only events. Falls back to `splits.market.singles.min_px`. Springsteen: `—` → `$50` + `src: TEvo singles` subtitle.
4. **Hero title wrap protection** — 83-char prod title fit at 1440 with only 24px gap to side panel. Extreme stress (213-char) would have pushed off-grid. Added `min-width: 0` + `overflow-wrap: anywhere` on `.hero-main`. 213-char now wraps to 2 lines cleanly.

### Commit 2 — Relative asset paths (CRITICAL — Render serving 404s)

While live-smoke-testing PR #160 against `vibepass-terminal-test.onrender.com`, every asset returned 404. Root cause: HTML referenced `/static/terminal/{style.css, event.js, lib/supabase.js, ...}` but `render-d0-terminal.yaml` sets `publishPath: static/terminal`, so the CDN serves those files at root (`/style.css`, `/event.js`, `/lib/supabase.js`).

The yaml has a rewrite rule (`/static/terminal/* → /:splat`) but it isn't active on the live service — likely the blueprint was edited after provisioning and the service config never re-imported.

Switching to relative paths makes the pages resilient to both deploy targets:
- localhost uvicorn at `/static/terminal/event.html` → relative `style.css` resolves to `/static/terminal/style.css` ✓
- Render CDN at `/event.html` → relative `style.css` resolves to `/style.css` ✓

54 references patched across 12 files: 6 HTML files (link/script srcs), nav.js (PAGES hrefs), auth.js (loginUrl + signOut + signInWithGoogle redirectTo via `new URL()` resolution), login.js (defaultReturn computed from pathname), home/movers/performer.js (event.html links).

Localhost preview re-verified post-fix: all 6 scripts + 2 CSS files load, all 10 event-page sections present, all globals (TerminalAuth, uPlot, supabase, Terminal) defined.

## Operator follow-up (after this merges + Render auto-deploys)

Add `https://vibepass-terminal-test.onrender.com/login.html` to Supabase project's Auth → URL Configuration → Redirect URLs. The existing localhost entry (`http://localhost:8000/static/terminal/login.html`) stays valid.

## Test plan

- [ ] After CI green + Render auto-deploy, `curl https://vibepass-terminal-test.onrender.com/event.html?event=3091413` returns 200 (was 200; verify HTML matches new shell)
- [ ] Browser-load that URL → CSS + JS load (network panel shows no 404s)
- [ ] After operator adds the new redirect URL, OAuth flow completes
- [ ] Signed-in @s4kent.com session → page renders Yankees 5/18 data live from `get_broker_event_page_v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)