### PR TITLE
feat(d0): performer blind-spots panel (Phase 2b/2c first sliver)

### DIFF
--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -53,9 +53,20 @@
       <div id="phEventsBody"></div>
     </section>
 
+    <section id="perf-blind-spots">
+      <div class="panel-title row">
+        <span>BLIND SPOTS — UPCOMING GAMES WE DON'T OWN</span>
+        <span class="muted small" id="phBlindSpotsCount"></span>
+      </div>
+      <div class="muted small" style="margin-bottom: 8px;">
+        Games where this performer has &gt;50 tix on market but our owned_tix = 0. Sorted by approx market notional (qty × median).
+      </div>
+      <div id="phBlindSpotsBody"></div>
+    </section>
+
     <section id="perf-context">
       <div class="panel-title">CONTEXT</div>
-      <div class="muted small">ESPN injuries / roster / news / cross-source xref — pending the cross-source explorer page</div>
+      <div class="muted small">ESPN standings / injuries / recent results — pending <code>get_broker_performer_page</code> RPC (Phase 2b ask)</div>
     </section>
   </main>
 

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -36,9 +36,10 @@
       } else {
         T.setStatus(`Loaded`, 'ok');
       }
-      try { renderHero(assets, portfolio); } catch (e) { console.error('hero', e); }
-      try { renderRollup(portfolio); }       catch (e) { console.error('rollup', e); }
-      try { renderEvents(portfolio); }       catch (e) { console.error('events', e); }
+      try { renderHero(assets, portfolio); }      catch (e) { console.error('hero', e); }
+      try { renderRollup(portfolio); }            catch (e) { console.error('rollup', e); }
+      try { renderEvents(portfolio); }            catch (e) { console.error('events', e); }
+      try { renderBlindSpots(portfolio); }        catch (e) { console.error('blindSpots', e); }
     });
   }
 
@@ -141,6 +142,97 @@
         <td class="num">${ownedShare}</td>
         <td><span class="badge ${lcCls}">${escapeHtml(String(lc).toUpperCase())}</span></td>
         <td>${isHome === '—' ? '—' : `<span class="badge ${isHome === 'HOME' ? 'lifecycle-active' : ''}">${isHome}</span>`}</td>
+      `;
+      tb.appendChild(tr);
+    });
+    body.appendChild(tbl);
+  }
+
+  // ---------- Blind spots — games we DON'T own ----------
+  //
+  // For each upcoming event under this performer where we hold zero
+  // inventory AND the market has > MIN_MARKET_TIX tickets active, surface
+  // the row sorted by approx market notional (qty × median). These are
+  // games we could profitably enter — broker decision-support, no Phase
+  // 2b/2c RPC needed (existing /api/portfolio events already carry
+  // owned_tickets_count + tickets_count + retail_median per row).
+  //
+  // Aligns with the entity-level Blind Spots framing in Phase 2c E.1
+  // (Snapshot/Motion/Coverage/Blind) — surfacing the "Coverage" gap at
+  // the performer drill-down rather than waiting for the dedicated
+  // /terminal/blind-spots page (Phase 2c proper, needs get_broker_
+  // blind_spots RPC from A1).
+
+  const BLIND_SPOT_MIN_MARKET_TIX = 50;
+  const BLIND_SPOT_MAX_ROWS       = 20;
+
+  function renderBlindSpots(portfolio) {
+    const body = document.getElementById('phBlindSpotsBody');
+    const countEl = document.getElementById('phBlindSpotsCount');
+    if (!body) return;
+    body.innerHTML = '';
+    if (!portfolio || portfolio.__err) {
+      body.innerHTML = '<div class="empty">portfolio unavailable — cannot derive blind spots</div>';
+      return;
+    }
+    const events = portfolio.events || [];
+
+    // Lifecycle gate first — speculative + ghost events surface elsewhere
+    // already (and aren't real blind-spot candidates per consumer storefront
+    // filter logic from PR #175). Then qty + ownership filter.
+    const candidates = events.filter((e) => {
+      const lifecycleActive = !e.lifecycle || e.lifecycle.is_active !== false;
+      if (!lifecycleActive) return false;
+      const owned = Number(e.owned_tickets_count || 0);
+      const market = Number(e.tickets_count || 0);
+      return owned === 0 && market > BLIND_SPOT_MIN_MARKET_TIX;
+    });
+
+    // Sort by approx market notional desc. Falls back to market qty when
+    // retail_median missing (small event with no median yet → still surfaces).
+    candidates.sort((a, b) => {
+      const an = (Number(a.tickets_count) || 0) * (Number(a.retail_median) || 0);
+      const bn = (Number(b.tickets_count) || 0) * (Number(b.retail_median) || 0);
+      if (bn !== an) return bn - an;
+      return (Number(b.tickets_count) || 0) - (Number(a.tickets_count) || 0);
+    });
+
+    const total = candidates.length;
+    if (countEl) countEl.textContent = total
+      ? `${total} blind spot${total === 1 ? '' : 's'} (showing top ${Math.min(total, BLIND_SPOT_MAX_ROWS)})`
+      : '';
+
+    if (!total) {
+      body.innerHTML = '<div class="empty">no blind spots — we have inventory on every active upcoming game for this performer ✓</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th>
+        <th>Venue</th>
+        <th class="num">T-days</th>
+        <th class="num">Mkt qty</th>
+        <th class="num">Mkt median</th>
+        <th class="num">Approx GMV</th>
+      </tr></thead>
+      <tbody></tbody>
+    `;
+    const tb = tbl.querySelector('tbody');
+    candidates.slice(0, BLIND_SPOT_MAX_ROWS).forEach((e) => {
+      const days = T.daysUntil(e.occurs_at_local);
+      const qty = Number(e.tickets_count) || 0;
+      const med = Number(e.retail_median) || 0;
+      const gmv = qty * med;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><a href="event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a></td>
+        <td>${escapeHtml(e.venue_name || '—')}</td>
+        <td class="num">${days === null ? '—' : days}</td>
+        <td class="num">${T.fmtNum(qty)}</td>
+        <td class="num">${med ? '$' + T.fmtNum(Math.round(med)) : '—'}</td>
+        <td class="num">${gmv ? '$' + T.fmtNum(Math.round(gmv)) : '—'}</td>
       `;
       tb.appendChild(tr);
     });


### PR DESCRIPTION
## Summary

First Phase 2c-style **Blind Spots** surface (per plan E.1 framing) at the performer drill-down level. Uses the existing `/api/portfolio` endpoint — **no new A1 RPC needed**.

Operator directive: "continue testing and building" — this is the smallest meaningful D0 build leveraging the foundation A1 just shipped (PR #178 A1.1 SG-sales tevo_event_id backfill + #179 A1.3+A1.4 entity-map aliases).

## What it does

For any `?performer=<id>` page, renders a "Blind Spots — Upcoming games we don't own" panel showing events where:

- `owned_tickets_count = 0` (we hold zero inventory)
- `tickets_count > 50` (market is meaningfully active)
- `lifecycle.is_active != false` (not cancelled/postponed)

Sorted by approx market notional (`qty × retail_median`) DESC, capped at top 20. Each row links into `event.html` for the per-event drill.

This is the same "Blind Spots" pattern the dedicated `/terminal/blind-spots` page (Phase 2c proper) will eventually use — this performer-scoped sliver is the cheapest first step that demonstrates the framing without depending on the `get_broker_blind_spots` RPC ask.

## What's NOT in this PR (deferred — Phase 2b RPC needed from A1)

The Phase 2b wireframe (plan E.18.c) also calls for:
- Standings strip (record, win%, streak, seed)
- Injuries panel (active list)
- Recent results (last 5 post-state games)

These all need ESPN data via the `get_broker_performer_page` RPC from A1. Left a note in the `#perf-context` placeholder referencing the dependency. Not a blocker — the blind-spots panel is independently valuable.

## Verification

Locally via stubbed `/api/portfolio` (6 synthetic Knicks events):
- 3 blind-spot candidates surfaced (Knicks @ Pacers G7, @ Heat G3, @ Pistons G1)
- 1 correctly excluded by below-threshold market filter (preseason game with 22 tix)
- 1 correctly excluded by lifecycle.is_active=false (cancelled vs LAC)
- Sorted by GMV desc: $4.0M > $1.1M > $276K ✓

## Test plan

- [ ] After merge + auto-deploy, open `https://vibepass-storefront-test.onrender.com/static/terminal/performer.html?performer=16303` (Knicks)
- [ ] Confirm "Blind Spots" section appears below "Upcoming Events"
- [ ] If we own every active Knicks game → empty-state message renders ✓
- [ ] If we have gaps → table shows top-20 by approx GMV
- [ ] Click any row → routes to `event.html?event=<id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)