### PR TITLE
feat(d0/event): tab nav + 3 full-list tabs + Last Snapshot panel

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -47,6 +47,15 @@
       </div>
     </section>
 
+    <nav class="event-tabs" id="eventTabs" role="tablist">
+      <button class="event-tab active" data-tab="overview" role="tab" aria-selected="true">Overview</button>
+      <button class="event-tab" data-tab="sg-listings" role="tab" aria-selected="false">SG Listings <span class="tab-count" id="tabCountSgListings"></span></button>
+      <button class="event-tab" data-tab="evo-listings" role="tab" aria-selected="false">EVO Listings <span class="tab-count" id="tabCountEvoListings"></span></button>
+      <button class="event-tab" data-tab="sg-sales" role="tab" aria-selected="false">SG Sales <span class="tab-count" id="tabCountSgSales"></span></button>
+    </nav>
+
+    <div class="tab-pane active" id="paneOverview" role="tabpanel">
+
     <section id="kpi-grid">
       <div class="kpi-cell" id="kpiOwnedPremium">
         <span class="kpi-lbl">OWNED PREMIUM %</span>
@@ -88,6 +97,14 @@
         <span class="kpi-val" id="kpiOwnedShareVal">—</span>
         <span class="kpi-sub" id="kpiOwnedShareSub"></span>
       </div>
+    </section>
+
+    <section id="last-snapshot">
+      <div class="panel-title row">
+        <span>LAST EVENT SNAPSHOT — event_metrics latest row</span>
+        <span class="muted small" id="lastSnapshotAge"></span>
+      </div>
+      <div id="lastSnapshotBody"></div>
     </section>
 
     <section id="chart">
@@ -182,6 +199,48 @@
       <div class="panel-title">PERFORMER ESPN — NEXT 5 GAMES</div>
       <div id="performerEspnBody"></div>
     </section>
+
+    </div><!-- /#paneOverview -->
+
+    <div class="tab-pane" id="paneSgListings" role="tabpanel" hidden>
+      <section id="sg-listings-full">
+        <div class="panel-title row">
+          <span>SG LISTINGS — FULL (deduped on sglid, last 7d)</span>
+          <span class="muted small" id="sgListingsFullMeta">tap tab to load</span>
+        </div>
+        <div id="sgListingsFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneEvoListings" role="tabpanel" hidden>
+      <section id="evo-listings-full">
+        <div class="panel-title row">
+          <span>EVO LISTINGS — FULL (deduped on tevo_ticket_group_id, last 7d, owned-first)</span>
+          <span class="muted small" id="evoListingsFullMeta">tap tab to load</span>
+        </div>
+        <div id="evoListingsFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneSgSales" role="tabpanel" hidden>
+      <section id="sg-sales-full">
+        <div class="panel-title row">
+          <span>SG SALES — FULL (DISTINCT ON sg_sale_id)</span>
+          <span class="sales-window-ctrl">
+            <label class="muted small" for="sgSalesWindow">window</label>
+            <select id="sgSalesWindow" class="range-select">
+              <option value="1">1d</option>
+              <option value="7">7d</option>
+              <option value="30" selected>30d</option>
+              <option value="60">60d</option>
+              <option value="90">90d</option>
+            </select>
+            <span class="muted small" id="sgSalesFullMeta">tap tab to load</span>
+          </span>
+        </div>
+        <div id="sgSalesFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
   </main>
 
   <script src="lib/supabase.js"></script>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -29,6 +29,8 @@
     }
 
     wireRangeSelector(eventId);
+    wireTabs(eventId);
+    wireSalesWindow(eventId);
     await loadAndRender(eventId);
   }
 
@@ -72,6 +74,7 @@
       safe('competingEvents',  () => renderCompetingEvents(data.competing_events));
       safe('recentListings',   () => renderRecentListings(data.recent_listings));
       safe('performerEspn',    () => renderPerformerEspn(data.performer_espn_context, data.performer));
+      safe('lastSnapshot',     () => renderLastSnapshot(data.chart_data));
     } catch (e) {
       handleRpcError(e);
     }
@@ -1314,6 +1317,355 @@
         badges.appendChild(b);
       }
     }
+  }
+
+  // ============================================================
+  // Tab navigation + lazy-load (Phase 2a Tabs — mig 20260517180000)
+  // ============================================================
+  const _tabState = { loaded: { 'sg-listings': false, 'evo-listings': false, 'sg-sales': false } };
+
+  function wireTabs(eventId) {
+    const nav = document.getElementById('eventTabs');
+    if (!nav) return;
+    nav.addEventListener('click', async (e) => {
+      const btn = e.target.closest('.event-tab');
+      if (!btn) return;
+      const tabId = btn.dataset.tab;
+      activateTab(tabId);
+      if (tabId === 'sg-listings' && !_tabState.loaded['sg-listings']) {
+        await loadSgListingsFull(eventId);
+      } else if (tabId === 'evo-listings' && !_tabState.loaded['evo-listings']) {
+        await loadEvoListingsFull(eventId);
+      } else if (tabId === 'sg-sales' && !_tabState.loaded['sg-sales']) {
+        await loadSgSalesFull(eventId);
+      }
+    });
+  }
+
+  function activateTab(tabId) {
+    document.querySelectorAll('.event-tab').forEach(b => {
+      const on = b.dataset.tab === tabId;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    const paneIds = {
+      'overview':     'paneOverview',
+      'sg-listings':  'paneSgListings',
+      'evo-listings': 'paneEvoListings',
+      'sg-sales':     'paneSgSales',
+    };
+    Object.entries(paneIds).forEach(([id, paneId]) => {
+      const pane = document.getElementById(paneId);
+      if (!pane) return;
+      if (id === tabId) {
+        pane.removeAttribute('hidden');
+        pane.classList.add('active');
+      } else {
+        pane.setAttribute('hidden', '');
+        pane.classList.remove('active');
+      }
+    });
+  }
+
+  function wireSalesWindow(eventId) {
+    const sel = document.getElementById('sgSalesWindow');
+    if (!sel) return;
+    sel.addEventListener('change', async () => {
+      _tabState.loaded['sg-sales'] = false;
+      const body = document.getElementById('sgSalesFullBody');
+      if (body) body.innerHTML = '<div class="empty">Loading…</div>';
+      await loadSgSalesFull(eventId);
+    });
+  }
+
+  async function rpcOrNull(rpcName, args) {
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      return { error: { message: 'no auth — Path C unavailable (localhost dev)' } };
+    }
+    return Auth.client.rpc(rpcName, args);
+  }
+
+  // ---------- SG Listings (full) ----------
+  async function loadSgListingsFull(eventId) {
+    const body = document.getElementById('sgListingsFullBody');
+    const meta = document.getElementById('sgListingsFullMeta');
+    if (body) body.innerHTML = '<div class="empty">Loading SG listings…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_sg_listings_full', { p_event_id: eventId, p_limit: 500 });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['sg-listings'] = true;
+    renderSgListingsFull(res.data, performance.now() - t0);
+  }
+
+  function renderSgListingsFull(d, ms) {
+    const body = document.getElementById('sgListingsFullBody');
+    const meta = document.getElementById('sgListingsFullMeta');
+    const countChip = document.getElementById('tabCountSgListings');
+    if (!body) return;
+    if (!d || d.hidden) {
+      const reason = d && d.reason === 'no_sg_bridge' ? 'no SG bridge for this event' : 'hidden';
+      body.innerHTML = `<div class="empty">${escapeHtml(reason)}</div>`;
+      if (meta) meta.textContent = '0 rows';
+      if (countChip) countChip.textContent = '0';
+      return;
+    }
+    const rows = d.rows || [];
+    if (meta) meta.textContent = `${rows.length} rows · ${ms.toFixed(0)}ms · sg_event_id ${d.sg_event_id}`;
+    if (countChip) countChip.textContent = String(rows.length);
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no SG listings in last 7 days</div>';
+      return;
+    }
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Captured</th><th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">Retail (all-in)</th><th class="num">Bcst</th>
+        <th>Stock</th><th>Delivery</th><th>Splits</th><th>In-hand</th>
+        <th>Source</th><th>Type</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      if (r.is_broker_owned) tr.className = 'owned-row';
+      tr.innerHTML = `
+        <td>${T.fmtDate(r.captured_at)}</td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${T.fmtNum(r.quantity)}</td>
+        <td class="num">${r.retail_price_all_in != null ? '$' + T.fmtNum(Math.round(r.retail_price_all_in)) : '—'}</td>
+        <td class="num">${r.broadcast_price != null ? '$' + T.fmtNum(Math.round(r.broadcast_price)) : '—'}</td>
+        <td>${escapeHtml(r.stock_type || '—')}</td>
+        <td>${escapeHtml(r.delivery_method || '—')}${r.is_instant_download ? ' <span class="pill">instant</span>' : ''}</td>
+        <td>${escapeHtml(Array.isArray(r.splits) ? r.splits.join(',') : (r.splits || '—'))}</td>
+        <td>${r.in_hand_date ? T.fmtDate(r.in_hand_date) : '—'}</td>
+        <td>${escapeHtml(r.market_source || '—')}</td>
+        <td>${r.is_broker_owned ? '<span class="pill broker">broker</span>' : '<span class="pill market">market</span>'}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+  }
+
+  // ---------- EVO Listings (full) ----------
+  async function loadEvoListingsFull(eventId) {
+    const body = document.getElementById('evoListingsFullBody');
+    const meta = document.getElementById('evoListingsFullMeta');
+    if (body) body.innerHTML = '<div class="empty">Loading EVO listings…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_evo_listings_full', { p_event_id: eventId, p_limit: 500 });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['evo-listings'] = true;
+    renderEvoListingsFull(res.data, performance.now() - t0);
+  }
+
+  function renderEvoListingsFull(d, ms) {
+    const body = document.getElementById('evoListingsFullBody');
+    const meta = document.getElementById('evoListingsFullMeta');
+    const countChip = document.getElementById('tabCountEvoListings');
+    if (!body) return;
+    const rows = (d && d.rows) || [];
+    if (meta) meta.textContent = `${rows.length} rows · ${ms.toFixed(0)}ms`;
+    if (countChip) countChip.textContent = String(rows.length);
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no EVO listings in last 7 days</div>';
+      return;
+    }
+    const ownedCount = rows.filter(r => r.is_owned).length;
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Captured</th><th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">Retail</th><th class="num">Wholesale</th>
+        <th class="num">Δ Retail</th><th class="num">Δ Qty</th>
+        <th>Format</th><th>Splits</th><th>Type</th>
+        <th>Brokerage</th><th>Office</th><th>Flags</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      if (r.is_owned) tr.className = 'owned-row';
+      const dRetail = (r.prev_retail_price != null && r.retail_price != null)
+        ? (Number(r.retail_price) - Number(r.prev_retail_price)) : null;
+      const dQty = (r.prev_quantity != null && r.quantity != null)
+        ? (Number(r.quantity) - Number(r.prev_quantity)) : null;
+      const dRetailHtml = dRetail == null ? '—'
+        : `<span class="${dRetail >= 0 ? 'pos' : 'neg'}">${dRetail >= 0 ? '+' : ''}$${T.fmtNum(Math.round(dRetail))}</span>`;
+      const dQtyHtml = dQty == null ? '—'
+        : `<span class="${dQty >= 0 ? 'pos' : 'neg'}">${dQty >= 0 ? '+' : ''}${dQty}</span>`;
+      const flags = [];
+      if (r.is_ancillary) flags.push('ancillary');
+      if (r.instant_delivery) flags.push('instant');
+      if (r.eticket) flags.push('eticket');
+      tr.innerHTML = `
+        <td>${T.fmtDate(r.captured_at)}</td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${T.fmtNum(r.quantity)}</td>
+        <td class="num">${r.retail_price != null ? '$' + T.fmtNum(Math.round(r.retail_price)) : '—'}</td>
+        <td class="num">${r.wholesale_price != null ? '$' + T.fmtNum(Math.round(r.wholesale_price)) : '—'}</td>
+        <td class="num">${dRetailHtml}</td>
+        <td class="num">${dQtyHtml}</td>
+        <td>${escapeHtml(r.format || '—')}</td>
+        <td>${escapeHtml(Array.isArray(r.splits) ? r.splits.join(',') : (r.splits || '—'))}</td>
+        <td>${escapeHtml(r.type || '—')}</td>
+        <td>${escapeHtml(r.brokerage_name || (r.brokerage_id != null ? String(r.brokerage_id) : '—'))}</td>
+        <td>${escapeHtml(r.office_name || '—')}</td>
+        <td>${r.is_owned ? '<span class="pill owned">ours</span>' : flags.map(f => `<span class="pill">${f}</span>`).join(' ') || '<span class="pill market">market</span>'}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+    if (meta) meta.textContent = `${rows.length} rows (${ownedCount} ours) · ${ms.toFixed(0)}ms`;
+  }
+
+  // ---------- SG Sales (full) ----------
+  async function loadSgSalesFull(eventId) {
+    const body = document.getElementById('sgSalesFullBody');
+    const meta = document.getElementById('sgSalesFullMeta');
+    const sel = document.getElementById('sgSalesWindow');
+    const windowDays = sel ? (parseInt(sel.value, 10) || 30) : 30;
+    if (body) body.innerHTML = '<div class="empty">Loading SG sales…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_sg_sales_full', {
+      p_event_id: eventId, p_limit: 500, p_window_days: windowDays
+    });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['sg-sales'] = true;
+    renderSgSalesFull(res.data, performance.now() - t0, windowDays);
+  }
+
+  function renderSgSalesFull(d, ms, windowDays) {
+    const body = document.getElementById('sgSalesFullBody');
+    const meta = document.getElementById('sgSalesFullMeta');
+    const countChip = document.getElementById('tabCountSgSales');
+    if (!body) return;
+    if (!d || d.hidden) {
+      const reason = d && d.reason === 'no_sg_bridge' ? 'no SG bridge for this event' : 'hidden';
+      body.innerHTML = `<div class="empty">${escapeHtml(reason)}</div>`;
+      if (meta) meta.textContent = '0 rows';
+      if (countChip) countChip.textContent = '0';
+      return;
+    }
+    const rows = d.rows || [];
+    if (meta) meta.textContent = `${rows.length} rows · ${ms.toFixed(0)}ms · ${windowDays}d window · sg_event_id ${d.sg_event_id}`;
+    if (countChip) countChip.textContent = String(rows.length);
+    if (!rows.length) {
+      body.innerHTML = `<div class="empty">no SG sales in last ${windowDays} days</div>`;
+      return;
+    }
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Sold</th><th>Pulled</th><th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">Bcst Price</th>
+        <th>Stock</th><th class="num">Days→Event</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${T.fmtDate(r.sale_at_utc)}</td>
+        <td class="muted">${T.fmtDate(r.pulled_at)}</td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${T.fmtNum(r.quantity)}</td>
+        <td class="num">${r.broadcast_price != null ? '$' + T.fmtNum(Math.round(r.broadcast_price)) : '—'}</td>
+        <td>${escapeHtml(r.stock_type || '—')}</td>
+        <td class="num">${r.days_to_event_at_sale != null ? T.fmtNum(r.days_to_event_at_sale) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+  }
+
+  // ---------- Last event snapshot (Overview tab) ----------
+  // Surfaces the latest non-null values from chart_data.event_metrics_series
+  // — the most recent row written by the cron, across all metrics. This is
+  // the "what does the event look like right now per our pull" panel.
+  function renderLastSnapshot(chart) {
+    const body = document.getElementById('lastSnapshotBody');
+    const ageEl = document.getElementById('lastSnapshotAge');
+    const section = document.getElementById('last-snapshot');
+    if (!body) return;
+    const rows = (chart && chart.event_metrics_series) || [];
+    if (!rows.length) {
+      if (section) section.style.display = 'none';
+      return;
+    }
+    if (section) section.style.display = '';
+    const latest = rows[rows.length - 1] || {};
+    const captured = latest.captured_at;
+    if (ageEl) {
+      const ageMin = captured ? Math.round((Date.now() - new Date(captured).getTime()) / 60000) : null;
+      ageEl.textContent = captured
+        ? `latest ${T.fmtDate(captured)} (${ageMin}m ago)`
+        : 'latest —';
+    }
+
+    // Walk back through rows to fill any null fields with the most recent
+    // non-null value for that field. Some series (zone medians, SG side)
+    // are populated less often than the headline market series.
+    const fields = [
+      ['tickets_count',          'TIX COUNT'],
+      ['listings_count',         'LISTINGS'],
+      ['owned_tickets_count',    'OUR TIX'],
+      ['owned_listings_count',   'OUR LISTINGS'],
+      ['retail_median',          'RETAIL MED', '$'],
+      ['nonowned_median_retail', 'NONOWNED MED', '$'],
+      ['owned_median_retail',    'OUR MED', '$'],
+      ['min_retail',             'GET-IN', '$'],
+      ['owned_min_retail',       'OUR MIN', '$'],
+      ['cost_median',            'COST MED', '$'],
+      ['retail_p25',             'P25', '$'],
+      ['retail_p75',             'P75', '$'],
+    ];
+    function latestNonNullField(col) {
+      for (let i = rows.length - 1; i >= 0; i--) {
+        const v = rows[i] && rows[i][col];
+        if (v !== null && v !== undefined && !Number.isNaN(Number(v))) {
+          return { val: Number(v), at: rows[i].captured_at };
+        }
+      }
+      return null;
+    }
+    const cells = fields.map(([col, label, prefix]) => {
+      const found = latestNonNullField(col);
+      const valHtml = found
+        ? `<span class="last-snap-val">${prefix === '$' ? '$' : ''}${T.fmtNum(Math.round(found.val))}</span>`
+        : `<span class="last-snap-val dim">—</span>`;
+      return `<div class="last-snap-cell"><span class="last-snap-lbl">${label}</span>${valHtml}</div>`;
+    }).join('');
+    body.innerHTML = `<div class="last-snap-grid">${cells}</div>
+      <div class="last-snap-meta">snapshot fields fall back to the most recent non-null value across the loaded window (${rows.length} pulls)</div>`;
   }
 
   // ---------- Util ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -656,27 +656,34 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
   grid-template-columns: repeat(12, 1fr);
   gap: 12px;
 }
-.wrap.event > section {
+/* Apply panel chrome + grid placement via descendant selectors so the
+   sections inside .tab-pane (display:contents) still participate. */
+.wrap.event section {
   background: var(--panel);
   border: 1px solid var(--line);
   padding: 12px 16px;
 }
-.wrap.event > #hero               { grid-column: 1 / -1; }
-.wrap.event > #kpi-grid           { grid-column: 1 / -1; padding: 12px 16px; }
-.wrap.event > #chart              { grid-column: 1 / -1; padding: 12px 8px; }
-.wrap.event > #sg-broker-sales    { grid-column: 1 / -1; }
-.wrap.event > #sg-listings-summary{ grid-column: 1 / -1; }
-.wrap.event > #splits             { grid-column: 1 / 7; }
-.wrap.event > #zones              { grid-column: 7 / 13; }
-.wrap.event > #sales-tape         { grid-column: 1 / -1; }
-.wrap.event > #espn               { grid-column: 1 / -1; }
-.wrap.event > #weather            { grid-column: 1 / -1; }
-.wrap.event > #order-strip        { grid-column: 1 / 7; }
-.wrap.event > #cross-source-orders{ grid-column: 7 / 13; }
-.wrap.event > #alerts             { grid-column: 1 / 7; }
-.wrap.event > #competing-events   { grid-column: 7 / 13; }
-.wrap.event > #recent-listings    { grid-column: 1 / 7; }
-.wrap.event > #performer-espn     { grid-column: 7 / 13; }
+.wrap.event #hero               { grid-column: 1 / -1; }
+.wrap.event #kpi-grid           { grid-column: 1 / -1; padding: 12px 16px; }
+.wrap.event #last-snapshot      { grid-column: 1 / -1; }
+.wrap.event #chart              { grid-column: 1 / -1; padding: 12px 8px; }
+.wrap.event #sg-broker-sales    { grid-column: 1 / -1; }
+.wrap.event #sg-listings-summary{ grid-column: 1 / -1; }
+.wrap.event #splits             { grid-column: 1 / 7; }
+.wrap.event #zones              { grid-column: 7 / 13; }
+.wrap.event #sales-tape         { grid-column: 1 / -1; }
+.wrap.event #espn               { grid-column: 1 / -1; }
+.wrap.event #weather            { grid-column: 1 / -1; }
+.wrap.event #order-strip        { grid-column: 1 / 7; }
+.wrap.event #cross-source-orders{ grid-column: 7 / 13; }
+.wrap.event #alerts             { grid-column: 1 / 7; }
+.wrap.event #competing-events   { grid-column: 7 / 13; }
+.wrap.event #recent-listings    { grid-column: 1 / 7; }
+.wrap.event #performer-espn     { grid-column: 7 / 13; }
+.wrap.event #sg-listings-full   { grid-column: 1 / -1; }
+.wrap.event #evo-listings-full  { grid-column: 1 / -1; }
+.wrap.event #sg-sales-full      { grid-column: 1 / -1; }
+.wrap.event nav.event-tabs      { grid-column: 1 / -1; }
 
 /* Hero band — main info left, status side panel right */
 .wrap.event > #hero {
@@ -1054,3 +1061,108 @@ body[data-page="login"] {
 .login-foot a { color: var(--accent); text-decoration: none; }
 .login-foot a:hover { text-decoration: underline; }
 .login-foot .dot { color: var(--dim); }
+
+/* ---------- Event-page tabs (Phase 2a) ---------- */
+.event-tabs {
+  display: flex; gap: 2px;
+  border-bottom: 1px solid var(--line);
+  margin: 8px 0 12px;
+  font-family: var(--mono);
+}
+.event-tab {
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  color: var(--muted);
+  padding: 8px 16px;
+  font-family: var(--mono); font-size: 12px;
+  font-weight: 600; letter-spacing: 0.4px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 100ms, background 100ms;
+}
+.event-tab:hover { color: var(--text); background: var(--panel-2); }
+.event-tab.active {
+  color: var(--accent);
+  background: var(--panel);
+  border-color: var(--line);
+  border-bottom: 1px solid var(--panel);
+  position: relative; top: 1px;
+}
+.event-tab .tab-count {
+  color: var(--dim);
+  font-weight: 400;
+  font-size: 11px;
+  margin-left: 4px;
+}
+.event-tab.active .tab-count { color: var(--text); }
+
+.tab-pane { display: contents; }
+.tab-pane[hidden] { display: none; }
+
+/* ---------- Last event snapshot (Overview tab) ---------- */
+#last-snapshot { padding: 12px 16px; }
+.last-snap-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px 16px;
+  font-family: var(--mono); font-size: 12px;
+}
+.last-snap-cell { display: flex; flex-direction: column; gap: 2px; padding: 4px 0; }
+.last-snap-lbl { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.4px; }
+.last-snap-val { color: var(--text); font-size: 14px; font-weight: 600; }
+.last-snap-val.dim { color: var(--dim); }
+.last-snap-meta { color: var(--muted); font-size: 11px; margin-top: 8px; }
+
+/* ---------- Full-list tabs (SG Listings / EVO Listings / SG Sales) ---------- */
+.full-list-tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono); font-size: 11px;
+}
+.full-list-tbl thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--line);
+  position: sticky; top: 0;
+  background: var(--panel);
+  z-index: 1;
+}
+.full-list-tbl tbody td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--line-2);
+  color: var(--text);
+  white-space: nowrap;
+}
+.full-list-tbl tbody tr:hover td { background: var(--shade); }
+.full-list-tbl .num { text-align: right; }
+.full-list-tbl .owned-row td { background: rgba(74, 222, 128, 0.04); }
+.full-list-tbl .owned-row td:first-child { border-left: 2px solid var(--pos); }
+.full-list-tbl .pill {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  border-radius: 2px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.full-list-tbl .pill.owned { color: var(--pos); border-color: var(--pos); }
+.full-list-tbl .pill.market { color: var(--muted); }
+.full-list-tbl .pill.broker { color: var(--accent); border-color: var(--accent); }
+.full-list-host { max-height: 70vh; overflow-y: auto; }
+
+.sales-window-ctrl {
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.sales-window-ctrl .range-select {
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--line);
+  font-family: var(--mono); font-size: 11px;
+  padding: 2px 4px;
+}

--- a/supabase/migrations/20260517180000_event_page_tabs_rpcs.sql
+++ b/supabase/migrations/20260517180000_event_page_tabs_rpcs.sql
@@ -1,0 +1,179 @@
+-- Migration 20260517180000 · lane:D0 (author) → A1 (apply) · writes:get_event_sg_listings_full + get_event_evo_listings_full + get_event_sg_sales_full · reads:seatgeek_listings_snapshots,listings_snapshots,seatgeek_sales_snapshots,seatgeek_event_xref · pre:20260517030000 · auth:operator-approved 2026-05-17
+--
+-- D0 Phase 2a tabs — 3 SECDEF RPCs powering the new event-page tabs:
+--   Tab "SG Listings"      — full window of SG listings (deduped on sglid)
+--   Tab "EVO Listings"     — full window of TEvo listings (deduped on tevo_ticket_group_id)
+--   Tab "SG Sales"         — full window of SG sales (deduped on sg_sale_id, 11x dedup factor)
+--
+-- The existing v3 sales_tape returns 20 deduped rows; this RPC returns up to
+-- 500 with optional p_window_hours so the tab can show full broker history.
+--
+-- All 3 follow the same pattern as v3 RPCs:
+--   - SECURITY DEFINER + email gate (@s4kent.com)
+--   - REVOKE ALL FROM PUBLIC; GRANT EXECUTE to anon + authenticated
+--   - 250-500 row caps to keep payloads sane
+--   - DISTINCT ON natural key to handle pull-time dedup (esp. SG sales 11x factor)
+--   - ORDER BY captured_at/pulled_at DESC for "newest first"
+--
+-- ## Pending operator apply via apply_migration
+
+-- ============================================================
+-- 1. SG Listings tab — all listings for an event from seatgeek_listings_snapshots
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_sg_listings_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 250
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (sglid)
+      sglid, captured_at, section, row, quantity,
+      retail_price_all_in, broadcast_price,
+      delivery_method, stock_type, is_broker_owned, is_instant_download,
+      market_source, splits, in_hand_date
+    FROM public.seatgeek_listings_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND captured_at > now() - interval '7 days'
+    ORDER BY sglid, captured_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sg_event_id', v_sg_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.captured_at DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY captured_at DESC LIMIT greatest(1, least(p_limit, 500))) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_listings_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_listings_full(integer, integer) TO anon, authenticated;
+
+-- ============================================================
+-- 2. EVO Listings tab — all TEvo listings for an event from listings_snapshots
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_evo_listings_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 250
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_rows  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (tevo_ticket_group_id)
+      tevo_ticket_group_id, captured_at, section, row, quantity,
+      retail_price, wholesale_price, format, splits,
+      is_owned, is_ancillary, brokerage_id, brokerage_name,
+      office_name, instant_delivery, eticket, type,
+      prev_retail_price, prev_quantity
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id
+      AND captured_at > now() - interval '7 days'
+    ORDER BY tevo_ticket_group_id, captured_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'event_id', p_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.is_owned DESC, l.captured_at DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY is_owned DESC, captured_at DESC LIMIT greatest(1, least(p_limit, 500))) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_evo_listings_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_evo_listings_full(integer, integer) TO anon, authenticated;
+
+-- ============================================================
+-- 3. SG Sales tab — full window of SG broker sales (deduped 11x firehose)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_sg_sales_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 250,
+  p_window_days integer DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  -- DISTINCT ON sg_sale_id mandatory per PROJECT_BIBLE §3 (11x dedup factor).
+  -- Scope to sg_event_id uses idx_sg_sales_sg_event_id_time (A1 ship 2026-05-16).
+  WITH latest AS (
+    SELECT DISTINCT ON (sg_sale_id)
+      sg_sale_id, sale_at_utc, pulled_at,
+      section, row, quantity, broadcast_price, stock_type,
+      days_to_event_at_sale
+    FROM public.seatgeek_sales_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND sale_at_utc > now() - make_interval(days => greatest(1, least(p_window_days, 90)))
+    ORDER BY sg_sale_id, pulled_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sg_event_id', v_sg_event_id,
+    'window_days', greatest(1, least(p_window_days, 90)),
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.sale_at_utc DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY sale_at_utc DESC LIMIT greatest(1, least(p_limit, 500))) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_sales_full(integer, integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_sales_full(integer, integer, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_sg_listings_full(integer, integer) IS
+  'D0 event-page tabs — full SG listings for an event (deduped on sglid, last 7d, capped 500). Email-gated.';
+
+COMMENT ON FUNCTION public.get_event_evo_listings_full(integer, integer) IS
+  'D0 event-page tabs — full TEvo listings for an event (deduped on tevo_ticket_group_id, last 7d, capped 500, owned-first sort). Email-gated.';
+
+COMMENT ON FUNCTION public.get_event_sg_sales_full(integer, integer, integer) IS
+  'D0 event-page tabs — full SG sales for an event (DISTINCT ON sg_sale_id, window 1-90d, capped 500). Uses idx_sg_sales_sg_event_id_time. Email-gated.';


### PR DESCRIPTION
## Summary

Adds 4-tab navigation to the event detail page (single-scroll → tabs):

- **Overview** — existing single-page content, now augmented with a new **Last Event Snapshot** panel that surfaces the most recent non-null value for every column in `chart_data.event_metrics_series` (tickets/listings counts, retail/owned/nonowned medians, get-in, cost, p25/p75). Walks backward through the loaded window so sparse-cron fields like `owned_min_retail` or `cost_median` get filled from the last pull that had them.
- **SG Listings (full)** — deduped on `sglid`, last 7d, capped at 500. Surfaces: section/row/qty/retail (all-in)/broadcast/stock/delivery/splits/in-hand/source/owned vs market. Owned rows visually highlighted (green left-border).
- **EVO Listings (full)** — deduped on `tevo_ticket_group_id`, last 7d, capped at 500, owned-first sort. Shows retail + wholesale + Δretail / Δqty vs the row's `prev_*` fields + format/splits/type/brokerage/office/flags.
- **SG Sales (full)** — `DISTINCT ON (sg_sale_id)` (mandatory per PROJECT_BIBLE §3, 11× dedup factor), selectable 1d/7d/30d/60d/90d window (default 30d), capped at 500. Uses `idx_sg_sales_sg_event_id_time` (A1 ship 2026-05-16). Shows sale_at_utc / pulled_at / section / row / qty / broadcast price / stock_type / days-to-event.

## Architecture

Each new tab **lazy-loads on first click** (one RPC per tab) instead of bloating `get_broker_event_page_v3`. This keeps the initial page load identical to today, and only fetches the firehose data when the operator actually opens that tab.

Empty / hidden / error states are explicit:
- `{hidden:true, reason:'no_sg_bridge'}` for SG tabs when the event has no `seatgeek_event_xref` row
- Empty array → "no rows in last 7d / Nd"
- RPC error → in-place \`RPC error: <message>\` with no crash

Tab count chips populate after first load and stay until window changes.

## Migration `20260517180000_event_page_tabs_rpcs.sql`

Three SECDEF RPCs follow the v3 pattern:
- `@s4kent.com` email gate (raises 42501 otherwise)
- `REVOKE ALL FROM PUBLIC; GRANT EXECUTE TO anon, authenticated`
- `SET search_path = public, extensions, pg_temp`
- 250 default / 500 max via `greatest(1, least(p_limit, 500))`

Pending **operator apply via apply_migration** (D0 not allowed to self-apply per CLAUDE.md §1).

## CSS notes

`.tab-pane` uses `display: contents` so the sections inside still participate in `.wrap.event`'s 12-col grid. Existing grid-placement selectors widened from `> #foo` to `#foo` (descendant) so they still match after the `.tab-pane` wrapper is interposed in the DOM. Hero stays as a direct grid child (always visible above the tabs).

## Verification

- Migration linted against the latest schema probe (sglid / tevo_ticket_group_id / sg_sale_id all confirmed present)
- Local browser preview (`http://localhost:8765/static/terminal/event.html`): tab switching verified for all 4 tabs (DOM inspect: `activeBtn`, `paneHidden`, `bodyText`, `meta`, `countChip`). Lazy-load fires correct RPC on first click; subsequent clicks of the same tab are no-ops. Last-Snapshot section element present and styled.
- Path A localhost fallback errors gracefully ("RPC error: no auth — Path C unavailable")

## Test plan

- [ ] After A1 applies migration, smoke-test on `vibepass-storefront-test.onrender.com/static/terminal/event.html?event=3091413` (Yankees-Jays, has SG bridge + sales)
- [ ] Switch all 4 tabs; verify counts + render times appear in meta
- [ ] Test SG Sales window selector (1d → 90d) — confirm RPC re-runs and rows update
- [ ] Test no-SG-bridge event (3309426 Bruce Springsteen) — confirm SG tabs show "no SG bridge for this event" empty state
- [ ] Test event with no recent EVO listings — confirm EVO tab shows empty state
- [ ] Verify owned rows visually distinct (left-border + tinted bg) on both listing tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)