### PR TITLE
feat(d0/home): full movers table + SG sales column + Blind Spots panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -3274,15 +3274,17 @@ def broker_movers(window_hours: int = 24, include_inactive: bool = False, _=Depe
     window_hours = max(1, min(int(window_hours), 168))
     db = require_sb()
 
-    # Pre-aggregated in SQL via get_event_movers RPC (mig 20260508040000).
-    # Returns one row per future-dated event with cur+prior values for
-    # market_median / owned_median / market_tix / owned_tix. ~300 rows
-    # max — small enough to top10/rollup in Python.
+    # Pre-aggregated in SQL via get_event_movers_with_sg RPC
+    # (mig 20260518000000 wraps the original get_event_movers from mig
+    # 20260508040000). Adds per-event SG sales count over the same window
+    # — powers the new "SG sales" column on movers + the "BLIND SPOTS —
+    # SG SELLING, WE'RE NOT" panel. DISTINCT ON (sg_sale_id) inside the
+    # RPC handles the 11x SG firehose dedup (PROJECT_BIBLE §3).
     #
     # Old approach (Python aggregation over a 50k-row window) was silently
     # capped at 1000 rows by PostgREST's per-request row limit, producing
     # an empty Movers report even when the underlying data was rich.
-    rpc_rows = db.rpc("get_event_movers", {"p_window_hours": window_hours}).execute().data or []
+    rpc_rows = db.rpc("get_event_movers_with_sg", {"p_window_hours": window_hours}).execute().data or []
 
     # Filter ghost/completed/cancelled events unless caller explicitly opts in.
     # event_lifecycle is a view over derive_event_lifecycle(); cheap to query
@@ -3350,6 +3352,11 @@ def broker_movers(window_hours: int = 24, include_inactive: bool = False, _=Depe
             "prev_owned_val":   round(prev_owned_val, 2) if prev_owned_val is not None else None,
             "delta_owned_val":  (None if cur_owned_val is None or prev_owned_val is None
                                  else round(cur_owned_val - prev_owned_val, 2)),
+            # SG broker-sales count over the same window (DISTINCT ON sg_sale_id
+            # inside the RPC handles 11x firehose dedup). Drives the new SG
+            # column on the movers table + BLIND SPOTS panel (sg_sales > N
+            # AND cur_owned_tix = 0).
+            "sg_sales_window":  r.get("sg_sales_window") or 0,
         })
 
     if not rows_built:

--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -1,36 +1,50 @@
 // D0 Terminal — Home page.
-// One fetch: /api/broker/movers?window_hours=24. Derives coverage band,
-// book summary, top-movers strip, and the owned-events list from the
-// single mover response (one row per future-dated active event).
+// One fetch: /api/broker/movers?window_hours=<window>. Derives coverage band,
+// blind spots panel, full movers table (with window/segment controls), and
+// the owned-events list from the single mover response.
+//
+// Movers table mirrors the standalone movers.html page — operator can change
+// the window or segment from home without page-hopping.
 
 (function () {
   'use strict';
   const T = window.Terminal;
 
+  const state = {
+    window: 24,
+    segment: 'all',          // 'all' | 'owned'
+    rows: [],
+    sortKey: 'delta_market_pct',
+    sortDir: 'desc',
+  };
+
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
-    T.setStatus('Loading home…');
-    T.api('/api/broker/movers?window_hours=24')
+    wireMoversControls();
+    load();
+  }
+
+  function load() {
+    T.setStatus(`Loading home · ${state.window}h…`);
+    T.api(`/api/broker/movers?window_hours=${state.window}`)
       .then(data => {
         T.setStatus('Loaded', 'ok');
         const events = (data && data.events) || {};
-        // owned_value_* and market_value_* are dedupe-disjoint top-10 lists,
-        // each row carries the full event fields. Build a row index for the
-        // coverage band / book summary by unioning across the lists.
-        const allRows = unionRows([
+        state.rows = unionRows([
           events.owned_winners, events.owned_losers,
           events.market_winners, events.market_losers,
           events.value_winners, events.value_losers,
           events.owned_value_winners, events.owned_value_losers,
         ]);
-        renderCoverage(allRows);
-        renderBook(allRows);
-        renderMovers(events.owned_value_winners, events.owned_value_losers);
-        renderOwnedEvents(allRows);
+        renderCoverage(state.rows);
+        renderBlindSpots(state.rows);
+        renderMovers();
+        renderOwnedEvents(state.rows);
       })
       .catch(e => {
         T.setStatus(e.message, 'err');
-        document.getElementById('moversGrid').innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
+        const body = document.getElementById('moversBody');
+        if (body) body.innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
       });
   }
 
@@ -64,57 +78,189 @@
     setText('cvToday', T.fmtNum(today));
   }
 
-  // ---------- Book summary ----------
+  // ---------- Blind spots panel — SG selling, we're not ----------
+  //
+  // Filter: sg_sales_window >= BLIND_SPOT_MIN_SG_SALES AND cur_owned_tix == 0.
+  // Operator can't capture revenue on inventory they don't hold; surface the
+  // gap so they can investigate (procure, contact buyer, or list elsewhere).
+  // The window matches the mover window selector — at 24h the chip threshold
+  // is "5 SG sales in 24h"; at 7d it's "5 SG sales in 7d". Threshold 5 is a
+  // tuning placeholder.
 
-  function renderBook(rows) {
-    let ownedTix = 0, marketTix = 0, ownedNotional = 0, ownedEvents = 0;
-    rows.forEach(r => {
-      const ot = +r.cur_owned_tix || 0;
-      const mt = +r.cur_market_tix || 0;
-      const om = +r.cur_owned_med || 0;
-      ownedTix += ot;
-      marketTix += mt;
-      ownedNotional += ot * om;
-      if (ot > 0) ownedEvents++;
-    });
-    setText('bkOwnedTix',      T.fmtNum(ownedTix));
-    setText('bkMarketTix',     T.fmtNum(marketTix));
-    setText('bkOwnedEvents',   T.fmtNum(ownedEvents));
-    setText('bkOwnedNotional', '$' + T.fmtNum(Math.round(ownedNotional)));
-  }
+  const BLIND_SPOT_MIN_SG_SALES = 5;
+  const BLIND_SPOT_MAX_ROWS     = 20;
 
-  // ---------- Movers strip (6 cards) ----------
-
-  function renderMovers(winners, losers) {
-    const grid = document.getElementById('moversGrid');
-    grid.innerHTML = '';
-    const cards = [
-      ...(winners || []).slice(0, 3).map(r => ({ row: r, sign: 'pos' })),
-      ...(losers  || []).slice(0, 3).map(r => ({ row: r, sign: 'neg' })),
-    ];
-    if (!cards.length) {
-      grid.innerHTML = '<div class="empty">no movers in the last 24h</div>';
+  function renderBlindSpots(rows) {
+    const body = document.getElementById('blindSpotsBody');
+    const countEl = document.getElementById('blindSpotsCount');
+    if (!body) return;
+    const candidates = rows
+      .filter(r => (+r.sg_sales_window || 0) >= BLIND_SPOT_MIN_SG_SALES
+                && (+r.cur_owned_tix || 0) === 0)
+      .sort((a, b) => {
+        const sa = +a.sg_sales_window || 0;
+        const sb = +b.sg_sales_window || 0;
+        if (sb !== sa) return sb - sa;
+        return (+b.cur_market_tix || 0) - (+a.cur_market_tix || 0);
+      });
+    const n = candidates.length;
+    if (countEl) countEl.textContent = n
+      ? `${n} event${n === 1 ? '' : 's'} (showing top ${Math.min(n, BLIND_SPOT_MAX_ROWS)})`
+      : '';
+    if (!n) {
+      body.innerHTML = '<div class="empty">no SG-only sales activity above threshold ✓</div>';
       return;
     }
-    cards.forEach(c => {
-      const r = c.row;
+    const tbl = document.createElement('table');
+    tbl.className = 'blind-spots-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th><th>Performer</th><th>Venue</th>
+        <th class="num">T-days</th>
+        <th class="num">SG sales</th>
+        <th class="num">Mkt qty</th>
+        <th class="num">Mkt median</th>
+      </tr></thead>
+      <tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    candidates.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
       const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
-      const dval = +r.delta_owned_val;
-      const dpct = +r.delta_owned_pct;
-      const card = document.createElement('a');
-      card.className = 'mover-card ' + c.sign;
-      card.href = 'event.html?event=' + r.event_id;
-      card.innerHTML = `
-        <div class="mc-name">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</div>
-        <div class="mc-meta">${escapeHtml(r.performer_name || '')}${r.venue_name ? ' · ' + escapeHtml(r.venue_name) : ''}</div>
-        <div class="mc-vals">
-          <span class="mc-dval">${(dval >= 0 ? '+' : '') + '$' + T.fmtNum(Math.round(Math.abs(dval)))}</span>
-          <span class="mc-dpct">${T.fmtPct(dpct, 1)}</span>
-        </div>
-        <div class="mc-foot">${d === null ? '' : (d <= 0 ? 'TODAY' : d === 1 ? 'TOMORROW' : 'T-' + d + 'd')} · ${T.fmtNum(+r.cur_owned_tix || 0)} owned</div>
-      `;
-      grid.appendChild(card);
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><a href="event.html?event=${r.event_id}">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
+        <td>${escapeHtml(r.performer_name || '—')}</td>
+        <td>${escapeHtml(r.venue_name || '—')}</td>
+        <td class="num">${d === null ? '—' : d}</td>
+        <td class="num warn">${T.fmtNum(+r.sg_sales_window || 0)}</td>
+        <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>
+        <td class="num">${r.cur_market_med ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>`;
+      tb.appendChild(tr);
     });
+    body.innerHTML = '';
+    body.appendChild(tbl);
+  }
+
+  // ---------- Full movers table (mirrors movers.html) ----------
+
+  function wireMoversControls() {
+    document.querySelectorAll('[data-window]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-window]').forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        state.window = parseInt(btn.dataset.window, 10);
+        load();
+      });
+    });
+    document.querySelectorAll('[data-segment]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-segment]').forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        state.segment = btn.dataset.segment;
+        renderMovers();
+      });
+    });
+  }
+
+  function renderMovers() {
+    const body = document.getElementById('moversBody');
+    if (!body) return;
+    const filtered = state.segment === 'owned'
+      ? state.rows.filter(r => (+r.cur_owned_tix || 0) > 0)
+      : state.rows;
+
+    const countEl = document.getElementById('moversCount');
+    if (countEl) countEl.textContent = filtered.length ? `${filtered.length} events` : '';
+
+    if (!filtered.length) {
+      body.innerHTML = '<div class="empty">no movers</div>';
+      return;
+    }
+
+    const sorted = [...filtered].sort((a, b) => {
+      const av = a[state.sortKey], bv = b[state.sortKey];
+      if (av === null || av === undefined) return 1;
+      if (bv === null || bv === undefined) return -1;
+      return state.sortDir === 'desc' ? bv - av : av - bv;
+    });
+
+    const cols = [
+      { key: null,                  label: 'Event',       align: 'left' },
+      { key: null,                  label: 'Performer',   align: 'left' },
+      { key: 'occurs_at_local',     label: 'T-days',      align: 'num' },
+      { key: 'cur_market_tix',      label: 'Mkt qty',     align: 'num' },
+      { key: 'cur_owned_tix',       label: 'Owned qty',   align: 'num' },
+      { key: 'cur_market_med',      label: 'Mkt median',  align: 'num' },
+      { key: 'cur_owned_med',       label: 'Own median',  align: 'num' },
+      { key: 'sg_sales_window',     label: 'SG sales',    align: 'num' },
+      { key: 'delta_market_pct',    label: 'Mkt %Δ',      align: 'num' },
+      { key: 'delta_owned_pct',     label: 'Own %Δ',      align: 'num' },
+      { key: 'delta_market_val',    label: 'Mkt Δ$',      align: 'num' },
+      { key: 'delta_owned_val',     label: 'Own Δ$',      align: 'num' },
+    ];
+
+    body.innerHTML = '';
+    const tbl = document.createElement('table');
+    tbl.className = 'movers-tbl';
+    const thead = document.createElement('thead');
+    const trh = document.createElement('tr');
+    cols.forEach(c => {
+      const th = document.createElement('th');
+      th.textContent = c.label;
+      if (c.align === 'num') th.classList.add('num');
+      if (c.key) {
+        th.classList.add('sortable');
+        th.dataset.sort = c.key;
+        if (state.sortKey === c.key) th.classList.add('is-sorted', state.sortDir);
+        th.addEventListener('click', () => {
+          if (state.sortKey === c.key) state.sortDir = state.sortDir === 'desc' ? 'asc' : 'desc';
+          else { state.sortKey = c.key; state.sortDir = 'desc'; }
+          renderMovers();
+        });
+      }
+      trh.appendChild(th);
+    });
+    thead.appendChild(trh);
+    tbl.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    sorted.slice(0, 100).forEach(r => {
+      const tr = document.createElement('tr');
+      tr.classList.add('clickable');
+      tr.addEventListener('click', () => { window.location.href = 'event.html?event=' + r.event_id; });
+      const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
+      const mDPct = +r.delta_market_pct;
+      const oDPct = +r.delta_owned_pct;
+      const mDVal = +r.delta_market_val;
+      const oDVal = +r.delta_owned_val;
+      const sg = +r.sg_sales_window || 0;
+      const ownedTix = +r.cur_owned_tix || 0;
+      const sgBlind = sg > BLIND_SPOT_MIN_SG_SALES && ownedTix === 0;
+      tr.innerHTML = `
+        <td><a href="event.html?event=${r.event_id}" onclick="event.stopPropagation()">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
+        <td>${escapeHtml(r.performer_name || '—')}</td>
+        <td class="num">${d === null ? '—' : d}</td>
+        <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>
+        <td class="num ${ownedTix > 0 ? 'ours' : ''}">${T.fmtNum(ownedTix)}</td>
+        <td class="num">${r.cur_market_med ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>
+        <td class="num">${r.cur_owned_med ? '$' + T.fmtNum(Math.round(+r.cur_owned_med)) : '—'}</td>
+        <td class="num ${sgBlind ? 'warn-cell' : ''}">${sg ? T.fmtNum(sg) : '—'}</td>
+        <td class="num ${pctCls(mDPct)}">${Number.isFinite(mDPct) ? T.fmtPct(mDPct, 1) : '—'}</td>
+        <td class="num ${pctCls(oDPct)}">${Number.isFinite(oDPct) ? T.fmtPct(oDPct, 1) : '—'}</td>
+        <td class="num ${pctCls(mDVal)}">${fmtDelta(mDVal)}</td>
+        <td class="num ${pctCls(oDVal)}">${fmtDelta(oDVal)}</td>`;
+      tbody.appendChild(tr);
+    });
+    tbl.appendChild(tbody);
+    body.appendChild(tbl);
+  }
+
+  function pctCls(v) {
+    if (!Number.isFinite(v)) return '';
+    return v > 0 ? 'pos' : v < 0 ? 'neg' : '';
+  }
+  function fmtDelta(v) {
+    if (!Number.isFinite(v)) return '—';
+    return (v >= 0 ? '+' : '−') + '$' + T.fmtNum(Math.round(Math.abs(v)));
   }
 
   // ---------- Owned events list (next 30d) ----------
@@ -132,10 +278,12 @@
       const days = (t - now) / day;
       return days >= -1 && days <= 30;
     }).sort((a, b) => {
-      // Sort by owned notional desc
-      const na = (+a.cur_owned_tix || 0) * (+a.cur_owned_med || 0);
-      const nb = (+b.cur_owned_tix || 0) * (+b.cur_owned_med || 0);
-      return nb - na;
+      // Soonest-first by event date.
+      const ta = new Date(a.occurs_at_local || a.occurs_at).getTime();
+      const tb = new Date(b.occurs_at_local || b.occurs_at).getTime();
+      if (!Number.isFinite(ta)) return 1;
+      if (!Number.isFinite(tb)) return -1;
+      return ta - tb;
     });
 
     countEl.textContent = upcoming.length ? `${upcoming.length} events` : '';

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -27,24 +27,34 @@
       </div>
     </section>
 
-    <section id="book-card">
-      <div class="panel-title">BOOK SUMMARY</div>
-      <div class="book-grid">
-        <div class="bk-row"><span class="bk-lbl">Total owned tickets</span><span class="bk-val" id="bkOwnedTix">—</span></div>
-        <div class="bk-row"><span class="bk-lbl">Owned notional (mark)</span><span class="bk-val" id="bkOwnedNotional">—</span></div>
-        <div class="bk-row"><span class="bk-lbl">Events with owned position</span><span class="bk-val" id="bkOwnedEvents">—</span></div>
-        <div class="bk-row"><span class="bk-lbl">Market tickets tracked</span><span class="bk-val" id="bkMarketTix">—</span></div>
+    <section id="blind-spots">
+      <div class="panel-title row">
+        <span>BLIND SPOTS — SG SELLING, WE'RE NOT</span>
+        <span class="muted small" id="blindSpotsCount"></span>
       </div>
+      <div id="blindSpotsBody"><div class="empty">loading…</div></div>
     </section>
 
-    <section id="movers-strip">
+    <section id="movers-panel">
       <div class="panel-title row">
-        <span>TOP MOVERS · 24H · OUR BOOK MARK-TO-MARKET</span>
-        <a href="movers.html" class="more-link">all movers →</a>
+        <span>MOVERS · OUR BOOK MARK-TO-MARKET</span>
+        <span class="muted small" id="moversCount"></span>
       </div>
-      <div class="movers-grid" id="moversGrid">
-        <div class="empty">loading…</div>
+      <div class="ctrl-row">
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">WINDOW</span>
+          <button class="ctrl-btn" data-window="1">1h</button>
+          <button class="ctrl-btn" data-window="6">6h</button>
+          <button class="ctrl-btn is-active" data-window="24">24h</button>
+          <button class="ctrl-btn" data-window="168">7d</button>
+        </div>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">SEGMENT</span>
+          <button class="ctrl-btn is-active" data-segment="all">All</button>
+          <button class="ctrl-btn" data-segment="owned">Owned only</button>
+        </div>
       </div>
+      <div id="moversBody"><div class="empty">loading…</div></div>
     </section>
 
     <section id="owned-events">
@@ -53,11 +63,6 @@
         <span class="muted small" id="ownedEventCount"></span>
       </div>
       <div id="ownedEventsBody"></div>
-    </section>
-
-    <section id="risk-alerts">
-      <div class="panel-title">RISK ALERTS</div>
-      <div id="riskBody" class="empty">order-book RPC pending — alerts unlock when hold_expires_at + owned_premium_pct surfaces land</div>
     </section>
   </main>
 

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -36,6 +36,14 @@
       </div>
     </section>
 
+    <section id="blind-spots">
+      <div class="panel-title row">
+        <span>BLIND SPOTS — SG SELLING, WE'RE NOT</span>
+        <span class="muted small" id="blindSpotsCount"></span>
+      </div>
+      <div id="blindSpotsBody"><div class="empty">loading…</div></div>
+    </section>
+
     <section id="movers-table">
       <div id="moversBody"><div class="empty">loading…</div></div>
     </section>

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -69,7 +69,63 @@
     return Array.from(seen.values());
   }
 
+  // Blind-spot threshold matches home.js — sg_sales >= N AND owned_tix = 0
+  // surfaces inventory we don't hold during active SG demand.
+  const BLIND_SPOT_MIN_SG_SALES = 5;
+  const BLIND_SPOT_MAX_ROWS     = 20;
+
+  function renderBlindSpots() {
+    const body = document.getElementById('blindSpotsBody');
+    const countEl = document.getElementById('blindSpotsCount');
+    if (!body) return;
+    const candidates = state.rows
+      .filter(r => (+r.sg_sales_window || 0) >= BLIND_SPOT_MIN_SG_SALES
+                && (+r.cur_owned_tix || 0) === 0)
+      .sort((a, b) => {
+        const sa = +a.sg_sales_window || 0;
+        const sb = +b.sg_sales_window || 0;
+        if (sb !== sa) return sb - sa;
+        return (+b.cur_market_tix || 0) - (+a.cur_market_tix || 0);
+      });
+    const n = candidates.length;
+    if (countEl) countEl.textContent = n
+      ? `${n} event${n === 1 ? '' : 's'} (showing top ${Math.min(n, BLIND_SPOT_MAX_ROWS)})`
+      : '';
+    if (!n) {
+      body.innerHTML = '<div class="empty">no SG-only sales activity above threshold ✓</div>';
+      return;
+    }
+    const tbl = document.createElement('table');
+    tbl.className = 'blind-spots-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th><th>Performer</th><th>Venue</th>
+        <th class="num">T-days</th>
+        <th class="num">SG sales</th>
+        <th class="num">Mkt qty</th>
+        <th class="num">Mkt median</th>
+      </tr></thead>
+      <tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    candidates.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
+      const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><a href="event.html?event=${r.event_id}">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
+        <td>${escapeHtml(r.performer_name || '—')}</td>
+        <td>${escapeHtml(r.venue_name || '—')}</td>
+        <td class="num">${d === null ? '—' : d}</td>
+        <td class="num warn">${T.fmtNum(+r.sg_sales_window || 0)}</td>
+        <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>
+        <td class="num">${r.cur_market_med ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    body.innerHTML = '';
+    body.appendChild(tbl);
+  }
+
   function render() {
+    renderBlindSpots();
     const body = document.getElementById('moversBody');
     const filtered = state.segment === 'owned'
       ? state.rows.filter(r => (+r.cur_owned_tix || 0) > 0)
@@ -98,6 +154,7 @@
       { key: 'cur_owned_tix',       label: 'Owned qty',   align: 'num' },
       { key: 'cur_market_med',      label: 'Mkt median',  align: 'num' },
       { key: 'cur_owned_med',       label: 'Own median',  align: 'num' },
+      { key: 'sg_sales_window',     label: 'SG sales',    align: 'num' },
       { key: 'delta_market_pct',    label: 'Mkt %Δ',      align: 'num' },
       { key: 'delta_owned_pct',     label: 'Own %Δ',      align: 'num' },
       { key: 'delta_market_val',    label: 'Mkt Δ$',      align: 'num' },
@@ -140,14 +197,18 @@
       const oDPct = +r.delta_owned_pct;
       const mDVal = +r.delta_market_val;
       const oDVal = +r.delta_owned_val;
+      const sg = +r.sg_sales_window || 0;
+      const ownedTix = +r.cur_owned_tix || 0;
+      const sgBlind = sg > BLIND_SPOT_MIN_SG_SALES && ownedTix === 0;
       tr.innerHTML = `
         <td><a href="event.html?event=${r.event_id}" onclick="event.stopPropagation()">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
         <td>${escapeHtml(r.performer_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
         <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>
-        <td class="num ${(+r.cur_owned_tix || 0) > 0 ? 'ours' : ''}">${T.fmtNum(+r.cur_owned_tix || 0)}</td>
+        <td class="num ${ownedTix > 0 ? 'ours' : ''}">${T.fmtNum(ownedTix)}</td>
         <td class="num">${r.cur_market_med ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>
         <td class="num">${r.cur_owned_med ? '$' + T.fmtNum(Math.round(+r.cur_owned_med)) : '—'}</td>
+        <td class="num ${sgBlind ? 'warn-cell' : ''}">${sg ? T.fmtNum(sg) : '—'}</td>
         <td class="num ${pctCls(mDPct)}">${Number.isFinite(mDPct) ? T.fmtPct(mDPct, 1) : '—'}</td>
         <td class="num ${pctCls(oDPct)}">${Number.isFinite(oDPct) ? T.fmtPct(oDPct, 1) : '—'}</td>
         <td class="num ${pctCls(mDVal)}">${fmtDelta(mDVal)}</td>

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -262,7 +262,7 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 
 .wrap.home {
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: 1fr;
   gap: 12px;
 }
 .wrap.home > section {
@@ -270,11 +270,39 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
   border: 1px solid var(--line);
   padding: 12px 16px;
 }
-#coverage-band { grid-column: 1 / 2; }
-#book-card     { grid-column: 2 / 3; }
-#movers-strip  { grid-column: 1 / -1; }
-#owned-events  { grid-column: 1 / -1; }
-#risk-alerts   { grid-column: 1 / -1; }
+
+/* Blind-spots table — used on home + movers.html */
+.blind-spots-tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono); font-size: 11px;
+}
+.blind-spots-tbl thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--line);
+}
+.blind-spots-tbl tbody td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--line-2);
+  color: var(--text);
+}
+.blind-spots-tbl .num { text-align: right; }
+.blind-spots-tbl .num.warn { color: var(--warn); font-weight: 600; }
+.blind-spots-tbl tbody tr:hover td { background: var(--shade); }
+
+/* Amber-cued SG sales cell on movers table when blind-spot conditions met
+   (sg > threshold AND owned_tix = 0) */
+.movers-tbl .warn-cell {
+  background: rgba(245, 158, 11, 0.10);
+  color: var(--warn);
+  font-weight: 600;
+}
 
 .coverage-grid, .rollup-grid {
   display: grid;

--- a/supabase/migrations/20260518000000_get_event_movers_with_sg_rpc.sql
+++ b/supabase/migrations/20260518000000_get_event_movers_with_sg_rpc.sql
@@ -1,0 +1,92 @@
+-- Migration 20260518000000 · lane:D0 (author) → A1 (apply) · writes:get_event_movers_with_sg · reads:get_event_movers,seatgeek_sales_snapshots,seatgeek_event_xref · pre:20260508040000 · auth:operator-approved 2026-05-17
+--
+-- D0 — wraps existing get_event_movers (mig 20260508040000) and adds a
+-- per-event SG sales count over the same window. Powers two new surfaces:
+--   1. New `SG 24h sales` column on the movers table (home + movers.html)
+--   2. New `BLIND SPOTS — SG SELLING, WE'RE NOT` panel (sg_sales > N AND
+--      cur_owned_tix = 0) — surfaces inventory gaps where SG demand is
+--      live but our office holds zero.
+--
+-- Per A1 pre-flight audit (bot_chat #299):
+--   - DISTINCT ON (sg_sale_id) is MANDATORY — seatgeek_sales_snapshots
+--     has 11x pull dedup (PROJECT_BIBLE §3). Without it, sales_24h would
+--     overcount by 11x.
+--   - Scope SG join on sg_event_id (uses idx_sg_sales_sg_event_id_time
+--     from PR #150 hotfix) for sub-100ms latency.
+--   - Bridge tevo_event_id ↔ sg_event_id via seatgeek_event_xref.
+--
+-- Plain SQL function (no SECDEF / no email gate) — matches the existing
+-- get_event_movers pattern. /api/broker/movers FastAPI endpoint already
+-- has require_auth wrapping the row-level access; consistent with the
+-- companion RPC's auth model. If/when the FE migrates this surface to
+-- Path C (direct supabase.rpc), a SECDEF wrapper can be added then.
+
+CREATE OR REPLACE FUNCTION public.get_event_movers_with_sg(p_window_hours int DEFAULT 24)
+RETURNS TABLE (
+  event_id              bigint,
+  name                  text,
+  primary_performer_id  bigint,
+  primary_performer_name text,
+  venue_id              bigint,
+  venue_name            text,
+  occurs_at_local       text,
+  latest_at             timestamptz,
+  prior_at              timestamptz,
+  cur_market_med        numeric,
+  prev_market_med       numeric,
+  cur_owned_med         numeric,
+  prev_owned_med        numeric,
+  cur_market_tix        integer,
+  prev_market_tix       integer,
+  cur_owned_tix         integer,
+  prev_owned_tix        integer,
+  sg_sales_window       integer
+)
+LANGUAGE sql STABLE
+SET search_path = public, extensions, pg_temp
+AS $$
+  WITH sg_window AS (
+    -- DISTINCT ON sg_sale_id collapses 11x firehose dedup before counting.
+    -- Scope by sg_event_id (idx_sg_sales_sg_event_id_time) then bridge to
+    -- tevo_event_id via xref. p_window_hours controls the look-back so the
+    -- "SG 24h sales" column tracks the same window as the mover deltas.
+    SELECT
+      x.tevo_event_id,
+      COUNT(*)::integer AS sg_sales_window
+    FROM (
+      SELECT DISTINCT ON (s.sg_sale_id)
+        s.sg_sale_id, s.sg_event_id, s.sale_at_utc
+      FROM public.seatgeek_sales_snapshots s
+      WHERE s.sale_at_utc > now() - (p_window_hours || ' hours')::interval
+      ORDER BY s.sg_sale_id, s.pulled_at DESC
+    ) deduped
+    JOIN public.seatgeek_event_xref x ON x.sg_event_id = deduped.sg_event_id
+    GROUP BY x.tevo_event_id
+  )
+  SELECT
+    m.event_id,
+    m.name,
+    m.primary_performer_id,
+    m.primary_performer_name,
+    m.venue_id,
+    m.venue_name,
+    m.occurs_at_local,
+    m.latest_at,
+    m.prior_at,
+    m.cur_market_med,
+    m.prev_market_med,
+    m.cur_owned_med,
+    m.prev_owned_med,
+    m.cur_market_tix,
+    m.prev_market_tix,
+    m.cur_owned_tix,
+    m.prev_owned_tix,
+    COALESCE(sg.sg_sales_window, 0)::integer AS sg_sales_window
+  FROM public.get_event_movers(p_window_hours) m
+  LEFT JOIN sg_window sg ON sg.tevo_event_id = m.event_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_event_movers_with_sg(int) TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_event_movers_with_sg(int) IS
+  'Wraps get_event_movers; adds per-event SG sales count over the same window. DISTINCT ON (sg_sale_id) for 11x firehose dedup. Powers movers SG column + Blind Spots panel.';


### PR DESCRIPTION
## Summary

PR A of 2 in this round of D0 polish (PR B = entity pages: performer index + venue page + tabs).

### Home page

- Replaces 6-card TOP MOVERS strip with the full 12-column sortable movers table — same UI as standalone `movers.html`. Window selector (1h/6h/24h/7d) + segment toggle (All/Owned only) wired; window change re-fetches, segment toggle filters client-side. Overflow bug from the strip resolves implicitly.
- New **BLIND SPOTS — SG SELLING, WE'RE NOT** panel above the movers table. Filter: `sg_sales_window >= 5 AND cur_owned_tix = 0`. Sorted by SG sales desc, capped 20.
- New **SG sales** column on the movers table, sortable, amber-cued when blind-spot conditions met.
- S4K-OWNED EVENTS table now sorted soonest-first by event date (was notional desc).
- BOOK SUMMARY + RISK ALERTS removed; `.wrap.home` grid collapses to single column.

### Standalone `movers.html` / `movers.js`

- Same BLIND SPOTS panel added above the existing movers table.
- Same SG sales column added.

Both surfaces share the same UI; standalone page stays alive.

### Migration `20260518000000_get_event_movers_with_sg_rpc.sql`

New RPC `get_event_movers_with_sg(p_window_hours int DEFAULT 24)`:
- Wraps existing `get_event_movers` (mig 20260508040000) and LEFT JOINs per-event SG sales count over the same window
- Plain SQL function (no SECDEF) — matches existing `get_event_movers` pattern; auth enforced by FastAPI `require_auth` wrapper
- Per A1 pre-flight audit (bot_chat #299):
  - `DISTINCT ON (sg_sale_id)` mandatory (11× SG firehose dedup, PROJECT_BIBLE §3)
  - Scope via `sg_event_id` (uses `idx_sg_sales_sg_event_id_time`)
  - Bridge via `seatgeek_event_xref`

`app.py` `/api/broker/movers` switches to the new RPC + carries `sg_sales_window` through to the JSON payload.

## Verification

- Local browser preview verified: 7 sections render in correct order (COVERAGE → BLIND SPOTS → MOVERS → S4K-OWNED EVENTS), `book-card` + `risk-alerts` gone from DOM, `.wrap.home` is 1-col grid, window buttons toggle `is-active` correctly.
- Owned events sort comparator now date-ascending (NaN-safe).
- Movers / movers.html: SG sales column placed between `Own median` and `Mkt %Δ`. Amber cue (`.warn-cell`) on cells where `sg_sales_window > 5 AND cur_owned_tix === 0`.

## Test plan (A1 smoke pre-merge, per process note in bot_chat #299)

- [ ] Smoke `get_event_movers_with_sg(24)` returns sane rows with `sg_sales_window` populated for at least one event with SG bridge
- [ ] Latency comparable to existing `get_event_movers` (target <250ms; uses `idx_sg_sales_sg_event_id_time`)
- [ ] `/api/broker/movers?window_hours=24` returns rows with `sg_sales_window` field
- [ ] Visit `/static/terminal/` → confirm BLIND SPOTS panel populates with real events where SG is active but we hold zero
- [ ] Visit `/static/terminal/movers.html` → same blind-spots panel + SG column

## Related

- PR B (follow-up in same round) — entity pages: performer 2-mode + venue page + tabs
- bot_chat #299 — A1 pre-flight audit corrections baked into both PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)