### PR TITLE
feat(d0): performer 2-mode + venue page + ESPN context tab

### DIFF
--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -11,8 +11,9 @@
   const PAGES = [
     { id: 'home',      label: 'HOME',      href: './' },
     { id: 'event',     label: 'EVENT',     href: 'event.html' },
-    { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
+    { id: 'venue',     label: 'VENUE',     href: 'venue.html' },
     { id: 'performer', label: 'PERFORMER', href: 'performer.html' },
+    { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
     { id: 'orders',    label: 'ORDERS',    href: 'orders.html' },
   ];
 
@@ -154,10 +155,7 @@
       if (vens.length) {
         parts.push('<div class="ts-section"><div class="ts-section-lbl">VENUES</div>');
         vens.forEach(v => {
-          // No venue.html yet — link to home with venue filter param for now;
-          // home filter is a future Phase 2b; for now the link still navigates
-          // and the URL captures the intent.
-          const href = `./?venue=${v.tevo_venue_id}`;
+          const href = `venue.html?venue=${v.tevo_venue_id}`;
           const meta = [v.city, v.state].filter(Boolean).join(', ');
           flat.push({ href, label: v.venue_name, kind: 'venue' });
           parts.push(`<a class="ts-row" href="${href}" data-kind="venue">

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -17,7 +17,18 @@
   </header>
 
   <main class="wrap performer">
-    <section id="perf-hero">
+
+    <!-- INDEX MODE: 4-league directory shown when no ?performer=<id> in URL. -->
+    <section id="perf-index" hidden>
+      <div class="panel-title row">
+        <span>PERFORMERS — NFL · NBA · MLB · MLS</span>
+        <span class="muted small" id="perfIndexCounts"></span>
+      </div>
+      <div id="perfIndexBody"><div class="empty">loading…</div></div>
+    </section>
+
+    <!-- DETAIL MODE: existing hero + rollup + tabbed sections. Shown when ?performer=<id>. -->
+    <section id="perf-hero" hidden>
       <div class="ph-left">
         <img id="phLogo" alt="" />
       </div>
@@ -33,41 +44,60 @@
       </div>
     </section>
 
-    <section id="perf-rollup">
-      <div class="panel-title">PORTFOLIO ROLLUP</div>
-      <div class="rollup-grid">
-        <div class="ru-cell"><span class="ru-num" id="ruEvents">—</span><span class="ru-lbl">active events</span></div>
-        <div class="ru-cell"><span class="ru-num" id="ruOwnedTix">—</span><span class="ru-lbl">owned tix</span></div>
-        <div class="ru-cell"><span class="ru-num" id="ruOwnedNotional">—</span><span class="ru-lbl">owned notional</span></div>
-        <div class="ru-cell"><span class="ru-num" id="ruOwnedShare">—</span><span class="ru-lbl">owned share (wt)</span></div>
-        <div class="ru-cell"><span class="ru-num" id="ruRetailMedAvg">—</span><span class="ru-lbl">retail median (wt)</span></div>
-        <div class="ru-cell"><span class="ru-num" id="ruEventsWithOwned">—</span><span class="ru-lbl">events with position</span></div>
-      </div>
-    </section>
+    <nav class="event-tabs" id="perfTabs" role="tablist" hidden>
+      <button class="event-tab active" data-tab="overview"  role="tab" aria-selected="true">Overview</button>
+      <button class="event-tab" data-tab="upcoming"  role="tab" aria-selected="false">Upcoming Events <span class="tab-count" id="tabCountUpcoming"></span></button>
+      <button class="event-tab" data-tab="blindspots" role="tab" aria-selected="false">Blind Spots <span class="tab-count" id="tabCountBlindspots"></span></button>
+      <button class="event-tab" data-tab="espn" role="tab" aria-selected="false">ESPN Context</button>
+    </nav>
 
-    <section id="perf-events">
-      <div class="panel-title row">
-        <span>UPCOMING EVENTS</span>
-        <span class="muted small" id="phEventCount"></span>
-      </div>
-      <div id="phEventsBody"></div>
-    </section>
+    <div class="tab-pane active" id="paneOverview" role="tabpanel" hidden>
+      <section id="perf-rollup">
+        <div class="panel-title">PORTFOLIO ROLLUP</div>
+        <div class="rollup-grid">
+          <div class="ru-cell"><span class="ru-num" id="ruEvents">—</span><span class="ru-lbl">active events</span></div>
+          <div class="ru-cell"><span class="ru-num" id="ruOwnedTix">—</span><span class="ru-lbl">owned tix</span></div>
+          <div class="ru-cell"><span class="ru-num" id="ruOwnedNotional">—</span><span class="ru-lbl">owned notional</span></div>
+          <div class="ru-cell"><span class="ru-num" id="ruOwnedShare">—</span><span class="ru-lbl">owned share (wt)</span></div>
+          <div class="ru-cell"><span class="ru-num" id="ruRetailMedAvg">—</span><span class="ru-lbl">retail median (wt)</span></div>
+          <div class="ru-cell"><span class="ru-num" id="ruEventsWithOwned">—</span><span class="ru-lbl">events with position</span></div>
+        </div>
+      </section>
+    </div>
 
-    <section id="perf-blind-spots">
-      <div class="panel-title row">
-        <span>BLIND SPOTS — UPCOMING GAMES WE DON'T OWN</span>
-        <span class="muted small" id="phBlindSpotsCount"></span>
-      </div>
-      <div class="muted small" style="margin-bottom: 8px;">
-        Games where this performer has &gt;50 tix on market but our owned_tix = 0. Sorted by approx market notional (qty × median).
-      </div>
-      <div id="phBlindSpotsBody"></div>
-    </section>
+    <div class="tab-pane" id="paneUpcoming" role="tabpanel" hidden>
+      <section id="perf-events">
+        <div class="panel-title row">
+          <span>UPCOMING EVENTS</span>
+          <span class="muted small" id="phEventCount"></span>
+        </div>
+        <div id="phEventsBody"></div>
+      </section>
+    </div>
 
-    <section id="perf-context">
-      <div class="panel-title">CONTEXT</div>
-      <div class="muted small">ESPN standings / injuries / recent results — pending <code>get_broker_performer_page</code> RPC (Phase 2b ask)</div>
-    </section>
+    <div class="tab-pane" id="paneBlindspots" role="tabpanel" hidden>
+      <section id="perf-blind-spots">
+        <div class="panel-title row">
+          <span>BLIND SPOTS — UPCOMING GAMES WE DON'T OWN</span>
+          <span class="muted small" id="phBlindSpotsCount"></span>
+        </div>
+        <div class="muted small" style="margin-bottom: 8px;">
+          Games where this performer has &gt;50 tix on market but our owned_tix = 0. Sorted by approx market notional (qty × median).
+        </div>
+        <div id="phBlindSpotsBody"></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneEspn" role="tabpanel" hidden>
+      <section id="perf-context">
+        <div class="panel-title row">
+          <span>ESPN CONTEXT</span>
+          <span class="muted small" id="phEspnContextMeta"></span>
+        </div>
+        <div id="phEspnContextBody"><div class="empty">tap tab to load</div></div>
+      </section>
+    </div>
+
   </main>
 
   <script src="lib/supabase.js"></script>

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -1,7 +1,14 @@
-// D0 Terminal — Performer detail page.
-// URL: ?performer=<id>. Fetches /api/broker/performer/{id}/assets for the
-// header + /api/portfolio?performer_id=<id> for the events list + rollup.
-// Injuries / roster / news / xref deferred to the cross-source explorer page.
+// D0 Terminal — Performer page (two modes).
+//
+// INDEX mode  (no ?performer in URL): 4-league directory from
+//   get_broker_performer_index. Click a row → DETAIL mode.
+// DETAIL mode (?performer=<id>):      hero + portfolio rollup +
+//   4 tabs (Overview / Upcoming Events / Blind Spots / ESPN Context).
+//   Fetches /api/broker/performer/{id}/assets + /api/portfolio?performer_id
+//   like before, plus get_broker_performer_page for the ESPN tab.
+//
+// ESPN tab is lazy-loaded on first click (one Path C RPC). Other tabs
+// derive from the assets + portfolio payload already in memory.
 
 (function () {
   'use strict';
@@ -18,12 +25,85 @@
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
     const performerId = getPerformerId();
     if (!performerId) {
-      T.setStatus('No performer id — pass ?performer=<id>', 'err');
-      document.getElementById('phName').textContent = 'Pick a performer';
-      document.getElementById('phEventsBody').innerHTML =
-        '<div class="empty">Append <code>?performer=&lt;id&gt;</code> to the URL. Find performer ids via the Movers page (click a row) or via the <code>events</code> table.</div>';
+      showIndexMode();
       return;
     }
+    showDetailMode(performerId);
+  }
+
+  // ============================================================
+  // INDEX mode — 4-league directory
+  // ============================================================
+  async function showIndexMode() {
+    const idx = document.getElementById('perf-index');
+    if (idx) idx.removeAttribute('hidden');
+    T.setStatus('Loading performer index…');
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      document.getElementById('perfIndexBody').innerHTML =
+        '<div class="empty">index needs auth — sign in with @s4kent.com</div>';
+      T.setStatus('Auth required', 'err');
+      return;
+    }
+    const res = await Auth.client.rpc('get_broker_performer_index');
+    if (res.error) {
+      T.setStatus(res.error.message, 'err');
+      document.getElementById('perfIndexBody').innerHTML =
+        `<div class="empty">RPC error: ${escapeHtml(res.error.message)}</div>`;
+      return;
+    }
+    T.setStatus('Loaded', 'ok');
+    renderIndex(res.data || {});
+  }
+
+  function renderIndex(d) {
+    const body = document.getElementById('perfIndexBody');
+    const countsEl = document.getElementById('perfIndexCounts');
+    const counts = d.counts || {};
+    const leagues = d.leagues || {};
+    if (countsEl) {
+      const parts = ['NFL','NBA','MLB','MLS']
+        .filter(l => counts[l])
+        .map(l => `${l} ${counts[l]}`);
+      if (counts.total) parts.push(`· ${counts.total} total`);
+      countsEl.textContent = parts.join(' · ');
+    }
+    body.innerHTML = '';
+    const grid = document.createElement('div');
+    grid.className = 'entity-index-grid';
+    ['NFL','NBA','MLB','MLS'].forEach(league => {
+      const teams = leagues[league] || [];
+      const col = document.createElement('div');
+      col.className = 'entity-index-col';
+      col.innerHTML = `<div class="entity-index-col-hdr">${league} <span class="muted small">(${teams.length})</span></div>`;
+      const ul = document.createElement('ul');
+      ul.className = 'entity-index-list';
+      teams.forEach(t => {
+        const li = document.createElement('li');
+        const upcoming = t.events_count_next_90d != null ? `<span class="entity-idx-count">${t.events_count_next_90d}</span>` : '';
+        li.innerHTML = `<a href="performer.html?performer=${t.tevo_performer_id}">
+            <span class="entity-idx-name">${escapeHtml(t.display_name || t.performer_name || '—')}</span>
+            ${t.abbreviation ? `<span class="muted small">${escapeHtml(t.abbreviation)}</span>` : ''}
+            ${upcoming}
+          </a>`;
+        ul.appendChild(li);
+      });
+      col.appendChild(ul);
+      grid.appendChild(col);
+    });
+    body.appendChild(grid);
+  }
+
+  // ============================================================
+  // DETAIL mode — hero + rollup + 4 tabs
+  // ============================================================
+  function showDetailMode(performerId) {
+    // Unhide DETAIL chrome
+    document.getElementById('perf-hero').removeAttribute('hidden');
+    document.getElementById('perfTabs').removeAttribute('hidden');
+    document.getElementById('paneOverview').removeAttribute('hidden');
+
+    wireTabs(performerId);
     T.setStatus(`Loading performer ${performerId}…`);
 
     Promise.all([
@@ -31,15 +111,50 @@
       T.api(`/api/portfolio?performer_id=${performerId}`).catch(e => ({ __err: e })),
     ]).then(([assets, portfolio]) => {
       const firstErr = [assets, portfolio].find(r => r && r.__err);
-      if (firstErr) {
-        T.setStatus(firstErr.__err.message, 'err');
-      } else {
-        T.setStatus(`Loaded`, 'ok');
-      }
+      if (firstErr) T.setStatus(firstErr.__err.message, 'err');
+      else T.setStatus('Loaded', 'ok');
       try { renderHero(assets, portfolio); }      catch (e) { console.error('hero', e); }
       try { renderRollup(portfolio); }            catch (e) { console.error('rollup', e); }
       try { renderEvents(portfolio); }            catch (e) { console.error('events', e); }
       try { renderBlindSpots(portfolio); }        catch (e) { console.error('blindSpots', e); }
+    });
+  }
+
+  // ---------- Tab nav ----------
+  const _tabState = { loaded: { espn: false }, performerId: null };
+
+  function wireTabs(performerId) {
+    _tabState.performerId = performerId;
+    const nav = document.getElementById('perfTabs');
+    if (!nav) return;
+    nav.addEventListener('click', async (e) => {
+      const btn = e.target.closest('.event-tab');
+      if (!btn) return;
+      const tabId = btn.dataset.tab;
+      activateTab(tabId);
+      if (tabId === 'espn' && !_tabState.loaded.espn) {
+        await loadEspnContext(performerId);
+      }
+    });
+  }
+
+  function activateTab(tabId) {
+    document.querySelectorAll('#perfTabs .event-tab').forEach(b => {
+      const on = b.dataset.tab === tabId;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    const paneIds = {
+      overview:   'paneOverview',
+      upcoming:   'paneUpcoming',
+      blindspots: 'paneBlindspots',
+      espn:       'paneEspn',
+    };
+    Object.entries(paneIds).forEach(([id, paneId]) => {
+      const pane = document.getElementById(paneId);
+      if (!pane) return;
+      if (id === tabId) { pane.removeAttribute('hidden'); pane.classList.add('active'); }
+      else { pane.setAttribute('hidden', ''); pane.classList.remove('active'); }
     });
   }
 
@@ -64,12 +179,8 @@
 
     const logo = document.getElementById('phLogo');
     const url = a.logo_default_url || a.logo_dark_url || a.logo_4k_primary_url;
-    if (url) {
-      logo.src = url;
-      logo.alt = name + ' logo';
-    } else {
-      logo.style.display = 'none';
-    }
+    if (url) { logo.src = url; logo.alt = name + ' logo'; }
+    else { logo.style.display = 'none'; }
 
     if (a.color_primary) {
       document.getElementById('perf-hero').style.borderLeft = `4px solid ${a.color_primary}`;
@@ -94,6 +205,7 @@
   function renderEvents(portfolio) {
     const body = document.getElementById('phEventsBody');
     const countEl = document.getElementById('phEventCount');
+    const tabCount = document.getElementById('tabCountUpcoming');
     body.innerHTML = '';
     if (!portfolio || portfolio.__err) {
       body.innerHTML = '<div class="empty">portfolio unavailable</div>';
@@ -101,6 +213,7 @@
     }
     const events = portfolio.events || [];
     countEl.textContent = events.length ? `${events.length} events` : '';
+    if (tabCount) tabCount.textContent = events.length ? String(events.length) : '';
     if (!events.length) {
       body.innerHTML = '<div class="empty">no upcoming events for this performer</div>';
       return;
@@ -148,27 +261,14 @@
     body.appendChild(tbl);
   }
 
-  // ---------- Blind spots — games we DON'T own ----------
-  //
-  // For each upcoming event under this performer where we hold zero
-  // inventory AND the market has > MIN_MARKET_TIX tickets active, surface
-  // the row sorted by approx market notional (qty × median). These are
-  // games we could profitably enter — broker decision-support, no Phase
-  // 2b/2c RPC needed (existing /api/portfolio events already carry
-  // owned_tickets_count + tickets_count + retail_median per row).
-  //
-  // Aligns with the entity-level Blind Spots framing in Phase 2c E.1
-  // (Snapshot/Motion/Coverage/Blind) — surfacing the "Coverage" gap at
-  // the performer drill-down rather than waiting for the dedicated
-  // /terminal/blind-spots page (Phase 2c proper, needs get_broker_
-  // blind_spots RPC from A1).
-
+  // ---------- Blind spots ----------
   const BLIND_SPOT_MIN_MARKET_TIX = 50;
   const BLIND_SPOT_MAX_ROWS       = 20;
 
   function renderBlindSpots(portfolio) {
     const body = document.getElementById('phBlindSpotsBody');
     const countEl = document.getElementById('phBlindSpotsCount');
+    const tabCount = document.getElementById('tabCountBlindspots');
     if (!body) return;
     body.innerHTML = '';
     if (!portfolio || portfolio.__err) {
@@ -176,10 +276,6 @@
       return;
     }
     const events = portfolio.events || [];
-
-    // Lifecycle gate first — speculative + ghost events surface elsewhere
-    // already (and aren't real blind-spot candidates per consumer storefront
-    // filter logic from PR #175). Then qty + ownership filter.
     const candidates = events.filter((e) => {
       const lifecycleActive = !e.lifecycle || e.lifecycle.is_active !== false;
       if (!lifecycleActive) return false;
@@ -187,26 +283,21 @@
       const market = Number(e.tickets_count || 0);
       return owned === 0 && market > BLIND_SPOT_MIN_MARKET_TIX;
     });
-
-    // Sort by approx market notional desc. Falls back to market qty when
-    // retail_median missing (small event with no median yet → still surfaces).
     candidates.sort((a, b) => {
       const an = (Number(a.tickets_count) || 0) * (Number(a.retail_median) || 0);
       const bn = (Number(b.tickets_count) || 0) * (Number(b.retail_median) || 0);
       if (bn !== an) return bn - an;
       return (Number(b.tickets_count) || 0) - (Number(a.tickets_count) || 0);
     });
-
     const total = candidates.length;
     if (countEl) countEl.textContent = total
       ? `${total} blind spot${total === 1 ? '' : 's'} (showing top ${Math.min(total, BLIND_SPOT_MAX_ROWS)})`
       : '';
-
+    if (tabCount) tabCount.textContent = total ? String(total) : '';
     if (!total) {
       body.innerHTML = '<div class="empty">no blind spots — we have inventory on every active upcoming game for this performer ✓</div>';
       return;
     }
-
     const tbl = document.createElement('table');
     tbl.innerHTML = `
       <thead><tr>
@@ -239,13 +330,104 @@
     body.appendChild(tbl);
   }
 
+  // ---------- ESPN Context (lazy-loaded tab) ----------
+  async function loadEspnContext(performerId) {
+    const body = document.getElementById('phEspnContextBody');
+    const meta = document.getElementById('phEspnContextMeta');
+    if (body) body.innerHTML = '<div class="empty">loading ESPN context…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      if (body) body.innerHTML = '<div class="empty">ESPN context needs auth — sign in with @s4kent.com</div>';
+      if (meta) meta.textContent = '';
+      return;
+    }
+    const t0 = performance.now();
+    const res = await Auth.client.rpc('get_broker_performer_page', { p_performer_id: performerId });
+    if (res.error) {
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message)}</div>`;
+      if (meta) meta.textContent = 'error';
+      return;
+    }
+    _tabState.loaded.espn = true;
+    renderEspnContext(res.data || {}, performance.now() - t0);
+  }
+
+  function renderEspnContext(d, ms) {
+    const body = document.getElementById('phEspnContextBody');
+    const meta = document.getElementById('phEspnContextMeta');
+    if (!body) return;
+    if (d.hidden) {
+      body.innerHTML = `<div class="empty">no ESPN xref for this performer (${escapeHtml(d.reason || 'hidden')})</div>`;
+      if (meta) meta.textContent = '';
+      return;
+    }
+    if (meta) meta.textContent = `${d.espn_league || ''} · team ${d.espn_team_id || ''} · ${ms.toFixed(0)}ms`;
+    const standings = d.standings || null;
+    const injuries  = d.injuries || [];
+    const recent    = d.recent_results || [];
+    const standingsHtml = !standings ? '<div class="empty">no standings snapshot</div>' : `
+      <table class="espn-standings">
+        <tbody>
+          <tr><td class="lbl">RECORD</td><td>${standings.wins ?? '—'}-${standings.losses ?? '—'}${standings.ties ? '-' + standings.ties : ''}</td></tr>
+          <tr><td class="lbl">WIN %</td><td>${standings.win_pct != null ? T.fmtPct(Number(standings.win_pct) * 100, 1) : '—'}</td></tr>
+          <tr><td class="lbl">STREAK</td><td>${escapeHtml(standings.streak || '—')}</td></tr>
+          <tr><td class="lbl">CONFERENCE RANK</td><td>${standings.conference_rank ?? '—'}</td></tr>
+          <tr><td class="lbl">DIVISION RANK</td><td>${standings.division_rank ?? '—'}</td></tr>
+          <tr><td class="lbl">PLAYOFF SEED</td><td>${standings.playoff_seed ?? '—'}</td></tr>
+          <tr><td class="lbl">GAMES BACK</td><td>${standings.games_back ?? '—'}</td></tr>
+          <tr><td class="lbl">SUMMARY</td><td class="muted">${escapeHtml(standings.standing_summary || standings.record_summary || '—')}</td></tr>
+          <tr><td class="lbl">CAPTURED</td><td class="muted small">${T.fmtDate(standings.captured_at)}</td></tr>
+        </tbody>
+      </table>`;
+    const injHtml = !injuries.length ? '<div class="empty">no current injury report</div>' : `
+      <table class="espn-injuries">
+        <thead><tr>
+          <th>Athlete</th><th>Pos</th><th>Status</th><th>Injury</th><th>Return</th><th>Note</th>
+        </tr></thead>
+        <tbody>${injuries.map(i => `
+          <tr>
+            <td>${escapeHtml(i.athlete_name || '—')}</td>
+            <td>${escapeHtml(i.position || '—')}</td>
+            <td><span class="injury-status">${escapeHtml(i.status || '—')}</span></td>
+            <td>${escapeHtml(i.injury_type || '—')}</td>
+            <td>${i.return_date ? T.fmtDate(i.return_date) : '—'}</td>
+            <td class="muted">${escapeHtml(i.short_comment || '')}</td>
+          </tr>`).join('')}
+        </tbody>
+      </table>`;
+    const recHtml = !recent.length ? '<div class="empty">no recent completed games</div>' : `
+      <table class="espn-recent">
+        <thead><tr>
+          <th>When</th><th>vs</th><th>Score</th><th>Status</th>
+        </tr></thead>
+        <tbody>${recent.map(g => {
+          const us = g.is_home ? g.home_score : g.away_score;
+          const them = g.is_home ? g.away_score : g.home_score;
+          return `
+            <tr>
+              <td class="muted">${T.fmtDate(g.captured_at)}</td>
+              <td>${g.is_home ? 'vs' : '@'} <strong>${escapeHtml(g.opponent_team_id || '?')}</strong></td>
+              <td class="num">${us ?? '—'} - ${them ?? '—'}</td>
+              <td>${escapeHtml(g.status_short || '—')}</td>
+            </tr>`;
+        }).join('')}
+        </tbody>
+      </table>`;
+    body.innerHTML = `
+      <div class="espn-grid">
+        <div class="espn-col"><div class="espn-col-hdr">STANDINGS</div>${standingsHtml}</div>
+        <div class="espn-col"><div class="espn-col-hdr">INJURY REPORT</div>${injHtml}</div>
+        <div class="espn-col espn-col-wide"><div class="espn-col-hdr">RECENT — last 5</div>${recHtml}</div>
+      </div>`;
+  }
+
   // ---------- Util ----------
 
   function setText(id, txt) {
     const el = document.getElementById(id);
     if (el) el.textContent = txt;
   }
-
   function escapeHtml(s) {
     if (s === null || s === undefined) return '';
     return String(s).replace(/[&<>"']/g, c => ({

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -420,6 +420,158 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 }
 #perf-hero .ph-right .meta .dot { margin: 0 8px; color: var(--dim); }
 
+/* ---------- VENUE page (mirrors performer page layout) ---------- */
+
+.wrap.venue { display: flex; flex-direction: column; gap: 12px; }
+.wrap.venue > section,
+.wrap.venue > .tab-pane > section {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 12px 16px;
+}
+#venue-hero {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 16px;
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  padding: 12px 16px;
+}
+#venue-hero .ph-left img {
+  width: 88px; height: 88px; object-fit: cover;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+}
+#venue-hero .ph-right .title { margin: 0 0 4px; font-size: 22px; }
+#venue-hero .ph-right .meta {
+  margin: 0; color: var(--muted);
+  font-family: var(--mono); font-size: 12px;
+}
+#venue-hero .ph-right .meta .dot { margin: 0 8px; color: var(--dim); }
+#venue-hero .ph-right .meta a { color: var(--accent); }
+
+/* Tab-panes on performer + venue pages use plain flex (not display:contents)
+   because the surrounding .wrap.{performer,venue} containers are flex columns
+   themselves, not 12-col grids like event page. */
+.wrap.performer .tab-pane,
+.wrap.venue     .tab-pane { display: block; }
+.wrap.performer .tab-pane[hidden],
+.wrap.venue     .tab-pane[hidden] { display: none; }
+
+/* ---------- Entity index (performer + venue 4-league directory) ---------- */
+
+.entity-index-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+.entity-index-col {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  padding: 8px;
+}
+.entity-index-col-hdr {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--line);
+}
+.entity-index-list {
+  list-style: none;
+  margin: 0; padding: 0;
+  font-family: var(--mono); font-size: 12px;
+  max-height: 70vh; overflow-y: auto;
+}
+.entity-index-list li {
+  border-bottom: 1px solid var(--line-2);
+}
+.entity-index-list li:last-child { border-bottom: 0; }
+.entity-index-list a {
+  display: flex; align-items: baseline; gap: 8px;
+  padding: 5px 6px;
+  color: var(--text);
+  text-decoration: none;
+}
+.entity-index-list a:hover {
+  background: var(--shade);
+  border-left: 2px solid var(--accent);
+  padding-left: 4px;
+}
+.entity-idx-name {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.entity-idx-count {
+  color: var(--muted);
+  font-size: 10px;
+  background: var(--panel);
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+}
+
+/* ---------- ESPN context tab (performer) ---------- */
+
+.espn-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 2fr;
+  gap: 12px;
+}
+.espn-col { min-width: 0; }
+.espn-col-wide { grid-column: span 1; }
+.espn-col-hdr {
+  font-family: var(--mono); font-size: 10px;
+  color: var(--muted);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--line-2);
+}
+.espn-standings, .espn-injuries, .espn-recent {
+  width: 100%; border-collapse: collapse;
+  font-family: var(--mono); font-size: 11px;
+}
+.espn-standings td {
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--line-2);
+}
+.espn-standings td.lbl {
+  color: var(--muted); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.4px;
+  width: 40%;
+}
+.espn-injuries thead th, .espn-recent thead th {
+  text-align: left;
+  color: var(--muted); font-weight: 600;
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.4px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--line);
+}
+.espn-injuries tbody td, .espn-recent tbody td {
+  padding: 3px 6px;
+  border-bottom: 1px solid var(--line-2);
+}
+.espn-injuries .injury-status {
+  color: var(--warn);
+  font-weight: 600;
+}
+.espn-recent .num { text-align: right; font-variant-numeric: tabular-nums; }
+
+/* Venue owned-inventory summary chip */
+.venue-owned-summary {
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--line-2);
+}
+
 /* ---------- ORDERS page ---------- */
 
 .wrap.orders { display: flex; flex-direction: column; gap: 12px; }

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=1440, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Terminal — Venue</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body data-page="venue">
+
+  <header class="topbar">
+    <span class="brand">TERMINAL · D0</span>
+    <span id="status" class="status">Loading…</span>
+  </header>
+
+  <main class="wrap venue">
+
+    <!-- INDEX MODE: 4-league venue directory. Shown when no ?venue=<id>. -->
+    <section id="venue-index" hidden>
+      <div class="panel-title row">
+        <span>VENUES — NFL · NBA · MLB · MLS</span>
+        <span class="muted small" id="venueIndexCounts"></span>
+      </div>
+      <div id="venueIndexBody"><div class="empty">loading…</div></div>
+    </section>
+
+    <!-- DETAIL MODE: hero + tabs. -->
+    <section id="venue-hero" hidden>
+      <div class="ph-left">
+        <img id="vhHero" alt="" />
+      </div>
+      <div class="ph-right">
+        <h1 class="title" id="vhName">—</h1>
+        <p class="meta">
+          <span id="vhCity">—</span>
+          <span class="dot">·</span>
+          <span id="vhCapacity">—</span>
+          <span class="dot">·</span>
+          <span id="vhIndoor" class="badge">—</span>
+          <span class="dot">·</span>
+          <a id="vhMapsLink" target="_blank" rel="noopener" class="muted small">map ↗</a>
+        </p>
+      </div>
+    </section>
+
+    <nav class="event-tabs" id="venueTabs" role="tablist" hidden>
+      <button class="event-tab active" data-tab="overview" role="tab" aria-selected="true">Overview</button>
+      <button class="event-tab" data-tab="events" role="tab" aria-selected="false">Upcoming Events <span class="tab-count" id="tabCountVenueEvents"></span></button>
+      <button class="event-tab" data-tab="owned"  role="tab" aria-selected="false">Owned Inventory</button>
+      <button class="event-tab" data-tab="sg"     role="tab" aria-selected="false">SG Activity</button>
+    </nav>
+
+    <div class="tab-pane active" id="vPaneOverview" role="tabpanel" hidden>
+      <section id="venue-rollup">
+        <div class="panel-title">VENUE ROLLUP — NEXT 90D</div>
+        <div class="rollup-grid">
+          <div class="ru-cell"><span class="ru-num" id="vrEvents">—</span><span class="ru-lbl">events</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrPerformers">—</span><span class="ru-lbl">distinct performers</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrMarketTix">—</span><span class="ru-lbl">market tickets</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrOwnedTix">—</span><span class="ru-lbl">owned tickets</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrOwnedNotional">—</span><span class="ru-lbl">owned notional</span></div>
+        </div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="vPaneEvents" role="tabpanel" hidden>
+      <section id="venue-events">
+        <div class="panel-title row">
+          <span>UPCOMING EVENTS — NEXT 90D</span>
+          <span class="muted small" id="vEventCount"></span>
+        </div>
+        <div id="vEventsBody"></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="vPaneOwned" role="tabpanel" hidden>
+      <section id="venue-owned">
+        <div class="panel-title">OWNED INVENTORY — AT THIS VENUE</div>
+        <div id="vOwnedBody"></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="vPaneSg" role="tabpanel" hidden>
+      <section id="venue-sg">
+        <div class="panel-title row">
+          <span>SG ACTIVITY — last 24h aggregate</span>
+          <span class="muted small" id="vSgMeta"></span>
+        </div>
+        <div id="vSgBody"></div>
+      </section>
+    </div>
+
+  </main>
+
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="venue.js"></script>
+</body>
+</html>

--- a/static/terminal/venue.js
+++ b/static/terminal/venue.js
@@ -1,0 +1,302 @@
+// D0 Terminal — Venue page (two modes).
+//
+// INDEX mode  (no ?venue in URL):   4-league venue directory from
+//   get_broker_venue_index. Click a row → DETAIL mode.
+// DETAIL mode (?venue=<id>):        hero + 4 tabs (Overview / Upcoming
+//   Events / Owned Inventory / SG Activity). One Path C RPC call to
+//   get_broker_venue_page returns all 4 tab payloads in one round-trip.
+//
+// Modeled on performer.js. Path C only — no Path A fallback.
+
+(function () {
+  'use strict';
+  const T = window.Terminal;
+
+  function getVenueId() {
+    const v = new URLSearchParams(location.search).get('venue');
+    if (!v) return null;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+
+  async function init() {
+    if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
+    const venueId = getVenueId();
+    if (!venueId) return showIndexMode();
+    return showDetailMode(venueId);
+  }
+
+  // ============================================================
+  // INDEX mode — 4-league venue directory
+  // ============================================================
+  async function showIndexMode() {
+    document.getElementById('venue-index').removeAttribute('hidden');
+    T.setStatus('Loading venue index…');
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      document.getElementById('venueIndexBody').innerHTML =
+        '<div class="empty">index needs auth — sign in with @s4kent.com</div>';
+      T.setStatus('Auth required', 'err');
+      return;
+    }
+    const res = await Auth.client.rpc('get_broker_venue_index');
+    if (res.error) {
+      T.setStatus(res.error.message, 'err');
+      document.getElementById('venueIndexBody').innerHTML =
+        `<div class="empty">RPC error: ${escapeHtml(res.error.message)}</div>`;
+      return;
+    }
+    T.setStatus('Loaded', 'ok');
+    renderIndex(res.data || {});
+  }
+
+  function renderIndex(d) {
+    const body = document.getElementById('venueIndexBody');
+    const countsEl = document.getElementById('venueIndexCounts');
+    const counts = d.counts || {};
+    const leagues = d.leagues || {};
+    if (countsEl) {
+      const parts = ['NFL','NBA','MLB','MLS']
+        .filter(l => counts[l])
+        .map(l => `${l} ${counts[l]}`);
+      if (counts.total_distinct_venues) parts.push(`· ${counts.total_distinct_venues} distinct venues`);
+      countsEl.textContent = parts.join(' · ');
+    }
+    body.innerHTML = '';
+    const grid = document.createElement('div');
+    grid.className = 'entity-index-grid';
+    ['NFL','NBA','MLB','MLS'].forEach(league => {
+      const venues = leagues[league] || [];
+      const col = document.createElement('div');
+      col.className = 'entity-index-col';
+      col.innerHTML = `<div class="entity-index-col-hdr">${league} <span class="muted small">(${venues.length})</span></div>`;
+      const ul = document.createElement('ul');
+      ul.className = 'entity-index-list';
+      venues.forEach(v => {
+        const li = document.createElement('li');
+        const location = [v.city, v.state].filter(Boolean).join(', ');
+        const upcoming = v.events_count_next_90d != null ? `<span class="entity-idx-count">${v.events_count_next_90d}</span>` : '';
+        li.innerHTML = `<a href="venue.html?venue=${v.tevo_venue_id}">
+            <span class="entity-idx-name">${escapeHtml(v.venue_name || '—')}</span>
+            ${location ? `<span class="muted small">${escapeHtml(location)}</span>` : ''}
+            ${upcoming}
+          </a>`;
+        ul.appendChild(li);
+      });
+      col.appendChild(ul);
+      grid.appendChild(col);
+    });
+    body.appendChild(grid);
+  }
+
+  // ============================================================
+  // DETAIL mode — hero + rollup + 4 tabs
+  // ============================================================
+  async function showDetailMode(venueId) {
+    document.getElementById('venue-hero').removeAttribute('hidden');
+    document.getElementById('venueTabs').removeAttribute('hidden');
+    document.getElementById('vPaneOverview').removeAttribute('hidden');
+    wireTabs();
+    T.setStatus(`Loading venue ${venueId}…`);
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      T.setStatus('Auth required — sign in with @s4kent.com', 'err');
+      return;
+    }
+    const res = await Auth.client.rpc('get_broker_venue_page', { p_venue_id: venueId });
+    if (res.error) {
+      T.setStatus(res.error.message, 'err');
+      return;
+    }
+    T.setStatus('Loaded', 'ok');
+    const d = res.data || {};
+    if (d.hidden) {
+      document.getElementById('vhName').textContent = 'venue not found';
+      return;
+    }
+    safe('hero', () => renderHero(d.venue));
+    safe('rollup', () => renderRollup(d.aggregate));
+    safe('events', () => renderEvents(d.events));
+    safe('owned', () => renderOwned(d.events, d.aggregate));
+    safe('sg', () => renderSg(d.sg_activity));
+  }
+
+  function safe(label, fn) { try { fn(); } catch (e) { console.error('[' + label + ']', e); } }
+
+  function wireTabs() {
+    const nav = document.getElementById('venueTabs');
+    if (!nav) return;
+    nav.addEventListener('click', (e) => {
+      const btn = e.target.closest('.event-tab');
+      if (!btn) return;
+      activateTab(btn.dataset.tab);
+    });
+  }
+
+  function activateTab(tabId) {
+    document.querySelectorAll('#venueTabs .event-tab').forEach(b => {
+      const on = b.dataset.tab === tabId;
+      b.classList.toggle('active', on);
+      b.setAttribute('aria-selected', on ? 'true' : 'false');
+    });
+    const paneIds = {
+      overview: 'vPaneOverview',
+      events:   'vPaneEvents',
+      owned:    'vPaneOwned',
+      sg:       'vPaneSg',
+    };
+    Object.entries(paneIds).forEach(([id, paneId]) => {
+      const pane = document.getElementById(paneId);
+      if (!pane) return;
+      if (id === tabId) { pane.removeAttribute('hidden'); pane.classList.add('active'); }
+      else { pane.setAttribute('hidden', ''); pane.classList.remove('active'); }
+    });
+  }
+
+  // ---------- Hero ----------
+  function renderHero(v) {
+    if (!v) return;
+    setText('vhName', v.venue_name || 'Venue');
+    setText('vhCity', [v.city, v.state, v.country].filter(Boolean).join(', ') || '—');
+    setText('vhCapacity', v.capacity ? `cap ${T.fmtNum(v.capacity)}` : 'cap —');
+    const indoorBadge = document.getElementById('vhIndoor');
+    if (v.is_indoor === true) { indoorBadge.textContent = 'INDOOR'; indoorBadge.classList.add('lifecycle-active'); }
+    else if (v.is_indoor === false) { indoorBadge.textContent = 'OUTDOOR'; indoorBadge.classList.add('lifecycle-ghost'); }
+    else { indoorBadge.style.display = 'none'; }
+    const mapsLink = document.getElementById('vhMapsLink');
+    if (v.latitude && v.longitude) {
+      mapsLink.href = `https://www.google.com/maps?q=${v.latitude},${v.longitude}`;
+    } else {
+      mapsLink.style.display = 'none';
+    }
+    const hero = document.getElementById('vhHero');
+    if (v.hero_image_url) {
+      hero.src = v.hero_image_url;
+      hero.alt = (v.venue_name || 'venue') + ' photo';
+    } else {
+      hero.style.display = 'none';
+    }
+  }
+
+  // ---------- Rollup ----------
+  function renderRollup(ag) {
+    if (!ag) return;
+    setText('vrEvents',         T.fmtNum(ag.events_count));
+    setText('vrPerformers',     T.fmtNum(ag.distinct_performers));
+    setText('vrMarketTix',      T.fmtNum(ag.market_tickets_total));
+    setText('vrOwnedTix',       T.fmtNum(ag.owned_tickets_total));
+    setText('vrOwnedNotional',  ag.owned_notional ? '$' + T.fmtNum(Math.round(+ag.owned_notional)) : '—');
+  }
+
+  // ---------- Upcoming Events tab ----------
+  function renderEvents(events) {
+    const body = document.getElementById('vEventsBody');
+    const countEl = document.getElementById('vEventCount');
+    const tabCount = document.getElementById('tabCountVenueEvents');
+    if (!body) return;
+    events = events || [];
+    if (countEl) countEl.textContent = events.length ? `${events.length} events` : '';
+    if (tabCount) tabCount.textContent = events.length ? String(events.length) : '';
+    body.innerHTML = '';
+    if (!events.length) {
+      body.innerHTML = '<div class="empty">no upcoming events at this venue in the next 90d</div>';
+      return;
+    }
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th><th>Performer</th><th class="num">T-days</th>
+        <th class="num">Mkt qty</th><th class="num">Mkt median</th>
+        <th class="num">Owned qty</th><th class="num">Owned med</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    events.forEach(e => {
+      const d = T.daysUntil(e.occurs_at_local);
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><a href="event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a></td>
+        <td>${escapeHtml(e.primary_performer_name || '—')}</td>
+        <td class="num">${d === null ? '—' : d}</td>
+        <td class="num">${T.fmtNum(e.tickets_count || 0)}</td>
+        <td class="num">${e.retail_median ? '$' + T.fmtNum(Math.round(+e.retail_median)) : '—'}</td>
+        <td class="num ${(e.owned_tickets_count || 0) > 0 ? 'ours' : ''}">${T.fmtNum(e.owned_tickets_count || 0)}</td>
+        <td class="num">${e.owned_median_retail ? '$' + T.fmtNum(Math.round(+e.owned_median_retail)) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    body.appendChild(tbl);
+  }
+
+  // ---------- Owned Inventory tab ----------
+  function renderOwned(events, agg) {
+    const body = document.getElementById('vOwnedBody');
+    if (!body) return;
+    const owned = (events || []).filter(e => (+e.owned_tickets_count || 0) > 0);
+    if (!owned.length) {
+      body.innerHTML = '<div class="empty">no owned inventory at this venue</div>';
+      return;
+    }
+    body.innerHTML = '';
+    const summary = document.createElement('div');
+    summary.className = 'venue-owned-summary';
+    summary.innerHTML = `
+      <div class="muted small">${owned.length} events with owned position · total ${T.fmtNum((agg && agg.owned_tickets_total) || 0)} tickets · notional ${agg && agg.owned_notional ? '$' + T.fmtNum(Math.round(+agg.owned_notional)) : '—'}</div>`;
+    body.appendChild(summary);
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th><th>Performer</th><th class="num">T-days</th>
+        <th class="num">Owned qty</th><th class="num">Owned med</th><th class="num">Owned notional</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    owned.forEach(e => {
+      const d = T.daysUntil(e.occurs_at_local);
+      const ot = +e.owned_tickets_count || 0;
+      const om = +e.owned_median_retail || 0;
+      const notional = ot * om;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><a href="event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a></td>
+        <td>${escapeHtml(e.primary_performer_name || '—')}</td>
+        <td class="num">${d === null ? '—' : d}</td>
+        <td class="num ours">${T.fmtNum(ot)}</td>
+        <td class="num">${om ? '$' + T.fmtNum(Math.round(om)) : '—'}</td>
+        <td class="num">${notional ? '$' + T.fmtNum(Math.round(notional)) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    body.appendChild(tbl);
+  }
+
+  // ---------- SG Activity tab ----------
+  function renderSg(sg) {
+    const body = document.getElementById('vSgBody');
+    const meta = document.getElementById('vSgMeta');
+    if (!body) return;
+    if (!sg || sg.sales_24h == null) {
+      body.innerHTML = '<div class="empty">no SG sales data for this venue</div>';
+      return;
+    }
+    if (meta) meta.textContent = `${sg.distinct_events_with_sales || 0} events with SG sales`;
+    body.innerHTML = `
+      <div class="kpi-strip">
+        <div class="kpi-strip-cell"><span class="kpi-lbl">SALES 24H</span><span class="kpi-val">${T.fmtNum(sg.sales_24h)}</span></div>
+        <div class="kpi-strip-cell"><span class="kpi-lbl">TIX 24H</span><span class="kpi-val">${T.fmtNum(sg.tickets_24h)}</span></div>
+        <div class="kpi-strip-cell"><span class="kpi-lbl">GMV 24H</span><span class="kpi-val">${sg.gmv_24h ? '$' + T.fmtNum(Math.round(+sg.gmv_24h)) : '—'}</span></div>
+        <div class="kpi-strip-cell"><span class="kpi-lbl">ACTIVE EVENTS</span><span class="kpi-val">${T.fmtNum(sg.distinct_events_with_sales)}</span></div>
+      </div>`;
+  }
+
+  // ---------- Util ----------
+  function setText(id, txt) { const el = document.getElementById(id); if (el) el.textContent = txt; }
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;',
+    }[c]));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/supabase/migrations/20260518010000_get_broker_performer_rpcs.sql
+++ b/supabase/migrations/20260518010000_get_broker_performer_rpcs.sql
@@ -1,0 +1,187 @@
+-- Migration 20260518010000 · lane:D0 (author) → A1 (apply) · writes:get_broker_performer_index + get_broker_performer_page · reads:performer_espn_team_xref,aq_performer_map,espn_teams_canonical,espn_team_snapshots,espn_injuries_snapshots,espn_event_snapshots,events · pre:none · auth:operator-approved 2026-05-17
+--
+-- D0 Phase 2b — two SECDEF RPCs powering the new performer page:
+--   1. get_broker_performer_index()   — 4-league directory (NFL/NBA/MLB/MLS) for the INDEX mode
+--   2. get_broker_performer_page(p)   — ESPN context (standings + injuries + recent results) for the DETAIL ESPN tab
+--
+-- Per A1 pre-flight audit (bot_chat #299):
+--   #1 League filter sourced from performer_espn_team_xref (canonical 32/30/30/30, UPPERCASE codes)
+--      — NOT from aq_performer_map.category (only Sports/Concerts/Comedy/NULL — zero league granularity)
+--   #2 Injury filter: `lower(status) <> 'active' AND status IS NOT NULL`
+--      — values are mixed-case (Out/Day-To-Day/Questionable/*-Day-IL/Active); no 'doubtful'
+--   #3 espn_event_snapshots ORDER BY captured_at (occurs_at_utc doesn't exist); state='post' filter
+--   #4 events.occurs_at_local is TEXT — guard with regex + cast to timestamptz
+--   #6 espn_team_snapshots has 8K dupes for 32×6 teams — DISTINCT ON (espn_team_id) mandatory
+--
+-- Both follow canonical v3 SECDEF: @s4kent.com gate, REVOKE PUBLIC + GRANT anon/auth.
+
+-- ============================================================
+-- 1. Performer Index (4-league directory)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_broker_performer_index()
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_result jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  WITH base AS (
+    SELECT
+      xt.tevo_performer_id,
+      xt.espn_team_id,
+      xt.espn_league,
+      ap.performer_name,
+      etc.display_name,
+      etc.abbreviation
+    FROM public.performer_espn_team_xref xt
+    LEFT JOIN public.aq_performer_map ap ON ap.tevo_performer_id = xt.tevo_performer_id
+    LEFT JOIN public.espn_teams_canonical etc ON etc.espn_team_id = xt.espn_team_id
+    WHERE xt.espn_league IN ('NFL','NBA','MLB','MLS')
+      AND xt.tevo_performer_id IS NOT NULL
+  ),
+  counts AS (
+    SELECT b.tevo_performer_id,
+           COUNT(*) AS events_count_next_90d
+    FROM base b
+    JOIN public.events ev ON ev.primary_performer_id = b.tevo_performer_id
+    WHERE ev.occurs_at_local ~ '^\d{4}'
+      AND ev.occurs_at_local::timestamptz >= now()
+      AND ev.occurs_at_local::timestamptz < now() + interval '90 days'
+    GROUP BY b.tevo_performer_id
+  ),
+  rows0 AS (
+    SELECT b.espn_league,
+           jsonb_build_object(
+             'tevo_performer_id', b.tevo_performer_id,
+             'performer_name',    b.performer_name,
+             'espn_team_id',      b.espn_team_id,
+             'abbreviation',      b.abbreviation,
+             'display_name',      b.display_name,
+             'events_count_next_90d', coalesce(c.events_count_next_90d, 0)
+           ) AS team_obj,
+           coalesce(b.display_name, b.performer_name, '') AS sort_key
+    FROM base b
+    LEFT JOIN counts c ON c.tevo_performer_id = b.tevo_performer_id
+  ),
+  per_league AS (
+    SELECT espn_league,
+           jsonb_agg(team_obj ORDER BY sort_key) AS teams,
+           COUNT(*) AS team_count
+    FROM rows0
+    GROUP BY espn_league
+  )
+  SELECT jsonb_build_object(
+    'counts',  jsonb_object_agg(espn_league, team_count) ||
+               jsonb_build_object('total', (SELECT sum(team_count) FROM per_league)),
+    'leagues', jsonb_object_agg(espn_league, teams)
+  )
+  INTO v_result
+  FROM per_league;
+
+  RETURN coalesce(v_result, jsonb_build_object('counts', '{}'::jsonb, 'leagues', '{}'::jsonb));
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_broker_performer_index() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_broker_performer_index() TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_broker_performer_index() IS
+  'D0 performer page INDEX mode — NFL/NBA/MLB/MLS teams grouped by league. UPPERCASE codes per performer_espn_team_xref. Email-gated.';
+
+-- ============================================================
+-- 2. Performer Page (ESPN context for DETAIL tab)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_broker_performer_page(p_performer_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email     text;
+  v_team_id   text;
+  v_league    text;
+  v_standings jsonb;
+  v_injuries  jsonb;
+  v_recent    jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- Resolve ESPN xref for this performer
+  SELECT espn_team_id, espn_league INTO v_team_id, v_league
+  FROM public.performer_espn_team_xref
+  WHERE tevo_performer_id = p_performer_id
+  LIMIT 1;
+
+  IF v_team_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_espn_xref');
+  END IF;
+
+  -- Standings: latest snap per team via DISTINCT ON (audit fix #6)
+  SELECT to_jsonb(s) INTO v_standings
+  FROM (
+    SELECT DISTINCT ON (espn_team_id)
+      wins, losses, ties, win_pct, games_back,
+      playoff_seed, conference_rank, division_rank,
+      record_summary, standing_summary, streak, captured_at
+    FROM public.espn_team_snapshots
+    WHERE espn_team_id = v_team_id
+    ORDER BY espn_team_id, captured_at DESC
+  ) s;
+
+  -- Injuries: latest per athlete, exclude active (audit fix #2)
+  SELECT coalesce(jsonb_agg(to_jsonb(i)), '[]'::jsonb)
+  INTO v_injuries
+  FROM (
+    SELECT DISTINCT ON (athlete_id)
+      athlete_id, athlete_name, position, status, injury_type,
+      short_comment, return_date, captured_at
+    FROM public.espn_injuries_snapshots
+    WHERE espn_team_id = v_team_id
+      AND lower(status) <> 'active'
+      AND status IS NOT NULL
+    ORDER BY athlete_id, captured_at DESC
+  ) i;
+
+  -- Recent results: state='post', latest 5 distinct games (audit fix #3)
+  SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.captured_at DESC), '[]'::jsonb)
+  INTO v_recent
+  FROM (
+    SELECT * FROM (
+      SELECT DISTINCT ON (espn_event_id)
+        espn_event_id, status_short, captured_at,
+        home_team_id, away_team_id, home_score, away_score, attendance,
+        (home_team_id = v_team_id) AS is_home,
+        CASE WHEN home_team_id = v_team_id THEN away_team_id ELSE home_team_id END AS opponent_team_id
+      FROM public.espn_event_snapshots
+      WHERE state = 'post'
+        AND (home_team_id = v_team_id OR away_team_id = v_team_id)
+      ORDER BY espn_event_id, captured_at DESC
+    ) deduped
+    ORDER BY captured_at DESC
+    LIMIT 5
+  ) e;
+
+  RETURN jsonb_build_object(
+    'espn_team_id',   v_team_id,
+    'espn_league',    v_league,
+    'standings',      v_standings,
+    'injuries',       v_injuries,
+    'recent_results', v_recent,
+    'hidden',         false
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_broker_performer_page(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_broker_performer_page(integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_broker_performer_page(integer) IS
+  'D0 performer page ESPN tab — standings (DISTINCT ON espn_team_id) + injuries (lower(status) != active) + recent_results (state=post, last 5 games). Email-gated. Returns {hidden:true, reason:no_espn_xref} for unlinked performers.';

--- a/supabase/migrations/20260518020000_get_broker_venue_rpcs.sql
+++ b/supabase/migrations/20260518020000_get_broker_venue_rpcs.sql
@@ -1,0 +1,233 @@
+-- Migration 20260518020000 · lane:D0 (author) → A1 (apply) · writes:get_broker_venue_index + get_broker_venue_page · reads:events,aq_performer_map,performer_espn_team_xref,aq_venue_map,venue_assets,event_metrics,seatgeek_sales_snapshots,seatgeek_event_xref · pre:20260518010000 · auth:operator-approved 2026-05-17
+--
+-- D0 Phase 2b — two SECDEF RPCs powering the new venue page:
+--   1. get_broker_venue_index()      — 4-league directory of major-league venues
+--   2. get_broker_venue_page(p_id)   — hero + aggregate + events + SG activity for DETAIL tabs
+--
+-- Per A1 pre-flight audit (bot_chat #299):
+--   #5 Venue→league derived via events→performer→performer_espn_team_xref
+--      (entity_venue_map has no espn_league column)
+--   #4 events.occurs_at_local is TEXT — regex guard + cast to timestamptz
+--
+-- Index sort: dedupe on (tevo_venue_id, espn_league) — a venue serving two
+-- leagues (MetLife = NFL + MLS) appears once per league it serves.
+--
+-- Both follow canonical v3 SECDEF: @s4kent.com gate, REVOKE PUBLIC + GRANT anon/auth.
+
+-- ============================================================
+-- 1. Venue Index (4-league directory)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_broker_venue_index()
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email  text;
+  v_result jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  WITH ev_join AS (
+    SELECT
+      av.tevo_venue_id,
+      av.venue_name,
+      av.city,
+      av.state,
+      av.latitude,
+      av.longitude,
+      va.capacity,
+      va.is_indoor,
+      xt.espn_league,
+      ev.id AS event_id,
+      ap.performer_name
+    FROM public.events ev
+    JOIN public.aq_venue_map av ON av.tevo_venue_id = ev.venue_id
+    LEFT JOIN public.venue_assets va ON va.tevo_venue_id = av.tevo_venue_id
+    JOIN public.performer_espn_team_xref xt ON xt.tevo_performer_id = ev.primary_performer_id
+    LEFT JOIN public.aq_performer_map ap ON ap.tevo_performer_id = ev.primary_performer_id
+    WHERE xt.espn_league IN ('NFL','NBA','MLB','MLS')
+      AND ev.occurs_at_local ~ '^\d{4}'
+      AND ev.occurs_at_local::timestamptz >= now()
+      AND ev.occurs_at_local::timestamptz < now() + interval '90 days'
+  ),
+  agg AS (
+    SELECT
+      espn_league,
+      tevo_venue_id,
+      max(venue_name)   AS venue_name,
+      max(city)         AS city,
+      max(state)        AS state,
+      max(latitude)     AS latitude,
+      max(longitude)    AS longitude,
+      max(capacity)     AS capacity,
+      bool_or(is_indoor) AS is_indoor,
+      COUNT(DISTINCT event_id) AS events_count_next_90d,
+      (array_agg(performer_name ORDER BY performer_name) FILTER (WHERE performer_name IS NOT NULL))[1] AS top_performer_name
+    FROM ev_join
+    GROUP BY espn_league, tevo_venue_id
+  ),
+  per_league AS (
+    SELECT espn_league,
+      jsonb_agg(
+        jsonb_build_object(
+          'tevo_venue_id', tevo_venue_id,
+          'venue_name',    venue_name,
+          'city',          city,
+          'state',         state,
+          'capacity',      capacity,
+          'is_indoor',     is_indoor,
+          'latitude',      latitude,
+          'longitude',     longitude,
+          'top_performer_name',    top_performer_name,
+          'events_count_next_90d', events_count_next_90d
+        )
+        ORDER BY venue_name
+      ) AS venues,
+      COUNT(*) AS venue_count
+    FROM agg
+    GROUP BY espn_league
+  )
+  SELECT jsonb_build_object(
+    'counts',  jsonb_object_agg(espn_league, venue_count) ||
+               jsonb_build_object(
+                 'total_distinct_venues',
+                 (SELECT COUNT(DISTINCT tevo_venue_id) FROM agg)
+               ),
+    'leagues', jsonb_object_agg(espn_league, venues)
+  )
+  INTO v_result
+  FROM per_league;
+
+  RETURN coalesce(v_result, jsonb_build_object('counts', '{}'::jsonb, 'leagues', '{}'::jsonb));
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_broker_venue_index() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_broker_venue_index() TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_broker_venue_index() IS
+  'D0 venue page INDEX mode — NFL/NBA/MLB/MLS venues derived via events→performer→performer_espn_team_xref. Deduped on (tevo_venue_id, espn_league); MetLife appears under both NFL and MLS. Email-gated.';
+
+-- ============================================================
+-- 2. Venue Page (DETAIL with 4 tab payloads in one round-trip)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_broker_venue_page(p_venue_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email     text;
+  v_venue     jsonb;
+  v_aggregate jsonb;
+  v_events    jsonb;
+  v_sg        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- Hero: venue identity + capacity / indoor / coords
+  SELECT jsonb_build_object(
+    'tevo_venue_id', av.tevo_venue_id,
+    'venue_name',    av.venue_name,
+    'city',          av.city,
+    'state',         av.state,
+    'country',       av.country,
+    'sg_venue_id',   av.sg_venue_id,
+    'tickpick_venue_id', av.tickpick_venue_id,
+    'latitude',      coalesce(va.latitude,  av.latitude),
+    'longitude',     coalesce(va.longitude, av.longitude),
+    'capacity',      va.capacity,
+    'is_indoor',     va.is_indoor,
+    'hero_image_url', va.hero_image_url
+  )
+  INTO v_venue
+  FROM public.aq_venue_map av
+  LEFT JOIN public.venue_assets va ON va.tevo_venue_id = av.tevo_venue_id
+  WHERE av.tevo_venue_id = p_venue_id
+  LIMIT 1;
+
+  IF v_venue IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'venue_not_found');
+  END IF;
+
+  -- Events tab: next-90d events at this venue with per-event metrics
+  WITH ev_rows AS (
+    SELECT
+      ev.id,
+      ev.name,
+      ev.primary_performer_name,
+      ev.occurs_at_local,
+      em.tickets_count,
+      em.retail_median,
+      em.owned_tickets_count,
+      em.owned_median_retail
+    FROM public.events ev
+    LEFT JOIN LATERAL (
+      SELECT tickets_count, retail_median, owned_tickets_count, owned_median_retail
+      FROM public.event_metrics em
+      WHERE em.event_id = ev.id
+      ORDER BY captured_at DESC
+      LIMIT 1
+    ) em ON true
+    WHERE ev.venue_id = p_venue_id
+      AND ev.occurs_at_local ~ '^\d{4}'
+      AND ev.occurs_at_local::timestamptz >= now()
+      AND ev.occurs_at_local::timestamptz < now() + interval '90 days'
+  )
+  SELECT
+    coalesce(jsonb_agg(to_jsonb(r) ORDER BY r.occurs_at_local), '[]'::jsonb),
+    jsonb_build_object(
+      'events_count',          count(*),
+      'distinct_performers',   count(DISTINCT r.primary_performer_name),
+      'market_tickets_total',  coalesce(sum(r.tickets_count), 0),
+      'owned_tickets_total',   coalesce(sum(r.owned_tickets_count), 0),
+      'owned_notional',        coalesce(sum(r.owned_tickets_count * r.owned_median_retail), 0)::numeric(20,2)
+    )
+  INTO v_events, v_aggregate
+  FROM ev_rows r;
+
+  -- SG Activity tab: 24h SG sales count across all events at this venue
+  -- (DISTINCT ON sg_sale_id mandatory per PROJECT_BIBLE §3 — 11x firehose dedup)
+  WITH event_xrefs AS (
+    SELECT x.sg_event_id
+    FROM public.events ev
+    JOIN public.seatgeek_event_xref x ON x.tevo_event_id = ev.id
+    WHERE ev.venue_id = p_venue_id
+  ),
+  deduped AS (
+    SELECT DISTINCT ON (s.sg_sale_id)
+      s.sg_sale_id, s.sg_event_id, s.broadcast_price, s.quantity
+    FROM public.seatgeek_sales_snapshots s
+    JOIN event_xrefs ex ON ex.sg_event_id = s.sg_event_id
+    WHERE s.sale_at_utc > now() - interval '24 hours'
+    ORDER BY s.sg_sale_id, s.pulled_at DESC
+  )
+  SELECT jsonb_build_object(
+    'sales_24h', count(*),
+    'tickets_24h', coalesce(sum(quantity), 0),
+    'gmv_24h', coalesce(sum(broadcast_price * quantity), 0)::numeric(20,2),
+    'distinct_events_with_sales', count(DISTINCT sg_event_id)
+  )
+  INTO v_sg
+  FROM deduped;
+
+  RETURN jsonb_build_object(
+    'venue',     v_venue,
+    'aggregate', v_aggregate,
+    'events',    v_events,
+    'sg_activity', v_sg,
+    'hidden',    false
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_broker_venue_page(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_broker_venue_page(integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_broker_venue_page(integer) IS
+  'D0 venue page DETAIL — hero (aq_venue_map + venue_assets) + aggregate + upcoming events (event_metrics) + SG activity (24h DISTINCT ON sg_sale_id). Email-gated.';


### PR DESCRIPTION
## Summary

PR B of 2 in this round of D0 polish (pairs with [apps#202](https://github.com/JulianS4K/Terminal-2/pull/202) home polish).

### Performer page — two modes

- **INDEX mode** (no `?performer` in URL): 4-league directory from `get_broker_performer_index` — NFL/NBA/MLB/MLS grouped, click row → DETAIL. Source league from `performer_espn_team_xref` (canonical 32/30/30/30, UPPERCASE codes) per A1 audit fix #1.
- **DETAIL mode** (`?performer=ID`): hero + tab navigation matching event-page pattern. Tabs:
  - Overview — existing portfolio rollup
  - Upcoming Events — existing events table
  - Blind Spots — existing blind-spots panel
  - ESPN Context — NEW, lazy-loads `get_broker_performer_page` on first click; renders Standings / Injuries / Recent Results. "no ESPN xref" empty state for unlinked performers.

### Venue page — net-new

- **INDEX mode**: 4-league venue directory from `get_broker_venue_index`. Derives league via `events → primary_performer_id → performer_espn_team_xref` (audit fix #5 — `entity_venue_map` has no league column). Deduped on `(tevo_venue_id, espn_league)` — MetLife appears under both NFL and MLS.
- **DETAIL mode** (`?venue=ID`): hero (name/city/capacity/indoor/maps link) + 4 tabs:
  - Overview — venue rollup (events, distinct performers, market tix, owned tix, owned notional)
  - Upcoming Events — next-90d events at venue with per-event metrics
  - Owned Inventory — owned positions at this venue
  - SG Activity — 24h SG sales aggregate at this venue
  
  One `get_broker_venue_page` RPC returns all 4 tab payloads in one round-trip.

### Migrations

`20260518010000_get_broker_performer_rpcs.sql` — both performer RPCs
`20260518020000_get_broker_venue_rpcs.sql` — both venue RPCs

Both files: canonical v3 SECDEF pattern — `@s4kent.com` email gate, `REVOKE ALL FROM PUBLIC`, `GRANT EXECUTE TO anon, authenticated`, `SET search_path = public, extensions, pg_temp`.

### A1 pre-flight audit corrections (bot_chat #299) baked in

- **#1** league filter from `performer_espn_team_xref` (UPPERCASE) — not `aq_performer_map.category`
- **#2** injury filter: `lower(status) <> 'active' AND status IS NOT NULL`
- **#3** `espn_event_snapshots`: `ORDER BY captured_at` + `state='post'` (no `occurs_at_utc`)
- **#4** `events.occurs_at_local` is TEXT — regex guard `~ '^\d{4}'` + `::timestamptz` cast
- **#5** venue→league via `events → performer xref`
- **#6** standings `DISTINCT ON (espn_team_id) ORDER BY espn_team_id, captured_at DESC` for 8K-row dedup

### nav.js

- Adds `VENUE` link between EVENT and PERFORMER in PAGES array
- Topbar search router (PR #200) updated: venue clicks route to `venue.html?venue=ID` (was `./?venue=ID` placeholder)

### style.css

- `.entity-index-grid` — 4-col directory layout for performer + venue index
- `.espn-grid` — 3-col Standings / Injuries / Recent Results layout
- `.wrap.venue` — mirrors performer page layout
- `.tab-pane` block display for non-grid wrap pages (different from event page's `display: contents` since `.wrap.{performer,venue}` are flex columns, not 12-col grids)

## Verification

Local browser preview verified:
- `performer.html` (no arg): INDEX shown, hero/tabs hidden, body shows "needs auth" on localhost ✓
- `performer.html?performer=27`: INDEX hidden, hero+tabs shown, 4 tabs (overview/upcoming/blindspots/espn), Overview active by default ✓
- Click ESPN tab → switches, paneEspn visible, lazy-loads RPC (shows "needs auth" empty state on localhost) ✓
- `venue.html` (no arg): INDEX shown, hero hidden, body shows "needs auth" ✓
- `venue.html?venue=39`: hero+tabs shown, 4 tabs (overview/events/owned/sg) ✓
- Topbar nav: HOME · EVENT · VENUE · PERFORMER · MOVERS · ORDERS ✓
- Search router: `nav.js` includes `venue.html?venue=` (old `./?venue=` removed) ✓

## Test plan (A1 smoke pre-merge per bot_chat #299 process note)

- [ ] `get_broker_performer_index()` returns 4 leagues with ~122 total teams; UPPERCASE keys
- [ ] `get_broker_performer_page(<NBA-linked performer>)` returns standings + injuries + recent_results populated; `get_broker_performer_page(<concert performer>)` returns `{hidden: true, reason: no_espn_xref}`
- [ ] `get_broker_venue_index()` returns 4 leagues with venues; MetLife (or equivalent dual-purpose venue) appears under both NFL and MLS
- [ ] `get_broker_venue_page(<MSG-equivalent>)` returns venue + aggregate + events + sg_activity; latency <500ms
- [ ] Topbar search clicking a venue result navigates to `venue.html?venue=ID` (not `./?venue=ID`)

## Related

- [apps#202](https://github.com/JulianS4K/Terminal-2/pull/202) — PR A (home polish + SG blind-spots)
- bot_chat #299 — A1 pre-flight audit corrections (all 6 baked into both PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)