### PR TITLE
fix(bridge): parking-bridge pollution cleanup + terminal_search occurs_at cast

### DIFF
--- a/supabase/migrations/20260517240000_terminal_search_occurs_at_cast.sql
+++ b/supabase/migrations/20260517240000_terminal_search_occurs_at_cast.sql
@@ -1,0 +1,115 @@
+-- Migration 20260517240000 · lane:A1 (fixup of #200) · writes:terminal_search · reads:events,aq_performer_map,aq_venue_map · pre:20260517230000 · auth:operator-approved 2026-05-17
+--
+-- A1 fixup for D0 PR #200: events.occurs_at_local is TEXT (not timestamptz),
+-- so the filter `occurs_at_local >= now() - interval '6 hours'` raises
+-- 42883 (operator does not exist) at runtime. Function compiled fine because
+-- PL/pgSQL is parse-only at CREATE — runtime smoke test caught it.
+--
+-- Fix: cast via ::timestamptz with a regex guard against malformed strings
+-- (same pattern used by sg_canonical_link_from_tevo_chunked + others —
+-- see PROJECT_BIBLE §3 column landmines for the events.occurs_at_local row).
+--
+-- Migration applied to prod directly via apply_migration; this file aligns
+-- git history with the live state.
+
+CREATE OR REPLACE FUNCTION public.terminal_search(
+  p_q     text,
+  p_limit integer DEFAULT 6
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_q     text;
+  v_pat   text;
+  v_cap   integer;
+  v_evs   jsonb;
+  v_perfs jsonb;
+  v_vens  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_q   := trim(coalesce(p_q, ''));
+  v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
+  IF length(v_q) < 2 THEN
+    RETURN jsonb_build_object('q', v_q, 'events', '[]'::jsonb, 'performers', '[]'::jsonb, 'venues', '[]'::jsonb);
+  END IF;
+  v_pat := '%' || v_q || '%';
+
+  SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.match_len, e.occurs_at_local), '[]'::jsonb)
+  INTO v_evs
+  FROM (
+    SELECT
+      id              AS tevo_event_id,
+      name,
+      venue_name,
+      occurs_at_local,
+      primary_performer_name,
+      length(name)    AS match_len
+    FROM public.events
+    WHERE name ILIKE v_pat
+      AND occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+      AND occurs_at_local::timestamptz >= now() - interval '6 hours'
+      AND coalesce(state, '') <> 'past'
+    ORDER BY length(name) ASC, occurs_at_local ASC
+    LIMIT v_cap
+  ) e;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(p) ORDER BY p.match_len, p.performer_name), '[]'::jsonb)
+  INTO v_perfs
+  FROM (
+    SELECT DISTINCT ON (m.tevo_performer_id)
+      m.tevo_performer_id,
+      m.performer_short_id,
+      m.performer_name,
+      m.category,
+      length(m.performer_name) AS match_len
+    FROM public.aq_performer_map m
+    WHERE m.tevo_performer_id IS NOT NULL
+      AND (
+        m.performer_name ILIKE v_pat
+        OR EXISTS (
+          SELECT 1 FROM unnest(coalesce(m.aliases, ARRAY[]::text[])) AS a(alias)
+          WHERE a.alias ILIKE v_pat
+        )
+      )
+    ORDER BY m.tevo_performer_id, length(m.performer_name) ASC
+    LIMIT v_cap
+  ) p;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(v) ORDER BY v.match_len, v.venue_name), '[]'::jsonb)
+  INTO v_vens
+  FROM (
+    SELECT DISTINCT ON (m.tevo_venue_id)
+      m.tevo_venue_id,
+      m.venue_short_id,
+      m.venue_name,
+      m.city,
+      m.state,
+      length(m.venue_name) AS match_len
+    FROM public.aq_venue_map m
+    WHERE m.tevo_venue_id IS NOT NULL
+      AND (m.venue_name ILIKE v_pat OR m.city ILIKE v_pat)
+    ORDER BY m.tevo_venue_id, length(m.venue_name) ASC
+    LIMIT v_cap
+  ) v;
+
+  RETURN jsonb_build_object(
+    'q', v_q,
+    'limit', v_cap,
+    'events', v_evs,
+    'performers', v_perfs,
+    'venues', v_vens
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.terminal_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.terminal_search(text, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.terminal_search(text, integer) IS
+  'D0 terminal topbar search — returns matching events (upcoming) / performers / venues. Email-gated. Cap 20/section. A1 fixup 2026-05-17: occurs_at_local is text, cast via ::timestamptz + regex guard.';

--- a/supabase/migrations/20260517250000_parking_bridge_pollution_cleanup.sql
+++ b/supabase/migrations/20260517250000_parking_bridge_pollution_cleanup.sql
@@ -1,0 +1,302 @@
+-- Migration 20260517250000 · lane:A1 · writes:auto_match_sg_canonical+sg_attempt_event_xref+trg_sgec_to_seatgeek_event_xref+seatgeek_event_xref+sg_events_canonical · reads:sg_events_canonical · pre:20260517240000 · auth:operator-approved 2026-05-17
+--
+-- A1 — parking-bridge pollution fix (bot_chat #293 from D0).
+--
+-- BACKGROUND
+-- ---------
+-- Operator caught: tevo_event_id 3348214 (Spurs Game 3) mapped to SG 18068272
+-- which is the *Parking* event ("Frost Bank Center Parking"), not the real
+-- game (SG 18068270 at "Frost Bank Center"). Symptom: PR #196 SG Listings /
+-- SG Sales tabs surface parking lot inventory instead of seat inventory for
+-- the affected events.
+--
+-- SCOPE (pre-cleanup, 2026-05-17 22:30 UTC)
+-- -----------------------------------------
+--   public.sg_events_canonical: 738 parking rows, 531 with tevo_event_id set
+--   public.seatgeek_event_xref: 519 polluted xref rows
+--     all match_method=auto_canonical_loop, conf 0.90
+--   Of those 519:
+--     515 have a clean non-parking SG sibling on same date+venue
+--         and that clean sibling is NOT yet in xref → UPDATE swap
+--     1   has a clean sibling already in xref → DELETE the parking row
+--     3   are parking-only orphans → DELETE the parking row
+--
+-- ROOT CAUSE
+-- ----------
+-- D0's initial diagnosis ("no new pollution accruing") was incorrect. The
+-- active cron cross_source_match_tick_30min (@ :09,:39) calls
+-- cross_source_match_tick() → sg_canonical_auto_match_tick() FIRST,
+-- which calls auto_match_sg_canonical() (v1, NO parking filter), THEN
+-- auto_match_sg_canonical_v3() (v3, WITH parking filter). v1 grabs the
+-- rows first so v3 never sees them. New pollution was accruing every 30
+-- minutes until this migration's Part 1 stopped the bleeding.
+--
+-- THREE-PART FIX
+-- --------------
+-- Part 1: stop the bleeding. Add parking guards to:
+--   - auto_match_sg_canonical()       — exclude parking in loop predicate
+--   - sg_attempt_event_xref()         — return NULL early if parking
+--   - trg_sgec_to_seatgeek_event_xref — defense-in-depth: trigger skips parking
+--
+-- Part 2: NULL out sg_events_canonical.tevo_event_id on parking rows.
+--         Otherwise the trigger re-mirrors them to xref on any update.
+--
+-- Part 3: Clean seatgeek_event_xref:
+--   3a UPDATE polluted rows to point at the clean sibling (515 cases)
+--   3b DELETE catch-all for the remaining 4 + any leakage during txn
+
+-- ============================================================
+-- Part 1a: auto_match_sg_canonical() — skip parking in iter loop
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.auto_match_sg_canonical()
+ RETURNS TABLE(attempted integer, newly_matched integer, still_unmatched integer, needs_tevo_search integer)
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  r RECORD;
+  v_match bigint;
+  v_attempted int := 0;
+  v_matched int := 0;
+  v_unmatched int := 0;
+BEGIN
+  FOR r IN
+    SELECT sg_event_id, sg_event_name, sg_event_date, sg_venue_name
+    FROM sg_events_canonical
+    WHERE tevo_event_id IS NULL
+      AND (sg_event_date IS NULL OR sg_event_date >= current_date - 30)
+      -- A1 parking guard 2026-05-17: never auto-match parking pseudo-events.
+      -- TEvo merges parking into the main listing; SG splits them out.
+      AND coalesce(sg_event_name, '') NOT ILIKE '%parking%'
+      AND coalesce(sg_venue_name, '') NOT ILIKE '%parking%'
+  LOOP
+    v_attempted := v_attempted + 1;
+    v_match := sg_attempt_event_xref(
+      r.sg_event_id, r.sg_event_name, r.sg_event_date, r.sg_venue_name
+    );
+    IF v_match IS NOT NULL THEN
+      UPDATE sg_events_canonical SET
+        tevo_event_id = v_match,
+        match_method = 'auto_canonical_loop',
+        match_confidence = 0.9,
+        matched_at = now(),
+        updated_at = now()
+      WHERE sg_event_id = r.sg_event_id;
+      v_matched := v_matched + 1;
+    ELSE
+      v_unmatched := v_unmatched + 1;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_attempted, v_matched, v_unmatched,
+    (SELECT count(*)::int FROM sg_events_canonical WHERE tevo_event_id IS NULL);
+END;
+$function$;
+
+-- ============================================================
+-- Part 1b: sg_attempt_event_xref() — return NULL early if parking
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.sg_attempt_event_xref(p_sg_event_id bigint, p_sg_event_name text, p_sg_event_date date, p_sg_venue text)
+ RETURNS bigint
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_tevo_event_id bigint;
+  v_existing      bigint;
+  v_sg_team_a     text;
+  v_sg_team_b     text;
+BEGIN
+  -- A1 parking guard 2026-05-17: never bridge parking pseudo-events.
+  IF coalesce(p_sg_event_name, '') ILIKE '%parking%'
+     OR coalesce(p_sg_venue, '')      ILIKE '%parking%' THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT tevo_event_id INTO v_existing
+  FROM seatgeek_event_xref WHERE sg_event_id = p_sg_event_id LIMIT 1;
+  IF v_existing IS NOT NULL THEN
+    UPDATE seatgeek_event_xref
+       SET sg_event_name = COALESCE(p_sg_event_name, sg_event_name),
+           sg_event_location = COALESCE(p_sg_venue, sg_event_location)
+     WHERE sg_event_id = p_sg_event_id;
+    RETURN v_existing;
+  END IF;
+
+  v_sg_team_a := trim(split_part(COALESCE(p_sg_event_name, ''), ' at ', 1));
+  v_sg_team_b := trim(split_part(COALESCE(p_sg_event_name, ''), ' at ', 2));
+  IF v_sg_team_b = '' THEN v_sg_team_b := v_sg_team_a; END IF;
+
+  SELECT e.id INTO v_tevo_event_id
+  FROM events e
+  LEFT JOIN event_lifecycle lc ON lc.event_id = e.id
+  WHERE e.occurs_at_local::date = p_sg_event_date
+    AND (
+      lower(trim(e.venue_name)) = lower(trim(COALESCE(p_sg_venue, '')))
+      OR lower(trim(e.venue_name)) LIKE lower(trim(COALESCE(p_sg_venue, ''))) || '%'
+      OR lower(trim(COALESCE(p_sg_venue, ''))) LIKE lower(trim(e.venue_name)) || '%'
+    )
+    AND (
+      v_sg_team_b <> '' AND (
+        lower(e.primary_performer_name) LIKE '%' || lower(v_sg_team_b) || '%'
+        OR lower(e.name) LIKE '%' || lower(v_sg_team_b) || '%'
+      )
+      OR
+      v_sg_team_a <> '' AND (
+        lower(e.primary_performer_name) LIKE '%' || lower(v_sg_team_a) || '%'
+        OR lower(e.name) LIKE '%' || lower(v_sg_team_a) || '%'
+      )
+    )
+  ORDER BY
+    CASE WHEN COALESCE(lc.is_active, true) THEN 0 ELSE 1 END,
+    CASE WHEN lower(trim(e.venue_name)) = lower(trim(COALESCE(p_sg_venue, ''))) THEN 0 ELSE 1 END,
+    CASE WHEN v_sg_team_b <> '' AND lower(e.primary_performer_name) LIKE '%' || lower(v_sg_team_b) || '%' THEN 0 ELSE 1 END
+  LIMIT 1;
+
+  IF v_tevo_event_id IS NOT NULL THEN
+    INSERT INTO seatgeek_event_xref (
+      tevo_event_id, sg_event_id, sg_event_name, sg_event_type,
+      sg_event_location, sg_start_data, match_method, match_confidence
+    ) VALUES (
+      v_tevo_event_id, p_sg_event_id, p_sg_event_name, NULL,
+      p_sg_venue,
+      make_timestamptz(
+        EXTRACT(YEAR FROM p_sg_event_date)::int,
+        EXTRACT(MONTH FROM p_sg_event_date)::int,
+        EXTRACT(DAY FROM p_sg_event_date)::int, 0, 0, 0, 'UTC'),
+      'auto_seller_inline_v2', 0.9
+    )
+    ON CONFLICT (tevo_event_id) DO UPDATE
+      SET sg_event_id = EXCLUDED.sg_event_id,
+          sg_event_name = EXCLUDED.sg_event_name,
+          sg_event_location = EXCLUDED.sg_event_location,
+          match_method = 'auto_seller_inline_v2',
+          matched_at = NOW();
+  END IF;
+  RETURN v_tevo_event_id;
+END $function$;
+
+-- ============================================================
+-- Part 1c: trg_sgec_to_seatgeek_event_xref — defense-in-depth
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trg_sgec_to_seatgeek_event_xref()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NEW.tevo_event_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+  -- A1 parking guard 2026-05-17: never mirror parking pseudo-events to xref.
+  -- Defense-in-depth — Part 1a + 1b already block via auto_match_sg_canonical
+  -- and sg_attempt_event_xref, but a manual UPDATE of sg_events_canonical
+  -- setting tevo_event_id on a parking row would otherwise propagate here.
+  IF coalesce(NEW.sg_event_name, '') ILIKE '%parking%'
+     OR coalesce(NEW.sg_venue_name, '') ILIKE '%parking%' THEN
+    RETURN NEW;
+  END IF;
+  INSERT INTO seatgeek_event_xref (
+      tevo_event_id, sg_event_id, sg_event_name, sg_event_type, sg_event_location,
+      sg_start_data, matched_at, match_method, match_confidence, meta)
+  VALUES (NEW.tevo_event_id, NEW.sg_event_id, NEW.sg_event_name, NEW.sg_category,
+          NULLIF(concat_ws(', ', NEW.sg_venue_name, NEW.sg_venue_city, NEW.sg_venue_state), ''),
+          NEW.sg_datetime_utc, COALESCE(NEW.matched_at, NOW()),
+          COALESCE(NEW.match_method, 'sg_canonical_auto'),
+          NEW.match_confidence,
+          jsonb_build_object('origin','sg_events_canonical'))
+  ON CONFLICT (tevo_event_id) DO UPDATE
+    SET sg_event_id=EXCLUDED.sg_event_id, sg_event_name=EXCLUDED.sg_event_name,
+        sg_event_type=EXCLUDED.sg_event_type, sg_event_location=EXCLUDED.sg_event_location,
+        sg_start_data=EXCLUDED.sg_start_data, match_method=EXCLUDED.match_method,
+        match_confidence=EXCLUDED.match_confidence, matched_at=EXCLUDED.matched_at,
+        meta=EXCLUDED.meta;
+  RETURN NEW;
+END;
+$function$;
+
+-- ============================================================
+-- Part 2: NULL out tevo_event_id on parking rows in sg_events_canonical
+-- ============================================================
+UPDATE public.sg_events_canonical
+SET tevo_event_id = NULL,
+    match_method = 'parking_cleanup_2026_05_17',
+    match_confidence = NULL,
+    updated_at = now()
+WHERE (sg_event_name ILIKE '%parking%' OR sg_venue_name ILIKE '%parking%')
+  AND tevo_event_id IS NOT NULL;
+
+-- ============================================================
+-- Part 3a: UPDATE xref polluted rows to clean sibling (when free)
+-- ============================================================
+WITH polluted AS (
+  SELECT x.tevo_event_id, x.sg_event_id AS bad_sg, sc.sg_event_date,
+         regexp_replace(sc.sg_venue_name, ' Parking$', '') AS clean_venue
+  FROM public.seatgeek_event_xref x
+  JOIN public.sg_events_canonical sc ON sc.sg_event_id = x.sg_event_id
+  WHERE sc.sg_event_name ILIKE '%parking%' OR sc.sg_venue_name ILIKE '%parking%'
+), remap AS (
+  SELECT p.tevo_event_id, p.bad_sg,
+         (SELECT sg_event_id FROM public.sg_events_canonical sc2
+          WHERE sc2.sg_event_date = p.sg_event_date
+            AND sc2.sg_venue_name = p.clean_venue
+            AND sc2.sg_event_name NOT ILIKE '%parking%'
+            AND sc2.sg_venue_name NOT ILIKE '%parking%'
+          LIMIT 1) AS clean_sg
+  FROM polluted p
+)
+UPDATE public.seatgeek_event_xref x
+SET sg_event_id = r.clean_sg,
+    sg_event_name = (SELECT sg_event_name FROM public.sg_events_canonical WHERE sg_event_id = r.clean_sg),
+    sg_event_location = (SELECT sg_venue_name FROM public.sg_events_canonical WHERE sg_event_id = r.clean_sg),
+    match_method = 'parking_remap_2026_05_17',
+    match_confidence = 0.95,
+    matched_at = now()
+FROM remap r
+WHERE x.tevo_event_id = r.tevo_event_id
+  AND x.sg_event_id = r.bad_sg
+  AND r.clean_sg IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM public.seatgeek_event_xref x2 WHERE x2.sg_event_id = r.clean_sg);
+
+-- ============================================================
+-- Part 3b: catch-all DELETE remaining xrefs pointing at parking SG ids
+--          Covers: the 1 case where clean target was already mapped, the 3
+--          parking-only orphans, plus any new pollution that snuck in
+--          between rows during the transaction.
+-- ============================================================
+DELETE FROM public.seatgeek_event_xref
+WHERE sg_event_id IN (
+  SELECT sg_event_id FROM public.sg_events_canonical
+  WHERE sg_event_name ILIKE '%parking%' OR sg_venue_name ILIKE '%parking%'
+);
+
+-- ============================================================
+-- Verification (assertions — migration fails if cleanup incomplete)
+-- ============================================================
+DO $verify$
+DECLARE v_parking_xrefs int; v_parking_canonical_with_tevo int;
+BEGIN
+  SELECT count(*) INTO v_parking_xrefs
+  FROM public.seatgeek_event_xref x
+  JOIN public.sg_events_canonical sc ON sc.sg_event_id = x.sg_event_id
+  WHERE sc.sg_event_name ILIKE '%parking%' OR sc.sg_venue_name ILIKE '%parking%';
+
+  SELECT count(*) INTO v_parking_canonical_with_tevo
+  FROM public.sg_events_canonical
+  WHERE (sg_event_name ILIKE '%parking%' OR sg_venue_name ILIKE '%parking%')
+    AND tevo_event_id IS NOT NULL;
+
+  IF v_parking_xrefs > 0 THEN
+    RAISE EXCEPTION 'parking cleanup incomplete: % polluted xref rows remain', v_parking_xrefs;
+  END IF;
+  IF v_parking_canonical_with_tevo > 0 THEN
+    RAISE EXCEPTION 'parking cleanup incomplete: % canonical parking rows still have tevo_event_id', v_parking_canonical_with_tevo;
+  END IF;
+
+  RAISE NOTICE 'parking cleanup verified: 0 polluted xrefs, 0 canonical parking rows with tevo';
+END $verify$;
+
+COMMENT ON FUNCTION public.auto_match_sg_canonical() IS
+  'Legacy v1 matcher loop. A1 2026-05-17: added parking guard in loop predicate. Newer cross_source_match_tick path (v3) is preferred but this is still called via sg_canonical_auto_match_tick → cross_source_match_tick cron.';
+COMMENT ON FUNCTION public.sg_attempt_event_xref(bigint, text, date, text) IS
+  'Legacy v1 SG→TEvo bridge. A1 2026-05-17: added parking guard at top — returns NULL for any name/venue containing the word parking.';


### PR DESCRIPTION
## Summary

Two A1 migrations already applied to prod via `apply_migration`; this PR aligns git history with live state.

### 1. `20260517240000_terminal_search_occurs_at_cast.sql` — PR #200 follow-up

D0's PR #200 filter `occurs_at_local >= now() - interval '6 hours'` raised **42883** (operator does not exist) at runtime because `events.occurs_at_local` is **text** not timestamptz. PL/pgSQL didn't catch it at CREATE (parse-only). Caught via post-apply smoke test.

Fix: regex guard + `::timestamptz` cast (same pattern as `sg_canonical_link_from_tevo_chunked`; see PROJECT_BIBLE §3 column landmines).

### 2. `20260517250000_parking_bridge_pollution_cleanup.sql` — bot_chat #293

Operator caught **Spurs Game 3** (TEvo 3348214) mapped to SG 18068272 = "Frost Bank Center **Parking**" instead of SG 18068270 (the real game). PR #196 SG Listings/Sales tabs were surfacing parking lot inventory.

**Scope (pre-cleanup)**:
- 519 polluted `seatgeek_event_xref` rows (all `auto_canonical_loop` @ 0.90)
- 531 `sg_events_canonical` parking rows with `tevo_event_id` set

**Root cause (D0's initial diagnosis missed this)**: the active cron `cross_source_match_tick_30min` (@ :09,:39) calls `sg_canonical_auto_match_tick` FIRST → `auto_match_sg_canonical()` (v1, NO parking filter), THEN `auto_match_sg_canonical_v3()` (v3, WITH parking filter). v1 grabbed rows first so v3 never saw them. **New pollution was accruing every 30 minutes** until this PR's Part 1 stopped the bleeding.

**Three-part fix**:
1. **Stop bleeding**: parking guards on `auto_match_sg_canonical()`, `sg_attempt_event_xref()` v1, and `trg_sgec_to_seatgeek_event_xref` trigger (defense-in-depth)
2. **NULL** `tevo_event_id` on 531 canonical parking rows
3. **UPDATE 515 xref to clean sibling + DELETE 4** (1 already-mapped + 3 parking-only orphans) + catch-all DELETE for any leakage

**Post-apply verification (asserted in DO block, migration would fail if incomplete)**:
- 0 polluted xref rows
- 0 canonical parking rows with `tevo_event_id`
- Spurs Game 3 now correctly maps to SG 18068270 ✓

## Test plan

- [x] Pre-flight: `information_schema.columns` confirms `events.occurs_at_local` is text
- [x] Post-apply smoke (events branch): `WHERE name ILIKE '%knicks%' AND occurs_at_local~'^\d{4}'::regex AND ::timestamptz >= now()-6h` returns 5 rows
- [x] Post-cleanup verification: 0 polluted xref rows, 0 canonical parking with tevo, Spurs Game 3 correctly mapped
- [ ] CI green (scan + check + pytest; Supabase Preview is standard no-token fail)
- [ ] D0 confirms `terminal_search` works on prod with @s4kent.com JWT