### PR TITLE
feat(d0/event): uncap 3 full-list tabs + new CROSS-SOURCE METRICS panel

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -111,6 +111,14 @@
       <div id="lastSnapshotBody"></div>
     </section>
 
+    <section id="cross-source-metrics">
+      <div class="panel-title row">
+        <span>CROSS-SOURCE METRICS — TEvo vs SG</span>
+        <span class="muted small" id="crossSourceMeta"></span>
+      </div>
+      <div id="crossSourceBody"><div class="empty">loading…</div></div>
+    </section>
+
     <section id="chart">
       <div class="chart-title">
         <span>PRICE &amp; INVENTORY · <span id="chartRangeLabel">7d</span></span>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -31,6 +31,10 @@
     wireRangeSelector(eventId);
     wireTabs(eventId);
     wireSalesWindow(eventId);
+    // Cross-source metrics RPC is independent of the v3 / Path A fetch
+    // — fire it in parallel so it renders even when fetchPayload fails
+    // (localhost dev without Path A API + without Path C auth).
+    loadCrossSourceMetrics(eventId).catch(e => console.error('[crossSource]', e));
     await loadAndRender(eventId);
   }
 
@@ -1405,7 +1409,8 @@
     if (body) body.innerHTML = '<div class="empty">Loading SG listings…</div>';
     if (meta) meta.textContent = 'loading…';
     const t0 = performance.now();
-    const res = await rpcOrNull('get_event_sg_listings_full', { p_event_id: eventId, p_limit: 500 });
+    // Omit p_limit — RPC default is now 100000 (mig 20260518030000), surfaces all rows.
+    const res = await rpcOrNull('get_event_sg_listings_full', { p_event_id: eventId });
     if (res.error) {
       if (meta) meta.textContent = 'error';
       if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
@@ -1476,7 +1481,8 @@
     if (body) body.innerHTML = '<div class="empty">Loading EVO listings…</div>';
     if (meta) meta.textContent = 'loading…';
     const t0 = performance.now();
-    const res = await rpcOrNull('get_event_evo_listings_full', { p_event_id: eventId, p_limit: 500 });
+    // Omit p_limit — RPC default 100000 (mig 20260518030000).
+    const res = await rpcOrNull('get_event_evo_listings_full', { p_event_id: eventId });
     if (res.error) {
       if (meta) meta.textContent = 'error';
       if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
@@ -1559,8 +1565,9 @@
     if (body) body.innerHTML = '<div class="empty">Loading SG sales…</div>';
     if (meta) meta.textContent = 'loading…';
     const t0 = performance.now();
+    // Omit p_limit — RPC default 100000 (mig 20260518030000); keep window selector.
     const res = await rpcOrNull('get_event_sg_sales_full', {
-      p_event_id: eventId, p_limit: 500, p_window_days: windowDays
+      p_event_id: eventId, p_window_days: windowDays
     });
     if (res.error) {
       if (meta) meta.textContent = 'error';
@@ -1838,6 +1845,85 @@
     host.appendChild(tbl);
     body.innerHTML = '';
     body.appendChild(host);
+  }
+
+  // ---------- Cross-source metrics (Overview tab) ----------
+  // Calls get_event_cross_source_metrics (mig 20260518040000). The RPC
+  // returns a pre-aligned `rows` array — FE just iterates + formats.
+  // Uses listings_all_* / listings_owned_* from PR #204 (not deprecated cost_*).
+  async function loadCrossSourceMetrics(eventId) {
+    const body = document.getElementById('crossSourceBody');
+    const meta = document.getElementById('crossSourceMeta');
+    if (body) body.innerHTML = '<div class="empty">loading cross-source metrics…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_cross_source_metrics', { p_event_id: eventId });
+    if (res.error) {
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      if (meta) meta.textContent = 'error';
+      return;
+    }
+    renderCrossSourceMetrics(res.data || {}, performance.now() - t0);
+  }
+
+  function renderCrossSourceMetrics(d, ms) {
+    const body = document.getElementById('crossSourceBody');
+    const meta = document.getElementById('crossSourceMeta');
+    if (!body) return;
+    const rows = d.rows || [];
+    const hasSg = d.sg_event_id != null;
+    if (meta) {
+      const parts = [`${ms != null ? ms.toFixed(0) + 'ms' : ''}`];
+      if (hasSg) parts.unshift(`sg_event_id ${d.sg_event_id}`);
+      else parts.unshift('no SG bridge — TEvo-only event');
+      meta.textContent = parts.filter(Boolean).join(' · ');
+    }
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no metrics available</div>';
+      return;
+    }
+    function fmtVal(v, isMoney) {
+      if (v === null || v === undefined) return '<span class="dim">—</span>';
+      const n = Number(v);
+      if (!Number.isFinite(n)) return '<span class="dim">—</span>';
+      if (isMoney) return '$' + T.fmtNum(Math.round(n));
+      return T.fmtNum(n);
+    }
+    function deltaPct(tevo, sg) {
+      // SG vs TEvo — positive means SG higher than TEvo
+      if (tevo === null || tevo === undefined || sg === null || sg === undefined) return null;
+      const t = Number(tevo), s = Number(sg);
+      if (!Number.isFinite(t) || !Number.isFinite(s) || t === 0) return null;
+      return ((s - t) / t) * 100;
+    }
+    function deltaCell(tevo, sg) {
+      const p = deltaPct(tevo, sg);
+      if (p === null) return '<span class="dim">—</span>';
+      const cls = Math.abs(p) < 1 ? '' : (p > 0 ? 'pos' : 'neg');
+      return `<span class="${cls}">${p >= 0 ? '+' : ''}${p.toFixed(1)}%</span>`;
+    }
+    const tbl = document.createElement('table');
+    tbl.className = 'cross-src-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Metric</th>
+        <th class="num">TEvo</th>
+        <th class="num">SG</th>
+        <th class="num">Δ SG vs TEvo</th>
+      </tr></thead>
+      <tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${escapeHtml(r.label || '')}</td>
+        <td class="num">${fmtVal(r.tevo, r.is_money)}</td>
+        <td class="num">${fmtVal(r.sg, r.is_money)}</td>
+        <td class="num">${deltaCell(r.tevo, r.sg)}</td>`;
+      tb.appendChild(tr);
+    });
+    body.innerHTML = '';
+    body.appendChild(tbl);
   }
 
   // ---------- Last event snapshot (Overview tab) ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -848,6 +848,7 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 .wrap.event #hero               { grid-column: 1 / -1; }
 .wrap.event #kpi-grid           { grid-column: 1 / -1; padding: 12px 16px; }
 .wrap.event #last-snapshot      { grid-column: 1 / -1; }
+.wrap.event #cross-source-metrics { grid-column: 1 / -1; }
 .wrap.event #chart              { grid-column: 1 / -1; padding: 12px 8px; }
 .wrap.event #sg-broker-sales    { grid-column: 1 / -1; }
 .wrap.event #sg-listings-summary{ grid-column: 1 / -1; }
@@ -1316,6 +1317,33 @@ body[data-page="login"] {
 .last-snap-val { color: var(--text); font-size: 14px; font-weight: 600; }
 .last-snap-val.dim { color: var(--dim); }
 .last-snap-meta { color: var(--muted); font-size: 11px; margin-top: 8px; }
+
+/* ---------- Cross-source metrics (TEvo vs SG side-by-side) ---------- */
+.cross-src-tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono); font-size: 12px;
+}
+.cross-src-tbl thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line);
+}
+.cross-src-tbl tbody td {
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--line-2);
+  color: var(--text);
+}
+.cross-src-tbl tbody tr:hover td { background: var(--shade); }
+.cross-src-tbl .num { text-align: right; font-variant-numeric: tabular-nums; }
+.cross-src-tbl .pos { color: var(--pos); }
+.cross-src-tbl .neg { color: var(--neg); }
+.cross-src-tbl .dim { color: var(--dim); }
 
 /* ---------- Full-list tabs (SG Listings / EVO Listings / SG Sales) ---------- */
 .full-list-tbl {

--- a/supabase/migrations/20260518030000_event_page_tabs_uncap.sql
+++ b/supabase/migrations/20260518030000_event_page_tabs_uncap.sql
@@ -1,0 +1,190 @@
+-- Migration 20260518030000 · lane:D0 (author) → A1 (apply) · writes:get_event_sg_listings_full + get_event_evo_listings_full + get_event_sg_sales_full · reads:seatgeek_listings_snapshots,listings_snapshots,seatgeek_sales_snapshots,seatgeek_event_xref,sg_events_canonical · pre:20260517180000 · auth:operator-approved 2026-05-17
+--
+-- D0 — drop the 500-row ceiling on the 3 event-page full-list tab RPCs
+-- shipped in PR #196 (mig 20260517180000) + the days_to_event_at_sale
+-- inline-compute hotfix from PR #197 (mig 20260517210000).
+--
+-- Operator ask: SG Listings / EVO Listings / SG Sales tabs should show
+-- ALL available data, not max 500.
+--
+-- Approach: CREATE OR REPLACE each function preserving signature, email
+-- gate, SECDEF, REVOKE/GRANT, DISTINCT ON dedup. Two changes only:
+--   1. Default p_limit bumped 250 → 100000 (practical "all rows" — SG
+--      firehose 24h-deduped per event maxes ~10k for hot events; 10× headroom).
+--   2. Inner LIMIT changed from `greatest(1, least(p_limit, 500))` to
+--      just `greatest(1, p_limit)` — keep floor (no zero/negative), drop ceiling.
+--
+-- Everything else unchanged (DISTINCT ON keys, ORDER BY, window filters,
+-- sg_event_id bridge, days_to_event_at_sale inline compute from A1's PR #197).
+--
+-- ## Pending operator apply via apply_migration
+
+-- ============================================================
+-- 1. SG Listings tab — uncapped
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_sg_listings_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 100000
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (sglid)
+      sglid, captured_at, section, row, quantity,
+      retail_price_all_in, broadcast_price,
+      delivery_method, stock_type, is_broker_owned, is_instant_download,
+      market_source, splits, in_hand_date
+    FROM public.seatgeek_listings_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND captured_at > now() - interval '7 days'
+    ORDER BY sglid, captured_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sg_event_id', v_sg_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.captured_at DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY captured_at DESC LIMIT greatest(1, p_limit)) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_listings_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_listings_full(integer, integer) TO anon, authenticated;
+
+-- ============================================================
+-- 2. EVO Listings tab — uncapped
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_evo_listings_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 100000
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_rows  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (tevo_ticket_group_id)
+      tevo_ticket_group_id, captured_at, section, row, quantity,
+      retail_price, wholesale_price, format, splits,
+      is_owned, is_ancillary, brokerage_id, brokerage_name,
+      office_name, instant_delivery, eticket, type,
+      prev_retail_price, prev_quantity
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id
+      AND captured_at > now() - interval '7 days'
+    ORDER BY tevo_ticket_group_id, captured_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'event_id', p_event_id,
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.is_owned DESC, l.captured_at DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY is_owned DESC, captured_at DESC LIMIT greatest(1, p_limit)) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_evo_listings_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_evo_listings_full(integer, integer) TO anon, authenticated;
+
+-- ============================================================
+-- 3. SG Sales tab — uncapped (preserves A1's PR #197 days_to_event_at_sale inline compute)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_sg_sales_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 100000,
+  p_window_days integer DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_event_date  date;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  -- A1 PR #197 hotfix preserved: days_to_event_at_sale isn't a column on
+  -- seatgeek_sales_snapshots — compute inline via sg_events_canonical lookup.
+  SELECT sg_event_date INTO v_event_date
+  FROM public.sg_events_canonical WHERE sg_event_id = v_sg_event_id LIMIT 1;
+
+  -- DISTINCT ON sg_sale_id mandatory per PROJECT_BIBLE §3 (11x dedup factor).
+  -- Scope to sg_event_id uses idx_sg_sales_sg_event_id_time.
+  WITH latest AS (
+    SELECT DISTINCT ON (sg_sale_id)
+      sg_sale_id, sale_at_utc, pulled_at,
+      section, row, quantity, broadcast_price, stock_type,
+      CASE
+        WHEN v_event_date IS NULL OR sale_at_utc IS NULL THEN NULL
+        ELSE (v_event_date - sale_at_utc::date)::int
+      END AS days_to_event_at_sale
+    FROM public.seatgeek_sales_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND sale_at_utc > now() - make_interval(days => greatest(1, least(p_window_days, 90)))
+    ORDER BY sg_sale_id, pulled_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sg_event_id', v_sg_event_id,
+    'window_days', greatest(1, least(p_window_days, 90)),
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.sale_at_utc DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY sale_at_utc DESC LIMIT greatest(1, p_limit)) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_sales_full(integer, integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_sales_full(integer, integer, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_sg_listings_full(integer, integer) IS
+  'D0 event-page tabs — full SG listings for an event (deduped on sglid, last 7d, UNCAPPED default 100000). Email-gated.';
+
+COMMENT ON FUNCTION public.get_event_evo_listings_full(integer, integer) IS
+  'D0 event-page tabs — full TEvo listings for an event (deduped on tevo_ticket_group_id, last 7d, UNCAPPED default 100000, owned-first sort). Email-gated.';
+
+COMMENT ON FUNCTION public.get_event_sg_sales_full(integer, integer, integer) IS
+  'D0 event-page tabs — full SG sales for an event (DISTINCT ON sg_sale_id, window 1-90d, UNCAPPED default 100000). Inline days_to_event_at_sale (PR #197). Uses idx_sg_sales_sg_event_id_time. Email-gated.';

--- a/supabase/migrations/20260518040000_get_event_cross_source_metrics_rpc.sql
+++ b/supabase/migrations/20260518040000_get_event_cross_source_metrics_rpc.sql
@@ -1,0 +1,101 @@
+-- Migration 20260518040000 · lane:D0 (author) → A1 (apply) · writes:get_event_cross_source_metrics · reads:event_metrics,seatgeek_event_metrics,seatgeek_event_xref · pre:20260518030000 · auth:operator-approved 2026-05-17
+--
+-- D0 — surfaces the canonical TEvo-vs-SG side-by-side metrics in one
+-- round-trip. Powers the new CROSS-SOURCE METRICS panel on the event
+-- Overview tab.
+--
+-- Source columns per operator's metrics inventory "Cross-source alignment":
+--   TEvo (event_metrics, latest row):
+--     tickets_count, groups_count, retail_median, retail_p90,
+--     getin_price, owned_median_retail, nonowned_median_retail
+--   SG (seatgeek_event_metrics, latest row — populated by PR #204):
+--     listings_all_count, listings_all_tickets, listings_all_median,
+--     listings_all_p90, listings_all_min, listings_owned_median,
+--     sold_price_median
+--
+-- The `rows` array is pre-aligned server-side so the FE renderer is a
+-- dumb table loop — no field-name knowledge required client-side.
+--
+-- Both sides use DISTINCT ON (key) ORDER BY key, captured_at DESC
+-- pattern for the latest snapshot per event. Bridge tevo↔sg via
+-- seatgeek_event_xref.
+
+CREATE OR REPLACE FUNCTION public.get_event_cross_source_metrics(p_event_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_tevo        jsonb;
+  v_sg          jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  -- TEvo side: latest event_metrics snapshot
+  SELECT to_jsonb(t) INTO v_tevo
+  FROM (
+    SELECT DISTINCT ON (event_id)
+      event_id, tickets_count, groups_count,
+      retail_median, retail_p90, getin_price,
+      owned_median_retail, nonowned_median_retail,
+      captured_at
+    FROM public.event_metrics
+    WHERE event_id = p_event_id
+    ORDER BY event_id, captured_at DESC
+  ) t;
+
+  -- SG side: latest seatgeek_event_metrics snapshot (PR #204 listings_all_* + listings_owned_*)
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT to_jsonb(s) INTO v_sg
+    FROM (
+      SELECT DISTINCT ON (sg_event_id)
+        sg_event_id,
+        listings_all_count, listings_all_tickets,
+        listings_all_median, listings_all_p90, listings_all_min,
+        listings_owned_median,
+        sold_price_median,
+        captured_at
+      FROM public.seatgeek_event_metrics
+      WHERE sg_event_id = v_sg_event_id
+      ORDER BY sg_event_id, captured_at DESC
+    ) s;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'event_id',    p_event_id,
+    'sg_event_id', v_sg_event_id,
+    'tevo',        v_tevo,
+    'sg',          v_sg,
+    -- Pre-aligned rows: FE renders directly without knowing column names.
+    'rows', jsonb_build_array(
+      jsonb_build_object('label', 'Listings count',
+        'tevo', v_tevo->'groups_count',         'sg', v_sg->'listings_all_count',   'is_money', false),
+      jsonb_build_object('label', 'Tickets count',
+        'tevo', v_tevo->'tickets_count',        'sg', v_sg->'listings_all_tickets', 'is_money', false),
+      jsonb_build_object('label', 'Ask median',
+        'tevo', v_tevo->'retail_median',        'sg', v_sg->'listings_all_median',  'is_money', true),
+      jsonb_build_object('label', 'Ask p90',
+        'tevo', v_tevo->'retail_p90',           'sg', v_sg->'listings_all_p90',     'is_money', true),
+      jsonb_build_object('label', 'Get-in / min',
+        'tevo', v_tevo->'getin_price',          'sg', v_sg->'listings_all_min',     'is_money', true),
+      jsonb_build_object('label', 'Owned-only median',
+        'tevo', v_tevo->'owned_median_retail',  'sg', v_sg->'listings_owned_median','is_money', true),
+      jsonb_build_object('label', 'Realized sale median',
+        'tevo', null,                            'sg', v_sg->'sold_price_median',    'is_money', true)
+    )
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_cross_source_metrics(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_cross_source_metrics(integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_cross_source_metrics(integer) IS
+  'D0 event Overview — canonical TEvo-vs-SG side-by-side metrics in one round-trip. 7 pre-aligned rows. Uses listings_all_*/listings_owned_* from PR #204 (not deprecated cost_*). Email-gated.';


### PR DESCRIPTION
## Summary

Two operator asks bundled in one small PR:

### 1. Drop 500-row cap on full-list tabs

`SG Listings`, `EVO Listings`, `SG Sales` tabs (PR #196) currently cap at 500 rows via `greatest(1, least(p_limit, 500))`. Migration `20260518030000_event_page_tabs_uncap.sql` does `CREATE OR REPLACE` on all 3 RPCs:
- Default `p_limit` bumped `250 → 100000` (practical "all rows" — SG firehose 24h-deduped per event maxes ~10k for hot events; 10× headroom)
- Inner LIMIT changed to `greatest(1, p_limit)` — keeps floor, drops 500 ceiling
- Preserves A1's PR #197 `days_to_event_at_sale` inline compute on the SG sales RPC

[event.js](static/terminal/event.js) updated to omit `p_limit` on the 3 RPC calls so the new 100000 default takes effect.

The 3 broker-tab RPCs from PR #199 (`our TEvo orders / our SG sales / TP+Vivid`) are intentionally untouched — their data is naturally small per event, no cap relief needed.

### 2. New CROSS-SOURCE METRICS panel on event Overview tab

Migration `20260518040000_get_event_cross_source_metrics_rpc.sql` adds new SECDEF RPC `get_event_cross_source_metrics(p_event_id integer)` — single round-trip returning a pre-aligned `rows` array with 7 canonical TEvo-vs-SG comparisons from the operator's metrics inventory:

| Metric | TEvo (`event_metrics`) | SG (`seatgeek_event_metrics`) |
|---|---|---|
| Listings count | `groups_count` | `listings_all_count` |
| Tickets count | `tickets_count` | `listings_all_tickets` |
| Ask median | `retail_median` | `listings_all_median` |
| Ask p90 | `retail_p90` | `listings_all_p90` |
| Get-in / min | `getin_price` | `listings_all_min` |
| Owned-only median | `owned_median_retail` | `listings_owned_median` |
| Realized sale median | n/a | `sold_price_median` |

Uses the **new `listings_all_*` + `listings_owned_*` columns from PR #204** — NOT the deprecated `cost_*` fields. Verified live in prod via schema probe before authoring.

Implementation: `DISTINCT ON (event_id) … ORDER BY captured_at DESC` latest-row pattern on both sides; bridge `tevo↔sg` via `seatgeek_event_xref`. TEvo-only events return `sg_event_id = null` + the SG column renders `—` gracefully (no crash).

Same canonical v3 SECDEF pattern (`@s4kent.com` gate, `REVOKE PUBLIC + GRANT anon/auth`, `search_path` locked, STABLE).

**FE**: panel slots between `#last-snapshot` and `#chart` inside `#paneOverview`. `rows` array is pre-aligned server-side so the client is a dumb table loop. `Δ%` column shows SG vs TEvo with pos/neg color cue (|Δ| < 1% = no cue). Loader fires from `init()` in parallel to the main `v3/Path-A` `fetchPayload` so it renders even when `fetchPayload` throws (localhost dev with no Path A API).

## Verification

Local browser preview at `event.html?event=3091413`:
- Panel inserted between Last Snapshot and Chart ✓
- DOM-order check passes: `kpi-grid → last-snapshot → cross-source-metrics → chart → sg-broker-sales → ...` ✓
- Localhost (no Path C auth): degrades to "RPC error: no auth — Path C unavailable" inside the panel; doesn't crash other panels ✓
- The 3 full-list tabs still load via lazy-click (omit p_limit, RPC default 100000 takes effect)

## Test plan (A1 smoke pre-merge per bot_chat #299 process note)

- [ ] `get_event_cross_source_metrics(3091413)` returns `rows` array with 7 entries, both `tevo` and `sg` populated, `sg_event_id` non-null
- [ ] `get_event_cross_source_metrics(3309426)` (Bruce Springsteen TEvo-only) returns `sg = null` + `sg_event_id = null` + rows still 7 with `sg = null` per row
- [ ] RPC perf <100ms (2 DISTINCT ON latest-row pulls against indexed columns)
- [ ] Smoke uncapped `get_event_sg_listings_full(3091413)` on a hot event — confirm row count exceeds 500
- [ ] Confirm signatures unchanged (`(integer, integer)` and `(integer, integer, integer)`) — drop+create would break the FE Path C calls

## Out of scope (deferred follow-ups)

- Migrating `sg_listings_summary` from `cost_*` to `listings_all_*` (inventory gap #4 — `compute_alerts_tick` still reads cost_median)
- Dropping deprecated `cost_*` columns from `seatgeek_event_metrics` (A1 territory after the readers migrate)
- Owner-side metric distribution (`event_metrics.owned_p25/p75/p90`) — inventory gap #5

## Related

- [apps#202](https://github.com/JulianS4K/Terminal-2/pull/202) — PR A (home polish)
- [apps#203](https://github.com/JulianS4K/Terminal-2/pull/203) — PR B (entity pages)
- PR #196 — original full-list tab RPCs (with the 500 cap)
- PR #197 — A1's `days_to_event_at_sale` hotfix (preserved here)
- PR #204 — added the `listings_all_*` + `listings_owned_*` columns this panel consumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)