### PR TITLE
d1: Sprint 4a — SEO basics (favicon + OG tags + meta description)

### DIFF
--- a/static/store/event.html
+++ b/static/store/event.html
@@ -6,7 +6,27 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
-  <title>VibePass — event</title>
+  <!-- Title + description are overridden per-event by store.js once the
+       /api/store/events/:id payload lands. These defaults are what crawlers
+       that don't run JS see, and what shows briefly before JS settles. -->
+  <title>VibePass — event tickets</title>
+  <meta name="description" content="Direct-inventory tickets for this event on VibePass. Transparent pricing, no daisy chains." />
+
+  <!-- Open Graph / share-card rendering. JS updates og:title, og:description,
+       og:url with per-event values when the event payload resolves so share
+       links render with the event name + venue + date. -->
+  <meta property="og:type" content="event" />
+  <meta property="og:site_name" content="VibePass" />
+  <meta property="og:title" content="VibePass — event tickets" />
+  <meta property="og:description" content="Direct-inventory tickets for this event." />
+  <meta property="og:url" content="" />
+  <meta property="og:image" content="https://vibepass-storefront-test.onrender.com/static/store/og-default.svg" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="VibePass — event tickets" />
+  <meta name="twitter:description" content="Direct-inventory tickets for this event." />
+
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="event">

--- a/static/store/favicon.svg
+++ b/static/store/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0e0f12"/>
+  <path d="M16 18 L32 50 L48 18 L40 18 L32 38 L24 18 Z" fill="#ff5c2a"/>
+  <path d="M14 14 L20 14 L17 18 Z" fill="#ffa066"/>
+</svg>

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -6,7 +6,26 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
-  <title>VibePass — tickets</title>
+  <title>VibePass — direct-inventory tickets for sports + live events</title>
+  <meta name="description" content="Browse sports and live-event tickets we hold directly. Transparent pricing, no daisy chains. New York metro + premium playoffs nationally." />
+
+  <!-- Open Graph / share-card rendering. iMessage/Slack/WhatsApp/Discord
+       use these tags to build link previews. The image URL must be
+       absolute (preview bots don't resolve relative paths). -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VibePass" />
+  <meta property="og:title" content="VibePass — direct-inventory tickets" />
+  <meta property="og:description" content="Sports + live-event tickets we hold directly. Transparent pricing." />
+  <meta property="og:url" content="https://vibepass-storefront-test.onrender.com/store" />
+  <meta property="og:image" content="https://vibepass-storefront-test.onrender.com/static/store/og-default.svg" />
+
+  <!-- Twitter Card — falls back to og:* tags when not specified, but
+       summary_large_image renders a wider preview on Twitter / X. -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="VibePass — direct-inventory tickets" />
+  <meta name="twitter:description" content="Sports + live-event tickets we hold directly. Transparent pricing." />
+
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="catalog">

--- a/static/store/og-default.svg
+++ b/static/store/og-default.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#0e0f12"/>
+  <rect x="0" y="0" width="1200" height="6" fill="#ff5c2a"/>
+
+  <!-- V mark -->
+  <g transform="translate(80, 130)">
+    <path d="M0 0 L70 140 L140 0 L105 0 L70 80 L35 0 Z" fill="#ff5c2a"/>
+    <path d="M-10 -20 L20 -20 L5 -2 Z" fill="#ffa066"/>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="250" y="220" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="92" font-weight="800" fill="#eef0f4" letter-spacing="-1">VibePass</text>
+
+  <!-- Tagline -->
+  <text x="80" y="380" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="48" font-weight="700" fill="#eef0f4">Direct-inventory tickets.</text>
+  <text x="80" y="440" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="48" font-weight="700" fill="#ffa066">Transparent pricing.</text>
+
+  <!-- Footer line -->
+  <text x="80" y="560" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="22" fill="#9aa0a6">Sports · live entertainment · NYC metro</text>
+</svg>

--- a/static/store/shares.html
+++ b/static/store/shares.html
@@ -6,7 +6,10 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
-  <title>VibePass — share links</title>
+  <meta name="robots" content="noindex" />
+  <title>Share links — VibePass admin</title>
+  <meta name="description" content="VibePass admin: manage revocable share links." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="shares">

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -770,6 +770,37 @@
   }
 
   // ---------- Event detail page ----------
+  // SEO + share-card metadata updater. Runs after /api/store/events/:id
+  // resolves so document.title + OG tags reflect the event name + venue.
+  // Pure DOM mutation; no fetches. Crawlers/preview-bots that run JS pick
+  // these up; static fallbacks in <head> cover the no-JS path.
+  function updateEventMeta(event) {
+    if (!event) return;
+    const name = String(event.name || "").trim();
+    const venue = event.venue || {};
+    const venueLabel = [venue.name, venue.location].filter(Boolean).join(", ");
+    const titleText = name
+      ? `${name} — VibePass`
+      : "Event tickets — VibePass";
+    const descText = name && venueLabel
+      ? `Direct-inventory tickets for ${name} at ${venueLabel}. Transparent pricing on VibePass.`
+      : (name
+          ? `Direct-inventory tickets for ${name}. Transparent pricing on VibePass.`
+          : "Direct-inventory event tickets. Transparent pricing on VibePass.");
+
+    document.title = titleText;
+    const setMeta = (selector, value) => {
+      const el = document.querySelector(selector);
+      if (el && value != null) el.setAttribute("content", String(value));
+    };
+    setMeta('meta[name="description"]', descText);
+    setMeta('meta[property="og:title"]', titleText);
+    setMeta('meta[property="og:description"]', descText);
+    setMeta('meta[property="og:url"]', location.href);
+    setMeta('meta[name="twitter:title"]', titleText);
+    setMeta('meta[name="twitter:description"]', descText);
+  }
+
   function mountEvent() {
     // The event/listings page is also the share-link surface — the URL is
     // the source of truth for the filter set. Two URL shapes can land here:
@@ -1486,6 +1517,12 @@
       const filters = res.filters || readFiltersFromUI();
 
       $("#evName").textContent = event.name || "Untitled event";
+
+      // Update SEO/share-card metadata from the resolved event payload.
+      // Crawlers that DO run JS (Googlebot, modern social previewers) pick
+      // up these mutations; static fallback values in <head> cover the
+      // no-JS / static-snapshot path.
+      updateEventMeta(event);
 
       // Venue hero image (audit-lane venue_assets.hero_image_url). Subtle
       // backdrop, dimmed by CSS so the heading stays legible.


### PR DESCRIPTION
## Summary
Storefront previously had no favicon, no OG meta tags, no \`<meta name="description">\`. Share links rendered as bare URLs in iMessage/Slack/WhatsApp/Discord; search-engine snippets fell back to whatever the crawler stitched from page text. This PR ships the SEO basics.

**New static assets**
- [static/store/favicon.svg](static/store/favicon.svg) — minimal "V" mark in accent on dark
- [static/store/og-default.svg](static/store/og-default.svg) — 1200×630 share card with wordmark + tagline

**index.html (homepage)**
- Better \`<title>\`, real \`<meta name="description">\`
- \`og:type=website\`, og:title, og:description, og:url, og:image
- twitter:card=summary_large_image + matching title/description
- favicon link

**event.html (event detail)**
- Same head scaffold with \`og:type=event\`
- Static defaults so crawlers without JS see "VibePass — event tickets"
- New \`updateEventMeta()\` in store.js rewrites \`document.title\` + meta description + og:title/og:description/og:url at the moment \`/api/store/events/:id\` resolves. Modern social previewers (Slack, Discord, Googlebot) execute JS and pick up the per-event values; iMessage / static-snapshot crawlers see the fallback.

**shares.html (admin)**
- robots: noindex (admin surface shouldn't appear in search)
- favicon + minimal meta description for browser tab

**JSON-LD intentionally skipped this PR.** \`<script type="application/ld+json">\` is gated by \`script-src 'self'\` in our CSP. Relaxing CSP for inline scripts (or adding a nonce/hash path) is a B1 review. External JSON-LD file (loaded as \`<link rel="alternate" type="application/ld+json">\`) is the natural follow-up — not in scope here.

## Test plan
- [x] \`pytest tests/ -q\` — 114 passed, 9 skipped
- [x] \`node --check static/store/store.js\` — syntax valid
- [x] HTML parses cleanly on all 3 modified pages
- [ ] After deploy:
  - Validate \`https://vibepass-storefront-test.onrender.com/store\` on https://www.opengraph.xyz/ — OG tags resolve, image renders
  - DevTools on \`/store/event/3346001\`: confirm \`document.title\` updates to "TBD at New York Knicks (Round 3 - Home Game 2) — VibePass" after API resolves
  - Favicon shows in browser tab
  - \`curl https://vibepass-storefront-test.onrender.com/static/store/og-default.svg\` → 200 image/svg+xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)