### PR TITLE
feat(d0): /version.json endpoint + nav.js async fallback (terminal pages show real SHA)

### DIFF
--- a/app.py
+++ b/app.py
@@ -650,6 +650,26 @@ def undelivered_landing():
     return FileResponse(os.path.join(STATIC_DIR, "undelivered", "index.html"))
 
 
+@app.get("/version.json")
+def version_json():
+    """Public deploy-version endpoint — same _STOREFRONT_VERSION the cache-bust
+    pipeline uses, plus the resolution chain that produced it, plus a deploy
+    indicator from common Render/Railway env vars. Consumed by nav.js's
+    version chip (PR #184) so terminal pages render a real SHA in the topbar
+    even though they don't go through _read_storefront_html (which only
+    rewrites store pages). Cheap; safe to call cross-origin."""
+    return {
+        "version": _STOREFRONT_VERSION,
+        "render_commit": os.environ.get("RENDER_GIT_COMMIT") or None,
+        "railway_commit": os.environ.get("RAILWAY_GIT_COMMIT_SHA") or None,
+        "git_commit": os.environ.get("GIT_COMMIT") or None,
+        "render_service_id": os.environ.get("RENDER_SERVICE_ID") or None,
+        "render_external_url": os.environ.get("RENDER_EXTERNAL_URL") or None,
+        "railway_public_domain": os.environ.get("RAILWAY_PUBLIC_DOMAIN") or None,
+        "deployed_at_iso": os.environ.get("RENDER_GIT_COMMIT_TIME") or None,
+    }
+
+
 @app.get("/healthz")
 def healthz():
     """Diagnostic endpoint. Public — no secrets returned, just boot + connectivity

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -75,6 +75,23 @@
     if (v) {
       chip.textContent = 'v:' + v.slice(0, 7);
       chip.title = `host: ${location.hostname}\nversion: ${v}`;
+    } else {
+      // Async fallback — fetch /version.json from same origin (cheap,
+      // ~5ms warm). Works on FastAPI-shell deploys (storefront-test +
+      // Railway) where terminal HTML is served verbatim without a
+      // cache-bust suffix to detect synchronously. Static CDN doesn't
+      // have this endpoint → chip stays "v:dev" which is the honest
+      // signal ("this came from CDN bytes, not the FastAPI shell").
+      fetch('/version.json', { credentials: 'omit' })
+        .then(r => r.ok ? r.json() : null)
+        .then(j => {
+          if (!j || !j.version || j.version === 'dev') return;
+          chip.textContent = 'v:' + String(j.version).slice(0, 7);
+          chip.title = `host: ${location.hostname}\nversion: ${j.version}` +
+            (j.render_external_url ? `\nrender: ${j.render_external_url}` : '') +
+            (j.railway_public_domain ? `\nrailway: ${j.railway_public_domain}` : '');
+        })
+        .catch(() => { /* chip stays "v:dev" — acceptable degraded state */ });
     }
   }
 


### PR DESCRIPTION
Follow-up to PR #184. Terminal HTML served verbatim (not through `_read_storefront_html`) → no `?v=` suffix to detect synchronously, so chip showed `v:dev` even on FastAPI-shell deploys.

Two-part fix:
1. New `/version.json` endpoint returns `_STOREFRONT_VERSION` + env resolution chain + deploy indicators (`render_external_url`, `railway_public_domain`)
2. nav.js falls back to async fetch when synchronous detection finds nothing. Chip starts `v:dev`, transitions to `v:eb1e2a4` once fetch resolves (~5ms warm). Tooltip enriched.

Terminal pages on storefront-test + Railway now show real SHA. CDN still shows `v:dev` (no FastAPI shell) — would need a build step; deferred.

🤖 Generated with Claude Code