### PR TITLE
docs(c1): RESOURCES_BIBLE §1 — note testing-unified runtime (per audit 247)

### DIFF
--- a/RESOURCES_BIBLE.md
+++ b/RESOURCES_BIBLE.md
@@ -32,7 +32,7 @@ Conventions:
 | Service | Purpose | Lane that owns the integration | Where it lives | Secret in vault |
 |---|---|---|---|---|
 | **Supabase** (Postgres + Edge Functions + Vault + Storage + Auth) | Primary DB and runtime | A1 (DB) + D1 (storefront uses anon key) | `hzrizjeaxlqcxfrtczpq` | (anon + service_role keys, exposed via `/api/public/config`) |
-| **Render** | Hosts `vibepass-storefront-test` (`app.py` + `static/store/*`) | **D1 (sole owner)** | service `srv-d8140bnaqgkc73al4asg` | env-side, not vault |
+| **Render** | Hosts `vibepass-storefront-test` (`app.py` + `static/store/*`). **Testing-unified runtime host (2026-05-16, PR #168)** — also mounts D2 dashboard `/api/d2/*` via `app.include_router`; D0 terminal static served from CDN (`vibepass-terminal-test`). See PROJECT_BIBLE.md §2 + CLAUDE.md §4 for the unified architecture + beta migration path. | **D1 (sole owner)** | service `srv-d8140bnaqgkc73al4asg` | env-side, not vault |
 | **TEvo** (TicketEvolution v9 API) | Live ticket inventory + (eventually) order placement | D2 (orders), D1 (storefront reads) | `evo_client.py` + `EvoClient` Python | `TEVO_API_TOKEN`, `TEVO_SECRET` |
 | **SeatGeek** | Marketplace data (orders, listings, performers) | D2 | `seatgeek_*` tables + edge fn `collect` | `SEATGEEK_API_TOKEN` |
 | **SeatData** | Wholesale-channel sales feed | D2 | `seatdata_*` tables | `SEATDATA_API_KEY` |


### PR DESCRIPTION
## Summary
1-line fix. RESOURCES_BIBLE §1 Render row now notes testing-unified runtime per PROJECT_BIBLE §2 + CLAUDE.md §4.

## Audit context
Surfaced by C1 audit per bot_chat 247 finding #3: drift between §1 services table and §2 architecture description (both within RESOURCES_BIBLE).

## Compliance
- One-concern PR (1 file, 1 line)
- ≤300-line doc target ✓ (changes 1 line)
- Squash merge per pr_governance.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)