### PR TITLE
feat(d0/event): 3 broker-account tabs (our TEvo orders / our SG sales / TP+Vivid)

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -52,6 +52,10 @@
       <button class="event-tab" data-tab="sg-listings" role="tab" aria-selected="false">SG Listings <span class="tab-count" id="tabCountSgListings"></span></button>
       <button class="event-tab" data-tab="evo-listings" role="tab" aria-selected="false">EVO Listings <span class="tab-count" id="tabCountEvoListings"></span></button>
       <button class="event-tab" data-tab="sg-sales" role="tab" aria-selected="false">SG Sales <span class="tab-count" id="tabCountSgSales"></span></button>
+      <span class="event-tabs-sep" aria-hidden="true">|</span>
+      <button class="event-tab" data-tab="evo-orders" role="tab" aria-selected="false">Our TEvo Orders <span class="tab-count" id="tabCountEvoOrders"></span></button>
+      <button class="event-tab" data-tab="sg-seller-orders" role="tab" aria-selected="false">Our SG Sales <span class="tab-count" id="tabCountSgSellerOrders"></span></button>
+      <button class="event-tab" data-tab="cross-broker" role="tab" aria-selected="false">TP + Vivid <span class="tab-count" id="tabCountCrossBroker"></span></button>
     </nav>
 
     <div class="tab-pane active" id="paneOverview" role="tabpanel">
@@ -239,6 +243,36 @@
           </span>
         </div>
         <div id="sgSalesFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneEvoOrders" role="tabpanel" hidden>
+      <section id="evo-orders-full">
+        <div class="panel-title row">
+          <span>OUR TEVO ORDERS — FULL (evo_orders ⨯ items, newest first)</span>
+          <span class="muted small" id="evoOrdersFullMeta">tap tab to load</span>
+        </div>
+        <div id="evoOrdersFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneSgSellerOrders" role="tabpanel" hidden>
+      <section id="sg-seller-orders-full">
+        <div class="panel-title row">
+          <span>OUR SG SALES — SellerDirect orders (our account)</span>
+          <span class="muted small" id="sgSellerOrdersFullMeta">tap tab to load</span>
+        </div>
+        <div id="sgSellerOrdersFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneCrossBroker" role="tabpanel" hidden>
+      <section id="cross-broker-full">
+        <div class="panel-title row">
+          <span>TICKPICK + VIVID — combined cross-marketplace orders</span>
+          <span class="muted small" id="crossBrokerFullMeta">tap tab to load</span>
+        </div>
+        <div id="crossBrokerFullBody"><div class="empty">Click the tab to load.</div></div>
       </section>
     </div>
   </main>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -1322,7 +1322,10 @@
   // ============================================================
   // Tab navigation + lazy-load (Phase 2a Tabs — mig 20260517180000)
   // ============================================================
-  const _tabState = { loaded: { 'sg-listings': false, 'evo-listings': false, 'sg-sales': false } };
+  const _tabState = { loaded: {
+    'sg-listings': false, 'evo-listings': false, 'sg-sales': false,
+    'evo-orders': false, 'sg-seller-orders': false, 'cross-broker': false,
+  } };
 
   function wireTabs(eventId) {
     const nav = document.getElementById('eventTabs');
@@ -1338,6 +1341,12 @@
         await loadEvoListingsFull(eventId);
       } else if (tabId === 'sg-sales' && !_tabState.loaded['sg-sales']) {
         await loadSgSalesFull(eventId);
+      } else if (tabId === 'evo-orders' && !_tabState.loaded['evo-orders']) {
+        await loadEvoOrdersFull(eventId);
+      } else if (tabId === 'sg-seller-orders' && !_tabState.loaded['sg-seller-orders']) {
+        await loadSgSellerOrdersFull(eventId);
+      } else if (tabId === 'cross-broker' && !_tabState.loaded['cross-broker']) {
+        await loadCrossBrokerFull(eventId);
       }
     });
   }
@@ -1349,10 +1358,13 @@
       b.setAttribute('aria-selected', on ? 'true' : 'false');
     });
     const paneIds = {
-      'overview':     'paneOverview',
-      'sg-listings':  'paneSgListings',
-      'evo-listings': 'paneEvoListings',
-      'sg-sales':     'paneSgSales',
+      'overview':         'paneOverview',
+      'sg-listings':      'paneSgListings',
+      'evo-listings':     'paneEvoListings',
+      'sg-sales':         'paneSgSales',
+      'evo-orders':       'paneEvoOrders',
+      'sg-seller-orders': 'paneSgSellerOrders',
+      'cross-broker':     'paneCrossBroker',
     };
     Object.entries(paneIds).forEach(([id, paneId]) => {
       const pane = document.getElementById(paneId);
@@ -1600,6 +1612,227 @@
         <td class="num">${r.broadcast_price != null ? '$' + T.fmtNum(Math.round(r.broadcast_price)) : '—'}</td>
         <td>${escapeHtml(r.stock_type || '—')}</td>
         <td class="num">${r.days_to_event_at_sale != null ? T.fmtNum(r.days_to_event_at_sale) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+  }
+
+  // ---------- Our TEvo Orders (full) ----------
+  async function loadEvoOrdersFull(eventId) {
+    const body = document.getElementById('evoOrdersFullBody');
+    const meta = document.getElementById('evoOrdersFullMeta');
+    if (body) body.innerHTML = '<div class="empty">Loading our TEvo orders…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_evo_orders_full', { p_event_id: eventId, p_limit: 500 });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['evo-orders'] = true;
+    renderEvoOrdersFull(res.data, performance.now() - t0);
+  }
+
+  function renderEvoOrdersFull(d, ms) {
+    const body = document.getElementById('evoOrdersFullBody');
+    const meta = document.getElementById('evoOrdersFullMeta');
+    const countChip = document.getElementById('tabCountEvoOrders');
+    if (!body) return;
+    const rows = (d && d.rows) || [];
+    const distinctOrders = (d && d.distinct_orders) || 0;
+    if (meta) meta.textContent = `${rows.length} items · ${distinctOrders} orders · ${ms.toFixed(0)}ms`;
+    if (countChip) countChip.textContent = String(distinctOrders);
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no TEvo orders for this event</div>';
+      return;
+    }
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Created</th><th>Order</th><th>State</th><th>Type</th>
+        <th>Section</th><th>Row</th><th>Seats</th>
+        <th class="num">Qty</th>
+        <th class="num">Item $</th><th class="num">Retail</th><th class="num">Whsl</th>
+        <th class="num">Total</th><th class="num">Fees</th>
+        <th>Hold Expires</th>
+        <th>Buyer Brokerage</th><th>Fraud</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    let lastOrderId = null;
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const firstOfOrder = r.evo_order_id !== lastOrderId;
+      lastOrderId = r.evo_order_id;
+      const stateCls = r.state ? 'status-' + String(r.state).toLowerCase() : '';
+      const seats = Array.isArray(r.ticket_group_seats) ? r.ticket_group_seats.join(',')
+                  : (r.ticket_group_seats == null ? '' : JSON.stringify(r.ticket_group_seats));
+      const holdExp = r.hold_expires_at ? T.fmtDate(r.hold_expires_at) : '—';
+      tr.innerHTML = `
+        <td>${firstOfOrder ? T.fmtDate(r.evo_created_at) : '<span class="muted">·</span>'}</td>
+        <td>${firstOfOrder ? '<strong>' + escapeHtml(String(r.evo_order_id)) + '</strong>' : '<span class="muted">·</span>'}</td>
+        <td>${firstOfOrder ? `<span class="pill ${stateCls}">${escapeHtml(r.state || '—')}</span>` : ''}</td>
+        <td>${firstOfOrder ? escapeHtml(r.type || '—') : ''}</td>
+        <td>${escapeHtml(r.ticket_group_section || '—')}</td>
+        <td>${escapeHtml(r.ticket_group_row || '—')}</td>
+        <td class="muted">${escapeHtml(seats)}</td>
+        <td class="num">${T.fmtNum(r.item_quantity != null ? r.item_quantity : r.ticket_group_quantity)}</td>
+        <td class="num">${r.item_price != null ? '$' + T.fmtNum(Math.round(r.item_price)) : '—'}</td>
+        <td class="num">${r.ticket_group_retail_price != null ? '$' + T.fmtNum(Math.round(r.ticket_group_retail_price)) : '—'}</td>
+        <td class="num">${r.ticket_group_wholesale_price != null ? '$' + T.fmtNum(Math.round(r.ticket_group_wholesale_price)) : '—'}</td>
+        <td class="num">${firstOfOrder && r.total != null ? '$' + T.fmtNum(Math.round(r.total)) : ''}</td>
+        <td class="num">${firstOfOrder && r.service_fee != null ? '$' + T.fmtNum(Math.round(r.service_fee)) : ''}</td>
+        <td>${firstOfOrder ? holdExp : ''}</td>
+        <td>${firstOfOrder ? escapeHtml(r.buyer_brokerage_name || '—') : ''}</td>
+        <td>${firstOfOrder ? escapeHtml(r.fraud_check_status || '—') : ''}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+  }
+
+  // ---------- Our SG SellerDirect Orders (full) ----------
+  async function loadSgSellerOrdersFull(eventId) {
+    const body = document.getElementById('sgSellerOrdersFullBody');
+    const meta = document.getElementById('sgSellerOrdersFullMeta');
+    if (body) body.innerHTML = '<div class="empty">Loading our SG SellerDirect orders…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_sg_seller_orders_full', { p_event_id: eventId, p_limit: 500 });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['sg-seller-orders'] = true;
+    renderSgSellerOrdersFull(res.data, performance.now() - t0);
+  }
+
+  function renderSgSellerOrdersFull(d, ms) {
+    const body = document.getElementById('sgSellerOrdersFullBody');
+    const meta = document.getElementById('sgSellerOrdersFullMeta');
+    const countChip = document.getElementById('tabCountSgSellerOrders');
+    if (!body) return;
+    if (!d || d.hidden) {
+      const reason = d && d.reason === 'no_sg_bridge' ? 'no SG bridge for this event' : 'hidden';
+      body.innerHTML = `<div class="empty">${escapeHtml(reason)}</div>`;
+      if (meta) meta.textContent = '0 rows';
+      if (countChip) countChip.textContent = '0';
+      return;
+    }
+    const rows = d.rows || [];
+    if (meta) meta.textContent = `${rows.length} rows · ${ms.toFixed(0)}ms · sg_event_id ${d.sg_event_id}`;
+    if (countChip) countChip.textContent = String(rows.length);
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no SG SellerDirect orders for this event</div>';
+      return;
+    }
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Created (SG)</th><th>Order</th><th>Status</th>
+        <th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">Sale $</th>
+        <th class="num">Payment Total</th><th class="num">Fees</th><th class="num">Tax</th>
+        <th>Delivery</th><th>Stock</th>
+        <th>Pulled</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const statusCls = r.status ? 'status-' + String(r.status).toLowerCase() : '';
+      tr.innerHTML = `
+        <td>${T.fmtDate(r.created_at_sg)}</td>
+        <td><strong>${escapeHtml(String(r.sg_order_id || '—'))}</strong></td>
+        <td><span class="pill ${statusCls}">${escapeHtml(r.status || '—')}</span></td>
+        <td>${escapeHtml(r.sale_section || '—')}</td>
+        <td>${escapeHtml(r.sale_row || '—')}</td>
+        <td class="num">${T.fmtNum(r.sale_quantity)}</td>
+        <td class="num">${r.sale_price != null ? '$' + T.fmtNum(Math.round(r.sale_price)) : '—'}</td>
+        <td class="num">${r.payment_total != null ? '$' + T.fmtNum(Math.round(r.payment_total)) : '—'}</td>
+        <td class="num">${r.payment_fees != null ? '$' + T.fmtNum(Math.round(r.payment_fees)) : '—'}</td>
+        <td class="num">${r.payment_tax != null ? '$' + T.fmtNum(Math.round(r.payment_tax)) : '—'}</td>
+        <td>${escapeHtml(r.delivery_method || r.delivery || '—')}</td>
+        <td>${escapeHtml(r.stock_type || '—')}</td>
+        <td class="muted">${T.fmtDate(r.pulled_at)}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+  }
+
+  // ---------- Cross-Broker (TickPick + Vivid combined, full) ----------
+  async function loadCrossBrokerFull(eventId) {
+    const body = document.getElementById('crossBrokerFullBody');
+    const meta = document.getElementById('crossBrokerFullMeta');
+    if (body) body.innerHTML = '<div class="empty">Loading TickPick + Vivid…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_cross_broker_orders_full', { p_event_id: eventId, p_limit: 500 });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['cross-broker'] = true;
+    renderCrossBrokerFull(res.data, performance.now() - t0);
+  }
+
+  function renderCrossBrokerFull(d, ms) {
+    const body = document.getElementById('crossBrokerFullBody');
+    const meta = document.getElementById('crossBrokerFullMeta');
+    const countChip = document.getElementById('tabCountCrossBroker');
+    if (!body) return;
+    const rows = (d && d.rows) || [];
+    const tpN = (d && d.tickpick_count) || 0;
+    const vvN = (d && d.vivid_count) || 0;
+    if (meta) meta.textContent = `${rows.length} rows · TP ${tpN} · Vivid ${vvN} · ${ms.toFixed(0)}ms`;
+    if (countChip) countChip.textContent = String(rows.length);
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no TickPick or Vivid orders for this event<div class="muted small">(Vivid bridge requires aq_short_event_id → sg_event_id → tevo_event_id; bridge data may be incomplete)</div></div>';
+      return;
+    }
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Source</th><th>Ordered</th><th>Order ID</th><th>Status</th>
+        <th>Section</th><th>Row</th><th>Seats</th>
+        <th class="num">Qty</th><th class="num">Total</th>
+        <th>Notes / Match</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const statusCls = r.status ? 'status-' + String(r.status).toLowerCase() : '';
+      const srcCls = 'src-' + String(r.source || '');
+      const seats = Array.isArray(r.seat_numbers) ? r.seat_numbers.join(',') : '';
+      const noteParts = [];
+      if (r.notes) noteParts.push(r.notes);
+      if (r.matched_via) noteParts.push(`match: ${r.matched_via}${r.match_confidence != null ? ' (' + Number(r.match_confidence).toFixed(2) + ')' : ''}`);
+      tr.innerHTML = `
+        <td><span class="pill ${srcCls}">${escapeHtml(r.source || '—')}</span></td>
+        <td>${T.fmtDate(r.ordered_at)}</td>
+        <td><strong>${escapeHtml(String(r.source_order_id || '—'))}</strong></td>
+        <td><span class="pill ${statusCls}">${escapeHtml(r.status || r.order_status || '—')}</span></td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="muted">${escapeHtml(seats)}</td>
+        <td class="num">${T.fmtNum(r.quantity)}</td>
+        <td class="num">${r.total != null ? '$' + T.fmtNum(Math.round(r.total)) : '—'}</td>
+        <td class="muted">${escapeHtml(noteParts.join(' · '))}</td>`;
       tb.appendChild(tr);
     });
     host.appendChild(tbl);

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -683,6 +683,9 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 .wrap.event #sg-listings-full   { grid-column: 1 / -1; }
 .wrap.event #evo-listings-full  { grid-column: 1 / -1; }
 .wrap.event #sg-sales-full      { grid-column: 1 / -1; }
+.wrap.event #evo-orders-full        { grid-column: 1 / -1; }
+.wrap.event #sg-seller-orders-full  { grid-column: 1 / -1; }
+.wrap.event #cross-broker-full      { grid-column: 1 / -1; }
 .wrap.event nav.event-tabs      { grid-column: 1 / -1; }
 
 /* Hero band — main info left, status side panel right */
@@ -1068,7 +1071,25 @@ body[data-page="login"] {
   border-bottom: 1px solid var(--line);
   margin: 8px 0 12px;
   font-family: var(--mono);
+  flex-wrap: wrap;
 }
+.event-tabs-sep {
+  color: var(--dim);
+  font-family: var(--mono);
+  font-size: 14px;
+  align-self: center;
+  padding: 0 6px;
+  user-select: none;
+}
+/* Order-status pills shown in our-order tabs */
+.full-list-tbl .pill.status-completed,
+.full-list-tbl .pill.status-accepted { color: var(--pos); border-color: var(--pos); }
+.full-list-tbl .pill.status-pending,
+.full-list-tbl .pill.status-hold     { color: var(--info); border-color: var(--info); }
+.full-list-tbl .pill.status-rejected,
+.full-list-tbl .pill.status-cancelled { color: var(--neg); border-color: var(--neg); }
+.full-list-tbl .pill.src-tickpick { color: var(--info); border-color: var(--info); }
+.full-list-tbl .pill.src-vivid    { color: #c084fc; border-color: #c084fc; }
 .event-tab {
   background: transparent;
   border: 1px solid transparent;

--- a/supabase/migrations/20260517220000_event_page_broker_tabs_rpcs.sql
+++ b/supabase/migrations/20260517220000_event_page_broker_tabs_rpcs.sql
@@ -1,0 +1,247 @@
+-- Migration 20260517220000 · lane:D0 (author) → A1 (apply) · writes:get_event_evo_orders_full + get_event_sg_seller_orders_full + get_event_cross_broker_orders_full · reads:evo_orders,evo_order_items,seatgeek_orders,seatgeek_event_xref,aq_event_map,tickpick_orders,vivid_orders · pre:20260517180000 · auth:operator-approved 2026-05-17
+--
+-- D0 Phase 2a tabs (round 2) — 3 broker-account SECDEF RPCs surfacing the
+-- "our office" side of the data, complementing the 3 marketplace firehoses
+-- already shipped in PR #196 (sg_listings / evo_listings / sg_sales):
+--   Tab "Our TEvo Orders"        — evo_orders ⨯ evo_order_items per event
+--   Tab "Our SG Sales"           — seatgeek_orders (SellerDirect) per event
+--   Tab "Cross-Broker (TP+Vivid)"— tickpick + vivid orders UNION per event
+--
+-- Source matrix per A1's "D0 tab option matrix" (RESOURCES_BIBLE.md):
+--   evo_orders            — our office's /v9/orders pulls, 99.5% tevo_event_id populated
+--   seatgeek_orders       — our office's SG SellerDirect, sg_event_id only (bridge via seatgeek_event_xref)
+--   tickpick_orders       — broker orders, 14% have direct tevo_event_id (94 distinct events)
+--   vivid_orders          — broker orders, 0% have tevo_event_id today; bridge via aq_short_event_id → aq_event_map → sg_event_id → seatgeek_event_xref
+--
+-- All 3 follow the canonical v3 SECDEF pattern:
+--   - SECURITY DEFINER + @s4kent.com email gate
+--   - REVOKE ALL FROM PUBLIC; GRANT EXECUTE to anon + authenticated
+--   - Hard 500-row cap via greatest(1, least(p_limit, 500))
+--   - Order by created/ordered/pulled timestamp DESC ("newest first")
+--
+-- ## Pending operator apply via apply_migration
+
+-- ============================================================
+-- 1. Our TEvo Orders — evo_orders joined with evo_order_items
+--    One row per order item; carries order-level context (state,
+--    totals, fees, buyer/seller brokerage, hold expiry) alongside
+--    item-level (section/row/seats, retail/wholesale).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_evo_orders_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 250
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_rows  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  WITH joined AS (
+    SELECT
+      o.evo_order_id, o.state, o.type, o.fraud_check_status,
+      o.total, o.subtotal, o.tax, o.service_fee, o.shipping, o.additional_expense, o.refunded, o.balance,
+      o.buyer_brokerage_id, o.buyer_brokerage_name,
+      o.seller_brokerage_id, o.seller_brokerage_name,
+      o.client_name,
+      o.evo_created_at, o.evo_updated_at,
+      o.hold_placed_at, o.hold_expires_at,
+      o.invoice_number, o.reference, o.po_number,
+      i.evo_item_id,
+      i.ticket_group_section,
+      i.ticket_group_row,
+      i.ticket_group_seats,
+      i.ticket_group_quantity,
+      i.ticket_group_retail_price,
+      i.ticket_group_wholesale_price,
+      i.quantity AS item_quantity,
+      i.price    AS item_price,
+      i.eticket_available, i.eticket_delivery, i.eticket_downloaded_at,
+      i.event_name, i.occurs_at, i.venue_name
+    FROM public.evo_orders o
+    LEFT JOIN public.evo_order_items i ON i.evo_order_id = o.evo_order_id
+    WHERE o.tevo_event_id = p_event_id
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'distinct_orders', count(DISTINCT j.evo_order_id),
+    'event_id', p_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(j) ORDER BY j.evo_created_at DESC NULLS LAST, j.evo_order_id DESC, j.evo_item_id), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (
+    SELECT * FROM joined
+    ORDER BY evo_created_at DESC NULLS LAST, evo_order_id DESC, evo_item_id
+    LIMIT greatest(1, least(p_limit, 500))
+  ) j;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_evo_orders_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_evo_orders_full(integer, integer) TO anon, authenticated;
+
+-- ============================================================
+-- 2. Our SG Sales — seatgeek_orders (our SellerDirect account).
+--    No tevo_event_id on this table (0/400 populated) — must
+--    bridge via seatgeek_event_xref like the marketplace SG tabs.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_sg_seller_orders_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 250
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  WITH rows0 AS (
+    SELECT
+      sg_order_id, status, created_at_sg, last_status_at,
+      sale_section, sale_row, sale_quantity, sale_price,
+      payment_total, payment_price, payment_fees, payment_tax, payment_delivery,
+      delivery, delivery_method, stock_type,
+      sg_listing_id, sg_event_name, sg_venue, sg_event_date,
+      fulfillment_issue_message, pulled_at
+    FROM public.seatgeek_orders
+    WHERE sg_event_id = v_sg_event_id
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sg_event_id', v_sg_event_id,
+    'event_id', p_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(r) ORDER BY r.created_at_sg DESC NULLS LAST), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (
+    SELECT * FROM rows0
+    ORDER BY created_at_sg DESC NULLS LAST
+    LIMIT greatest(1, least(p_limit, 500))
+  ) r;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_seller_orders_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_seller_orders_full(integer, integer) TO anon, authenticated;
+
+-- ============================================================
+-- 3. Cross-Broker Orders — TickPick + Vivid combined.
+--    TickPick: filter directly on tevo_event_id (94 distinct events
+--    have it populated). Vivid today has 0 tevo_event_id rows (bridge
+--    cron not landing data); bridge via aq_short_event_id → aq_event_map
+--    → sg_event_id → seatgeek_event_xref. Returns empty Vivid section
+--    for events without that 2-hop bridge; that's a separate D2/B1 lane
+--    issue to fix the Vivid bridge cron.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_cross_broker_orders_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 250
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email          text;
+  v_sg_event_id    bigint;
+  v_aq_short_ids   text[];
+  v_rows           jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- Resolve aq_short_event_id(s) for Vivid bridge: tevo_event_id → sg_event_id → aq_event_map
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT array_agg(DISTINCT aq_short_event_id) INTO v_aq_short_ids
+    FROM public.aq_event_map WHERE sg_event_id = v_sg_event_id;
+  END IF;
+
+  WITH tp AS (
+    SELECT
+      'tickpick'::text AS source,
+      tp_order_id      AS source_order_id,
+      status,
+      order_status,
+      ordered_at,
+      section, row, seat_numbers,
+      quantity, total,
+      event_name, event_date,
+      notes,
+      matched_via, match_confidence
+    FROM public.tickpick_orders
+    WHERE tevo_event_id = p_event_id
+  ),
+  vv AS (
+    SELECT
+      'vivid'::text  AS source,
+      vivid_order_id AS source_order_id,
+      status,
+      NULL::text     AS order_status,
+      ordered_at,
+      section, row,
+      NULL::text[]   AS seat_numbers,
+      quantity, total,
+      event_name, event_date,
+      NULL::text     AS notes,
+      NULL::text     AS matched_via,
+      NULL::numeric  AS match_confidence
+    FROM public.vivid_orders
+    WHERE (v_aq_short_ids IS NOT NULL AND aq_short_event_id = ANY(v_aq_short_ids))
+  ),
+  combined AS (
+    SELECT * FROM tp UNION ALL SELECT * FROM vv
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'tickpick_count', count(*) FILTER (WHERE source = 'tickpick'),
+    'vivid_count',    count(*) FILTER (WHERE source = 'vivid'),
+    'event_id',       p_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(c) ORDER BY c.ordered_at DESC NULLS LAST), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (
+    SELECT * FROM combined
+    ORDER BY ordered_at DESC NULLS LAST
+    LIMIT greatest(1, least(p_limit, 500))
+  ) c;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_cross_broker_orders_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_cross_broker_orders_full(integer, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_evo_orders_full(integer, integer) IS
+  'D0 event-page tabs (round 2) — our office TEvo orders ⨯ items per event (capped 500). Email-gated.';
+
+COMMENT ON FUNCTION public.get_event_sg_seller_orders_full(integer, integer) IS
+  'D0 event-page tabs (round 2) — our SG SellerDirect orders per event (bridge via seatgeek_event_xref, capped 500). Email-gated.';
+
+COMMENT ON FUNCTION public.get_event_cross_broker_orders_full(integer, integer) IS
+  'D0 event-page tabs (round 2) — TickPick + Vivid orders UNION per event (TP direct tevo_event_id; Vivid via aq_event_map bridge, capped 500). Email-gated.';


### PR DESCRIPTION
## Summary

Round 2 of event-page tabs. PR #196 shipped 3 marketplace firehoses (SG Listings / EVO Listings / SG Sales). This PR adds the 3 broker-account companions:

- **Our TEvo Orders** (`get_event_evo_orders_full`) — `evo_orders` ⨯ `evo_order_items` per event. Surfaces: state / type / fraud_check_status / totals + fees + refunds + balance / buyer + seller brokerage / client / hold_placed_at + hold_expires_at / per-item section + row + seats + retail + wholesale + item price. One row per order item with first-of-order context columns shown only on the first row of each order (reduces visual repetition).
- **Our SG Sales** (`get_event_sg_seller_orders_full`) — `seatgeek_orders` (SellerDirect, our account). Bridges via `seatgeek_event_xref` since the table has 0% `tevo_event_id` populated (400/400 use `sg_event_id`).
- **TP + Vivid** (`get_event_cross_broker_orders_full`) — UNION over `tickpick_orders` + `vivid_orders`. TickPick filters directly on `tevo_event_id` (94 distinct events have it). Vivid bridges via `aq_short_event_id` → `aq_event_map` → `sg_event_id` → `seatgeek_event_xref` (2-hop because `vivid_orders.tevo_event_id` is 0% populated today; the Vivid-side bridge cron is a separate D2/B1 lane issue, flagged in commit body).

Per A1's **D0 tab option matrix** in [RESOURCES_BIBLE.md](RESOURCES_BIBLE.md) (PR [apps#198](https://github.com/JulianS4K/Terminal-2/pull/198)) — this PR takes options 2, 3, 4 from the proposed-next-surfaces list.

## Architecture

Same lazy-load + SECDEF pattern as PR #196:
- Each tab loads only on first click (one RPC per tab)
- Tab nav now 7 tabs with thin `|` separator splitting "marketplace firehoses" from "our account orders"; `flex-wrap` handles overflow
- All RPCs cap at 500 rows via `greatest(1, least(p_limit, 500))`
- Empty / no-bridge / error states explicit in-pane

## Migration `20260517220000_event_page_broker_tabs_rpcs.sql`

Three SECDEF RPCs following the canonical pattern:
- `@s4kent.com` email gate (raises 42501 otherwise)
- `REVOKE ALL FROM PUBLIC; GRANT EXECUTE TO anon, authenticated`
- `SET search_path = public, extensions, pg_temp`
- `STABLE` + `SECURITY DEFINER`

Pending **operator apply via apply_migration**.

## Notes for A1

- Vivid bridge gap: `vivid_orders.tevo_event_id` is 0% populated. My RPC bridges via the 2-hop `aq_short_event_id → aq_event_map.sg_event_id → seatgeek_event_xref.tevo_event_id` path, but most events will return 0 Vivid rows until the Vivid-side bridge cron lands. Flagging this as a separate item — happy to follow up with a bot_chat to D2/B1 to investigate the bridge.
- TickPick has 14% tevo_event_id populated (176/1226), so most TickPick orders won't show even though direct match works.

## Verification

- Schema probed against `evo_orders`/`evo_order_items`/`seatgeek_orders`/`tickpick_orders`/`vivid_orders` before authoring — no missing-column landmines.
- Local browser preview (`http://localhost:8765/static/terminal/event.html`): all 7 tabs render in nav, all 7 panes in DOM (3 new ones hidden by default), switching to each new tab activates the right pane + fires the right RPC + degrades to in-pane "RPC error: no auth" on localhost.
- DOM inspect confirms grid layout intact for the 3 new sections (`grid-column: 1 / -1`).

## Test plan

- [ ] After A1 applies migration, smoke-test on `vibepass-storefront-test.onrender.com/static/terminal/event.html?event=3344960` (event with 13 EVO orders — best for the Our TEvo Orders tab)
- [ ] Try `?event=3091422` for TP coverage (has TickPick orders)
- [ ] Switch all 7 tabs; verify per-tab counts + render times appear in meta
- [ ] Verify Our TEvo Orders tab shows hold_expires_at where present (key new signal per A1's recommendation)
- [ ] Verify Our SG Sales empty state on a non-SG-bridged event (e.g. 3309426 Springsteen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)