### PR TITLE
docs(governance): note testing-unified architecture in PROJECT_BIBLE + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ Lane assignments per `LANE_DISCIPLINE.md`:
 - **C1** — supervisor docs + audit harnesses + lane discipline
 - Operator may explicitly route HTML work to a bot outside its default lane (this is the override path)
 
-### 4. Render workspace — per-service scoped access (2026-05-14, reorg 2026-05-15)
+### 4. Render workspace — per-service scoped access (2026-05-14, reorg 2026-05-15; testing-unified 2026-05-16)
+
+**Testing-unified architecture (2026-05-16, PR #168)**: During dev/test, all runtime traffic flows through `vibepass-storefront-test` (starter plan, no cold-start drag). It hosts D0 terminal + D1 storefront + D2 dashboard via `app.include_router` mounts in `app.py`. `vibepass-terminal-test` remains as the D0 static CDN host; `d2-orders-dashboard` stays alive as an idle placeholder. At beta, each surface migrates back to its own service via dedicated DNS + un-mounting from `app.py`.
 
 Render MCP tools (`mcp__render__*`) are gated per-bot. Cross-service writes are forbidden without operator approval.
 

--- a/PROJECT_BIBLE.md
+++ b/PROJECT_BIBLE.md
@@ -45,10 +45,12 @@ A1 (admin · sole prod pusher · Render workspace owner)
 | Bot | Render service | Service ID | Scope |
 |---|---|---|---|
 | A1 | workspace-wide | — | exclusive provisioning + deletes |
-| D0 | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | write OK |
-| D1 | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | write OK |
-| D2 | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | write OK |
+| D0 | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | write OK (CDN only during testing) |
+| D1 | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | write OK · **TESTING UNIFIED RUNTIME** |
+| D2 | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | write OK (idle placeholder during testing) |
 | B1, C1, D3, D4, E1 | (all services) | — | read only |
+
+**Testing-unified architecture (2026-05-16, PR #168)**: All runtime traffic flows through `vibepass-storefront-test` (starter plan, no cold starts). It hosts D0 terminal + D1 storefront + D2 dashboard via `app.include_router` mounts. `vibepass-terminal-test` continues to serve as a CDN for D0 static files; `d2-orders-dashboard` stays alive as a beta-time placeholder but has no live traffic. At beta, each surface migrates back to its own service via dedicated DNS + un-mounting from `app.py`.
 
 Code-dir ownership (per `LANE_DISCIPLINE.md`):
 - D0 → `static/terminal/*` + Terminal FE


### PR DESCRIPTION
## Summary

Documents the testing-unified architecture shipped in PR #168 (d2_router mounted on storefront-test app.py). Follow-up doc PR per ratification spec.

## Changes (2 files, +8/-4 LOC)

- **`PROJECT_BIBLE.md §2`**: scope notes added to Render service ownership table + a new paragraph explaining the testing-unified architecture (warm runtime on storefront-test; cold services preserved as beta placeholders; beta migration path)
- **`CLAUDE.md §4`**: prepended a testing-unified note to the Render workspace section so bots see the architecture context before reading the per-service scope rules

## bot_chat closures

- **180** (D2 architecture question, 4 sub-questions) — closed by bot_chat 241 status reply with answers A/B/C/D matching PR #168 implementation
- **240** (C1 audit ask from PR #167) — extended with new audit ask on PR #168 / this PR via bot_chat 247

## Test plan

- [x] PROJECT_BIBLE.md §2 reflects PR #168 mount + beta migration plan
- [x] CLAUDE.md §4 has testing-unified note at top of Render workspace section
- [x] No conflict with prior bibles or governance docs
- [x] bot_chat 180 → 241 resolve chain visible in v_bot_chat_unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)