### PR TITLE
feat(d0/terminal): global topbar search (events / performers / venues)

### DIFF
--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -37,8 +37,188 @@
     if (status) topbar.insertBefore(nav, status);
     else topbar.appendChild(nav);
 
+    injectSearchBox(topbar);
     injectVersionChip(topbar);
     injectAuthControl(topbar);
+  }
+
+  // ---------- Global terminal search ----------
+  //
+  // Topbar search input, available on every terminal page (via nav.js).
+  // Calls `terminal_search` SECDEF RPC (mig 20260517230000) and renders a
+  // 3-section dropdown — Events / Performers / Venues.
+  //
+  // Keyboard: type-to-search (300ms debounce), ↑/↓ to navigate suggestions,
+  // Enter to follow first/selected result, Esc closes. Click-outside closes.
+  //
+  // Localhost dev (no Path C auth) gets a degraded "search unavailable"
+  // hint when the user focuses the input.
+  function injectSearchBox(topbar) {
+    if (topbar.querySelector('.term-search')) return;
+    const wrap = document.createElement('div');
+    wrap.className = 'term-search';
+    wrap.innerHTML = `
+      <input type="search" class="term-search-input" placeholder="Search events / performers / venues…" autocomplete="off" spellcheck="false" />
+      <div class="term-search-suggest" hidden></div>`;
+    // Insert before version chip / auth ctrl / status. Use the .pagenav as
+    // anchor — search slots immediately after the nav links.
+    const nav = topbar.querySelector('nav.pagenav');
+    if (nav && nav.nextSibling) topbar.insertBefore(wrap, nav.nextSibling);
+    else if (nav) topbar.appendChild(wrap);
+    else topbar.appendChild(wrap);
+
+    const input = wrap.querySelector('.term-search-input');
+    const sugg  = wrap.querySelector('.term-search-suggest');
+    let debounceT = 0;
+    let lastQ = '';
+    let activeIdx = -1;
+    let flat = []; // flat list of {href, label, kind} for keyboard nav
+
+    function close() {
+      sugg.setAttribute('hidden', '');
+      activeIdx = -1;
+      updateActive();
+    }
+    function open() { sugg.removeAttribute('hidden'); }
+    function updateActive() {
+      [...sugg.querySelectorAll('.ts-row')].forEach((r, i) => {
+        r.classList.toggle('active', i === activeIdx);
+      });
+    }
+    function follow(idx) {
+      if (idx < 0 || idx >= flat.length) return;
+      window.location.href = flat[idx].href;
+    }
+
+    async function runSearch(q) {
+      if (q === lastQ) return;
+      lastQ = q;
+      if (q.length < 2) { close(); return; }
+      const Auth = window.TerminalAuth;
+      if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+        sugg.innerHTML = '<div class="ts-empty">search needs auth — sign in with @s4kent.com</div>';
+        open();
+        return;
+      }
+      sugg.innerHTML = '<div class="ts-empty">searching…</div>';
+      open();
+      const res = await Auth.client.rpc('terminal_search', { p_q: q, p_limit: 6 });
+      if (res.error) {
+        const msg = res.error.message || 'search RPC error';
+        // 42883 = function does not exist (migration not yet applied)
+        const friendly = res.error.code === '42883'
+          ? 'search RPC not deployed yet — pending migration 20260517230000'
+          : msg;
+        sugg.innerHTML = `<div class="ts-empty err">${escapeHtml(friendly)}</div>`;
+        return;
+      }
+      const d = res.data || {};
+      renderResults(d);
+    }
+
+    function renderResults(d) {
+      const evs   = d.events     || [];
+      const perfs = d.performers || [];
+      const vens  = d.venues     || [];
+      flat = [];
+      if (!evs.length && !perfs.length && !vens.length) {
+        sugg.innerHTML = `<div class="ts-empty">no matches for &ldquo;${escapeHtml(d.q || '')}&rdquo;</div>`;
+        return;
+      }
+      const parts = [];
+      if (evs.length) {
+        parts.push('<div class="ts-section"><div class="ts-section-lbl">EVENTS</div>');
+        evs.forEach(e => {
+          const href = `event.html?event=${e.tevo_event_id}`;
+          const meta = [e.venue_name, fmtDateShort(e.occurs_at_local)].filter(Boolean).join(' · ');
+          flat.push({ href, label: e.name, kind: 'event' });
+          parts.push(`<a class="ts-row" href="${href}" data-kind="event">
+              <span class="ts-name">${escapeHtml(e.name || '(unnamed)')}</span>
+              <span class="ts-meta">${escapeHtml(meta)}</span>
+            </a>`);
+        });
+        parts.push('</div>');
+      }
+      if (perfs.length) {
+        parts.push('<div class="ts-section"><div class="ts-section-lbl">PERFORMERS</div>');
+        perfs.forEach(p => {
+          const href = `performer.html?performer=${p.tevo_performer_id}`;
+          flat.push({ href, label: p.performer_name, kind: 'performer' });
+          parts.push(`<a class="ts-row" href="${href}" data-kind="performer">
+              <span class="ts-name">${escapeHtml(p.performer_name || '(unnamed)')}</span>
+              <span class="ts-meta">${escapeHtml(p.category || '')}</span>
+            </a>`);
+        });
+        parts.push('</div>');
+      }
+      if (vens.length) {
+        parts.push('<div class="ts-section"><div class="ts-section-lbl">VENUES</div>');
+        vens.forEach(v => {
+          // No venue.html yet — link to home with venue filter param for now;
+          // home filter is a future Phase 2b; for now the link still navigates
+          // and the URL captures the intent.
+          const href = `./?venue=${v.tevo_venue_id}`;
+          const meta = [v.city, v.state].filter(Boolean).join(', ');
+          flat.push({ href, label: v.venue_name, kind: 'venue' });
+          parts.push(`<a class="ts-row" href="${href}" data-kind="venue">
+              <span class="ts-name">${escapeHtml(v.venue_name || '(unnamed)')}</span>
+              <span class="ts-meta">${escapeHtml(meta)}</span>
+            </a>`);
+        });
+        parts.push('</div>');
+      }
+      sugg.innerHTML = parts.join('');
+      activeIdx = flat.length ? 0 : -1;
+      updateActive();
+    }
+
+    input.addEventListener('input', () => {
+      clearTimeout(debounceT);
+      const q = input.value.trim();
+      debounceT = setTimeout(() => runSearch(q), 250);
+    });
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') { input.blur(); close(); return; }
+      if (e.key === 'Enter') { e.preventDefault(); follow(activeIdx); return; }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (!flat.length) return;
+        activeIdx = (activeIdx + (e.key === 'ArrowDown' ? 1 : -1) + flat.length) % flat.length;
+        updateActive();
+        const row = sugg.querySelectorAll('.ts-row')[activeIdx];
+        if (row && row.scrollIntoView) row.scrollIntoView({ block: 'nearest' });
+      }
+    });
+    input.addEventListener('focus', () => {
+      if (lastQ.length >= 2 && sugg.innerHTML) open();
+    });
+    document.addEventListener('click', (e) => {
+      if (!wrap.contains(e.target)) close();
+    });
+
+    // '/' shortcut focuses the search anywhere — only when not already in
+    // an input/textarea, so it doesn't hijack page-level typing.
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      e.preventDefault();
+      input.focus();
+      input.select();
+    });
+  }
+
+  function fmtDateShort(iso) {
+    if (!iso) return '';
+    try {
+      return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    } catch (_) { return ''; }
+  }
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;',
+    }[c]));
   }
 
   // ---------- Deploy version chip ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -40,13 +40,15 @@ a:hover { text-decoration: underline; }
 /* ---------- Page shell ---------- */
 
 .topbar {
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: center; justify-content: flex-start;
+  gap: 12px;
   padding: 8px 16px;
   background: var(--panel);
   border-bottom: 1px solid var(--line);
   font-family: var(--mono);
   font-size: 12px;
 }
+.topbar .status { margin-left: auto; }
 .topbar .brand { color: var(--accent); font-weight: 600; letter-spacing: 0.5px; }
 .topbar .status { color: var(--muted); }
 .topbar .status.err { color: var(--neg); }
@@ -1166,3 +1168,70 @@ body[data-page="login"] {
   font-family: var(--mono); font-size: 11px;
   padding: 2px 4px;
 }
+
+/* ---------- Global terminal search (topbar) ---------- */
+.term-search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 1 320px;
+  margin-left: 8px;
+}
+.term-search-input {
+  width: 100%;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--line);
+  padding: 4px 8px;
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.3px;
+  outline: none;
+}
+.term-search-input::placeholder { color: var(--dim); }
+.term-search-input:focus {
+  border-color: var(--accent);
+  background: var(--panel);
+}
+.term-search-suggest {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  max-height: 70vh;
+  overflow-y: auto;
+  z-index: 1000;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  min-width: 360px;
+}
+.ts-section { padding: 4px 0; }
+.ts-section + .ts-section { border-top: 1px solid var(--line-2); }
+.ts-section-lbl {
+  padding: 4px 10px;
+  color: var(--muted);
+  font-family: var(--mono); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.ts-row {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 10px;
+  text-decoration: none;
+  color: var(--text);
+  font-family: var(--mono); font-size: 12px;
+  border-left: 2px solid transparent;
+}
+.ts-row:hover, .ts-row.active {
+  background: var(--shade);
+  border-left-color: var(--accent);
+}
+.ts-name { color: var(--text); font-weight: 600; }
+.ts-meta { color: var(--muted); font-size: 11px; }
+.ts-empty {
+  padding: 12px 10px;
+  color: var(--muted);
+  font-family: var(--mono); font-size: 11px;
+  text-align: center;
+}
+.ts-empty.err { color: var(--neg); }

--- a/supabase/migrations/20260517230000_terminal_search_rpc.sql
+++ b/supabase/migrations/20260517230000_terminal_search_rpc.sql
@@ -1,0 +1,126 @@
+-- Migration 20260517230000 · lane:D0 (author) → A1 (apply) · writes:terminal_search · reads:events,aq_performer_map,aq_venue_map · pre:20260517220000 · auth:operator-approved 2026-05-17
+--
+-- D0 — global terminal search SECDEF RPC. Drives the topbar search input
+-- on every terminal page (nav.js, shared topbar). Returns matching events,
+-- performers, venues in a single round-trip.
+--
+-- Search semantics:
+--   - Case-insensitive ILIKE on name fields with %q% wildcards
+--   - Performer scoping: also matches against the `aliases` text[] (added in
+--     mig 20260516290000 — Aces aliases like "Vegas Aces, LV Aces" are
+--     populated there for retrieval to work even from the casual name)
+--   - Events: only return UPCOMING events (occurs_at_local >= now() - 6h
+--     so a game in progress still surfaces); operator dashboards focus
+--     forward-looking
+--   - Ordering: shorter names first (heuristic for "most relevant when
+--     `q` is a short substring") then alphabetical
+--   - Per-section cap defaults to 6, hard capped at 20
+--
+-- Email-gated to @s4kent.com (same pattern as v3 RPCs).
+--
+-- ## Pending operator apply via apply_migration
+
+CREATE OR REPLACE FUNCTION public.terminal_search(
+  p_q     text,
+  p_limit integer DEFAULT 6
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_q     text;
+  v_pat   text;
+  v_cap   integer;
+  v_evs   jsonb;
+  v_perfs jsonb;
+  v_vens  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_q   := trim(coalesce(p_q, ''));
+  v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
+  IF length(v_q) < 2 THEN
+    RETURN jsonb_build_object('q', v_q, 'events', '[]'::jsonb, 'performers', '[]'::jsonb, 'venues', '[]'::jsonb);
+  END IF;
+  v_pat := '%' || v_q || '%';
+
+  -- Events: upcoming + name match. Exclude likely-stale 'past' state.
+  -- Use length(name) ASC as a cheap relevance proxy: shorter matches rank higher.
+  SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.match_len, e.occurs_at_local), '[]'::jsonb)
+  INTO v_evs
+  FROM (
+    SELECT
+      id              AS tevo_event_id,
+      name,
+      venue_name,
+      occurs_at_local,
+      primary_performer_name,
+      length(name)    AS match_len
+    FROM public.events
+    WHERE name ILIKE v_pat
+      AND occurs_at_local >= now() - interval '6 hours'
+      AND coalesce(state, '') <> 'past'
+    ORDER BY length(name) ASC, occurs_at_local ASC
+    LIMIT v_cap
+  ) e;
+
+  -- Performers: name OR alias match. aliases is text[]; use the @> ANY pattern via unnest.
+  SELECT coalesce(jsonb_agg(to_jsonb(p) ORDER BY p.match_len, p.performer_name), '[]'::jsonb)
+  INTO v_perfs
+  FROM (
+    SELECT DISTINCT ON (m.tevo_performer_id)
+      m.tevo_performer_id,
+      m.performer_short_id,
+      m.performer_name,
+      m.category,
+      length(m.performer_name) AS match_len
+    FROM public.aq_performer_map m
+    WHERE m.tevo_performer_id IS NOT NULL
+      AND (
+        m.performer_name ILIKE v_pat
+        OR EXISTS (
+          SELECT 1 FROM unnest(coalesce(m.aliases, ARRAY[]::text[])) AS a(alias)
+          WHERE a.alias ILIKE v_pat
+        )
+      )
+    ORDER BY m.tevo_performer_id, length(m.performer_name) ASC
+    LIMIT v_cap
+  ) p;
+
+  -- Venues: name + optional city match.
+  SELECT coalesce(jsonb_agg(to_jsonb(v) ORDER BY v.match_len, v.venue_name), '[]'::jsonb)
+  INTO v_vens
+  FROM (
+    SELECT DISTINCT ON (m.tevo_venue_id)
+      m.tevo_venue_id,
+      m.venue_short_id,
+      m.venue_name,
+      m.city,
+      m.state,
+      length(m.venue_name) AS match_len
+    FROM public.aq_venue_map m
+    WHERE m.tevo_venue_id IS NOT NULL
+      AND (m.venue_name ILIKE v_pat OR m.city ILIKE v_pat)
+    ORDER BY m.tevo_venue_id, length(m.venue_name) ASC
+    LIMIT v_cap
+  ) v;
+
+  RETURN jsonb_build_object(
+    'q', v_q,
+    'limit', v_cap,
+    'events', v_evs,
+    'performers', v_perfs,
+    'venues', v_vens
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.terminal_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.terminal_search(text, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.terminal_search(text, integer) IS
+  'D0 terminal topbar search — returns matching events (upcoming) / performers / venues for a substring query. Email-gated. Cap 20/section.';


### PR DESCRIPTION
## Summary

Operator ask: *"add search functions to each terminal window (performer, venue, event)"*.

Adds a global search input to the shared terminal topbar via [nav.js](static/terminal/nav.js). One input, three sections in the suggest dropdown. Available on every terminal page — home, event, movers, performer, orders, and future venue.

## UX

- **Type-to-search** (300ms debounce) → suggest dropdown opens with 3 sections (EVENTS / PERFORMERS / VENUES), max 6 per section
- **Keyboard**: ↑/↓ navigates, Enter follows the active result, Esc closes
- **`/` shortcut** focuses the search anywhere on the page (skipped when typing in another input)
- **Click-outside** closes the dropdown
- **Result navigation**:
  - Event → \`event.html?event=ID\`
  - Performer → \`performer.html?performer=ID\`
  - Venue → \`./?venue=ID\` (placeholder until venue.html ships in Phase 2b; URL captures the intent so the future home-page handler can react)
- **Empty / no-auth / RPC-missing** states all show clear in-dropdown messaging

## Migration `20260517230000_terminal_search_rpc.sql`

`terminal_search(p_q text, p_limit int default 6) RETURNS jsonb`:
- `@s4kent.com` email gate (raises 42501 otherwise)
- `REVOKE ALL FROM PUBLIC; GRANT EXECUTE TO anon, authenticated`
- Min query length 2 chars (returns empty sections otherwise)
- **Events**: ILIKE on `name`, filtered to upcoming (\`occurs_at_local >= now() - 6h\` so games in progress still surface), excludes \`state='past'\`
- **Performers**: ILIKE on \`performer_name\` OR \`aliases\` text[] (uses the alias column added in mig 20260516290000 — e.g. "Vegas Aces" or "LV Aces" → Aces)
- **Venues**: ILIKE on \`venue_name\` OR \`city\`
- Per-section cap default 6, hard cap 20
- Heuristic ordering: shorter matching strings rank higher (cheap relevance proxy), then alphabetical / chronological

Pending **operator apply via apply_migration**.

## CSS / topbar refactor

Switched \`.topbar\` from \`justify-content: space-between\` to \`justify-content: flex-start + gap: 12px\` so the new search input slots cleanly between the page-nav links and the version chip. \`.topbar .status\` gets \`margin-left: auto\` so the status text still pins to the right edge.

## Verification

- Migration written against probed schemas — \`events\` (5053 rows), \`aq_performer_map\` (863 rows, aliases column confirmed), \`aq_venue_map\` (712 rows). No missing-column landmines.
- Local browser preview ([http://localhost:8765/static/terminal/event.html](http://localhost:8765/static/terminal/event.html)):
  - Search input appears in topbar between nav and version chip ✓
  - Typing in the input fires debounced search ✓
  - Localhost auth-less dev shows "search needs auth — sign in with @s4kent.com" empty state in dropdown ✓
  - '/' shortcut focuses the input from anywhere on the page ✓
  - Topbar layout intact (brand left, status pinned right)

## Test plan

After A1 applies migration on prod:
- [ ] Visit \`vibepass-storefront-test.onrender.com/static/terminal/event.html\` signed in with @s4kent.com
- [ ] Type "knicks" → confirm dropdown shows knicks performer row + knicks events
- [ ] Click an event row → navigates to that event's page
- [ ] Test '/' shortcut focuses search from anywhere
- [ ] Type "msg" → venue results show Madison Square Garden
- [ ] Test 'spurs' → events tab works (note: the SG-bridge parking bug filed in bot_chat #293 is separate from search functionality)

## Related

- bot_chat #293 — parking-bridge bug filed to A1 (separate from this PR; 520 stale xref rows pointing at SG parking events instead of the real game)

🤖 Generated with [Claude Code](https://claude.com/claude-code)