### PR TITLE
docs(governance): D0 → full Render permissions (workspace-wide parity with A1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,16 +77,17 @@ Lane assignments per `LANE_DISCIPLINE.md`:
 
 Render MCP tools (`mcp__render__*`) are gated per-bot. Cross-service writes are forbidden without operator approval.
 
-**A1 (Admin) — exclusive workspace-wide access:**
+**A1 (Admin) — workspace-wide access:**
 - All `mcp__render__*` tools on any service
 - Workspace-level operations: `create_web_service`, `create_postgres`, `create_static_site`, `create_cron_job`, `select_workspace`
-- A1 is the only bot authorized to provision, delete, or change ownership of services
+- Provisioning, deletion, ownership changes
 
-**D0 — consolidated frontend lane (2026-05-15 reorg):**
-- **Write authority on all three frontend services**: `vibepass-terminal-test` (`srv-d839339kh4rs73ac3s20`), `vibepass-storefront-test` (`srv-d8140bnaqgkc73al4asg`), `d2-orders-dashboard` (`srv-d82b4kl7vvec73b4r3r0`)
-- Permitted writes (no per-call ask): `update_environment_variables`, `update_web_service`, restart, redeploy triggers
+**D0 — workspace-wide access (2026-05-16, operator directive — "full Render permissions"):**
+- **Parity with A1 on Render**: all `mcp__render__*` tools on any service in the workspace, plus workspace-level operations (`create_*`, `select_workspace`, deletion, ownership changes)
+- Standing write authority on all three frontend services (`vibepass-terminal-test`, `vibepass-storefront-test`, `d2-orders-dashboard`) + any future services D0 provisions
 - D0 is sign-off authority on D1/D2 subordinate PRs touching their respective surfaces
-- Forbidden: workspace-level operations (A1-only)
+- No restrictions — full Render parity with A1
+- Coordination expectation: provisioning/deletion of customer-facing services is high-impact; D0 posts a `bot_chat` `flag` event for transparency, but no per-call operator approval required
 
 **D1, D2 — subordinate coding arm under D0 (2026-05-15 reorg):**
 - D1 still authors `static/store/*`, `app.py /api/store/*`, `render.yaml` (storefront IaC)

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -125,7 +125,9 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 - Any cron schedule
 - Any edge function that mutates data
 - Any other lane's files
-- **Render workspace** (D1 owns; D0 has no deploy infra of its own yet)
+
+**Render workspace authority (2026-05-16 operator directive — "full Render permissions"):**
+D0 has full workspace-wide Render permissions, parity with A1. All `mcp__render__*` tools available on every service + workspace-level operations (`create_*`, `select_workspace`, deletion, ownership changes). Standing write on `vibepass-terminal-test`, `vibepass-storefront-test`, `d2-orders-dashboard`, and any future services D0 provisions. Coordination expectation: bot_chat `flag` event when provisioning/deleting customer-facing services for transparency, but no per-call operator approval required.
 
 **Reads:** entire data plane (charts, predictive models, possibly Grok integration)
 
@@ -294,9 +296,9 @@ See also: `docs/bot-hierarchy.mermaid` (visual diagram) and `MIGRATION_CONVENTIO
 
    - **D0 is the lane owner** across all three frontend services as of 2026-05-15. D0 manages env vars, deploy config, log monitoring, and IaC for every frontend service.
    - **D1 and D2 are subordinate coding arms.** They still author code in their respective directories (D1 → storefront, D2 → dashboard) but their PRs require **D0 sign-off** in a PR comment before A1 merges. D1/D2 have Render MCP **read-only** access; writes route through D0 + A1.
-   - Per-bot Render access scope (per CLAUDE.md §4, updated 2026-05-15):
-     - **A1** — exclusive workspace-wide access: all read + write ops on any service, plus `create_*` / `select_workspace` (only bot authorized to provision or delete services)
-     - **D0** — write authority on all three frontend services; forbidden workspace-level ops (A1-only)
+   - Per-bot Render access scope (per CLAUDE.md §4, updated 2026-05-16 with D0 full-permissions directive):
+     - **A1** — workspace-wide access: all read + write ops on any service, plus `create_*` / `select_workspace`, provisioning, deletion, ownership changes
+     - **D0** — **workspace-wide parity with A1** (2026-05-16): all read + write ops on any service, plus `create_*`, deletion, ownership changes, future-service provisioning. No restrictions.
      - **D1, D2** — read-only on all Render surfaces; writes route through D0 review + A1 merge
      - **B1 / C1 / D3 / D4** — read-only across all services; writes require operator approval
    - **Deploy gating (2026-05-15)**: backend test workflow (`.github/workflows/tests.yml`) must pass on a PR before A1 merges to `main`. Auto-deploy fires only after green CI lands on `main`. No exceptions.

--- a/PROJECT_BIBLE.md
+++ b/PROJECT_BIBLE.md
@@ -44,10 +44,10 @@ A1 (admin · sole prod pusher · Render workspace owner)
 
 | Bot | Render service | Service ID | Scope |
 |---|---|---|---|
-| A1 | workspace-wide | — | exclusive provisioning + deletes |
-| D0 | `vibepass-terminal-test` | `srv-d839339kh4rs73ac3s20` | write OK (CDN only during testing) |
-| D1 | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | write OK · **TESTING UNIFIED RUNTIME** |
-| D2 | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | write OK (idle placeholder during testing) |
+| A1 | workspace-wide | — | full (read + write + provisioning + delete) |
+| **D0** | **workspace-wide** | — | **full Render parity with A1 (2026-05-16)** — read + write + provisioning + delete across all services |
+| D1 | `vibepass-storefront-test` | `srv-d8140bnaqgkc73al4asg` | code author only; Render MCP read-only (writes route through D0 + A1) |
+| D2 | `d2-orders-dashboard` | `srv-d82b4kl7vvec73b4r3r0` | code author only; Render MCP read-only (writes route through D0 + A1) |
 | B1, C1, D3, D4, E1 | (all services) | — | read only |
 
 **Testing-unified architecture (2026-05-16, PR #168)**: All runtime traffic flows through `vibepass-storefront-test` (starter plan, no cold starts). It hosts D0 terminal + D1 storefront + D2 dashboard via `app.include_router` mounts. `vibepass-terminal-test` continues to serve as a CDN for D0 static files; `d2-orders-dashboard` stays alive as a beta-time placeholder but has no live traffic. At beta, each surface migrates back to its own service via dedicated DNS + un-mounting from `app.py`.


### PR DESCRIPTION
## Summary

Operator directive 2026-05-16: "give D0 full Render permissions". D0 upgraded from 3-service write authority to **full workspace-wide parity with A1**.

## Changes (3 files, +17/-14 LOC)

### `CLAUDE.md §4`
- A1: now "workspace-wide" instead of "exclusive workspace-wide" (A1 stays workspace-wide but loses exclusivity to D0)
- **D0: rewritten from "Write authority on all three frontend services" → "workspace-wide parity with A1"**. Removed the "Forbidden: workspace-level operations" restriction. Added coordination expectation: bot_chat `flag` on provisioning/deletion of customer-facing services (transparency, no per-call ask).

### `PROJECT_BIBLE.md §2`
- Render service ownership table: A1 = "full"; D0 = "workspace-wide, full Render parity with A1 (2026-05-16)"
- D1/D2 explicitly downgraded to "code author only, Render MCP read-only" (writes route through D0 + A1)

### `LANE_DISCIPLINE.md` (2 sections)
- D0 lane: replaced stale "D1 owns; D0 has no deploy infra" with new "Render workspace authority" subsection
- Per-bot Render access scope table (§6): A1 + D0 rows updated to reflect parity

## Effective permissions for D0 (new)

| Operation | Before (2026-05-15 reorg) | After (this PR) |
|---|---|---|
| Read on any service | ✅ | ✅ |
| Write on `vibepass-terminal-test` | ✅ | ✅ |
| Write on `vibepass-storefront-test` | ✅ | ✅ |
| Write on `d2-orders-dashboard` | ✅ | ✅ |
| `create_web_service` / `create_static_site` / `create_postgres` | ❌ | **✅** |
| `select_workspace` / workspace-level ops | ❌ | **✅** |
| Service deletion + ownership changes | ❌ | **✅** |
| Provisioning new services | ❌ | **✅** |

D0 now has parity with A1 on Render. A1 retains all DB / migration / push-to-main authority (unchanged).

## Coordination expectation (lightweight)

When D0 provisions or deletes a customer-facing service, post a `bot_chat` `flag` event for transparency. No per-call operator approval required — D0 has authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)