### PR TITLE
fix(d0): host-aware API_BASE fixes Railway 'failed to fetch'

### DIFF
--- a/static/terminal/app.js
+++ b/static/terminal/app.js
@@ -6,19 +6,39 @@
 
   const STATUS = document.getElementById('status');
 
-  // API host. The terminal deploys as a static site on
-  // vibepass-terminal-test.onrender.com (per render-d0-terminal.yaml — D0's
-  // assigned Render service, srv-d839339kh4rs73ac3s20). FastAPI lives on
-  // D1's vibepass-storefront-test service. So in prod we cross-origin to
-  // D1's host; on localhost everything is same-origin against the dev
-  // uvicorn. Override at runtime via localStorage.terminalApiBase if the
-  // operator wants to point at a different host (preview, staging).
+  // API host — resolves the FastAPI shell location based on where the
+  // browser opened the terminal pages. Three deploy topologies:
+  //
+  //   1. localhost dev (uvicorn) — same-origin. `/api/*` lives next to the
+  //      static files.
+  //   2. Static CDN (vibepass-terminal-test.onrender.com, per render-d0-
+  //      terminal.yaml) — cross-origin to the FastAPI shell on a sibling
+  //      service. CSP `connect-src` allowlists the shell host.
+  //   3. FastAPI shell directly (vibepass-storefront-test.onrender.com OR
+  //      its Railway mirror at glorious-appreciation-production-a6ce.up.
+  //      railway.app OR any future preview/staging host) — same-origin.
+  //      Cross-origin to the canonical Render host from here is wrong: it
+  //      forces a CORS preflight + cold-start trip just to talk to ourselves,
+  //      and breaks entirely when the canonical shell is sleeping (FREE plan
+  //      cold-start, PROJECT_BIBLE §10). Operator hit "failed to fetch" on
+  //      Railway 2026-05-17 — that path is what triggered this fix.
+  //
+  // Override via localStorage.terminalApiBase for ad-hoc preview/staging.
   const API_BASE = (function () {
     const override = (typeof localStorage !== 'undefined') && localStorage.getItem('terminalApiBase');
     if (override) return override.replace(/\/$/, '');
     const h = location.hostname;
+    // Topology 1: localhost dev.
     if (h === 'localhost' || h === '127.0.0.1' || h === '') return '';
-    return 'https://vibepass-storefront-test.onrender.com';
+    // Topology 2: static CDN — cross-origin to the canonical FastAPI shell.
+    // Includes the original publishPath=static/terminal layout and the new
+    // wider publishPath=static layout (PR #181); both serve from this host.
+    if (h.includes('terminal-test')) {
+      return 'https://vibepass-storefront-test.onrender.com';
+    }
+    // Topology 3: FastAPI shell deploys (any other host). Use same-origin
+    // so /api/* hits the local FastAPI without a CORS round-trip.
+    return '';
   })();
 
   function setStatus(msg, cls) {


### PR DESCRIPTION
## Bug

Operator opened **https://glorious-appreciation-production-a6ce.up.railway.app/terminal/** → all `T.api()` calls returned "failed to fetch".

## Root cause

`static/terminal/app.js:19-21` hardcoded API_BASE to `https://vibepass-storefront-test.onrender.com` for ANY non-localhost hostname. Railway IS a FastAPI shell (faithful mirror of storefront-test), so its terminal JS was cross-origining ITSELF back to Render — forcing a CORS preflight + paying the Render FREE-plan cold-start blackout penalty just to call endpoints that already live on the same Railway origin. "Failed to fetch" = the browser bailing on cold-start OR a CORS denial.

## Fix

Widened to 3 topologies (was 2):

| Topology | Detect | API_BASE |
|---|---|---|
| 1. Localhost dev | `hostname in (localhost, 127.0.0.1, '')` | `''` (same-origin) |
| 2. Static CDN | `hostname.includes('terminal-test')` | `https://vibepass-storefront-test.onrender.com` |
| 3. **FastAPI shell (NEW)** | anything else | `''` (same-origin) |

Topology 3 handles Railway + storefront-test direct + any future preview/staging/custom-domain FastAPI deploy without future code changes. `localStorage.terminalApiBase` override unchanged.

## No regressions

- Localhost: still `''` ✓
- terminal-test CDN: still cross-origin to storefront-test ✓
- vibepass-storefront-test.onrender.com: was cross-origining to itself via explicit URL match → now `''` same-origin (strictly faster, no CORS preflight, no functional change)

## Verified

localhost preview reload: API_BASE='' confirmed via 404 path having no host prefix (`/api/broker/performer/16303/assets` not `https://.../api/...`); Performer page DOM intact (5 sections including PR #180's `perf-blind-spots`).

## After merge

Auto-deploys to:
- `vibepass-storefront-test.onrender.com` (Render) — silent improvement (strictly fewer cross-origin trips)
- `glorious-appreciation-production-a6ce.up.railway.app` (Railway) — bug fix lands
- `vibepass-terminal-test.onrender.com` (Render CDN) — no behavior change (still Topology 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)