### PR TITLE
feat(sg-bridge): cross-source venue map + active TEvo search bridge + owned-first tracking + 2 OPS hotfixes

### DIFF
--- a/PROJECT_BIBLE.md
+++ b/PROJECT_BIBLE.md
@@ -78,6 +78,8 @@ Every entry here cost real session time when discovered. CHECK column names agai
 | `events` | `is_classified`, `tbd` | (neither exists — use `EXISTS(event_xref...)` for sports; parse `(Date TBD)` from name) |
 | `listings_snapshots` (TEvo firehose 8M rows) | filter by `aq_short_event_id` | **0% populated** — query by `event_id` only. Filter ours: `is_owned=true AND brokerage_id=1768` |
 | `seatgeek_sales/listings_snapshots.tevo_event_id` | use as join key | **0% populated** — always query by `sg_event_id` (indexes added 2026-05-16) |
+| `sg_events_canonical` Parking pseudo-events | match against TEvo | **TEvo merges parking into main listing** — skip `sg_category IN ('Parking','parking')` and `*venue_name ILIKE '%parking%'` rows. Matcher v3 enforces this. |
+| TEvo `/v9/events` date filter | `occurs_at_gte` (underscore) | **`"occurs_at.gte"` (dotted)** — underscore returns 422 Invalid Parameters |
 
 ---
 
@@ -100,6 +102,11 @@ Every entry here cost real session time when discovered. CHECK column names agai
 | `espn_scoreboard_queue(lookahead_days)` | int (default **270**) | ESPN scoreboard ingest. Bumped 2026-05-16 to capture full NFL season. |
 | `espn_scoreboard_process()` | — | Process ESPN responses → date_lookup |
 | `refresh_sg_broker_sales_event_metrics(max_events)` | int (default 200) | Populate `seatgeek_event_metrics.sold_*` from deduped (DISTINCT ON sg_sale_id) sales snapshots. Hourly cron @ :17. |
+| `sg_canonical_refresh_v2_pull(window_minutes)` | int (default 15; NULL = full) | Reconciles `sg_events_canonical.last_v2_pull_at` + `last_v2_listings_count` + `last_v2_status` + `has_v2_listings_pulled` from `seatgeek_listings_snapshots`. Cron @ :12,:42. Backfill ran 2026-05-16: 574 rows brought to 100% coverage. |
+| `sg_attempt_event_xref_v3(...)` | bigint, text, date, timestamptz, text, [text], [text], [text] | **Matcher v3**: ±24h date tolerance + parking skip + `cross_source_venue_resolve` lookup. Replaces v2 in `cross_source_match_tick`. |
+| `auto_match_sg_canonical_v3()` | — | Sweeps all unlinked SG canonical rows through matcher v3. Returns `(attempted, newly_matched, parking_skipped, still_unmatched, needs_tevo_search)`. |
+| `cross_source_venue_resolve(name, city, state)` | text, [text], [text] | Returns `tevo_venue_id` from any-source venue name via 3-tier match (canonical / aliases array / prefix). Driven by `cross_source_venue_map` (391 TEvo rows + 129 SG / 94 TickPick / 85 Vivid aliases as of 2026-05-16). |
+| `refresh_cross_source_venue_map()` | — | Rebuilds `cross_source_venue_map` from events/sg_events_canonical/tickpick_orders.raw/vivid_orders.raw. Idempotent. |
 | `release_health_check()` | — | All-checks rollup |
 
 For the full RPC list + arg detail + composition relationships → `RESOURCES_BIBLE.md §3` and the migration headers.
@@ -211,6 +218,37 @@ END IF;
 v_aq := 'SYS-' || substring(md5(name || '|' || venue || '|' ||
             to_char(date::timestamptz, 'YYYY-MM-DD"T"HH24:MI')) from 1 for 10);
 ```
+
+### TEvo `/v9/events` search procedure (autotrack cold bridge)
+For events we have in SG/TickPick/Vivid but missing from local `events` table — use the active search bridge instead of waiting for broker-listed events.
+
+**Endpoint**: `GET /v9/events` (signed HMAC-SHA256, see `tevo_sign_get()`)
+
+**Filter params (verified 2026-05-16)**:
+- `venue_id` (int) — TEvo venue id; resolve from `cross_source_venue_map` via `cross_source_venue_resolve(name, city, state)`
+- `name` (text, partial match) — fallback when venue_id unknown
+- `performer_id` (int)
+- `category_id` (int)
+- `"occurs_at.gte"` / `"occurs_at.lte"` (text dates, **dotted notation required** — `occurs_at_gte` returns 422)
+- `per_page` (int, max 100), `page` (int)
+- `only_with_available_tickets` (bool) — set FALSE for full event lookup, TRUE for crawl-ready listings
+
+**Two-tier search strategy** (matches edge fn `sg-to-tevo-search-bridge`):
+1. Tier 1: `venue_id` + date range — most precise
+2. Tier 2: `name` (team name) + date range — fallback if no venue_id resolved or empty result
+
+**Result scoring**: `+50` venue_id match, `+40` slug venue match, `+25` prefix venue match, `+10/token` team-name overlap, `+24-hoursAway` date proximity. Accept at `score >= 50` (= venue OK + at least 1 team hit).
+
+**Attempt tracking**: every search writes to `sg_tevo_search_attempts` (PK `sg_event_id`) with result `matched | no_results | low_score`. Don't retry within 24h.
+
+**Live invocation pattern**:
+```sql
+SELECT public._cron_invoke_edge_fn(
+  'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/sg-to-tevo-search-bridge?limit=40&min_score=50',
+  '{}'::jsonb);
+```
+
+**Observed hit rate (2026-05-16)**: 75% on first live batch (30/40), with venue-map-resolved candidates scoring 64–214.
 
 ---
 

--- a/supabase/functions/sg-to-tevo-search-bridge/index.ts
+++ b/supabase/functions/sg-to-tevo-search-bridge/index.ts
@@ -1,18 +1,27 @@
-// sg-to-tevo-search-bridge
+// sg-to-tevo-search-bridge (v4)
 //
 // COLD BRIDGE: for SG events that have no corresponding row in TEvo's local
 // `events` table, actively call TEvo /v9/events search (with date+performer
 // query) to discover the matching event. Upsert into events + write
-// seatgeek_event_xref. This replaces the "wait until a broker lists it" path
-// that leaves 1,800+ future SG events unmatched.
+// seatgeek_event_xref.
 //
-// Operator directive 2026-05-16 ("auto-track any event we're tracking on SG
-// on evo and vice versa. use evo search to find events directly").
+// Operator directive 2026-05-16:
+//   - "auto-track any event we're tracking on SG on evo and vice versa"
+//   - "use evo search to find events directly"
+//   - "track all sg and evo events where our listings > 0 by default, then
+//      expand beyond to track entire market. first wire to only track known."
 //
-// POST /functions/v1/sg-to-tevo-search-bridge?limit=20&dry_run=false
-//   -> { attempted, matched, no_results, errored, samples }
+// v4 (2026-05-16): added owned_first / owned_only modes. When ownedFirst (default
+// true), prioritizes SG events that appear in seatgeek_seller_listings (we own
+// inventory on them). In owned_only mode, ONLY scans those events — using an
+// .in(ownedIds) filter so date-ordered pagination doesn't miss far-future events.
 //
-// Body-gate: requires x-cron-secret header (per PROJECT_BIBLE §1 hard rule #7).
+// GET /functions/v1/sg-to-tevo-search-bridge?limit=20&dry_run=false
+//                                            &owned_first=true   (default ON)
+//                                            &owned_only=true    (drain owned only)
+//                                            &min_score=50
+//
+// Body-gated via requireCronSecret per PROJECT_BIBLE §1 rule #7.
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
 import { requireCronSecret } from "../_shared/cron-auth.ts";
@@ -22,9 +31,7 @@ const BASE = `https://${HOST}`;
 
 async function hmac(secret: string, msg: string): Promise<string> {
   const enc = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
-  );
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
   const sig = await crypto.subtle.sign("HMAC", key, enc.encode(msg));
   let bin = ""; for (const b of new Uint8Array(sig)) bin += String.fromCharCode(b);
   return btoa(bin);
@@ -45,11 +52,7 @@ async function tevoSearch(token: string, secret: string, params: Record<string, 
   const queryStr = qs(params);
   const sig = await hmac(secret, `GET ${HOST}${path}?${queryStr}`);
   const r = await fetch(`${BASE}${path}?${queryStr}`, {
-    headers: {
-      "X-Token": token,
-      "X-Signature": sig,
-      "Accept": "application/vnd.ticketevolution.api+json; version=9",
-    },
+    headers: { "X-Token": token, "X-Signature": sig, "Accept": "application/vnd.ticketevolution.api+json; version=9" },
   });
   if (r.status !== 200) return { ok: false, status: r.status, body: (await r.text()).slice(0, 300) };
   return { ok: true, body: await r.json() };
@@ -58,18 +61,11 @@ async function tevoSearch(token: string, secret: string, params: Record<string, 
 const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
 const tokenSet = (s: string) => new Set(s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 1));
 
-function score(candidate: any, sg: {
-  name: string; date: string; venue: string;
-  tevo_venue_id: number | null; team_a: string; team_b: string;
-}): number {
+function score(candidate: any, sg: { name: string; date: string; venue: string; tevo_venue_id: number | null; team_a: string; team_b: string }): number {
   let s = 0;
-  // Venue match (highest signal)
   if (sg.tevo_venue_id && candidate.venue?.id === sg.tevo_venue_id) s += 50;
   else if (candidate.venue?.name && slug(candidate.venue.name) === slug(sg.venue)) s += 40;
-  else if (candidate.venue?.name && (slug(candidate.venue.name).startsWith(slug(sg.venue)) ||
-                                     slug(sg.venue).startsWith(slug(candidate.venue.name)))) s += 25;
-
-  // Team-name overlap
+  else if (candidate.venue?.name && (slug(candidate.venue.name).startsWith(slug(sg.venue)) || slug(sg.venue).startsWith(slug(candidate.venue.name)))) s += 25;
   const candidateTokens = tokenSet(candidate.name ?? "");
   const teamBTokens = tokenSet(sg.team_b);
   const teamATokens = tokenSet(sg.team_a);
@@ -77,92 +73,88 @@ function score(candidate: any, sg: {
   for (const t of teamBTokens) if (candidateTokens.has(t)) teamHits++;
   for (const t of teamATokens) if (candidateTokens.has(t)) teamHits++;
   s += teamHits * 10;
-
-  // Date proximity (in hours, max ±24)
   const sgT = new Date(sg.date).getTime();
   const candT = new Date(candidate.occurs_at).getTime();
   const hours = Math.abs((candT - sgT) / 3600000);
-  if (!isNaN(hours)) s += Math.max(0, 24 - hours);  // closer = better
-
+  if (!isNaN(hours)) s += Math.max(0, 24 - hours);
   return s;
-}
-
-interface Candidate {
-  sg_event_id: number;
-  sg_event_name: string;
-  sg_event_date: string;     // YYYY-MM-DD
-  sg_datetime_utc: string;
-  sg_venue_name: string;
-  sg_venue_city: string | null;
-  sg_venue_state: string | null;
-  sg_category: string | null;
-  tevo_venue_id_resolved: number | null;
 }
 
 Deno.serve(async (req) => {
   const authErr = requireCronSecret(req);
   if (authErr) return authErr;
 
-  if (req.method !== "POST" && req.method !== "GET") {
-    return new Response("POST or GET only", { status: 405 });
-  }
-
-  const sb = createClient(
-    Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
-    { auth: { persistSession: false, autoRefreshToken: false } },
-  );
+  const sb = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!, { auth: { persistSession: false, autoRefreshToken: false } });
   const tevoToken = Deno.env.get("TEVO_TOKEN") ?? Deno.env.get("TEVO_API_TOKEN") ?? "";
   const tevoSecret = Deno.env.get("TEVO_SECRET") ?? Deno.env.get("TEVO_API_SECRET") ?? "";
-  if (!tevoToken || !tevoSecret) {
-    return new Response(JSON.stringify({ ok: false, error: "missing TEvo creds" }),
-      { status: 500, headers: { "content-type": "application/json" } });
-  }
+  if (!tevoToken || !tevoSecret) return new Response(JSON.stringify({ ok: false, error: "missing TEvo creds" }), { status: 500, headers: { "content-type": "application/json" } });
 
   const url = new URL(req.url);
-  const limit = Math.max(1, Math.min(100, Number(url.searchParams.get("limit") ?? "20")));
+  const limit = Math.max(1, Math.min(200, Number(url.searchParams.get("limit") ?? "20")));
   const dryRun = url.searchParams.get("dry_run") === "true";
   const minScore = Number(url.searchParams.get("min_score") ?? "50");
+  const ownedFirst = url.searchParams.get("owned_first") !== "false";  // default ON
+  const ownedOnly = url.searchParams.get("owned_only") === "true";
 
-  // Pull unmatched candidates — exclude parking + already-attempted-recently
-  // (sg_tevo_search_attempts table tracks attempts so we don't burn API)
-  const { data: candidates, error: candErr } = await sb
-    .from("sg_events_canonical")
-    .select("sg_event_id, sg_event_name, sg_event_date, sg_datetime_utc, sg_venue_name, sg_venue_city, sg_venue_state, sg_category")
-    .is("tevo_event_id", null)
-    .gt("sg_datetime_utc", new Date().toISOString())
-    .not("sg_category", "in", "(Parking,parking)")
-    .order("sg_datetime_utc", { ascending: true })
-    .limit(limit);
-  if (candErr) {
-    return new Response(JSON.stringify({ ok: false, error: candErr.message }),
-      { status: 500, headers: { "content-type": "application/json" } });
+  const cutoffIso = new Date(Date.now() - 24 * 3600000).toISOString();
+  const { data: recentlyTried } = await sb.from("sg_tevo_search_attempts").select("sg_event_id").gte("attempted_at", cutoffIso);
+  const triedSet = new Set((recentlyTried ?? []).map((r: any) => r.sg_event_id));
+
+  let ownedIds: number[] = [];
+  if (ownedFirst || ownedOnly) {
+    const { data: ownedRows } = await sb.from("seatgeek_seller_listings").select("sg_event_id");
+    ownedIds = Array.from(new Set((ownedRows ?? []).map((r: any) => r.sg_event_id)));
+  }
+  const ownedSet = new Set(ownedIds);
+
+  // owned_only / owned_first: fetch owned events directly via .in() (no date pagination)
+  let ownedCandidates: any[] = [];
+  if ((ownedFirst || ownedOnly) && ownedIds.length > 0) {
+    const { data: ownedPool } = await sb
+      .from("sg_events_canonical")
+      .select("sg_event_id, sg_event_name, sg_event_date, sg_datetime_utc, sg_venue_name, sg_venue_city, sg_venue_state, sg_category")
+      .is("tevo_event_id", null)
+      .gt("sg_datetime_utc", new Date().toISOString())
+      .in("sg_event_id", ownedIds)
+      .order("sg_datetime_utc", { ascending: true });
+    ownedCandidates = (ownedPool ?? [])
+      .filter((c: any) => !triedSet.has(c.sg_event_id))
+      .filter((c: any) => !/parking/i.test(c.sg_venue_name ?? "") && !/parking/i.test(c.sg_event_name ?? ""))
+      .filter((c: any) => !['Parking','parking'].includes(c.sg_category ?? ''));
   }
 
-  // Filter out parking by name + venue
-  const filtered = (candidates ?? []).filter((c: any) =>
-    !/parking/i.test(c.sg_venue_name ?? "") &&
-    !/parking/i.test(c.sg_event_name ?? "")) as Candidate[];
+  // General pool — only fetched when not owned_only
+  let otherCandidates: any[] = [];
+  if (!ownedOnly) {
+    const { data: pool } = await sb
+      .from("sg_events_canonical")
+      .select("sg_event_id, sg_event_name, sg_event_date, sg_datetime_utc, sg_venue_name, sg_venue_city, sg_venue_state, sg_category")
+      .is("tevo_event_id", null)
+      .gt("sg_datetime_utc", new Date().toISOString())
+      .not("sg_category", "in", "(Parking,parking)")
+      .order("sg_datetime_utc", { ascending: true })
+      .limit(limit * 6);
+    otherCandidates = (pool ?? [])
+      .filter((c: any) => !triedSet.has(c.sg_event_id))
+      .filter((c: any) => !ownedSet.has(c.sg_event_id))
+      .filter((c: any) => !/parking/i.test(c.sg_venue_name ?? "") && !/parking/i.test(c.sg_event_name ?? ""));
+  }
 
-  // Resolve tevo_venue_id for each via the venue map RPC
-  const idsToResolve = filtered.map((c) => ({
-    sg_event_id: c.sg_event_id,
-    venue: c.sg_venue_name,
-    city: c.sg_venue_city,
-    state: c.sg_venue_state,
-  }));
+  const filtered: any[] = ownedOnly ? ownedCandidates.slice(0, limit)
+                       : ownedFirst ? [...ownedCandidates, ...otherCandidates].slice(0, limit)
+                                    : otherCandidates.slice(0, limit);
+
   const venueMap = new Map<number, number | null>();
-  for (const v of idsToResolve) {
-    const { data } = await sb.rpc("cross_source_venue_resolve", {
-      p_venue_name: v.venue, p_city: v.city, p_state: v.state,
-    });
-    venueMap.set(v.sg_event_id, data ?? null);
+  for (const c of filtered) {
+    const { data } = await sb.rpc("cross_source_venue_resolve", { p_venue_name: c.sg_venue_name, p_city: c.sg_venue_city, p_state: c.sg_venue_state });
+    venueMap.set(c.sg_event_id, data ?? null);
   }
 
   const samples: any[] = [];
-  let matched = 0, noResults = 0, errored = 0;
+  let matched = 0, noResults = 0, errored = 0, ownedAttempted = 0;
 
   for (const c of filtered) {
+    if (ownedSet.has(c.sg_event_id)) ownedAttempted++;
     const teamA = (c.sg_event_name || "").split(" at ")[0]?.trim() || "";
     const teamB = (c.sg_event_name || "").split(" at ")[1]?.trim() || teamA;
     const tevoVenueId = venueMap.get(c.sg_event_id) ?? null;
@@ -170,143 +162,75 @@ Deno.serve(async (req) => {
     const dateGte = new Date(sgT - 24 * 3600000).toISOString().slice(0, 10);
     const dateLte = new Date(sgT + 24 * 3600000).toISOString().slice(0, 10);
 
-    // Tier 1: search by venue_id + date — most precise
     let resp = tevoVenueId
-      ? await tevoSearch(tevoToken, tevoSecret, {
-          venue_id: tevoVenueId,
-          "occurs_at.gte": dateGte,
-          "occurs_at.lte": dateLte,
-          per_page: 25,
-          page: 1,
-        })
-      : { ok: false, status: 0, body: null };
+      ? await tevoSearch(tevoToken, tevoSecret, { venue_id: tevoVenueId, "occurs_at.gte": dateGte, "occurs_at.lte": dateLte, per_page: 25, page: 1 })
+      : { ok: false as const, status: 0, body: null };
 
-    // Tier 2: fall back to team-name query if venue-id search returns nothing
     if (resp.ok && (((resp.body as any).events ?? []) as any[]).length === 0) {
-      resp = await tevoSearch(tevoToken, tevoSecret, {
-        q: teamB || teamA,
-        occurs_at_gte: dateGte,
-        occurs_at_lte: dateLte,
-        per_page: 25,
-        page: 1,
-      });
+      resp = await tevoSearch(tevoToken, tevoSecret, { name: teamB || teamA, "occurs_at.gte": dateGte, "occurs_at.lte": dateLte, per_page: 25, page: 1 });
     } else if (!resp.ok) {
-      resp = await tevoSearch(tevoToken, tevoSecret, {
-        q: teamB || teamA,
-        occurs_at_gte: dateGte,
-        occurs_at_lte: dateLte,
-        per_page: 25,
-        page: 1,
-      });
+      resp = await tevoSearch(tevoToken, tevoSecret, { name: teamB || teamA, "occurs_at.gte": dateGte, "occurs_at.lte": dateLte, per_page: 25, page: 1 });
     }
 
-    if (!resp.ok) {
-      errored++;
-      samples.push({ sg_event_id: c.sg_event_id, error: resp.status, body: resp.body });
-      continue;
-    }
+    if (!resp.ok) { errored++; samples.push({ sg_event_id: c.sg_event_id, error: resp.status, body: resp.body }); continue; }
 
     const events: any[] = ((resp.body as any).events ?? []) as any[];
     if (events.length === 0) {
       noResults++;
-      // Log attempt so we don't repeatedly burn API
-      await sb.from("sg_tevo_search_attempts").upsert({
-        sg_event_id: c.sg_event_id,
-        attempted_at: new Date().toISOString(),
-        result: "no_results",
-        meta: { date_gte: dateGte, date_lte: dateLte, q: teamB || teamA, tevo_venue_id: tevoVenueId },
-      }, { onConflict: "sg_event_id" });
+      await sb.from("sg_tevo_search_attempts").upsert({ sg_event_id: c.sg_event_id, attempted_at: new Date().toISOString(), result: "no_results", meta: { date_gte: dateGte, date_lte: dateLte, name: teamB || teamA, tevo_venue_id: tevoVenueId, owned: ownedSet.has(c.sg_event_id) } }, { onConflict: "sg_event_id" });
       continue;
     }
 
-    // Score + pick best
     let best: any = null;
     let bestScore = -1;
     for (const ev of events) {
-      const sc = score(ev, {
-        name: c.sg_event_name, date: c.sg_datetime_utc, venue: c.sg_venue_name,
-        tevo_venue_id: tevoVenueId, team_a: teamA, team_b: teamB,
-      });
+      const sc = score(ev, { name: c.sg_event_name, date: c.sg_datetime_utc, venue: c.sg_venue_name, tevo_venue_id: tevoVenueId, team_a: teamA, team_b: teamB });
       if (sc > bestScore) { bestScore = sc; best = ev; }
     }
 
     if (!best || bestScore < minScore) {
       noResults++;
-      await sb.from("sg_tevo_search_attempts").upsert({
-        sg_event_id: c.sg_event_id,
-        attempted_at: new Date().toISOString(),
-        result: "low_score",
-        meta: { best_score: bestScore, best_id: best?.id, best_name: best?.name, top_n: events.length },
-      }, { onConflict: "sg_event_id" });
+      await sb.from("sg_tevo_search_attempts").upsert({ sg_event_id: c.sg_event_id, attempted_at: new Date().toISOString(), result: "low_score", meta: { best_score: bestScore, best_id: best?.id, best_name: best?.name, top_n: events.length, owned: ownedSet.has(c.sg_event_id) } }, { onConflict: "sg_event_id" });
       continue;
     }
 
-    // Match found — upsert into events + write seatgeek_event_xref
     if (!dryRun) {
       const performances = best.performances ?? [];
       const primaryPerf = performances.find((p: any) => p.primary) ?? performances[0];
       await sb.from("events").upsert({
-        id: best.id,
-        name: best.name,
-        occurs_at_local: best.occurs_at_local ?? best.occurs_at,
-        state: best.state,
-        venue_id: best.venue?.id ?? null,
-        venue_name: best.venue?.name ?? null,
-        venue_location: best.venue?.location ?? null,
-        primary_performer_id: primaryPerf?.performer?.id ?? null,
-        primary_performer_name: primaryPerf?.performer?.name ?? null,
+        id: best.id, name: best.name, occurs_at_local: best.occurs_at_local ?? best.occurs_at, state: best.state,
+        venue_id: best.venue?.id ?? null, venue_name: best.venue?.name ?? null, venue_location: best.venue?.location ?? null,
+        primary_performer_id: primaryPerf?.performer?.id ?? null, primary_performer_name: primaryPerf?.performer?.name ?? null,
         performer_ids: performances.map((p: any) => p.performer?.id).filter((x: any) => x),
-        event_type: best.category?.slug ?? null,
-        last_seen: new Date().toISOString(),
+        event_type: best.category?.slug ?? null, last_seen: new Date().toISOString(),
       }, { onConflict: "id" });
 
       await sb.from("seatgeek_event_xref").upsert({
-        tevo_event_id: best.id,
-        sg_event_id: c.sg_event_id,
-        sg_event_name: c.sg_event_name,
-        sg_event_location: c.sg_venue_name,
-        sg_start_data: c.sg_datetime_utc,
-        match_method: "tevo_search_autotrack",
+        tevo_event_id: best.id, sg_event_id: c.sg_event_id, sg_event_name: c.sg_event_name,
+        sg_event_location: c.sg_venue_name, sg_start_data: c.sg_datetime_utc,
+        match_method: ownedSet.has(c.sg_event_id) ? "tevo_search_owned_priority" : "tevo_search_autotrack",
         match_confidence: bestScore >= 70 ? 0.95 : 0.80,
         matched_at: new Date().toISOString(),
       }, { onConflict: "tevo_event_id" });
 
       await sb.from("sg_events_canonical").update({
         tevo_event_id: best.id,
-        match_method: "tevo_search_autotrack",
+        match_method: ownedSet.has(c.sg_event_id) ? "tevo_search_owned_priority" : "tevo_search_autotrack",
         match_confidence: bestScore >= 70 ? 0.95 : 0.80,
-        matched_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
+        matched_at: new Date().toISOString(), updated_at: new Date().toISOString(),
       }).eq("sg_event_id", c.sg_event_id);
 
-      await sb.from("sg_tevo_search_attempts").upsert({
-        sg_event_id: c.sg_event_id,
-        attempted_at: new Date().toISOString(),
-        result: "matched",
-        meta: { tevo_event_id: best.id, score: bestScore, name: best.name },
-      }, { onConflict: "sg_event_id" });
+      await sb.from("sg_tevo_search_attempts").upsert({ sg_event_id: c.sg_event_id, attempted_at: new Date().toISOString(), result: "matched", meta: { tevo_event_id: best.id, score: bestScore, name: best.name, owned: ownedSet.has(c.sg_event_id) } }, { onConflict: "sg_event_id" });
     }
 
     matched++;
-    if (samples.length < 15) {
-      samples.push({
-        sg_event_id: c.sg_event_id,
-        sg_name: c.sg_event_name,
-        sg_venue: c.sg_venue_name,
-        sg_date: c.sg_event_date,
-        matched_to: { id: best.id, name: best.name, venue: best.venue?.name, occurs_at: best.occurs_at_local },
-        score: bestScore,
-      });
-    }
+    if (samples.length < 18) samples.push({ sg_event_id: c.sg_event_id, sg_name: c.sg_event_name, sg_venue: c.sg_venue_name, sg_date: c.sg_event_date, owned: ownedSet.has(c.sg_event_id), matched_to: { id: best.id, name: best.name, venue: best.venue?.name, occurs_at: best.occurs_at_local }, score: bestScore });
   }
 
   return new Response(JSON.stringify({
-    ok: true,
-    dry_run: dryRun,
-    limit, min_score: minScore,
-    attempted: filtered.length,
-    parking_skipped: (candidates?.length ?? 0) - filtered.length,
-    matched, no_results: noResults, errored,
-    samples,
+    ok: true, dry_run: dryRun, limit, min_score: minScore,
+    owned_first: ownedFirst, owned_only: ownedOnly,
+    owned_pool_size: ownedCandidates.length, owned_attempted: ownedAttempted,
+    attempted: filtered.length, matched, no_results: noResults, errored, samples,
   }, null, 2), { headers: { "content-type": "application/json" } });
 });

--- a/supabase/functions/sg-to-tevo-search-bridge/index.ts
+++ b/supabase/functions/sg-to-tevo-search-bridge/index.ts
@@ -1,0 +1,312 @@
+// sg-to-tevo-search-bridge
+//
+// COLD BRIDGE: for SG events that have no corresponding row in TEvo's local
+// `events` table, actively call TEvo /v9/events search (with date+performer
+// query) to discover the matching event. Upsert into events + write
+// seatgeek_event_xref. This replaces the "wait until a broker lists it" path
+// that leaves 1,800+ future SG events unmatched.
+//
+// Operator directive 2026-05-16 ("auto-track any event we're tracking on SG
+// on evo and vice versa. use evo search to find events directly").
+//
+// POST /functions/v1/sg-to-tevo-search-bridge?limit=20&dry_run=false
+//   -> { attempted, matched, no_results, errored, samples }
+//
+// Body-gate: requires x-cron-secret header (per PROJECT_BIBLE §1 hard rule #7).
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
+import { requireCronSecret } from "../_shared/cron-auth.ts";
+
+const HOST = "api.ticketevolution.com";
+const BASE = `https://${HOST}`;
+
+async function hmac(secret: string, msg: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(msg));
+  let bin = ""; for (const b of new Uint8Array(sig)) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function qs(p: Record<string, unknown>): string {
+  const pairs: [string, string][] = [];
+  for (const [k, v] of Object.entries(p)) {
+    if (v === null || v === undefined || v === "") continue;
+    pairs.push([k, typeof v === "boolean" ? (v ? "true" : "false") : String(v)]);
+  }
+  pairs.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return pairs.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");
+}
+
+async function tevoSearch(token: string, secret: string, params: Record<string, unknown>) {
+  const path = "/v9/events";
+  const queryStr = qs(params);
+  const sig = await hmac(secret, `GET ${HOST}${path}?${queryStr}`);
+  const r = await fetch(`${BASE}${path}?${queryStr}`, {
+    headers: {
+      "X-Token": token,
+      "X-Signature": sig,
+      "Accept": "application/vnd.ticketevolution.api+json; version=9",
+    },
+  });
+  if (r.status !== 200) return { ok: false, status: r.status, body: (await r.text()).slice(0, 300) };
+  return { ok: true, body: await r.json() };
+}
+
+const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+const tokenSet = (s: string) => new Set(s.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 1));
+
+function score(candidate: any, sg: {
+  name: string; date: string; venue: string;
+  tevo_venue_id: number | null; team_a: string; team_b: string;
+}): number {
+  let s = 0;
+  // Venue match (highest signal)
+  if (sg.tevo_venue_id && candidate.venue?.id === sg.tevo_venue_id) s += 50;
+  else if (candidate.venue?.name && slug(candidate.venue.name) === slug(sg.venue)) s += 40;
+  else if (candidate.venue?.name && (slug(candidate.venue.name).startsWith(slug(sg.venue)) ||
+                                     slug(sg.venue).startsWith(slug(candidate.venue.name)))) s += 25;
+
+  // Team-name overlap
+  const candidateTokens = tokenSet(candidate.name ?? "");
+  const teamBTokens = tokenSet(sg.team_b);
+  const teamATokens = tokenSet(sg.team_a);
+  let teamHits = 0;
+  for (const t of teamBTokens) if (candidateTokens.has(t)) teamHits++;
+  for (const t of teamATokens) if (candidateTokens.has(t)) teamHits++;
+  s += teamHits * 10;
+
+  // Date proximity (in hours, max ±24)
+  const sgT = new Date(sg.date).getTime();
+  const candT = new Date(candidate.occurs_at).getTime();
+  const hours = Math.abs((candT - sgT) / 3600000);
+  if (!isNaN(hours)) s += Math.max(0, 24 - hours);  // closer = better
+
+  return s;
+}
+
+interface Candidate {
+  sg_event_id: number;
+  sg_event_name: string;
+  sg_event_date: string;     // YYYY-MM-DD
+  sg_datetime_utc: string;
+  sg_venue_name: string;
+  sg_venue_city: string | null;
+  sg_venue_state: string | null;
+  sg_category: string | null;
+  tevo_venue_id_resolved: number | null;
+}
+
+Deno.serve(async (req) => {
+  const authErr = requireCronSecret(req);
+  if (authErr) return authErr;
+
+  if (req.method !== "POST" && req.method !== "GET") {
+    return new Response("POST or GET only", { status: 405 });
+  }
+
+  const sb = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  const tevoToken = Deno.env.get("TEVO_TOKEN") ?? Deno.env.get("TEVO_API_TOKEN") ?? "";
+  const tevoSecret = Deno.env.get("TEVO_SECRET") ?? Deno.env.get("TEVO_API_SECRET") ?? "";
+  if (!tevoToken || !tevoSecret) {
+    return new Response(JSON.stringify({ ok: false, error: "missing TEvo creds" }),
+      { status: 500, headers: { "content-type": "application/json" } });
+  }
+
+  const url = new URL(req.url);
+  const limit = Math.max(1, Math.min(100, Number(url.searchParams.get("limit") ?? "20")));
+  const dryRun = url.searchParams.get("dry_run") === "true";
+  const minScore = Number(url.searchParams.get("min_score") ?? "50");
+
+  // Pull unmatched candidates — exclude parking + already-attempted-recently
+  // (sg_tevo_search_attempts table tracks attempts so we don't burn API)
+  const { data: candidates, error: candErr } = await sb
+    .from("sg_events_canonical")
+    .select("sg_event_id, sg_event_name, sg_event_date, sg_datetime_utc, sg_venue_name, sg_venue_city, sg_venue_state, sg_category")
+    .is("tevo_event_id", null)
+    .gt("sg_datetime_utc", new Date().toISOString())
+    .not("sg_category", "in", "(Parking,parking)")
+    .order("sg_datetime_utc", { ascending: true })
+    .limit(limit);
+  if (candErr) {
+    return new Response(JSON.stringify({ ok: false, error: candErr.message }),
+      { status: 500, headers: { "content-type": "application/json" } });
+  }
+
+  // Filter out parking by name + venue
+  const filtered = (candidates ?? []).filter((c: any) =>
+    !/parking/i.test(c.sg_venue_name ?? "") &&
+    !/parking/i.test(c.sg_event_name ?? "")) as Candidate[];
+
+  // Resolve tevo_venue_id for each via the venue map RPC
+  const idsToResolve = filtered.map((c) => ({
+    sg_event_id: c.sg_event_id,
+    venue: c.sg_venue_name,
+    city: c.sg_venue_city,
+    state: c.sg_venue_state,
+  }));
+  const venueMap = new Map<number, number | null>();
+  for (const v of idsToResolve) {
+    const { data } = await sb.rpc("cross_source_venue_resolve", {
+      p_venue_name: v.venue, p_city: v.city, p_state: v.state,
+    });
+    venueMap.set(v.sg_event_id, data ?? null);
+  }
+
+  const samples: any[] = [];
+  let matched = 0, noResults = 0, errored = 0;
+
+  for (const c of filtered) {
+    const teamA = (c.sg_event_name || "").split(" at ")[0]?.trim() || "";
+    const teamB = (c.sg_event_name || "").split(" at ")[1]?.trim() || teamA;
+    const tevoVenueId = venueMap.get(c.sg_event_id) ?? null;
+    const sgT = new Date(c.sg_datetime_utc).getTime();
+    const dateGte = new Date(sgT - 24 * 3600000).toISOString().slice(0, 10);
+    const dateLte = new Date(sgT + 24 * 3600000).toISOString().slice(0, 10);
+
+    // Tier 1: search by venue_id + date — most precise
+    let resp = tevoVenueId
+      ? await tevoSearch(tevoToken, tevoSecret, {
+          venue_id: tevoVenueId,
+          "occurs_at.gte": dateGte,
+          "occurs_at.lte": dateLte,
+          per_page: 25,
+          page: 1,
+        })
+      : { ok: false, status: 0, body: null };
+
+    // Tier 2: fall back to team-name query if venue-id search returns nothing
+    if (resp.ok && (((resp.body as any).events ?? []) as any[]).length === 0) {
+      resp = await tevoSearch(tevoToken, tevoSecret, {
+        q: teamB || teamA,
+        occurs_at_gte: dateGte,
+        occurs_at_lte: dateLte,
+        per_page: 25,
+        page: 1,
+      });
+    } else if (!resp.ok) {
+      resp = await tevoSearch(tevoToken, tevoSecret, {
+        q: teamB || teamA,
+        occurs_at_gte: dateGte,
+        occurs_at_lte: dateLte,
+        per_page: 25,
+        page: 1,
+      });
+    }
+
+    if (!resp.ok) {
+      errored++;
+      samples.push({ sg_event_id: c.sg_event_id, error: resp.status, body: resp.body });
+      continue;
+    }
+
+    const events: any[] = ((resp.body as any).events ?? []) as any[];
+    if (events.length === 0) {
+      noResults++;
+      // Log attempt so we don't repeatedly burn API
+      await sb.from("sg_tevo_search_attempts").upsert({
+        sg_event_id: c.sg_event_id,
+        attempted_at: new Date().toISOString(),
+        result: "no_results",
+        meta: { date_gte: dateGte, date_lte: dateLte, q: teamB || teamA, tevo_venue_id: tevoVenueId },
+      }, { onConflict: "sg_event_id" });
+      continue;
+    }
+
+    // Score + pick best
+    let best: any = null;
+    let bestScore = -1;
+    for (const ev of events) {
+      const sc = score(ev, {
+        name: c.sg_event_name, date: c.sg_datetime_utc, venue: c.sg_venue_name,
+        tevo_venue_id: tevoVenueId, team_a: teamA, team_b: teamB,
+      });
+      if (sc > bestScore) { bestScore = sc; best = ev; }
+    }
+
+    if (!best || bestScore < minScore) {
+      noResults++;
+      await sb.from("sg_tevo_search_attempts").upsert({
+        sg_event_id: c.sg_event_id,
+        attempted_at: new Date().toISOString(),
+        result: "low_score",
+        meta: { best_score: bestScore, best_id: best?.id, best_name: best?.name, top_n: events.length },
+      }, { onConflict: "sg_event_id" });
+      continue;
+    }
+
+    // Match found — upsert into events + write seatgeek_event_xref
+    if (!dryRun) {
+      const performances = best.performances ?? [];
+      const primaryPerf = performances.find((p: any) => p.primary) ?? performances[0];
+      await sb.from("events").upsert({
+        id: best.id,
+        name: best.name,
+        occurs_at_local: best.occurs_at_local ?? best.occurs_at,
+        state: best.state,
+        venue_id: best.venue?.id ?? null,
+        venue_name: best.venue?.name ?? null,
+        venue_location: best.venue?.location ?? null,
+        primary_performer_id: primaryPerf?.performer?.id ?? null,
+        primary_performer_name: primaryPerf?.performer?.name ?? null,
+        performer_ids: performances.map((p: any) => p.performer?.id).filter((x: any) => x),
+        event_type: best.category?.slug ?? null,
+        last_seen: new Date().toISOString(),
+      }, { onConflict: "id" });
+
+      await sb.from("seatgeek_event_xref").upsert({
+        tevo_event_id: best.id,
+        sg_event_id: c.sg_event_id,
+        sg_event_name: c.sg_event_name,
+        sg_event_location: c.sg_venue_name,
+        sg_start_data: c.sg_datetime_utc,
+        match_method: "tevo_search_autotrack",
+        match_confidence: bestScore >= 70 ? 0.95 : 0.80,
+        matched_at: new Date().toISOString(),
+      }, { onConflict: "tevo_event_id" });
+
+      await sb.from("sg_events_canonical").update({
+        tevo_event_id: best.id,
+        match_method: "tevo_search_autotrack",
+        match_confidence: bestScore >= 70 ? 0.95 : 0.80,
+        matched_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }).eq("sg_event_id", c.sg_event_id);
+
+      await sb.from("sg_tevo_search_attempts").upsert({
+        sg_event_id: c.sg_event_id,
+        attempted_at: new Date().toISOString(),
+        result: "matched",
+        meta: { tevo_event_id: best.id, score: bestScore, name: best.name },
+      }, { onConflict: "sg_event_id" });
+    }
+
+    matched++;
+    if (samples.length < 15) {
+      samples.push({
+        sg_event_id: c.sg_event_id,
+        sg_name: c.sg_event_name,
+        sg_venue: c.sg_venue_name,
+        sg_date: c.sg_event_date,
+        matched_to: { id: best.id, name: best.name, venue: best.venue?.name, occurs_at: best.occurs_at_local },
+        score: bestScore,
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({
+    ok: true,
+    dry_run: dryRun,
+    limit, min_score: minScore,
+    attempted: filtered.length,
+    parking_skipped: (candidates?.length ?? 0) - filtered.length,
+    matched, no_results: noResults, errored,
+    samples,
+  }, null, 2), { headers: { "content-type": "application/json" } });
+});

--- a/supabase/migrations/20260516230000_sg_canonical_refresh_v2_pull.sql
+++ b/supabase/migrations/20260516230000_sg_canonical_refresh_v2_pull.sql
@@ -1,0 +1,132 @@
+-- ============================================================================
+-- Fix: sg_events_canonical.last_v2_pull_at / last_v2_listings_count /
+--      last_v2_status / has_v2_listings_pulled are not being populated by the
+--      SG v2 listings ingest path. As of 2026-05-16:
+--          actual sg_events with v2 listing rows: 574
+--          canonical flag set:                     25  (4.4%)
+--      Sales / orders / seller_listings flags are healthy (98.7% / 100% / 100%),
+--      so the bug is isolated to the v2 listings path.
+--
+-- Found by: A1 spot-check 2026-05-16 (5 random forward-dated events; 1 of 5 had
+--   288 SG v2 listing rows + recent captures with NULL last_v2_pull_at).
+--
+-- Approach: reconciliation cron, not a per-INSERT trigger. The listings table
+--   ingests at ~86K rows/day in bursts; per-row trigger overhead is not
+--   warranted when a 5-min reconciliation pass keeps the column within an
+--   acceptable freshness window for queue gating.
+--
+-- Changes:
+--   1. CREATE FUNCTION sg_canonical_refresh_v2_pull(p_window_minutes integer)
+--      Reconciles last_v2_pull_at + last_v2_listings_count + last_v2_status +
+--      has_v2_listings_pulled from seatgeek_listings_snapshots for any
+--      sg_event with rows captured in the last p_window_minutes (default 15).
+--   2. CREATE cron job sg_canonical_v2_pull_refresh_5min @ :12,:17,:22,:27,...
+--      (off-cycle from sg_broker_listings_queue/process at :02/:07/:32/:37)
+--   3. One-shot full backfill from ALL historical listings rows (set window=NULL
+--      to skip the time filter).
+-- ============================================================================
+
+-- 1. The reconciliation function
+CREATE OR REPLACE FUNCTION public.sg_canonical_refresh_v2_pull(
+  p_window_minutes integer DEFAULT 15
+)
+RETURNS TABLE(rows_updated integer, sg_events_touched integer, window_minutes integer)
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_count int := 0;
+  v_window text;
+BEGIN
+  v_window := CASE WHEN p_window_minutes IS NULL THEN 'ALL' ELSE p_window_minutes::text END;
+
+  WITH last_pull AS (
+    -- Most recent captured_at per sg_event in the reconciliation window
+    SELECT sls.sg_event_id, max(sls.captured_at) AS last_captured
+    FROM public.seatgeek_listings_snapshots sls
+    WHERE p_window_minutes IS NULL
+       OR sls.captured_at > now() - make_interval(mins => p_window_minutes)
+    GROUP BY sls.sg_event_id
+  ),
+  agg AS (
+    -- listings_count = distinct sglids in the latest pull burst (within 2 min
+    -- of max captured_at — one /v2/listings pull writes all rows in one txn)
+    SELECT
+      lp.sg_event_id,
+      lp.last_captured,
+      count(DISTINCT sls.sglid) AS listing_cnt
+    FROM last_pull lp
+    JOIN public.seatgeek_listings_snapshots sls
+      ON sls.sg_event_id = lp.sg_event_id
+     AND sls.captured_at >= lp.last_captured - interval '2 minutes'
+    GROUP BY lp.sg_event_id, lp.last_captured
+  ),
+  upd AS (
+    UPDATE public.sg_events_canonical sec
+    SET
+      last_v2_pull_at         = GREATEST(COALESCE(sec.last_v2_pull_at, agg.last_captured), agg.last_captured),
+      last_v2_listings_count  = agg.listing_cnt,
+      last_v2_status          = 200,  -- HTTP status code; 200=OK (column is int4)
+      has_v2_listings_pulled  = true,
+      updated_at              = now()
+    FROM agg
+    WHERE sec.sg_event_id = agg.sg_event_id
+      AND (
+        sec.last_v2_pull_at IS NULL
+        OR sec.last_v2_pull_at < agg.last_captured
+        OR sec.last_v2_listings_count IS DISTINCT FROM agg.listing_cnt
+        OR NOT sec.has_v2_listings_pulled
+      )
+    RETURNING sec.sg_event_id
+  )
+  SELECT count(*)::int INTO v_count FROM upd;
+
+  RETURN QUERY SELECT v_count, v_count, p_window_minutes;
+END $func$;
+
+REVOKE EXECUTE ON FUNCTION public.sg_canonical_refresh_v2_pull(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.sg_canonical_refresh_v2_pull(integer) TO service_role;
+
+COMMENT ON FUNCTION public.sg_canonical_refresh_v2_pull(integer) IS
+  'Reconciles sg_events_canonical v2-listings tracking columns from seatgeek_listings_snapshots. Called every 5 min off-cycle from the SG listings queue/process pair. Pass NULL window for full-history backfill.';
+
+-- 2. One-shot full backfill (covers the 549 events missing the flag)
+SELECT * FROM public.sg_canonical_refresh_v2_pull(NULL);
+
+-- 3. Schedule reconciliation cron @ :12,:42 (off-cycle from queue :02,:32
+--    and process :07,:37)
+DO $body$
+DECLARE
+  v_jobid bigint;
+BEGIN
+  -- Unschedule any prior version
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'sg_canonical_v2_pull_refresh_30min';
+  IF v_jobid IS NOT NULL THEN
+    PERFORM cron.unschedule(v_jobid);
+  END IF;
+
+  PERFORM cron.schedule(
+    'sg_canonical_v2_pull_refresh_30min',
+    '12,42 * * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_canonical_v2_pull_refresh_30min') THEN RETURN; END IF;
+      PERFORM public.sg_canonical_refresh_v2_pull(60);
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+-- 4. Cron policy entry (budget-capped, idle 48 daily max)
+INSERT INTO public.cron_policy (
+  jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+  daily_max_fires, enabled, notes
+) VALUES (
+  'sg_canonical_v2_pull_refresh_30min',
+  '{9,10,11,12,13,14,15,16,17,18,19,20}'::int[],
+  30, 30, 48, true,
+  'Reconciles sg_events_canonical v2-listings tracking from seatgeek_listings_snapshots. Fixes 95% population gap discovered in A1 spot-check 2026-05-16.'
+)
+ON CONFLICT (jobname) DO UPDATE SET
+  notes = EXCLUDED.notes,
+  enabled = EXCLUDED.enabled,
+  updated_at = now();

--- a/supabase/migrations/20260516240000_matcher_v3_venue_map_parking_skip.sql
+++ b/supabase/migrations/20260516240000_matcher_v3_venue_map_parking_skip.sql
@@ -1,0 +1,385 @@
+-- ============================================================================
+-- Matcher v3 — date ±24h tolerance + parking skip + cross-source venue map
+--
+-- Context: A1 spot-check 2026-05-16 found 2,121 future SG events unlinked to
+-- TEvo. Dry sim of current matcher: 0 fixable. Dry sim of v3 (±24h, parking
+-- skip, soft venue): 11 fixable + 232 cleanly skipped as parking pseudo-events.
+-- True residual gap (1,878) is "TEvo doesn't have the event row yet" — fixed
+-- separately by Migration B (sg_to_tevo_search_autotrack via /v9/events).
+--
+-- This migration ships:
+--   1. cross_source_venue_map (table) — denormalized TEvo↔SG↔TickPick↔Vivid
+--      venue resolver. One row per TEvo venue, multi-source name aliases.
+--   2. cross_source_venue_resolve(name TEXT, city TEXT, state TEXT) — returns
+--      best tevo_venue_id. Uses normalized name + city/state + fuzzy match.
+--   3. sg_attempt_event_xref_v3() — ±24h tolerance + venue map lookup +
+--      ignores Parking pseudo-events. Returns tevo_event_id or NULL.
+--   4. auto_match_sg_canonical_v3() — replaces auto_match_sg_canonical in the
+--      cross_source_match_tick cron pipeline.
+--
+-- Idempotency: ON CONFLICT / IF NOT EXISTS / re-runnable.
+-- Bible §4 RPCs updated separately.
+-- ============================================================================
+
+-- 1. cross_source_venue_map
+CREATE TABLE IF NOT EXISTS public.cross_source_venue_map (
+  tevo_venue_id      bigint PRIMARY KEY,
+  tevo_venue_name    text NOT NULL,
+  tevo_venue_location text,
+  canonical_name     text GENERATED ALWAYS AS (lower(regexp_replace(tevo_venue_name, '[^a-z0-9]+', '', 'gi'))) STORED,
+  city               text,
+  state              text,
+  country            text,
+  -- Per-source aliases (jsonb arrays of strings — multiple variants possible)
+  sg_aliases         jsonb DEFAULT '[]'::jsonb,
+  sg_venue_id        bigint,
+  tickpick_aliases   jsonb DEFAULT '[]'::jsonb,
+  tickpick_venue_id  bigint,
+  vivid_aliases      jsonb DEFAULT '[]'::jsonb,
+  -- Stats
+  sources_count      int GENERATED ALWAYS AS (
+    1
+    + (CASE WHEN jsonb_array_length(coalesce(sg_aliases,'[]'::jsonb)) > 0 THEN 1 ELSE 0 END)
+    + (CASE WHEN jsonb_array_length(coalesce(tickpick_aliases,'[]'::jsonb)) > 0 THEN 1 ELSE 0 END)
+    + (CASE WHEN jsonb_array_length(coalesce(vivid_aliases,'[]'::jsonb)) > 0 THEN 1 ELSE 0 END)
+  ) STORED,
+  created_at         timestamptz DEFAULT now(),
+  updated_at         timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_csvm_canonical_name ON public.cross_source_venue_map(canonical_name);
+CREATE INDEX IF NOT EXISTS idx_csvm_city_state ON public.cross_source_venue_map(city, state);
+CREATE INDEX IF NOT EXISTS idx_csvm_sg_venue_id ON public.cross_source_venue_map(sg_venue_id) WHERE sg_venue_id IS NOT NULL;
+
+COMMENT ON TABLE public.cross_source_venue_map IS
+  'Cross-source venue lookup: TEvo canonical anchor + name aliases from SG, TickPick, Vivid. Drives matcher v3 venue normalization. Refresh via refresh_cross_source_venue_map().';
+
+-- 2. Refresh function — populates from existing events/sg/tickpick/vivid data
+CREATE OR REPLACE FUNCTION public.refresh_cross_source_venue_map()
+RETURNS TABLE(tevo_rows int, sg_links int, tickpick_links int, vivid_links int)
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  v_tevo int; v_sg int; v_tp int; v_v int;
+BEGIN
+  -- (a) Upsert TEvo venues from events table
+  INSERT INTO public.cross_source_venue_map (
+    tevo_venue_id, tevo_venue_name, tevo_venue_location, city, state, country
+  )
+  SELECT DISTINCT ON (e.venue_id)
+    e.venue_id, e.venue_name, e.venue_location,
+    -- Parse city/state from venue_location ("City, ST")
+    nullif(trim(split_part(e.venue_location, ',', 1)), ''),
+    nullif(trim(split_part(e.venue_location, ',', 2)), ''),
+    'US'
+  FROM public.events e
+  WHERE e.venue_id IS NOT NULL AND e.venue_name IS NOT NULL
+  ORDER BY e.venue_id, e.last_seen DESC NULLS LAST
+  ON CONFLICT (tevo_venue_id) DO UPDATE SET
+    tevo_venue_name = EXCLUDED.tevo_venue_name,
+    tevo_venue_location = EXCLUDED.tevo_venue_location,
+    city = COALESCE(EXCLUDED.city, public.cross_source_venue_map.city),
+    state = COALESCE(EXCLUDED.state, public.cross_source_venue_map.state),
+    updated_at = now();
+  GET DIAGNOSTICS v_tevo = ROW_COUNT;
+
+  -- (b) Link SG aliases by canonical-name + city/state match
+  WITH sg_unique AS (
+    SELECT DISTINCT
+      sg_venue_id,
+      sg_venue_name,
+      sg_venue_city,
+      sg_venue_state,
+      lower(regexp_replace(sg_venue_name, '[^a-z0-9]+', '', 'gi')) AS canonical
+    FROM public.sg_events_canonical
+    WHERE sg_venue_name IS NOT NULL
+  ),
+  matches AS (
+    SELECT m.tevo_venue_id, s.sg_venue_id, s.sg_venue_name
+    FROM sg_unique s
+    JOIN public.cross_source_venue_map m
+      ON m.canonical_name = s.canonical
+     AND (
+       (m.city IS NULL OR s.sg_venue_city IS NULL OR lower(m.city) = lower(s.sg_venue_city))
+       AND (m.state IS NULL OR s.sg_venue_state IS NULL OR upper(m.state) = upper(s.sg_venue_state))
+     )
+  )
+  UPDATE public.cross_source_venue_map m
+  SET sg_venue_id = matches.sg_venue_id,
+      sg_aliases = (
+        SELECT jsonb_agg(DISTINCT name)
+        FROM jsonb_array_elements_text(coalesce(m.sg_aliases,'[]'::jsonb) || to_jsonb(matches.sg_venue_name)) AS name
+      ),
+      updated_at = now()
+  FROM matches
+  WHERE m.tevo_venue_id = matches.tevo_venue_id;
+  GET DIAGNOSTICS v_sg = ROW_COUNT;
+
+  -- (c) Link TickPick aliases from raw->event->venue jsonb
+  WITH tp_unique AS (
+    SELECT DISTINCT
+      (raw->'event'->'venue'->>'id')::bigint AS tp_venue_id,
+      raw->'event'->'venue'->>'name' AS tp_venue_name,
+      raw->'event'->'venue'->>'city' AS tp_city,
+      raw->'event'->'venue'->>'state' AS tp_state,
+      lower(regexp_replace(raw->'event'->'venue'->>'name', '[^a-z0-9]+', '', 'gi')) AS canonical
+    FROM public.tickpick_orders
+    WHERE raw IS NOT NULL AND raw->'event'->'venue'->>'name' IS NOT NULL
+  ),
+  matches AS (
+    SELECT m.tevo_venue_id, t.tp_venue_id, t.tp_venue_name
+    FROM tp_unique t
+    JOIN public.cross_source_venue_map m
+      ON m.canonical_name = t.canonical
+     AND (m.state IS NULL OR t.tp_state IS NULL OR upper(m.state) = upper(t.tp_state))
+  )
+  UPDATE public.cross_source_venue_map m
+  SET tickpick_venue_id = matches.tp_venue_id,
+      tickpick_aliases = (
+        SELECT jsonb_agg(DISTINCT name)
+        FROM jsonb_array_elements_text(coalesce(m.tickpick_aliases,'[]'::jsonb) || to_jsonb(matches.tp_venue_name)) AS name
+      ),
+      updated_at = now()
+  FROM matches
+  WHERE m.tevo_venue_id = matches.tevo_venue_id;
+  GET DIAGNOSTICS v_tp = ROW_COUNT;
+
+  -- (d) Vivid is messier (single concatenated string); skip canonical match,
+  -- store raw venue strings as aliases for direct equality only
+  WITH v_unique AS (
+    SELECT DISTINCT
+      raw->>'venue' AS vivid_venue,
+      lower(regexp_replace(split_part(raw->>'venue', ' - ', 1), '[^a-z0-9]+', '', 'gi')) AS canonical
+    FROM public.vivid_orders
+    WHERE raw->>'venue' IS NOT NULL
+  ),
+  matches AS (
+    SELECT m.tevo_venue_id, v.vivid_venue
+    FROM v_unique v
+    JOIN public.cross_source_venue_map m ON m.canonical_name = v.canonical
+  )
+  UPDATE public.cross_source_venue_map m
+  SET vivid_aliases = (
+        SELECT jsonb_agg(DISTINCT name)
+        FROM jsonb_array_elements_text(coalesce(m.vivid_aliases,'[]'::jsonb) || to_jsonb(matches.vivid_venue)) AS name
+      ),
+      updated_at = now()
+  FROM matches
+  WHERE m.tevo_venue_id = matches.tevo_venue_id;
+  GET DIAGNOSTICS v_v = ROW_COUNT;
+
+  RETURN QUERY SELECT v_tevo, v_sg, v_tp, v_v;
+END $func$;
+
+REVOKE EXECUTE ON FUNCTION public.refresh_cross_source_venue_map() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.refresh_cross_source_venue_map() TO service_role;
+
+COMMENT ON FUNCTION public.refresh_cross_source_venue_map() IS
+  'Rebuilds cross_source_venue_map from events/sg_events_canonical/tickpick_orders.raw/vivid_orders.raw. Idempotent. Used by matcher v3 + cross-source bridges.';
+
+-- 3. Venue resolver function — any-source venue name → tevo_venue_id
+CREATE OR REPLACE FUNCTION public.cross_source_venue_resolve(
+  p_venue_name text,
+  p_city       text DEFAULT NULL,
+  p_state      text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  v_canonical text;
+  v_id bigint;
+BEGIN
+  IF p_venue_name IS NULL OR p_venue_name = '' THEN RETURN NULL; END IF;
+  v_canonical := lower(regexp_replace(p_venue_name, '[^a-z0-9]+', '', 'gi'));
+
+  -- Tier 1: exact canonical_name + (optional) city/state match
+  SELECT tevo_venue_id INTO v_id
+  FROM public.cross_source_venue_map
+  WHERE canonical_name = v_canonical
+    AND (p_city IS NULL OR city IS NULL OR lower(city) = lower(p_city))
+    AND (p_state IS NULL OR state IS NULL OR upper(state) = upper(p_state))
+  LIMIT 1;
+  IF v_id IS NOT NULL THEN RETURN v_id; END IF;
+
+  -- Tier 2: alias-array match across SG/TickPick/Vivid
+  SELECT tevo_venue_id INTO v_id
+  FROM public.cross_source_venue_map
+  WHERE sg_aliases ? p_venue_name
+     OR tickpick_aliases ? p_venue_name
+     OR vivid_aliases ? p_venue_name
+  LIMIT 1;
+  IF v_id IS NOT NULL THEN RETURN v_id; END IF;
+
+  -- Tier 3: prefix match on canonical
+  SELECT tevo_venue_id INTO v_id
+  FROM public.cross_source_venue_map
+  WHERE canonical_name LIKE v_canonical || '%'
+     OR v_canonical LIKE canonical_name || '%'
+  ORDER BY length(canonical_name) DESC  -- prefer longer matches
+  LIMIT 1;
+  RETURN v_id;
+END $func$;
+
+GRANT EXECUTE ON FUNCTION public.cross_source_venue_resolve(text, text, text) TO service_role, authenticated;
+
+-- 4. sg_attempt_event_xref_v3 — improved matcher
+CREATE OR REPLACE FUNCTION public.sg_attempt_event_xref_v3(
+  p_sg_event_id      bigint,
+  p_sg_event_name    text,
+  p_sg_event_date    date,
+  p_sg_datetime_utc  timestamptz,
+  p_sg_venue         text,
+  p_sg_venue_city    text DEFAULT NULL,
+  p_sg_venue_state   text DEFAULT NULL,
+  p_sg_category      text DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  v_tevo_event_id bigint;
+  v_existing      bigint;
+  v_sg_team_a     text;
+  v_sg_team_b     text;
+  v_tevo_venue_id bigint;
+BEGIN
+  -- Skip parking pseudo-events outright (TEvo merges parking into main listing)
+  IF p_sg_category IN ('Parking','parking') OR coalesce(p_sg_venue,'') ILIKE '%parking%' OR coalesce(p_sg_event_name,'') ILIKE '%parking%' THEN
+    RETURN NULL;
+  END IF;
+
+  -- Already mapped? short-circuit
+  SELECT tevo_event_id INTO v_existing FROM public.seatgeek_event_xref WHERE sg_event_id = p_sg_event_id LIMIT 1;
+  IF v_existing IS NOT NULL THEN RETURN v_existing; END IF;
+
+  v_sg_team_a := trim(split_part(coalesce(p_sg_event_name,''), ' at ', 1));
+  v_sg_team_b := trim(split_part(coalesce(p_sg_event_name,''), ' at ', 2));
+  IF v_sg_team_b = '' THEN v_sg_team_b := v_sg_team_a; END IF;
+
+  -- Resolve SG venue → TEvo venue_id via venue map
+  v_tevo_venue_id := public.cross_source_venue_resolve(p_sg_venue, p_sg_venue_city, p_sg_venue_state);
+
+  -- Match within ±24h of SG datetime, with venue + performer constraints
+  SELECT e.id INTO v_tevo_event_id
+  FROM public.events e
+  LEFT JOIN public.event_lifecycle lc ON lc.event_id = e.id
+  WHERE
+    -- Date tolerance ±24h (handles UTC vs local mismatches and timezone shifts)
+    e.occurs_at_local::timestamptz BETWEEN
+      coalesce(p_sg_datetime_utc, p_sg_event_date::timestamptz) - interval '24 hours'
+      AND coalesce(p_sg_datetime_utc, p_sg_event_date::timestamptz) + interval '24 hours'
+    -- Venue: tevo_venue_id match (preferred) OR name fuzzy match (fallback)
+    AND (
+      (v_tevo_venue_id IS NOT NULL AND e.venue_id = v_tevo_venue_id)
+      OR lower(trim(coalesce(e.venue_name,''))) = lower(trim(coalesce(p_sg_venue,'')))
+      OR lower(trim(coalesce(e.venue_name,''))) LIKE lower(trim(coalesce(p_sg_venue,''))) || '%'
+      OR lower(trim(coalesce(p_sg_venue,''))) LIKE lower(trim(coalesce(e.venue_name,''))) || '%'
+    )
+    -- Team-name overlap required (avoids ghost cross-events at multi-venue days)
+    AND (
+      (v_sg_team_b <> '' AND (
+        lower(coalesce(e.primary_performer_name,'')) LIKE '%' || lower(v_sg_team_b) || '%'
+        OR lower(coalesce(e.name,'')) LIKE '%' || lower(v_sg_team_b) || '%'))
+      OR
+      (v_sg_team_a <> '' AND (
+        lower(coalesce(e.primary_performer_name,'')) LIKE '%' || lower(v_sg_team_a) || '%'
+        OR lower(coalesce(e.name,'')) LIKE '%' || lower(v_sg_team_a) || '%'))
+    )
+  ORDER BY
+    -- Closest in time first
+    abs(extract(epoch FROM (e.occurs_at_local::timestamptz - coalesce(p_sg_datetime_utc, p_sg_event_date::timestamptz)))),
+    -- Active (non-ghost) first
+    CASE WHEN coalesce(lc.is_active, true) THEN 0 ELSE 1 END,
+    -- Venue-id match wins over name match
+    CASE WHEN v_tevo_venue_id IS NOT NULL AND e.venue_id = v_tevo_venue_id THEN 0 ELSE 1 END
+  LIMIT 1;
+
+  IF v_tevo_event_id IS NOT NULL THEN
+    INSERT INTO public.seatgeek_event_xref (
+      tevo_event_id, sg_event_id, sg_event_name, sg_event_type,
+      sg_event_location, sg_start_data, match_method, match_confidence
+    ) VALUES (
+      v_tevo_event_id, p_sg_event_id, p_sg_event_name, p_sg_category,
+      p_sg_venue,
+      coalesce(p_sg_datetime_utc, make_timestamptz(
+        EXTRACT(YEAR FROM p_sg_event_date)::int,
+        EXTRACT(MONTH FROM p_sg_event_date)::int,
+        EXTRACT(DAY FROM p_sg_event_date)::int, 0, 0, 0, 'UTC')),
+      'matcher_v3_pm24h', 0.9
+    )
+    ON CONFLICT (tevo_event_id) DO UPDATE SET
+      sg_event_id = EXCLUDED.sg_event_id,
+      sg_event_name = EXCLUDED.sg_event_name,
+      sg_event_location = EXCLUDED.sg_event_location,
+      match_method = 'matcher_v3_pm24h',
+      matched_at = NOW();
+  END IF;
+  RETURN v_tevo_event_id;
+END $func$;
+
+REVOKE EXECUTE ON FUNCTION public.sg_attempt_event_xref_v3(bigint, text, date, timestamptz, text, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.sg_attempt_event_xref_v3(bigint, text, date, timestamptz, text, text, text, text) TO service_role;
+
+-- 5. auto_match_sg_canonical_v3 — sweeps all unlinked with v3
+CREATE OR REPLACE FUNCTION public.auto_match_sg_canonical_v3()
+RETURNS TABLE(attempted int, newly_matched int, parking_skipped int, still_unmatched int, needs_tevo_search int)
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  r RECORD;
+  v_match bigint;
+  v_attempted int := 0;
+  v_matched int := 0;
+  v_parking int := 0;
+  v_unmatched int := 0;
+BEGIN
+  FOR r IN
+    SELECT sg_event_id, sg_event_name, sg_event_date, sg_datetime_utc,
+           sg_venue_name, sg_venue_city, sg_venue_state, sg_category
+    FROM public.sg_events_canonical
+    WHERE tevo_event_id IS NULL
+      AND (sg_event_date IS NULL OR sg_event_date >= current_date - 30)
+  LOOP
+    v_attempted := v_attempted + 1;
+
+    -- Pre-skip parking before calling matcher to track stat
+    IF r.sg_category IN ('Parking','parking')
+       OR coalesce(r.sg_venue_name,'') ILIKE '%parking%'
+       OR coalesce(r.sg_event_name,'') ILIKE '%parking%' THEN
+      v_parking := v_parking + 1;
+      CONTINUE;
+    END IF;
+
+    v_match := public.sg_attempt_event_xref_v3(
+      r.sg_event_id, r.sg_event_name, r.sg_event_date, r.sg_datetime_utc,
+      r.sg_venue_name, r.sg_venue_city, r.sg_venue_state, r.sg_category
+    );
+
+    IF v_match IS NOT NULL THEN
+      UPDATE public.sg_events_canonical SET
+        tevo_event_id = v_match,
+        match_method = 'matcher_v3_pm24h',
+        match_confidence = 0.9,
+        matched_at = now(),
+        updated_at = now()
+      WHERE sg_event_id = r.sg_event_id;
+      v_matched := v_matched + 1;
+    ELSE
+      v_unmatched := v_unmatched + 1;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_attempted, v_matched, v_parking, v_unmatched,
+    (SELECT count(*)::int FROM public.sg_events_canonical WHERE tevo_event_id IS NULL AND sg_datetime_utc > now());
+END $func$;
+
+REVOKE EXECUTE ON FUNCTION public.auto_match_sg_canonical_v3() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.auto_match_sg_canonical_v3() TO service_role;
+
+COMMENT ON FUNCTION public.auto_match_sg_canonical_v3() IS
+  'Matcher v3 sweep over all unlinked sg_events_canonical. ±24h tolerance, parking skip, venue map lookup. Replaces auto_match_sg_canonical in cross_source_match_tick. Residual needs_tevo_search count drives the search-autotrack queue.';

--- a/supabase/migrations/20260516250000_sg_to_tevo_search_bridge_cron.sql
+++ b/supabase/migrations/20260516250000_sg_to_tevo_search_bridge_cron.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- sg-to-tevo-search-bridge cron + tracking table
+--
+-- Companion to migration 20260516240000 (matcher v3). Where matcher v3 handles
+-- the local-data path (zero API cost), this migration wires up the ACTIVE
+-- TEvo /v9/events search-based autotrack for events that aren't yet in our
+-- local `events` table.
+--
+-- Architecture:
+--   1. Edge fn `sg-to-tevo-search-bridge` (deployed separately, code in
+--      supabase/functions/sg-to-tevo-search-bridge/) calls TEvo /v9/events
+--      with venue_id + date range (or name + date range fallback), scores
+--      candidates, upserts winners into events + seatgeek_event_xref.
+--   2. This migration creates:
+--        a. sg_tevo_search_attempts (PK sg_event_id) — 24h retry suppression
+--        b. cron sg_to_tevo_search_bridge_30min @ :23,:53 (off-cycle)
+--        c. cron_policy entry — 30 fires/day cap (= 1,200 attempts/day)
+--   3. Operator directive 2026-05-16 — "auto-track any event we're tracking
+--      on SG on evo and vice versa. use evo search to find events directly."
+--
+-- Expected outcome: drains the ~1,900 unmatched-future-SG backlog in 2-3 days
+-- at ~75% hit rate (observed first-batch live run 2026-05-16).
+-- ============================================================================
+
+-- 1. Attempts tracking table (already applied via MCP, codified here)
+CREATE TABLE IF NOT EXISTS public.sg_tevo_search_attempts (
+  sg_event_id   bigint PRIMARY KEY,
+  attempted_at  timestamptz NOT NULL DEFAULT now(),
+  result        text NOT NULL,   -- 'matched' | 'no_results' | 'low_score' | 'error'
+  meta          jsonb,
+  retries       int NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_sg_tevo_search_attempts_attempted_at
+  ON public.sg_tevo_search_attempts(attempted_at);
+CREATE INDEX IF NOT EXISTS idx_sg_tevo_search_attempts_result
+  ON public.sg_tevo_search_attempts(result);
+
+COMMENT ON TABLE public.sg_tevo_search_attempts IS
+  'Tracks TEvo search-bridge attempts per sg_event_id to avoid burning API on repeat queries within 24h.';
+
+-- 2. Update cross_source_match_tick to call matcher v3 alongside v2
+CREATE OR REPLACE FUNCTION public.cross_source_match_tick()
+RETURNS jsonb
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE v_sg jsonb; v_evo record; v_sd record; v_v3 record;
+BEGIN
+  v_sg  := sg_canonical_auto_match_tick();
+  SELECT * INTO v_v3 FROM auto_match_sg_canonical_v3();
+  SELECT * INTO v_evo FROM evo_orphan_event_resolve();
+  SELECT * INTO v_sd  FROM sd_xref_resolve();
+  RETURN jsonb_build_object(
+    'sg', v_sg,
+    'v3_attempted', v_v3.attempted,
+    'v3_newly_matched', v_v3.newly_matched,
+    'v3_parking_skipped', v_v3.parking_skipped,
+    'v3_needs_tevo_search', v_v3.needs_tevo_search,
+    'evo', jsonb_build_object('orphans_seen', v_evo.orphans_seen, 'attempts_logged', v_evo.attempts_logged),
+    'sd', jsonb_build_object('orphan_xref_rows', v_sd.orphan_xref_rows, 'sd_pulls_logged', v_sd.sd_pulls_logged),
+    'ran_at', now()
+  );
+END;
+$function$;
+
+-- 3. Cron schedule @ :23,:53 (off-cycle from matcher v3 @ :09,:39)
+DO $body$
+DECLARE v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'sg_to_tevo_search_bridge_30min';
+  IF v_jobid IS NOT NULL THEN PERFORM cron.unschedule(v_jobid); END IF;
+
+  PERFORM cron.schedule(
+    'sg_to_tevo_search_bridge_30min',
+    '23,53 * * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_to_tevo_search_bridge_30min') THEN RETURN; END IF;
+      PERFORM public._cron_invoke_edge_fn(
+        'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/sg-to-tevo-search-bridge?limit=40&min_score=50',
+        '{}'::jsonb
+      );
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+INSERT INTO public.cron_policy (
+  jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+  daily_max_fires, enabled, notes
+) VALUES (
+  'sg_to_tevo_search_bridge_30min',
+  '{9,10,11,12,13,14,15,16,17,18,19,20}'::int[],
+  30, 60, 30, true,
+  'Active TEvo /v9/events search bridge for SG events with no local TEvo row. 40/run × 30 fires/day = 1,200 attempts/day. Drains 1,800 backlog in ~4 days at 75% hit rate.'
+) ON CONFLICT (jobname) DO UPDATE SET
+  notes = EXCLUDED.notes, enabled = EXCLUDED.enabled, updated_at = now();

--- a/supabase/migrations/20260516260000_drop_match_to_aq_event_id_v1_overload.sql
+++ b/supabase/migrations/20260516260000_drop_match_to_aq_event_id_v1_overload.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- B1 OPS-HIGH (bot_chat #258, active 5+h): drop 7-arg match_to_aq_event_id.
+--
+-- Problem: two overloads coexist —
+--   • 7-arg: (text, bigint, text, text, timestamptz, numeric DEFAULT NULL, numeric DEFAULT NULL)
+--   • 8-arg: (text, bigint, text, text, timestamptz, numeric DEFAULT NULL, numeric DEFAULT NULL, bigint DEFAULT NULL)
+-- The 5-arg call sites inside `match_unmatched_orders_sweep` (Vivid + SG
+-- branches) match BOTH overloads via the DEFAULT fill, so Postgres refuses
+-- to resolve and the cron `match_unmatched_orders_sweep_hourly` has been
+-- failing every :22 since at least 18:22 UTC 2026-05-16.
+--
+-- Fix: drop the 7-arg overload. B1 verified no app-side or edge-fn callers
+-- reference the 7-arg directly; all current callers route cleanly to 8-arg
+-- (5-arg Vivid/SG + 8-arg TickPick/SG-snapshots/EVO via default fill).
+--
+-- Verification: `SELECT count(*) FROM pg_proc ... WHERE proname='match_to_aq_event_id'`
+-- returns 1. Next :22 firing of match_unmatched_orders_sweep_hourly
+-- succeeds.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.match_to_aq_event_id(
+  p_source text, p_source_event_id bigint, p_event_name text, p_venue_name text,
+  p_event_date timestamp with time zone, p_lat numeric, p_lon numeric
+);
+
+DO $check$ DECLARE n int; BEGIN
+  SELECT count(*) INTO n FROM pg_proc p
+  JOIN pg_namespace ns ON ns.oid = p.pronamespace
+  WHERE ns.nspname='public' AND p.proname='match_to_aq_event_id';
+  IF n <> 1 THEN
+    RAISE EXCEPTION 'expected exactly 1 match_to_aq_event_id overload after drop, found %', n;
+  END IF;
+END $check$;

--- a/supabase/migrations/20260516270000_fix_queue_performer_wiki_orphan_filter.sql
+++ b/supabase/migrations/20260516270000_fix_queue_performer_wiki_orphan_filter.sql
@@ -1,0 +1,71 @@
+-- ============================================================================
+-- B1 OPS-MED (bot_chat #259, active 90+min): performer_wiki_pending FK violation.
+--
+-- Problem: `queue_performer_wiki_searches(p_limit)` pulls events.primary_performer_id
+-- candidates directly. FK `performer_wiki_pending.tevo_performer_id →
+-- performer_metadata.performer_id` (NOT VALID) enforces on new inserts.
+-- Events can reference performer_ids not yet ingested into performer_metadata
+-- (R2 sequencing gap), so the cron crashes every :17/:47 firing.
+--
+-- Fix: add `EXISTS (SELECT 1 FROM performer_metadata WHERE performer_id = ...)`
+-- to the queue-source WHERE clause. Skips orphans cleanly without altering
+-- the FK semantics. Existing rows unaffected.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.queue_performer_wiki_searches(p_limit integer DEFAULT 50)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  r RECORD;
+  v_req_id bigint;
+  v_count int := 0;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT e.primary_performer_id AS pid, e.primary_performer_name AS pname
+    FROM events e
+    LEFT JOIN performer_wikipedia pw ON pw.tevo_performer_id = e.primary_performer_id
+    LEFT JOIN performer_wiki_pending pwp
+      ON pwp.tevo_performer_id = e.primary_performer_id
+     AND pwp.fired_at > now() - interval '1 hour'
+    WHERE e.primary_performer_id IS NOT NULL
+      AND e.primary_performer_name IS NOT NULL
+      AND pw.tevo_performer_id IS NULL
+      AND pwp.tevo_performer_id IS NULL
+      -- B1 #259 (2026-05-16): skip events whose performer hasn't been
+      -- ingested into performer_metadata yet; the FK (NOT VALID) enforces
+      -- on new inserts. Without this filter the cron crashes every 30 min.
+      AND EXISTS (
+        SELECT 1 FROM performer_metadata pm
+        WHERE pm.performer_id = e.primary_performer_id
+      )
+    ORDER BY e.primary_performer_id
+    LIMIT p_limit
+  LOOP
+    SELECT net.http_get(
+      url := 'https://en.wikipedia.org/w/api.php',
+      params := jsonb_build_object(
+        'action', 'opensearch',
+        'namespace', '0',
+        'limit', '1',
+        'format', 'json',
+        'search', r.pname
+      ),
+      timeout_milliseconds := 10000
+    ) INTO v_req_id;
+
+    INSERT INTO performer_wiki_pending(
+      tevo_performer_id, performer_name, stage, search_request_id, fired_at
+    ) VALUES (r.pid, r.pname, 'search', v_req_id, now())
+    ON CONFLICT (tevo_performer_id, stage) DO UPDATE SET
+      search_request_id = EXCLUDED.search_request_id,
+      fired_at = now(),
+      resolved_at = NULL;
+
+    v_count := v_count + 1;
+    PERFORM pg_sleep(0.2);
+  END LOOP;
+  RETURN v_count;
+END;
+$function$;


### PR DESCRIPTION
## Summary

Four cleanly-themed commits from today's SG↔TEvo bridge investigation arc, opened as one consolidated PR (operator directive 2026-05-16):

| # | Commit | Concern |
|---|---|---|
| 1 | `60fbc5a` | **Fix**: `sg_events_canonical.last_v2_pull_at` 99.5% population gap |
| 2 | `f66f80a` | **Feature**: matcher v3 + venue map + active TEvo search bridge |
| 3 | `cee822e` | **Feature**: v4 owned-first prioritization (track-what-we-own) |
| 4 | `4bdc78b` | **Fix**: B1 OPS #258 + #259 (match_to_aq overload + wiki orphan filter) |

Drives the operator directive: "track all SG and Evo events where our listings > 0 by default, and then expand beyond to track entire market. first wire to only track known."

---

## Sections

### 1. SG canonical v2_pull reconciliation (commit 60fbc5a)

A1 spot-check 2026-05-16 found `sg_events_canonical.last_v2_pull_at` + `last_v2_listings_count` + `last_v2_status` + `has_v2_listings_pulled` were NULL on **4,584 of 4,609** canonical rows (99.5% gap) despite `seatgeek_listings_snapshots` having data for 574 distinct sg_events.

**Migration 20260516230000** ships:
- `sg_canonical_refresh_v2_pull(p_window_minutes)` — SECDEF reconciliation function. Pass NULL for full backfill.
- Cron `sg_canonical_v2_pull_refresh_30min` @ `:12,:42` (off-cycle from queue `:04,:34` / process `:18,:48`).
- Backfill ran post-apply: **574 rows updated → coverage now 574/574**.

### 2. Cross-source venue map + matcher v3 + active TEvo search bridge (commit f66f80a)

**Diagnosis** (Inter Miami @ Revolution 2026-11-01 case study): SG showed the event, TEvo had it (verified via `/v9/events`: 11,241 broker listings + 10 of ours), but our local `events` table didn't — watchlist crawl's `searchEventsAll` pagination cap (50×100) drops far-future games for high-volume performers like NE Revolution.

**Migration 20260516240000** ships:
- `cross_source_venue_map` table — TEvo-anchored, with SG/TickPick/Vivid name aliases. Populated: 391 TEvo + 129 SG + 94 TickPick + 85 Vivid.
- `refresh_cross_source_venue_map()` — idempotent rebuild from existing data.
- `cross_source_venue_resolve(name, city, state)` — 3-tier match (canonical / aliases / prefix).
- `sg_attempt_event_xref_v3` — ±24h date tolerance + parking skip + venue map lookup.
- `auto_match_sg_canonical_v3` — sweeps unlinked SG canonical via v3.
- Initial run: 19 newly matched + 232 parking pseudo-events cleanly skipped.

**Migration 20260516250000** + **edge fn `sg-to-tevo-search-bridge` v1** ship:
- `sg_tevo_search_attempts` table (24h retry suppression).
- Edge fn calls TEvo `/v9/events` with `venue_id + occurs_at.gte/lte` (dotted-notation — `occurs_at_gte` underscore variant returns 422), scores results, upserts winners. Body-gated via `requireCronSecret` per Bible §1 rule #7.
- Cron `sg_to_tevo_search_bridge_30min` @ `:23,:53`.
- `cross_source_match_tick` updated to invoke matcher v3.

**Live results (first batch of 40)**: 30 matched (75% hit rate), e.g.:
- `Pantages Theatre - CA` → `Hollywood Pantages Theatre - CA`
- `Belasco Theatre New York` → `Belasco Theatre - NY`
- `Charlie Puth` → `Charlie Puth with Daniel Seavey and Ally Salort` at `Fox Theatre - Detroit`

### 3. Owned-first prioritization (commit cee822e)

Edge fn upgraded to **v4** with `owned_first` (default ON) and `owned_only` query flags. Source of truth for "where we own listings": `seatgeek_seller_listings`. Uses `.in(ownedIds)` filter in owned mode so far-future events (Nov '26 etc.) aren't missed by date-ordered pagination.

**Pivot rationale**: tried TEvo `/v9/events?owned_by_office=true` first (returned 422 — filter not allowed) and `/v9/inventory/ticket_groups` (404). No clean office-scoped GET endpoint exists in v9, so SG seller_listings is the proxy signal.

**Drain results**:
- 14 actionable owned candidates, 11 matched (78.5%) — Diljit Dosanjh, Jack Harlow ×2, Chicago Sky @ NY Liberty, Inter Miami @ Chicago Fire, Trevor Noah, etc.
- 1 false-positive caught + undone (Salsa Spectacular venue+date collision with LA Philharmonic).
- 3 TEvo-genuinely-missing (HONNE, LSU @ Kentucky, Mariners @ Marlins).

**Coverage scoreboard**:

| Metric | Before | After |
|---|---:|---:|
| SG events where we have seller_listings | 47 | 47 |
| Of those, linked to TEvo | 29 | **39 (83%)** |

**Bonus**: post-bridge collect-listings on 11 newly-tracked events captured **2,134 new listings_snapshots** (451 of ours).

### 4. B1 OPS hotfixes (commit 4bdc78b)

Two B1 flags resolved during this work:

**#258 OPS-HIGH** (active 5+h) — `match_unmatched_orders_sweep_hourly` failing every `:22` with "function not unique". Two overloads of `match_to_aq_event_id` coexisted (7-arg + 8-arg with `p_source_venue_id DEFAULT NULL`); 5-arg callers matched both via default fill.
- **Migration 20260516260000** drops the dead 7-arg overload (B1 verified no callers reference it directly). Post-apply check enforces exactly 1 overload.

**#259 OPS-MED** (active 90+min) — `performer_wiki_queue_searches_5min` failing every `:17,:47` with FK violation on `performer_wiki_pending.tevo_performer_id → performer_metadata.performer_id`. Events can reference performer_ids not yet ingested (R2 sequencing gap).
- **Migration 20260516270000** adds `EXISTS (SELECT 1 FROM performer_metadata WHERE performer_id = e.primary_performer_id)` filter so orphans are skipped cleanly.

### 5. PROJECT_BIBLE updates

- §4 RPCs: 5 new entries (sg_canonical_refresh_v2_pull, sg_attempt_event_xref_v3, auto_match_sg_canonical_v3, cross_source_venue_resolve, refresh_cross_source_venue_map).
- §3 landmines: parking pseudo-event skip + TEvo dotted-key date filter convention.
- §7 macros: full TEvo `/v9/events` search procedure documented (endpoint, params, 2-tier strategy, scoring, attempt tracking, live invocation pattern).

---

## Files (8)

```
PROJECT_BIBLE.md                                                              [edit]
supabase/migrations/20260516230000_sg_canonical_refresh_v2_pull.sql           [new]
supabase/migrations/20260516240000_matcher_v3_venue_map_parking_skip.sql      [new]
supabase/migrations/20260516250000_sg_to_tevo_search_bridge_cron.sql          [new]
supabase/migrations/20260516260000_drop_match_to_aq_event_id_v1_overload.sql  [new]
supabase/migrations/20260516270000_fix_queue_performer_wiki_orphan_filter.sql [new]
supabase/functions/sg-to-tevo-search-bridge/index.ts                          [new — v4 deployed]
```

---

## Test plan

- [x] Migrations 20260516230000–20260516270000 applied to prod via MCP `apply_migration`. All 5 returned `{"success": true}`.
- [x] `sg_canonical_refresh_v2_pull(NULL)` backfill: **574 rows updated → 574/574 coverage**.
- [x] `auto_match_sg_canonical_v3()` initial run: **19 newly matched + 232 parking skipped**.
- [x] Edge fn `sg-to-tevo-search-bridge` v4 deployed (verify_jwt=true + body-level cron-secret).
- [x] Dry-run on 15 random unmatched: **9/15 matched** at score 64–214.
- [x] Live batch of 40: **30/40 matched (75%)**.
- [x] Owned-only drain of 14: **11/14 matched (78.5%)**, 1 false-positive caught + undone.
- [x] Inter Miami @ Revolution event 3222237: 0 → **177 listings captured** locally (10 ours).
- [x] OPS #258 fix: post-apply check confirms exactly 1 `match_to_aq_event_id` overload. Next `:22` firing should land green (pending observation).
- [x] OPS #259 fix: smoke-tested `queue_performer_wiki_searches(3)` — succeeds with orphan filter.
- [x] bot_chat trail: 261, 262, 263 posted; 258 + 259 resolved.

---

## Known follow-ups

- **A1.1 backfill blocked** (`seatgeek_sales_snapshots.tevo_event_id`): unique-index collision risk. Needs operator sign-off on `seatgeek_sales_dedup` index strategy change (drop + replace with `UNIQUE(sg_event_id, sg_sale_id, pulled_at)` to match actual ingest semantics). Standalone follow-up PR.
- **Salsa Spectacular** sg_event_id 18084072 flagged in `sg_tevo_search_attempts.meta.manual_review = true` for human review.
- **Watchlist pagination cap fix** (root cause from collect-listings 7-30d / 60d+ misses): B1 #255 in progress; this PR works around via search bridge but doesn't fix the upstream sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
