### PR TITLE
feat(d0): version chip in terminal topbar (tell deploys apart)

### DIFF
--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -37,7 +37,73 @@
     if (status) topbar.insertBefore(nav, status);
     else topbar.appendChild(nav);
 
+    injectVersionChip(topbar);
     injectAuthControl(topbar);
+  }
+
+  // ---------- Deploy version chip ----------
+  //
+  // Operator request 2026-05-17: visible version indicator on every page so
+  // they can distinguish which deploy a tab is on at a glance — independent
+  // of URL bar (might show terminal-test vs storefront-test vs Railway) and
+  // data shown (might be cached or stale).
+  //
+  // Detection cascade — each layer covers a different deploy topology:
+  //   1. <meta name="x-app-version" content="..."> in HTML
+  //      (server-side rendered; FastAPI shell could swap "dev" → SHA in
+  //      _read_storefront_html; not wired yet for terminal pages)
+  //   2. Any script tag with `?v=<sha>` cache-bust query suffix — that's
+  //      what _read_storefront_html (app.py:73-97) injects on FastAPI shell
+  //      deploys. Works on storefront-test + Railway today.
+  //   3. Any stylesheet with `?v=<sha>` — same fallback.
+  //   4. Render-CDN-only fetch of /version.json (added by future build
+  //      step that writes RENDER_GIT_COMMIT to disk). Until that ships,
+  //      CDN shows "dev" — that's an honest signal the CDN HTML wasn't
+  //      rewritten through the cache-bust pipeline.
+  //
+  // The chip displays `v:<first-7-of-sha>` with a hover title showing the
+  // full SHA + the deploy hostname so the operator can copy/diff.
+  function injectVersionChip(topbar) {
+    const status = topbar.querySelector('#status');
+    const chip = document.createElement('span');
+    chip.className = 'version-chip muted small';
+    chip.textContent = 'v:dev';
+    chip.title = `host: ${location.hostname}\nversion: dev (no cache-bust suffix found)`;
+    if (status) topbar.insertBefore(chip, status);
+    else topbar.appendChild(chip);
+    const v = detectVersion();
+    if (v) {
+      chip.textContent = 'v:' + v.slice(0, 7);
+      chip.title = `host: ${location.hostname}\nversion: ${v}`;
+    }
+  }
+
+  function detectVersion() {
+    // 1. Meta tag (future-proof — FastAPI shell can render this)
+    const meta = document.querySelector('meta[name="x-app-version"]');
+    if (meta && meta.content && meta.content !== 'dev' && meta.content !== '') {
+      return meta.content;
+    }
+    // 2. Script src ?v=<sha>
+    for (const s of document.scripts) {
+      const m = (s.src || '').match(/[?&]v=([^&#]+)/);
+      if (m && m[1] !== 'dev') return decodeURIComponent(m[1]);
+    }
+    // 3. Stylesheet href ?v=<sha>
+    for (let i = 0; i < document.styleSheets.length; i++) {
+      try {
+        const href = document.styleSheets[i].href || '';
+        const m = href.match(/[?&]v=([^&#]+)/);
+        if (m && m[1] !== 'dev') return decodeURIComponent(m[1]);
+      } catch (_) { /* cross-origin stylesheet access throws — ignore */ }
+    }
+    // 4. Link tag ?v=<sha> (fallback for stylesheets that haven't loaded)
+    const links = document.querySelectorAll('link[rel="stylesheet"]');
+    for (const l of links) {
+      const m = (l.href || '').match(/[?&]v=([^&#]+)/);
+      if (m && m[1] !== 'dev') return decodeURIComponent(m[1]);
+    }
+    return null;
   }
 
   function injectAuthControl(topbar) {

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -496,6 +496,22 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
   line-height: 1.5;
 }
 
+/* ---------- Deploy version chip (in topbar) ---------- */
+
+.version-chip {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+  padding: 2px 6px;
+  margin-right: 8px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  letter-spacing: 0.3px;
+  cursor: help;
+}
+.version-chip:hover { color: var(--text); border-color: var(--muted); }
+
 /* ---------- Top-nav auth control ---------- */
 
 .auth-ctrl {


### PR DESCRIPTION
Operator request — visible deploy-version indicator in topbar so tabs on terminal-test vs storefront-test vs Railway can be told apart even when URL+data look identical.

nav.js detection cascade: meta tag → script ?v= → stylesheet ?v= → 'dev' fallback. Tooltip shows full SHA + hostname. No per-HTML changes needed.

Verified locally: http://localhost:8765 → 'v:dev'; injected ?v=eb1e2a4 → returns 'eb1e2a4'.

CDN follow-up (separate): a build step that writes RENDER_GIT_COMMIT to a static version.json so CDN tabs also show the SHA. For now CDN shows 'v:dev' which IS a useful signal.

🤖 Generated with Claude Code