### PR TITLE
fix(d0/event): days_to_event_at_sale inline (PR #196 follow-up)

### DIFF
--- a/supabase/migrations/20260517180000_event_page_tabs_rpcs.sql
+++ b/supabase/migrations/20260517180000_event_page_tabs_rpcs.sql
@@ -129,6 +129,7 @@ AS $func$
 DECLARE
   v_email       text;
   v_sg_event_id bigint;
+  v_event_date  date;
   v_rows        jsonb;
 BEGIN
   v_email := coalesce(auth.jwt()->>'email', '');
@@ -143,13 +144,20 @@ BEGIN
     RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
   END IF;
 
+  -- A1 fixup (PR follow-up to #196): days_to_event_at_sale column doesn't
+  -- exist on seatgeek_sales_snapshots — compute inline via sg_events_canonical.
+  SELECT sg_event_date INTO v_event_date
+  FROM public.sg_events_canonical WHERE sg_event_id = v_sg_event_id LIMIT 1;
+
   -- DISTINCT ON sg_sale_id mandatory per PROJECT_BIBLE §3 (11x dedup factor).
   -- Scope to sg_event_id uses idx_sg_sales_sg_event_id_time (A1 ship 2026-05-16).
   WITH latest AS (
     SELECT DISTINCT ON (sg_sale_id)
       sg_sale_id, sale_at_utc, pulled_at,
       section, row, quantity, broadcast_price, stock_type,
-      days_to_event_at_sale
+      CASE WHEN v_event_date IS NOT NULL
+           THEN (v_event_date - sale_at_utc::date)::int
+           ELSE NULL END AS days_to_event_at_sale
     FROM public.seatgeek_sales_snapshots
     WHERE sg_event_id = v_sg_event_id
       AND sale_at_utc > now() - make_interval(days => greatest(1, least(p_window_days, 90)))


### PR DESCRIPTION
## Summary

- PR #196 ship had `seatgeek_sales_snapshots.days_to_event_at_sale` in the `get_event_sg_sales_full` RPC — but **that column doesn't exist on the table** (confirmed via `information_schema.columns`). First call would have raised `column does not exist`.
- Caught during pre-flight before apply. Applied the patched version directly to prod via `apply_migration` (smoke test: 5 rows on event 3091413 for all 3 RPCs). This PR aligns git history with live prod state.
- Fix: `DECLARE v_event_date date` + populate from `sg_events_canonical.sg_event_date` (indexed single-row lookup), compute inline as `(v_event_date - sale_at_utc::date)::int` with NULL-safe CASE.

## Test plan

- [x] Pre-flight: `information_schema.columns WHERE table_name = 'seatgeek_sales_snapshots' AND column_name = 'days_to_event_at_sale'` → 0 rows (column does not exist)
- [x] Applied patched migration to prod via MCP `apply_migration` (success)
- [x] Smoke: `get_event_sg_sales_full(3091413, 5, 30)` → 5 rows returned, `days_to_event_at_sale` populated as int
- [x] Smoke: other 2 RPCs (`get_event_sg_listings_full`, `get_event_evo_listings_full`) → 5 rows each
- [ ] CI green on this PR
- [ ] Merge to align git history with prod