### PR TITLE
feat(sg): A1.1 — seatgeek_sales_snapshots.tevo_event_id backfill (87% coverage, was 0.03%)

### DIFF
--- a/supabase/migrations/20260516280000_a1_1_seatgeek_sales_dedup_and_tevo_backfill.sql
+++ b/supabase/migrations/20260516280000_a1_1_seatgeek_sales_dedup_and_tevo_backfill.sql
@@ -1,0 +1,121 @@
+-- ============================================================================
+-- A1.1 — seatgeek_sales_snapshots.tevo_event_id backfill enablement
+--
+-- Closes D0 audit proposal A1.1 (bot_chat 251/262/266).
+--
+-- Before this migration:
+--   - seatgeek_sales_snapshots.tevo_event_id was 0.03% populated (365 of 1.3M)
+--   - D2's v_sg_broker_sales_by_event view (mig 20260516220100) GROUP BYs on
+--     tevo_event_id → 99% of event-grouped aggregates collapsed to NULL row
+--   - Old UNIQUE(tevo_event_id, sg_sale_id) constraint only enforced on the
+--     365 non-NULL rows (NULLs aren't equal in unique index), so 32,627 truly
+--     identical rows existed across the table from ingest pipeline writing
+--     the same (sg_event_id, sg_sale_id, pulled_at) tuple 2-3 times within
+--     the same microsecond of a pulled_at batch.
+--
+-- This migration:
+--   1. Dedups truly-identical rows (keep MIN(id) per natural key). Verified
+--      safe: all duplicate rows share IDENTICAL (sg_event_id, sg_sale_id,
+--      pulled_at, broadcast_price, quantity, section, sale_at_utc, ...) —
+--      only id differs. Pre-flight count: 32,627 rows to delete.
+--   2. Drops old UNIQUE constraint seatgeek_sales_dedup. Verified safe via
+--      pg_depend: 0 functional / FK / view dependencies on it.
+--   3. Adds new UNIQUE INDEX seatgeek_sales_dedup_v2 on (sg_event_id,
+--      sg_sale_id, pulled_at) — the natural key for SG broker sales ingest.
+--   4. BEFORE INSERT trigger trg_sg_sales_populate_tevo_event_id auto-
+--      populates tevo_event_id from seatgeek_event_xref on all new rows.
+--      Confirmed working via post-apply smoke test (Inter Miami sg_event_id
+--      17921050 → tevo_event_id 3222237 populated correctly).
+--   5. backfill_seatgeek_sales_tevo_event_id(p_chunk_size) function for
+--      chunked historical backfill. Post-apply ran 5 chunks totaling
+--      1,139,091 row updates → 87.35% column coverage (the remaining 13%
+--      are sg_event_ids with no xref entry yet; will populate via trigger
+--      as the search bridge keeps linking events).
+--
+-- Verified post-apply:
+--   - seatgeek_sales_dedup_v2 index PRESENT
+--   - old seatgeek_sales_dedup constraint GONE (count=0)
+--   - trg_sg_sales_populate_tevo_event_id trigger PRESENT
+--   - synthetic insert test: NULL → 3222237 via trigger
+--   - v_sg_broker_sales_by_event: 60% of event rows now have tevo_event_id
+--     populated (was ~0%)
+--
+-- Unblocks: D2's two broker-sales views + arbitrage view + any future
+-- per-event SG sales analytics.
+-- ============================================================================
+
+-- 1. Dedup
+WITH ranked AS (
+  SELECT id, row_number() OVER (
+    PARTITION BY sg_event_id, sg_sale_id, pulled_at ORDER BY id
+  ) AS rn
+  FROM public.seatgeek_sales_snapshots
+)
+DELETE FROM public.seatgeek_sales_snapshots
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- 2. Drop old unique constraint (which owns the index)
+ALTER TABLE public.seatgeek_sales_snapshots DROP CONSTRAINT IF EXISTS seatgeek_sales_dedup;
+
+-- 3. New natural-key unique index
+CREATE UNIQUE INDEX IF NOT EXISTS seatgeek_sales_dedup_v2
+  ON public.seatgeek_sales_snapshots(sg_event_id, sg_sale_id, pulled_at);
+
+COMMENT ON INDEX public.seatgeek_sales_dedup_v2 IS
+  'Natural-key dedup for SG broker sales firehose. Each (sg_event_id, sg_sale_id, pulled_at) is one observation row. A1.1 2026-05-16: replaced old (tevo_event_id, sg_sale_id) which only enforced on 0.03% of rows.';
+
+-- 4. BEFORE INSERT trigger — auto-populate tevo_event_id from xref on new rows
+CREATE OR REPLACE FUNCTION public.trg_sg_sales_populate_tevo_event_id()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $func$
+BEGIN
+  IF NEW.tevo_event_id IS NULL AND NEW.sg_event_id IS NOT NULL THEN
+    SELECT sgx.tevo_event_id INTO NEW.tevo_event_id
+    FROM public.seatgeek_event_xref sgx
+    WHERE sgx.sg_event_id = NEW.sg_event_id LIMIT 1;
+  END IF;
+  RETURN NEW;
+END $func$;
+
+DROP TRIGGER IF EXISTS trg_sg_sales_populate_tevo_event_id ON public.seatgeek_sales_snapshots;
+CREATE TRIGGER trg_sg_sales_populate_tevo_event_id
+  BEFORE INSERT ON public.seatgeek_sales_snapshots
+  FOR EACH ROW EXECUTE FUNCTION public.trg_sg_sales_populate_tevo_event_id();
+
+-- 5. Chunked backfill helper (idempotent — re-runnable for any new sg_event_ids
+--    that get xref'd later but predate the trigger)
+CREATE OR REPLACE FUNCTION public.backfill_seatgeek_sales_tevo_event_id(p_chunk_size int DEFAULT 100000)
+RETURNS TABLE(rows_updated int, rows_remaining int)
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE v_updated int := 0; v_remaining int;
+BEGIN
+  WITH to_update AS (
+    SELECT s.id, sgx.tevo_event_id
+    FROM public.seatgeek_sales_snapshots s
+    JOIN public.seatgeek_event_xref sgx ON sgx.sg_event_id = s.sg_event_id
+    WHERE s.tevo_event_id IS NULL
+    LIMIT p_chunk_size
+  ),
+  upd AS (
+    UPDATE public.seatgeek_sales_snapshots s
+    SET tevo_event_id = tu.tevo_event_id
+    FROM to_update tu
+    WHERE s.id = tu.id
+    RETURNING s.id
+  )
+  SELECT count(*)::int INTO v_updated FROM upd;
+
+  SELECT count(*)::int INTO v_remaining
+  FROM public.seatgeek_sales_snapshots s
+  WHERE s.tevo_event_id IS NULL
+    AND EXISTS (SELECT 1 FROM public.seatgeek_event_xref sgx WHERE sgx.sg_event_id = s.sg_event_id);
+
+  RETURN QUERY SELECT v_updated, v_remaining;
+END $func$;
+
+REVOKE EXECUTE ON FUNCTION public.backfill_seatgeek_sales_tevo_event_id(int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.backfill_seatgeek_sales_tevo_event_id(int) TO service_role;


### PR DESCRIPTION
## Summary

Closes **D0 audit proposal A1.1** (bot_chat 251 / 262 / 266) — `seatgeek_sales_snapshots.tevo_event_id` backfill enablement. Unblocks D2's `v_sg_broker_sales_by_event` view + arbitrage view + any future per-event SG sales analytics.

### Before
- `seatgeek_sales_snapshots.tevo_event_id`: **0.03% populated** (365 of 1.3M rows)
- Old `UNIQUE(tevo_event_id, sg_sale_id)` constraint blocked backfill — would have collided on 1.1M rows once populated (NULLs aren't equal in the existing index, so duplicate `(NULL, sg_sale_id)` rows coexisted)
- Ingest pipeline writes 2-3 identical rows per `(sg_event_id, sg_sale_id, pulled_at)` microsecond → 32,627 truly-identical duplicate rows in table

### What this migration does

1. **Dedup**: `DELETE` 32,627 truly-identical rows (keep `MIN(id)` per natural key). Pre-flight verified all duplicates share identical `broadcast_price, quantity, section, sale_at_utc` — only `id` differs.

2. **Drop old constraint** `seatgeek_sales_dedup`. `pg_depend` verified zero functional / FK / view dependencies on it.

3. **New natural-key unique index** `seatgeek_sales_dedup_v2` on `(sg_event_id, sg_sale_id, pulled_at)`. Matches actual ingest semantics — each pull-time snapshot of each sale is one row.

4. **BEFORE INSERT trigger** `trg_sg_sales_populate_tevo_event_id` — auto-populates `NEW.tevo_event_id` from `seatgeek_event_xref` on all new inserts. Smoke-tested: Inter Miami `sg_event_id=17921050` insert → trigger populated `tevo_event_id=3222237`.

5. **Chunked backfill helper** `backfill_seatgeek_sales_tevo_event_id(p_chunk_size)` — re-runnable for any sg_event_ids xref'd later but predate the trigger.

### Post-apply state (verified live)

| Metric | Before | After |
|---|---:|---:|
| `seatgeek_sales_snapshots` total rows | 1,339,505 | **1,306,878** (−32,627 dedups) |
| Rows with `tevo_event_id` populated | 365 (0.03%) | **1,141,578 (87.35%)** |
| `seatgeek_sales_dedup_v2` index | — | PRESENT |
| Old `seatgeek_sales_dedup` constraint | enforced | REMOVED |
| `trg_sg_sales_populate_tevo_event_id` trigger | — | PRESENT + working |
| `v_sg_broker_sales_by_event` event rows w/ `tevo_event_id` | <1% | **~60%** |

Backfill drained across 5 chunks (100K / 200K / 300K / 300K / 239,106) = **1,139,091 row updates**. The remaining 13% of column-NULL rows are `sg_event_id`s with no xref entry yet — those will populate via trigger as the search bridge keeps linking SG↔TEvo events.

### Test plan

- [x] Pre-flight: counted exactly 32,627 duplicate rows to delete (all truly identical).
- [x] Pre-flight: `pg_depend` confirmed 0 external dependencies on old index.
- [x] Pre-flight: verified `(sg_event_id, sg_sale_id, pulled_at)` would be unique post-dedup.
- [x] Migration applied to prod via MCP `apply_migration` → `{success: true}`.
- [x] Backfill drained: 5 sequential `backfill_seatgeek_sales_tevo_event_id()` chunks until `rows_remaining=0`.
- [x] Trigger smoke test: inserted synthetic row with `tevo_event_id=NULL` for `sg_event_id=17921050` → trigger populated `tevo_event_id=3222237` correctly. Test row cleaned up.
- [x] Post-apply: new index PRESENT, old constraint GONE, trigger PRESENT.
- [x] View backfill: `v_sg_broker_sales_by_event` immediately benefits — 60% of event rows now grouped by real `tevo_event_id`.
- [x] Test branch deleted (Supabase branch `a1_1_dedup_index_test` / `7faf44bf-05ba-434b-9443-92b6a652e41a`).

### Per operator directive

> "for a1.1 test first to see effects, then if good ship"

Tested static + simulated effects before applying. All ship-criteria green. Branch cleanup complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
