### PR TITLE
feat(unified-shell): mount d2_dashboard.router on storefront-test (testing-only architecture)

### DIFF
--- a/app.py
+++ b/app.py
@@ -6771,6 +6771,27 @@ def store_test_media_test_page(_=Depends(_require_non_prod)):
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "media_test.html"))
 
 
+# ============================================================
+# D2 dashboard mount (unified-for-testing architecture, 2026-05-16)
+# ============================================================
+# Operator directive: keep 3 services alive (terminal-test, storefront-test,
+# d2-orders-dashboard) but route warm runtime traffic to storefront-test during
+# dev/test to avoid cold-start drag. At beta, each surface migrates back to its
+# own service. PR #129 exposed d2_dashboard.main.router for this purpose.
+#
+# Mount strategy: prefix-less include_router (resolves bot_chat 180 question A).
+# D2's `/api/d2/*` routes land at same paths. D2's standalone `@router.get("/")`
+# is shadowed by the earlier `@app.get("/")` homescreen (FastAPI: first-registered
+# wins for matching). Auth (question B): D2 routes reuse their own dependency
+# injection; the shell's `require_auth` applies on app.py's own routes.
+try:
+    from d2_dashboard.main import router as d2_router  # type: ignore
+    app.include_router(d2_router)
+    logging.getLogger(__name__).info("d2_dashboard router mounted at unified shell (%d routes)", len(d2_router.routes))
+except Exception as _d2_import_err:  # pragma: no cover — d2 module optional in dev
+    logging.getLogger(__name__).warning("d2_dashboard router NOT mounted: %s", _d2_import_err)
+
+
 # Static assets (CSS / JS / images) served from /static.
 # Keep this LAST so explicit routes above win.
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")


### PR DESCRIPTION
## Summary

Operator directive 2026-05-16: unified-for-testing architecture. Route runtime traffic through `vibepass-storefront-test` (already on starter plan, no cold starts) during dev/test. Keep `vibepass-terminal-test` + `d2-orders-dashboard` services alive as placeholders for beta-time migration back to per-surface services.

## What changed

`app.py` +21 LOC at the end: import `d2_dashboard.main.router` and `app.include_router(d2_router)`.

## Routes added to unified shell (8 /api/d2/* routes)

- `/api/d2/config`
- `/api/d2/config-public`
- `/api/d2/orders`
- `/api/d2/cron-freshness`
- `/api/d2/health`
- `/api/d2/order/{source}/{order_id}`
- `/api/d2/metrics`
- `/api/d2/sales-feed`

D2's standalone `@router.get("/")` is shadowed by app.py's earlier `@app.get("/")` homescreen (FastAPI: first-registered wins for matching) — intentional. The standalone `d2-orders-dashboard` service still serves its own `/` for direct access during beta.

## bot_chat 180 architecture decisions resolved

- **A. Mount strategy**: APIRouter prefix-less `include_router` (D2's recommendation; clean middleware composition)
- **B. Auth**: D2 routes use their own dependency injection. Shell's `require_auth` applies on app.py's own routes. No shell injection needed.
- **C. Homescreen**: 3 hardcoded tiles (already shipped at `/home/index.html`)
- **D. Cutover**: incremental, non-destructive. `vibepass-terminal-test` + `d2-orders-dashboard` services stay alive as beta-time placeholders.

## Smoke test

```
STOREFRONT_SQL_ONLY=true py -3 -c "from app import app; print([r.path for r in app.routes if 'd2' in r.path or r.path in ['/','/terminal','/undelivered','/store']])"
```

Returns: 8 d2 routes + all 4 entry routes intact. Tested locally on this PR's HEAD.

## Architecture diagram

```
                  vibepass-storefront-test (UNIFIED RUNTIME)
                  ├── /                  homescreen
                  ├── /home              homescreen (alias)
                  ├── /terminal          D0 terminal UI
                  ├── /undelivered       D0 undelivered UI (D2 fills via /api/d2/*)
                  ├── /store             D1 storefront UI
                  ├── /api/store/*       D1 storefront API (existing)
                  ├── /api/broker/*      Broker API (existing)
                  └── /api/d2/*          D2 dashboard API (NEW — this PR)

vibepass-terminal-test (CDN, idle except terminal-test deploys for D0)
d2-orders-dashboard (web_service, idle — preserved for beta migration)
```

## Beta migration path (future, not this session)

When a surface graduates to beta:
1. Re-enable its service (still provisioned, just no traffic)
2. Update DNS / link routing to point that surface's domain to its own service
3. Optionally remove the corresponding mount from `app.py`
4. Each surface gets dedicated resources + isolation

## Test plan

- [x] `pytest tests/` green
- [x] Local smoke shows 8 d2 routes mounted + 4 entry routes intact
- [x] No conflicts with existing routes (`/`, `/store`, `/terminal`, `/undelivered`)
- [ ] Post-merge: verify storefront-test serves `/api/d2/health` correctly

## Carry-forward

- D0 follow-up: update `static/undelivered/undelivered.js` to call same-origin `/api/d2/*` instead of cross-origin `d2-orders-dashboard.onrender.com/api/d2/*` (CSP already allows both per earlier `index.html` config)
- PROJECT_BIBLE.md §2 Render service ownership: note testing-unified architecture
- bot_chat 180 closure (status reply pointing at this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)