### PR TITLE
feat(metrics): fix 5 per-event metrics gaps (sentiment + competitors + sections + cost_* cleanup + owned dist)

### DIFF
--- a/supabase/migrations/20260518010000_event_sentiment_cron.sql
+++ b/supabase/migrations/20260518010000_event_sentiment_cron.sql
@@ -1,0 +1,30 @@
+-- Migration 20260518010000 · lane:A1 · writes:cron+cron_policy · reads:event_metrics,event_lifecycle · pre:20260517260000 · auth:operator-approved 2026-05-18
+--
+-- A1 PR-1 — schedule the existing backfill_event_sentiment (from mig 20260509130000).
+-- Functions live on prod, never called. 30-min cadence — sentiment is delta-driven,
+-- so faster cadence captures velocity changes mid-day.
+
+DO $body$ DECLARE v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'event_sentiment_compute_30min';
+  IF v_jobid IS NOT NULL THEN PERFORM cron.unschedule(v_jobid); END IF;
+
+  PERFORM cron.schedule(
+    'event_sentiment_compute_30min',
+    '15,45 * * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('event_sentiment_compute_30min') THEN RETURN; END IF;
+      PERFORM public.backfill_event_sentiment(200);
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+INSERT INTO public.cron_policy (jobname, peak_hours_et, peak_min_interval_min,
+  offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES (
+  'event_sentiment_compute_30min',
+  '{9,10,11,12,13,14,15,16,17,18,19,20}'::int[],
+  30, 30, 48, true,
+  'Schedule existing backfill_event_sentiment (mig 20260509130000). Reads 2 event_metrics snapshots per event, computes sentiment_index + velocity signals. NULL-safe on missing prior snapshots (function returns NULL if no 6-36h-old prior).'
+) ON CONFLICT (jobname) DO UPDATE SET enabled = true, updated_at = now();

--- a/supabase/migrations/20260518020000_event_competitors_cron.sql
+++ b/supabase/migrations/20260518020000_event_competitors_cron.sql
@@ -1,0 +1,31 @@
+-- Migration 20260518020000 · lane:A1 · writes:cron+cron_policy · reads:events,v_venue_neighbors · pre:20260518010000 · auth:operator-approved 2026-05-18
+--
+-- A1 PR-2 — re-schedule the existing refresh_event_competitors (mig 20260509350000).
+-- The cron event_competitors_refresh_hourly was scheduled in 2026-05-09 and lost at some
+-- point. refresh_event_competitors() TRUNCATEs + re-INSERTs from v_competing_events.
+-- Sparse coverage is BY DESIGN — only events with venue neighbors within 20mi/24h get rows.
+
+DO $body$ DECLARE v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'event_competitors_refresh_hourly';
+  IF v_jobid IS NOT NULL THEN PERFORM cron.unschedule(v_jobid); END IF;
+
+  PERFORM cron.schedule(
+    'event_competitors_refresh_hourly',
+    '40 * * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('event_competitors_refresh_hourly') THEN RETURN; END IF;
+      PERFORM public.refresh_event_competitors();
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+INSERT INTO public.cron_policy (jobname, peak_hours_et, peak_min_interval_min,
+  offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES (
+  'event_competitors_refresh_hourly',
+  '{9,10,11,12,13,14,15,16,17,18,19,20}'::int[],
+  60, 60, 24, true,
+  'Re-schedule TRUNCATE+rebuild from v_competing_events (was scheduled in mig 20260509350000, unscheduled at some point). Sparse coverage by-design — only events with 20mi/24h venue neighbors.'
+) ON CONFLICT (jobname) DO UPDATE SET enabled = true, updated_at = now();

--- a/supabase/migrations/20260518030000_event_section_row_batch_cron.sql
+++ b/supabase/migrations/20260518030000_event_section_row_batch_cron.sql
@@ -1,0 +1,69 @@
+-- Migration 20260518030000 · lane:A1 · writes:rollup_event_section_row_batch+cron+cron_policy · reads:listings_snapshots,event_section_row_snapshots · pre:20260518020000 · auth:operator-approved 2026-05-18
+--
+-- A1 PR-3 — wire the existing rollup_event_section_row (single-event, mig 20260512100150)
+-- into a batch wrapper + hourly cron. Table currently empty despite 6 months of schema.
+-- Reads listings_snapshots, groups by _sec_norm(section)+row, computes min/median/max
+-- price + listings_count + owned_quantity per cell.
+
+CREATE OR REPLACE FUNCTION public.rollup_event_section_row_batch(
+  p_max_events integer DEFAULT 100
+)
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE r RECORD; v_total int := 0; v_n int;
+BEGIN
+  -- Pick events with fresh listings_snapshots in the last 2 hours that don't have
+  -- a section_row rollup yet for that capture timestamp. Use MAX(captured_at) per
+  -- event to dedupe in case multiple captures landed.
+  FOR r IN
+    SELECT ls.event_id, MAX(ls.captured_at) AS captured_at
+    FROM public.listings_snapshots ls
+    WHERE ls.captured_at > now() - interval '2 hours'
+      AND ls.event_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.event_section_row_snapshots esrs
+        WHERE esrs.event_id = ls.event_id
+          AND esrs.source = 'tevo'
+          AND esrs.captured_at > now() - interval '2 hours'
+      )
+    GROUP BY ls.event_id
+    LIMIT p_max_events
+  LOOP
+    v_n := public.rollup_event_section_row(r.event_id, r.captured_at);
+    v_total := v_total + COALESCE(v_n, 0);
+  END LOOP;
+  RETURN v_total;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.rollup_event_section_row_batch(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rollup_event_section_row_batch(integer) TO service_role;
+
+COMMENT ON FUNCTION public.rollup_event_section_row_batch(integer) IS
+  'A1 2026-05-18 — batch wrapper around rollup_event_section_row (single-event, mig 20260512100150). Picks events with fresh listings_snapshots in last 2h lacking a recent section rollup, processes up to p_max_events. Hourly cron @ :03. Writes source=tevo only; SG mirror pending future PR.';
+
+DO $body$ DECLARE v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'event_section_row_rollup_hourly';
+  IF v_jobid IS NOT NULL THEN PERFORM cron.unschedule(v_jobid); END IF;
+
+  PERFORM cron.schedule(
+    'event_section_row_rollup_hourly',
+    '3 * * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('event_section_row_rollup_hourly') THEN RETURN; END IF;
+      PERFORM public.rollup_event_section_row_batch(100);
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+INSERT INTO public.cron_policy (jobname, peak_hours_et, peak_min_interval_min,
+  offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES (
+  'event_section_row_rollup_hourly',
+  '{9,10,11,12,13,14,15,16,17,18,19,20}'::int[],
+  60, 60, 24, true,
+  'Per-section rollup from listings_snapshots (source=tevo). SG-side rollup (source=seatgeek) pending future PR.'
+) ON CONFLICT (jobname) DO UPDATE SET enabled = true, updated_at = now();

--- a/supabase/migrations/20260518040000_cost_readers_migrate_v_event_price_arbitrage.sql
+++ b/supabase/migrations/20260518040000_cost_readers_migrate_v_event_price_arbitrage.sql
@@ -1,0 +1,63 @@
+-- Migration 20260518040000 · lane:A1 · writes:v_event_price_arbitrage · reads:seatgeek_event_metrics · pre:20260518030000 · auth:operator-approved 2026-05-18
+--
+-- A1 PR-4a (part 1 of 5) — migrate v_event_price_arbitrage from legacy cost_*
+-- to listings_owned_* (real broker inv) + listings_all_* (full firehose).
+--
+-- 3-way arbitrage payload now:
+--   tevo_retail (TEvo broker board) vs sg_owned (SG broker-held real inv)
+--                                    vs sg_all (full SG marketplace including spec)
+--                                    vs sg_sale (realized SG sales — already wired)
+--
+-- DROP+CREATE because column renames inside view aliases.
+
+DROP VIEW IF EXISTS public.v_event_price_arbitrage;
+
+CREATE VIEW public.v_event_price_arbitrage AS
+SELECT
+  e.id AS tevo_event_id,
+  e.name AS event_name,
+  e.venue_name,
+  e.occurs_at_local,
+  sgx.sg_event_id,
+  em.retail_median AS tevo_retail_median,
+  em.retail_min AS tevo_retail_min,
+  em.tickets_count AS tevo_listings_count,
+  em.owned_tickets_count,
+  sgm.listings_owned_median AS sg_owned_median,
+  sgm.listings_owned_min AS sg_owned_min,
+  sgm.listings_all_median AS sg_all_median,
+  sgm.listings_all_min AS sg_all_min,
+  sgm.listings_all_count AS sg_listings_count,
+  sgm.sold_price_median AS sg_sale_median_realized,
+  sgm.sold_price_mean AS sg_sale_mean_realized,
+  sgm.sold_quantity AS sg_sales_count,
+  (sgm.sold_price_median - em.retail_median) AS sale_minus_retail_median,
+  (sgm.listings_owned_median - em.retail_median) AS sg_owned_minus_retail_median,
+  (sgm.listings_all_median - em.retail_median) AS sg_all_minus_retail_median,
+  em.captured_at AS tevo_metrics_at,
+  sgm.captured_at AS sg_metrics_at
+FROM public.events e
+LEFT JOIN public.latest_event_metrics em ON em.event_id = e.id
+LEFT JOIN public.seatgeek_event_xref sgx ON sgx.tevo_event_id = e.id
+LEFT JOIN LATERAL (
+  SELECT id, tevo_event_id, sg_event_id, captured_at,
+         listings_all_count, listings_all_tickets,
+         listings_all_min, listings_all_p25, listings_all_median, listings_all_mean,
+         listings_all_p75, listings_all_p90, listings_all_max,
+         listings_owned_count, listings_owned_tickets,
+         listings_owned_min, listings_owned_p25, listings_owned_median, listings_owned_mean,
+         listings_owned_p75, listings_owned_p90, listings_owned_max,
+         sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_mean, sold_price_max
+  FROM public.seatgeek_event_metrics
+  WHERE tevo_event_id = e.id
+  ORDER BY captured_at DESC
+  LIMIT 1
+) sgm ON true
+WHERE e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+  AND e.occurs_at_local::timestamptz > now()
+  AND e.occurs_at_local::timestamptz < now() + interval '180 days';
+
+GRANT SELECT ON public.v_event_price_arbitrage TO anon, authenticated, service_role;
+
+COMMENT ON VIEW public.v_event_price_arbitrage IS
+  'A1 2026-05-18 — 3-way price comparison: TEvo retail vs SG owned (broker-held real inv) vs SG all-listings (full firehose incl spec) + SG realized sales. Was reading cost_* legacy cols pre-PR #204; migrated to listings_owned_* and listings_all_* (PR-4a).';

--- a/supabase/migrations/20260518040001_v_event_full_v2_listings_all_swap.sql
+++ b/supabase/migrations/20260518040001_v_event_full_v2_listings_all_swap.sql
@@ -1,0 +1,55 @@
+-- A1 PR-4a (part 2 of 5) — migrate v_event_full_v2 (cost_* → listings_all_*).
+-- DROP+CREATE because column renames inside view aliases.
+
+DROP VIEW IF EXISTS public.v_event_full_v2;
+
+CREATE VIEW public.v_event_full_v2 AS
+SELECT
+  ef.tevo_event_id, ef.tevo_name, ef.event_date, ef.tevo_venue_name,
+  ef.canonical_label, ef.lifecycle_status, ef.sources_count,
+  ef.espn_event_id, ef.sd_event_id, ef.sg_event_id, ef.sg_category,
+  ef.home_performer, ef.venue,
+  ef.tevo_pricing, ef.sg_pricing, ef.sg_seller_pricing, ef.sd_pricing,
+  sgm.captured_at AS sg_metrics_captured_at,
+  -- A1 2026-05-18 PR-4a: cost_* swap → listings_all_*
+  sgm.listings_all_count AS sg_metrics_listings_all,
+  sgm.listings_all_tickets AS sg_metrics_listings_all_tix,
+  sgm.listings_all_min AS sg_metrics_listings_all_min,
+  sgm.listings_all_median AS sg_metrics_listings_all_median,
+  sgm.listings_all_p90 AS sg_metrics_listings_all_p90,
+  sgm.listings_owned_count AS sg_metrics_listings_owned,
+  sgm.listings_owned_median AS sg_metrics_listings_owned_median,
+  sgm.orders_open AS sg_metrics_orders_open,
+  sgm.orders_fulfilled AS sg_metrics_orders_fulfilled,
+  sgm.sold_quantity AS sg_metrics_sold_qty,
+  sgm.sold_gross AS sg_metrics_sold_gross,
+  sgm.fill_rate AS sg_metrics_fill_rate,
+  es.captured_at AS sentiment_captured_at,
+  es.sentiment_index,
+  es.tix_per_hour,
+  es.getin_per_hour,
+  es.owned_share_change,
+  es.pairs_change_per_hour
+FROM public.v_event_full ef
+LEFT JOIN LATERAL (
+  SELECT captured_at,
+    listings_all_count, listings_all_tickets,
+    listings_all_min, listings_all_p25, listings_all_median, listings_all_mean,
+    listings_all_p75, listings_all_p90, listings_all_max,
+    listings_owned_count, listings_owned_tickets,
+    listings_owned_min, listings_owned_median, listings_owned_max,
+    orders_open, orders_pending, orders_confirmed, orders_fulfilled, orders_delivered, orders_cancelled,
+    sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_mean, sold_price_max,
+    edelivery_share, instant_share, unique_sections, unique_rows, fill_rate
+  FROM public.seatgeek_event_metrics
+  WHERE tevo_event_id = ef.tevo_event_id
+  ORDER BY captured_at DESC LIMIT 1
+) sgm ON true
+LEFT JOIN LATERAL (
+  SELECT captured_at, sentiment_index, tix_per_hour, getin_per_hour, owned_share_change, pairs_change_per_hour
+  FROM public.event_sentiment
+  WHERE event_id = ef.tevo_event_id
+  ORDER BY captured_at DESC LIMIT 1
+) es ON true;
+
+GRANT SELECT ON public.v_event_full_v2 TO anon, authenticated, service_role;

--- a/supabase/migrations/20260518040002_v_event_velocity_windows_listings_all_swap.sql
+++ b/supabase/migrations/20260518040002_v_event_velocity_windows_listings_all_swap.sql
@@ -1,0 +1,77 @@
+-- A1 PR-4a (part 3 of 5) — migrate v_event_velocity_windows.
+-- Source for v3 RPC's `velocity` payload. SG get-in approximated by listings_all_min;
+-- SG median by listings_all_median.
+
+DROP VIEW IF EXISTS public.v_event_velocity_windows;
+
+CREATE VIEW public.v_event_velocity_windows AS
+WITH tevo_now AS (
+  SELECT DISTINCT ON (event_metrics.event_id) event_metrics.event_id,
+    event_metrics.captured_at, event_metrics.getin_price,
+    event_metrics.retail_median, event_metrics.tickets_count
+  FROM public.event_metrics
+  ORDER BY event_metrics.event_id, event_metrics.captured_at DESC
+),
+tevo_w AS (
+  SELECT n.event_id,
+    n.captured_at AS tevo_now_at,
+    n.getin_price AS tevo_getin_now,
+    n.retail_median AS tevo_median_now,
+    n.tickets_count AS tevo_tix_now,
+    (SELECT em.getin_price FROM public.event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '1 hour'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_getin_1h_ago,
+    (SELECT em.tickets_count FROM public.event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '1 hour'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_tix_1h_ago,
+    (SELECT em.getin_price FROM public.event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '6 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_getin_6h_ago,
+    (SELECT em.getin_price FROM public.event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '24 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_getin_24h_ago,
+    (SELECT em.tickets_count FROM public.event_metrics em
+      WHERE em.event_id = n.event_id AND em.captured_at <= n.captured_at - interval '24 hours'
+      ORDER BY em.captured_at DESC LIMIT 1) AS tevo_tix_24h_ago
+  FROM tevo_now n
+),
+sg_w AS (
+  SELECT sgm.tevo_event_id AS event_id,
+    sgm.captured_at AS sg_now_at,
+    -- A1 2026-05-18 PR-4a: cost_min → listings_all_min (cheapest live broker listing = SG "get-in" equivalent)
+    sgm.listings_all_min AS sg_getin_now,
+    sgm.listings_all_median AS sg_median_now,
+    sgm.listings_all_tickets AS sg_tix_now,
+    (SELECT x.listings_all_min FROM public.seatgeek_event_metrics x
+      WHERE x.tevo_event_id = sgm.tevo_event_id AND x.captured_at <= sgm.captured_at - interval '1 hour'
+      ORDER BY x.captured_at DESC LIMIT 1) AS sg_getin_1h_ago,
+    (SELECT x.listings_all_min FROM public.seatgeek_event_metrics x
+      WHERE x.tevo_event_id = sgm.tevo_event_id AND x.captured_at <= sgm.captured_at - interval '24 hours'
+      ORDER BY x.captured_at DESC LIMIT 1) AS sg_getin_24h_ago
+  FROM (
+    SELECT DISTINCT ON (tevo_event_id) tevo_event_id, captured_at,
+           listings_all_min, listings_all_median, listings_all_tickets
+    FROM public.seatgeek_event_metrics
+    WHERE tevo_event_id IS NOT NULL
+    ORDER BY tevo_event_id, captured_at DESC
+  ) sgm
+)
+SELECT e.id AS tevo_event_id,
+  e.name, e.occurs_at_local, e.venue_name,
+  t.tevo_now_at, t.tevo_getin_now, t.tevo_median_now, t.tevo_tix_now,
+  (t.tevo_getin_now - t.tevo_getin_1h_ago) AS tevo_getin_d1h,
+  (t.tevo_getin_now - t.tevo_getin_6h_ago) AS tevo_getin_d6h,
+  (t.tevo_getin_now - t.tevo_getin_24h_ago) AS tevo_getin_d24h,
+  (t.tevo_tix_now - t.tevo_tix_1h_ago) AS tevo_tix_d1h,
+  (t.tevo_tix_now - t.tevo_tix_24h_ago) AS tevo_tix_d24h,
+  CASE WHEN t.tevo_getin_1h_ago > 0 THEN round(((t.tevo_getin_now - t.tevo_getin_1h_ago) / t.tevo_getin_1h_ago * 100)::numeric, 2) ELSE NULL END AS tevo_getin_d1h_pct,
+  CASE WHEN t.tevo_getin_24h_ago > 0 THEN round(((t.tevo_getin_now - t.tevo_getin_24h_ago) / t.tevo_getin_24h_ago * 100)::numeric, 2) ELSE NULL END AS tevo_getin_d24h_pct,
+  s.sg_now_at, s.sg_getin_now, s.sg_median_now, s.sg_tix_now,
+  (s.sg_getin_now - s.sg_getin_1h_ago) AS sg_getin_d1h,
+  (s.sg_getin_now - s.sg_getin_24h_ago) AS sg_getin_d24h
+FROM public.events e
+LEFT JOIN tevo_w t ON t.event_id = e.id
+LEFT JOIN sg_w s ON s.event_id = e.id
+WHERE t.event_id IS NOT NULL OR s.event_id IS NOT NULL;
+
+GRANT SELECT ON public.v_event_velocity_windows TO anon, authenticated, service_role;

--- a/supabase/migrations/20260518040003_v2_rpc_listings_all_swap.sql
+++ b/supabase/migrations/20260518040003_v2_rpc_listings_all_swap.sql
@@ -1,0 +1,277 @@
+-- A1 PR-4a (part 4 of 5) — v2 RPC sg_side_by_side cost_* → listings_all_* + listings_owned_*
+-- Per zany-skipping-fox plan: payload key names renamed (cost_median → listings_all_median).
+-- D0 already familiar with the naming via PR #204.
+
+CREATE OR REPLACE FUNCTION public.get_broker_event_page_v2(p_event_id integer, p_chart_hours integer DEFAULT 720)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email           text;
+  v_base            jsonb;
+  v_now             timestamptz := now();
+  v_sg_event_id     bigint;
+  v_aq_id           text;
+  v_espn_event_id   text;
+  v_espn_league     text;
+  v_venue_tevo_id   bigint;
+  v_is_indoor       boolean;
+  v_event_at        timestamptz;
+  v_sales_tape      jsonb;
+  v_weather         jsonb;
+  v_espn            jsonb;
+  v_event_alerts    jsonb;
+  v_sg_sxs          jsonb;
+  v_splits          jsonb;
+  v_freshness       jsonb;
+  v_max_tevo        timestamptz;
+  v_max_sg_lst      timestamptz;
+  v_max_sg_sales    timestamptz;
+  v_max_weather     timestamptz;
+  v_max_espn_team   timestamptz;
+  v_max_espn_inj    timestamptz;
+  v_max_sd_sales    timestamptz;
+  v_home_team_id    text;
+  v_away_team_id    text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_base := public.get_broker_event_page(p_event_id, p_chart_hours);
+
+  SELECT v.sg_event_id, v.aq_short_event_id, v.espn_event_id, v.espn_league,
+         v.venue_tevo_id, v.is_indoor, v.event_at_utc
+  INTO v_sg_event_id, v_aq_id, v_espn_event_id, v_espn_league,
+       v_venue_tevo_id, v_is_indoor, v_event_at
+  FROM public._v_d0_event_index v
+  WHERE v.tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_event_at IS NULL THEN
+    SELECT CASE WHEN e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+                THEN e.occurs_at_local::timestamptz ELSE NULL END,
+           e.venue_id, va.is_indoor
+    INTO v_event_at, v_venue_tevo_id, v_is_indoor
+    FROM public.events e
+    LEFT JOIN public.venue_assets va ON va.tevo_venue_id = e.venue_id
+    WHERE e.id = p_event_id LIMIT 1;
+  END IF;
+
+  IF v_espn_event_id IS NULL THEN
+    SELECT ex.espn_event_id, ex.espn_league INTO v_espn_event_id, v_espn_league
+    FROM public.event_xref ex WHERE ex.tevo_event_id = p_event_id LIMIT 1;
+  END IF;
+  IF v_sg_event_id IS NULL THEN
+    SELECT sgx.sg_event_id INTO v_sg_event_id
+    FROM public.seatgeek_event_xref sgx WHERE sgx.tevo_event_id = p_event_id LIMIT 1;
+  END IF;
+  IF v_aq_id IS NULL THEN
+    IF v_sg_event_id IS NOT NULL THEN
+      SELECT aem.aq_short_event_id INTO v_aq_id
+      FROM public.aq_event_map aem WHERE aem.sg_event_id = v_sg_event_id LIMIT 1;
+    END IF;
+    IF v_aq_id IS NULL THEN
+      SELECT aem.aq_short_event_id INTO v_aq_id
+      FROM public.events e
+      JOIN public.aq_event_map aem
+        ON aem.aq_short_event_id = 'SYS-' || substring(
+             md5(coalesce(e.name,'') || '|' || coalesce(e.venue_name,'') || '|' ||
+                 coalesce(to_char(e.occurs_at_local::timestamptz, 'YYYY-MM-DD"T"HH24:MI'),''))
+             from 1 for 10)
+      WHERE e.id = p_event_id
+        AND e.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}'
+      LIMIT 1;
+    END IF;
+  END IF;
+
+  -- sales_tape (unchanged)
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH latest_per_sale AS (
+      SELECT DISTINCT ON (sg_sale_id) sg_sale_id, sale_at_utc, section, row, quantity, broadcast_price, stock_type
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id AND sale_at_utc > now() - interval '30 days'
+      ORDER BY sg_sale_id, pulled_at DESC
+    )
+    SELECT coalesce(jsonb_agg(to_jsonb(lp) ORDER BY lp.sale_at_utc DESC), '[]'::jsonb)
+    INTO v_sales_tape
+    FROM (SELECT * FROM latest_per_sale ORDER BY sale_at_utc DESC LIMIT 20) lp;
+  ELSE
+    v_sales_tape := '[]'::jsonb;
+  END IF;
+
+  -- weather (unchanged)
+  IF v_is_indoor IS FALSE AND v_venue_tevo_id IS NOT NULL AND v_event_at IS NOT NULL THEN
+    WITH forecast AS (
+      SELECT is_forecast, observed_at, temp_f, precip_pct, precip_in, wind_mph, gust_mph, humidity_pct, weather_summary
+      FROM public.weather_observations
+      WHERE tevo_venue_id = v_venue_tevo_id AND is_forecast = true
+        AND observed_at BETWEEN now() AND now() + interval '7 days'
+      ORDER BY abs(EXTRACT(epoch FROM (observed_at - v_event_at))) LIMIT 6
+    ),
+    recent_obs AS (
+      SELECT is_forecast, observed_at, temp_f, precip_pct, precip_in, wind_mph, gust_mph, humidity_pct, weather_summary
+      FROM public.weather_observations
+      WHERE tevo_venue_id = v_venue_tevo_id AND is_forecast = false
+        AND observed_at > now() - interval '24 hours'
+      ORDER BY observed_at DESC LIMIT 3
+    ),
+    active_alerts AS (
+      SELECT id, event, severity, urgency, headline, expires_at, area_desc
+      FROM public.nws_alerts WHERE expires_at > now() ORDER BY expires_at LIMIT 5
+    )
+    SELECT jsonb_build_object(
+      'venue_tevo_id', v_venue_tevo_id, 'event_at', v_event_at,
+      'forecast', coalesce((SELECT jsonb_agg(to_jsonb(f) ORDER BY f.observed_at) FROM forecast f), '[]'::jsonb),
+      'recent_obs', coalesce((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.observed_at DESC) FROM recent_obs r), '[]'::jsonb),
+      'nws_alerts', coalesce((SELECT jsonb_agg(to_jsonb(a)) FROM active_alerts a), '[]'::jsonb)
+    ) INTO v_weather;
+  ELSE
+    v_weather := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_is_indoor IS TRUE THEN 'indoor_venue'
+           WHEN v_venue_tevo_id IS NULL THEN 'no_venue_xref'
+           WHEN v_event_at IS NULL THEN 'no_event_time'
+           ELSE 'unknown' END);
+  END IF;
+
+  -- ESPN (unchanged)
+  IF v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id INTO v_home_team_id, v_away_team_id
+    FROM public.espn_event_snapshots
+    WHERE espn_event_id = v_espn_event_id ORDER BY captured_at DESC LIMIT 1;
+    IF v_home_team_id IS NULL THEN
+      SELECT home_team_id, away_team_id INTO v_home_team_id, v_away_team_id
+      FROM public.espn_event_date_lookup WHERE espn_event_id = v_espn_event_id LIMIT 1;
+    END IF;
+    WITH team_snaps AS (
+      SELECT DISTINCT ON (espn_team_id) espn_team_id, captured_at, wins, losses, ties, win_pct,
+             record_summary, standing_summary, streak, playoff_seed
+      FROM public.espn_team_snapshots
+      WHERE espn_league = v_espn_league AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+      ORDER BY espn_team_id, captured_at DESC
+    ),
+    injuries AS (
+      SELECT DISTINCT ON (athlete_id, espn_team_id) espn_team_id, athlete_name, position, status, injury_type, short_comment, return_date, last_seen_at
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id])
+        AND last_seen_at > now() - interval '7 days'
+      ORDER BY athlete_id, espn_team_id, last_seen_at DESC
+    ),
+    recent_results AS (
+      SELECT DISTINCT ON (espn_event_id) espn_event_id, captured_at, state, status_short, home_team_id, away_team_id, home_score, away_score
+      FROM public.espn_event_snapshots
+      WHERE espn_league = v_espn_league AND state = 'post'
+        AND (home_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]) OR away_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]))
+        AND captured_at > now() - interval '60 days'
+      ORDER BY espn_event_id, captured_at DESC
+    )
+    SELECT jsonb_build_object(
+      'espn_event_id', v_espn_event_id, 'espn_league', v_espn_league,
+      'home_team_id', v_home_team_id, 'away_team_id', v_away_team_id,
+      'team_standings', coalesce((SELECT jsonb_agg(to_jsonb(t)) FROM team_snaps t), '[]'::jsonb),
+      'injuries', coalesce((SELECT jsonb_agg(to_jsonb(i) ORDER BY i.last_seen_at DESC) FROM injuries i), '[]'::jsonb),
+      'recent_results', coalesce((SELECT jsonb_agg(to_jsonb(r) ORDER BY r.captured_at DESC) FROM recent_results r LIMIT 10), '[]'::jsonb)
+    ) INTO v_espn;
+  ELSE
+    v_espn := jsonb_build_object('hidden', true, 'reason', 'no_espn_xref');
+  END IF;
+
+  -- event_alerts (unchanged)
+  SELECT coalesce(jsonb_agg(to_jsonb(a) ORDER BY a.fired_at DESC), '[]'::jsonb) INTO v_event_alerts
+  FROM (
+    SELECT id, rule_key, fired_at, severity, message, payload, acknowledged_at
+    FROM public.event_alerts
+    WHERE tevo_event_id = p_event_id AND fired_at > now() - make_interval(hours => greatest(1, least(coalesce(p_chart_hours, 720), 4320)))
+    ORDER BY fired_at DESC LIMIT 50
+  ) a;
+
+  -- sg_side_by_side — A1 2026-05-18 PR-4a: cost_* swap → listings_all_* + listings_owned_*
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH em_latest AS (
+      SELECT row_number() OVER (ORDER BY captured_at DESC) AS rn,
+             captured_at,
+             listings_all_count, listings_all_tickets,
+             listings_all_min, listings_all_p25, listings_all_median, listings_all_mean,
+             listings_all_p75, listings_all_p90, listings_all_max,
+             listings_owned_count, listings_owned_tickets,
+             listings_owned_min, listings_owned_p25, listings_owned_median, listings_owned_mean,
+             listings_owned_p75, listings_owned_p90, listings_owned_max,
+             sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_max,
+             unique_sections, unique_rows
+      FROM public.seatgeek_event_metrics WHERE sg_event_id = v_sg_event_id
+      ORDER BY captured_at DESC LIMIT 25
+    )
+    SELECT jsonb_build_object(
+      'sg_event_id', v_sg_event_id,
+      'current',  (SELECT to_jsonb(e) FROM em_latest e WHERE rn = 1),
+      'd24h_ago', (SELECT to_jsonb(e) FROM em_latest e WHERE e.captured_at <= now() - interval '24 hours' ORDER BY e.captured_at DESC LIMIT 1)
+    ) INTO v_sg_sxs;
+  ELSE
+    v_sg_sxs := jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge');
+  END IF;
+
+  -- splits (unchanged)
+  WITH latest_per_tg AS (
+    SELECT DISTINCT ON (tevo_ticket_group_id) quantity, is_owned, retail_price, brokerage_id
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id AND captured_at > now() - interval '24 hours'
+    ORDER BY tevo_ticket_group_id, captured_at DESC
+  ),
+  bucketed AS (
+    SELECT CASE WHEN is_owned AND brokerage_id = 1768 THEN 'owned' ELSE 'market' END AS src,
+      CASE WHEN quantity = 1 THEN 'singles' WHEN quantity = 2 THEN 'pairs' WHEN quantity = 3 THEN 'triples' WHEN quantity = 4 THEN 'quads' ELSE 'five_plus' END AS bucket,
+      quantity, retail_price
+    FROM latest_per_tg
+  )
+  SELECT coalesce(jsonb_object_agg(src, bucket_data), jsonb_build_object('owned','{}'::jsonb, 'market','{}'::jsonb))
+  INTO v_splits
+  FROM (
+    SELECT src, jsonb_object_agg(bucket, jsonb_build_object(
+      'tg_count', tg_count, 'tix_count', tix_count,
+      'min_px', round(min_px::numeric, 2), 'avg_px', round(avg_px::numeric, 2), 'max_px', round(max_px::numeric, 2)
+    )) AS bucket_data
+    FROM (
+      SELECT src, bucket, count(*) AS tg_count, sum(quantity) AS tix_count,
+             min(retail_price) AS min_px, avg(retail_price) AS avg_px, max(retail_price) AS max_px
+      FROM bucketed GROUP BY src, bucket
+    ) ia GROUP BY src
+  ) oa;
+  IF v_splits IS NULL THEN v_splits := jsonb_build_object('owned','{}'::jsonb, 'market','{}'::jsonb); END IF;
+
+  -- Freshness (unchanged)
+  SELECT max(captured_at) INTO v_max_tevo FROM public.listings_snapshots WHERE event_id = p_event_id;
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT max(captured_at) INTO v_max_sg_lst FROM public.seatgeek_listings_snapshots WHERE sg_event_id = v_sg_event_id;
+    SELECT max(sale_at_utc) INTO v_max_sg_sales FROM public.seatgeek_sales_snapshots WHERE sg_event_id = v_sg_event_id;
+  END IF;
+  IF v_venue_tevo_id IS NOT NULL THEN
+    SELECT max(observed_at) INTO v_max_weather FROM public.weather_observations WHERE tevo_venue_id = v_venue_tevo_id AND is_forecast = false;
+    IF v_max_weather IS NULL THEN
+      SELECT max(observed_at) INTO v_max_weather FROM public.weather_observations WHERE tevo_venue_id = v_venue_tevo_id AND is_forecast = true;
+    END IF;
+  END IF;
+  IF v_espn_event_id IS NOT NULL THEN
+    SELECT max(captured_at) INTO v_max_espn_team FROM public.espn_team_snapshots WHERE espn_league = v_espn_league AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]);
+    SELECT max(last_seen_at) INTO v_max_espn_inj FROM public.espn_injuries_snapshots WHERE espn_league = v_espn_league AND espn_team_id = ANY(ARRAY[v_home_team_id, v_away_team_id]);
+  END IF;
+  SELECT max(sale_timestamp) INTO v_max_sd_sales FROM public.sd_sales_normalized WHERE tevo_event_id = p_event_id;
+
+  v_freshness := jsonb_build_object(
+    'tevo_listings_latest', v_max_tevo, 'sg_listings_latest', v_max_sg_lst,
+    'sg_sales_latest', v_max_sg_sales, 'weather_latest', v_max_weather,
+    'espn_team_latest', v_max_espn_team, 'espn_inj_latest', v_max_espn_inj,
+    'sd_sales_latest', v_max_sd_sales, 'computed_at', v_now
+  );
+
+  RETURN v_base || jsonb_build_object(
+    'v', 'v2',
+    'bridge_ids', jsonb_build_object(
+      'tevo_event_id', p_event_id, 'sg_event_id', v_sg_event_id, 'aq_short_event_id', v_aq_id,
+      'espn_event_id', v_espn_event_id, 'espn_league', v_espn_league, 'venue_tevo_id', v_venue_tevo_id
+    ),
+    'sales_tape', v_sales_tape, 'weather', v_weather, 'espn', v_espn, 'event_alerts', v_event_alerts,
+    'sg_side_by_side', v_sg_sxs, 'splits', v_splits, 'freshness', v_freshness
+  );
+END $function$;

--- a/supabase/migrations/20260518040004_v3_rpc_listings_all_swap.sql
+++ b/supabase/migrations/20260518040004_v3_rpc_listings_all_swap.sql
@@ -1,0 +1,213 @@
+-- A1 PR-4a (part 5 of 5) — v3 RPC sg_listings_summary cost_* → listings_all_* + listings_owned_*
+
+CREATE OR REPLACE FUNCTION public.get_broker_event_page_v3(p_event_id integer, p_chart_hours integer DEFAULT 720)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email                text;
+  v_base                 jsonb;
+  v_now                  timestamptz := now();
+  v_sg_event_id          bigint;
+  v_espn_event_id        text;
+  v_espn_team_id         text;
+  v_espn_league          text;
+  v_tevo_performer_id    bigint;
+  v_performer            jsonb;
+  v_velocity             jsonb;
+  v_sg_broker_sales      jsonb;
+  v_sg_listings_summary  jsonb;
+  v_competing_events     jsonb;
+  v_cross_source_orders  jsonb;
+  v_recent_listings      jsonb;
+  v_zone_deltas          jsonb;
+  v_performer_espn       jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_base := public.get_broker_event_page_v2(p_event_id, p_chart_hours);
+  v_sg_event_id    := nullif(v_base->'bridge_ids'->>'sg_event_id', '')::bigint;
+  v_espn_event_id  := nullif(v_base->'bridge_ids'->>'espn_event_id', '');
+  v_espn_league    := nullif(v_base->'bridge_ids'->>'espn_league', '');
+
+  SELECT primary_performer_id INTO v_tevo_performer_id
+  FROM public.events WHERE id = p_event_id LIMIT 1;
+
+  IF v_tevo_performer_id IS NOT NULL THEN
+    SELECT to_jsonb(p) INTO v_performer FROM (
+      SELECT pm.performer_id AS tevo_performer_id, pm.name,
+        pm.logo_default_url, pm.logo_dark_url, pm.logo_4k_primary_url,
+        pm.color_primary, pm.color_alternate, pm.espn_league, pm.espn_team_id,
+        pm.what_event_type, pm.popularity_score, em.genre, em.top_category_name
+      FROM public.performer_metadata pm
+      LEFT JOIN public.entity_performer_map em ON em.tevo_performer_id = pm.performer_id
+      WHERE pm.performer_id = v_tevo_performer_id LIMIT 1
+    ) p;
+    IF v_performer IS NOT NULL THEN
+      v_espn_team_id := v_performer->>'espn_team_id';
+      IF v_espn_league IS NULL THEN v_espn_league := v_performer->>'espn_league'; END IF;
+    END IF;
+  END IF;
+  IF v_performer IS NULL THEN v_performer := jsonb_build_object('hidden', true, 'reason', 'no_performer_id'); END IF;
+
+  SELECT to_jsonb(v) INTO v_velocity FROM (
+    SELECT tevo_event_id, tevo_now_at, tevo_tix_now, tevo_tix_d1h, tevo_tix_d24h,
+      tevo_getin_now, tevo_getin_d1h, tevo_getin_d6h, tevo_getin_d24h,
+      tevo_getin_d1h_pct, tevo_getin_d24h_pct, tevo_median_now,
+      sg_now_at, sg_tix_now, sg_getin_now, sg_median_now, sg_getin_d1h, sg_getin_d24h
+    FROM public.v_event_velocity_windows WHERE tevo_event_id = p_event_id LIMIT 1
+  ) v;
+  IF v_velocity IS NULL THEN v_velocity := jsonb_build_object('hidden', true, 'reason', 'no_velocity_row'); END IF;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH dedup AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, quantity, broadcast_price, section, sale_at_utc
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id AND section IS NOT NULL
+      ORDER BY sg_sale_id, pulled_at DESC
+    ),
+    agg AS (
+      SELECT count(*) AS sales_count,
+             sum(quantity)::bigint AS tickets_sold,
+             sum(broadcast_price * COALESCE(quantity, 1)::numeric) AS gross_estimate,
+             min(broadcast_price) AS min_sale_price,
+             round(percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price::double precision)::numeric, 2) AS median_sale_price,
+             max(broadcast_price) AS max_sale_price,
+             count(DISTINCT section) AS distinct_sections,
+             max(sale_at_utc) AS latest_sale_at
+      FROM dedup
+    )
+    SELECT to_jsonb(s) INTO v_sg_broker_sales FROM (
+      SELECT v_sg_event_id AS sg_event_id, sgc.sg_event_name, sgc.sg_event_date,
+        a.sales_count, a.tickets_sold, a.gross_estimate, a.min_sale_price,
+        a.median_sale_price, a.max_sale_price, a.distinct_sections, a.latest_sale_at
+      FROM agg a LEFT JOIN public.sg_events_canonical sgc ON sgc.sg_event_id = v_sg_event_id
+      WHERE a.sales_count > 0 LIMIT 1
+    ) s;
+  END IF;
+  IF v_sg_broker_sales IS NULL THEN
+    v_sg_broker_sales := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_sg_event_id IS NULL THEN 'no_sg_bridge' ELSE 'no_broker_sales_row' END);
+  END IF;
+
+  -- sg_listings_summary — A1 2026-05-18 PR-4a: cost_* swap → listings_all_* + listings_owned_*
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT to_jsonb(m) INTO v_sg_listings_summary FROM (
+      SELECT captured_at,
+        listings_all_count, listings_all_tickets,
+        listings_all_min, listings_all_p25, listings_all_median, listings_all_mean,
+        listings_all_p75, listings_all_p90, listings_all_max,
+        listings_owned_count, listings_owned_tickets,
+        listings_owned_min, listings_owned_p25, listings_owned_median, listings_owned_mean,
+        listings_owned_p75, listings_owned_p90, listings_owned_max,
+        fill_rate, unique_sections, unique_rows, edelivery_share, instant_share
+      FROM public.seatgeek_event_metrics
+      WHERE sg_event_id = v_sg_event_id
+      ORDER BY captured_at DESC LIMIT 1
+    ) m;
+  END IF;
+  IF v_sg_listings_summary IS NULL THEN
+    v_sg_listings_summary := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_sg_event_id IS NULL THEN 'no_sg_bridge' ELSE 'no_sg_metrics_row' END);
+  END IF;
+
+  SELECT jsonb_build_object(
+    'count', competitors_count, 'refreshed_at', refreshed_at,
+    'events', coalesce(competitors, '[]'::jsonb)
+  ) INTO v_competing_events
+  FROM public.event_competitors_snapshot WHERE tevo_event_id = p_event_id LIMIT 1;
+  IF v_competing_events IS NULL THEN v_competing_events := jsonb_build_object('count', 0, 'events', '[]'::jsonb); END IF;
+
+  SELECT jsonb_build_object(
+    'tickpick', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'tp_order_id', tp_order_id, 'status', status, 'quantity', quantity,
+        'total', total, 'section', section, 'row', row, 'ordered_at', ordered_at
+      ) ORDER BY ordered_at DESC NULLS LAST)
+      FROM public.tickpick_orders WHERE tevo_event_id = p_event_id LIMIT 50
+    ), '[]'::jsonb),
+    'vivid', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'vivid_order_id', vivid_order_id, 'status', status, 'quantity', quantity,
+        'total', total, 'section', section, 'row', row, 'ordered_at', ordered_at
+      ) ORDER BY ordered_at DESC NULLS LAST)
+      FROM public.vivid_orders WHERE tevo_event_id = p_event_id LIMIT 50
+    ), '[]'::jsonb)
+  ) INTO v_cross_source_orders;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.captured_at DESC), '[]'::jsonb)
+  INTO v_recent_listings FROM (
+    SELECT DISTINCT ON (tevo_ticket_group_id)
+      tevo_ticket_group_id, captured_at, section, row, quantity,
+      retail_price, format, is_owned, brokerage_name
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id AND captured_at > now() - interval '24 hours'
+    ORDER BY tevo_ticket_group_id, captured_at DESC LIMIT 10
+  ) l;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (zone) zone, retail_median, tickets_count, owned_tickets_count, captured_at
+    FROM public.section_metrics
+    WHERE event_id = p_event_id AND zone IS NOT NULL
+    ORDER BY zone, captured_at DESC
+  ),
+  prior AS (
+    SELECT DISTINCT ON (zone) zone, retail_median AS prior_median, tickets_count AS prior_tix, captured_at AS prior_at
+    FROM public.section_metrics
+    WHERE event_id = p_event_id AND zone IS NOT NULL
+      AND captured_at <= now() - interval '24 hours'
+    ORDER BY zone, captured_at DESC
+  )
+  SELECT coalesce(jsonb_agg(jsonb_build_object(
+    'zone', l.zone, 'cur_median', l.retail_median, 'cur_tix', l.tickets_count,
+    'cur_owned_tix', l.owned_tickets_count,
+    'prior_median', p.prior_median, 'prior_tix', p.prior_tix,
+    'delta_median_pct',
+      CASE WHEN p.prior_median IS NULL OR p.prior_median = 0 THEN NULL
+           ELSE round(((l.retail_median - p.prior_median) / p.prior_median * 100)::numeric, 2) END,
+    'delta_tix_abs',
+      CASE WHEN p.prior_tix IS NULL THEN NULL ELSE l.tickets_count - p.prior_tix END,
+    'latest_at', l.captured_at, 'prior_at', p.prior_at
+  ) ORDER BY l.tickets_count DESC NULLS LAST), '[]'::jsonb)
+  INTO v_zone_deltas
+  FROM latest l LEFT JOIN prior p ON p.zone = l.zone;
+
+  IF v_espn_team_id IS NOT NULL AND v_espn_league IS NOT NULL THEN
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+      'espn_event_id', espn_event_id, 'game_at_utc', game_at_utc,
+      'home_team_id', home_team_id, 'away_team_id', away_team_id,
+      'status_short', status_short,
+      'is_home', home_team_id = v_espn_team_id
+    ) ORDER BY game_at_utc), '[]'::jsonb)
+    INTO v_performer_espn FROM (
+      SELECT * FROM public.espn_event_date_lookup
+      WHERE espn_league = v_espn_league
+        AND (home_team_id = v_espn_team_id OR away_team_id = v_espn_team_id)
+        AND game_at_utc > now() - interval '1 day'
+      ORDER BY game_at_utc LIMIT 5
+    ) g;
+  END IF;
+  IF v_performer_espn IS NULL THEN
+    v_performer_espn := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_espn_team_id IS NULL THEN 'no_performer_espn_xref' ELSE 'no_upcoming_games' END);
+  END IF;
+
+  RETURN v_base || jsonb_build_object(
+    'v', 'v3',
+    'performer', v_performer,
+    'velocity', v_velocity,
+    'sg_broker_sales', v_sg_broker_sales,
+    'sg_listings_summary', v_sg_listings_summary,
+    'competing_events', v_competing_events,
+    'cross_source_orders', v_cross_source_orders,
+    'recent_listings', v_recent_listings,
+    'zone_deltas', v_zone_deltas,
+    'performer_espn_context', v_performer_espn
+  );
+END $function$;

--- a/supabase/migrations/20260518050000_cost_columns_drop.sql
+++ b/supabase/migrations/20260518050000_cost_columns_drop.sql
@@ -1,0 +1,21 @@
+-- Migration 20260518050000 · lane:A1 · writes:seatgeek_event_metrics+drops compute_seatgeek_event_metrics · pre:20260518040004 · auth:operator-approved 2026-05-18
+--
+-- A1 PR-4b — drop the deprecated cost_* columns + retire the legacy populator.
+-- Pre-flight verified zero readers via pg_proc + pg_views scan after PR-4a:
+--   migrated v_event_price_arbitrage + v_event_full_v2 + v_event_velocity_windows
+--   + get_broker_event_page_v2 + get_broker_event_page_v3 all to listings_all_*
+
+DROP FUNCTION IF EXISTS public.compute_seatgeek_event_metrics(bigint);
+
+ALTER TABLE public.seatgeek_event_metrics
+  DROP COLUMN IF EXISTS cost_min,
+  DROP COLUMN IF EXISTS cost_p25,
+  DROP COLUMN IF EXISTS cost_median,
+  DROP COLUMN IF EXISTS cost_mean,
+  DROP COLUMN IF EXISTS cost_p75,
+  DROP COLUMN IF EXISTS cost_p90,
+  DROP COLUMN IF EXISTS cost_max,
+  DROP COLUMN IF EXISTS cost_sum;
+
+COMMENT ON TABLE public.seatgeek_event_metrics IS
+  'Per-event SG-side aggregates. A1 2026-05-18: dropped legacy cost_* columns (SellerDirect-only populator retired). Active columns: listings_all_* (PR #204), listings_owned_* (PR #204), sold_* (PR #161), orders_* (legacy, no active writer), edelivery_share/instant_share/fill_rate/unique_sections/unique_rows (also inert post-drop).';

--- a/supabase/migrations/20260518060000_event_metrics_owned_distribution.sql
+++ b/supabase/migrations/20260518060000_event_metrics_owned_distribution.sql
@@ -1,0 +1,23 @@
+-- Migration 20260518060000 · lane:A1 (DDL only; writer is cross-lane Python) · writes:event_metrics · pre:20260518050000 · auth:operator-approved 2026-05-18
+--
+-- A1 PR-5 — add owned_p25/p75/p90 to event_metrics. DDL only (A1 lane).
+-- Writer (Python app.py event-processor) lives outside A1 lane; columns sit at
+-- NULL until writer-owner ships parallel change. bot_chat handoff posted with
+-- the patch template.
+--
+-- Pattern reference (already used for owned_median_retail):
+--   percentile_cont(0.25) WITHIN GROUP (ORDER BY retail_price) FILTER (WHERE is_owned)
+-- See compute_event_section_metrics + compute_event_zone_metrics for canonical
+-- templates at the section/zone tier.
+
+ALTER TABLE public.event_metrics
+  ADD COLUMN IF NOT EXISTS owned_p25 numeric,
+  ADD COLUMN IF NOT EXISTS owned_p75 numeric,
+  ADD COLUMN IF NOT EXISTS owned_p90 numeric;
+
+COMMENT ON COLUMN public.event_metrics.owned_p25 IS
+  'A1 2026-05-18 added. Pattern: percentile_cont(0.25) WITHIN GROUP (ORDER BY retail_price) FILTER (WHERE is_owned). Populated by event-processor (Python app.py) — pending writer-side change.';
+COMMENT ON COLUMN public.event_metrics.owned_p75 IS
+  'A1 2026-05-18 added. percentile_cont(0.75) ... FILTER (WHERE is_owned). Pending writer-side change.';
+COMMENT ON COLUMN public.event_metrics.owned_p90 IS
+  'A1 2026-05-18 added. percentile_cont(0.90) ... FILTER (WHERE is_owned). Pending writer-side change.';


### PR DESCRIPTION
## Summary

Operator: *"lets fix the gaps."* Sequential 5-PR plan from `zany-skipping-fox.md`, bundled into one PR (10 migrations) because all applied to prod cleanly. Pre-flight discovery: 3 of 5 "gaps" had compute fns lacking a cron caller; 2 were deprecation + DDL.

## What landed

| Gap | Action | Migration |
|---|---|---|
| event_sentiment 0% pop | Schedule existing `backfill_event_sentiment(200)` @ :15,:45 | `20260518010000` |
| event_competitors lost cron | Re-schedule `refresh_event_competitors()` @ :40 (was lost) | `20260518020000` |
| event_section_row empty | New `rollup_event_section_row_batch` + cron @ :03 | `20260518030000` |
| cost_* readers (5 of them) | Swap to `listings_all_*` + `listings_owned_*` | `20260518040000`–`040004` |
| cost_* columns DROP | DROP 8 cols + retire `compute_seatgeek_event_metrics` | `20260518050000` |
| owned distribution | ADD `owned_p25/p75/p90` to event_metrics (DDL; writer cross-lane) | `20260518060000` |

## Verification (consolidated, post-apply)

```sql
SELECT
  (SELECT count(*) FROM event_sentiment WHERE captured_at > now() - interval '2 hours') AS sentiment_rows_2h,
  (SELECT count(DISTINCT tevo_event_id) FROM event_competitors_snapshot WHERE refreshed_at > now() - interval '1 hour') AS competitors_events_1h,
  (SELECT count(*) FROM event_section_row_snapshots WHERE captured_at > now() - interval '2 hours') AS section_rows_2h,
  (SELECT count(*) FROM information_schema.columns WHERE table_name='seatgeek_event_metrics' AND column_name LIKE 'cost_%') AS cost_cols_remaining,
  (SELECT count(*) FROM information_schema.columns WHERE table_name='event_metrics' AND column_name IN ('owned_p25','owned_p75','owned_p90')) AS new_owned_cols,
  (SELECT count(*) FROM cron.job WHERE jobname IN ('event_sentiment_compute_30min','event_competitors_refresh_hourly','event_section_row_rollup_hourly') AND active=true) AS new_crons_active,
  (SELECT count(*) FROM v_event_price_arbitrage WHERE sg_all_median IS NOT NULL OR sg_owned_median IS NOT NULL) AS arbitrage_rows;
-- Result: 8 / 816 / 1268 / 0 / 3 / 3 / 302
```

## Payload shape changes (D0 heads-up)

`get_broker_event_page_v2.sg_side_by_side` and `get_broker_event_page_v3.sg_listings_summary` payload keys renamed:
- `cost_min/p25/median/mean/p75/p90/max/sum` → `listings_all_*` (8 keys) + `listings_owned_*` (9 new keys for broker-owned cohort)
- `cost_sum` dropped (no listings_all_sum equivalent; not used by D0)

D0 is already familiar with the `listings_all_*` / `listings_owned_*` naming via PR #204. Bot_chat handoff posted with FE-grep tips.

## Cross-lane

PR-5 columns (`owned_p25/p75/p90`) sit at NULL until the Python `app.py` event-processor writer is updated. Separate bot_chat to operator/D2 with the `percentile_cont` patch template.

## Test plan

- [x] All 10 migrations applied + smoke-tested on prod
- [x] Zero cost_* readers remaining (verified via `pg_get_functiondef` + `pg_views` scan)
- [x] All 3 new crons active in `cron.job`
- [x] Arbitrage view returns 3-way data (Cavs/Pistons Game 7: TEvo $249 / SG owned $536 / SG all $402)
- [ ] CI green (scan + check + pytest; Supabase Preview standard no-token fail)
- [ ] First cron fires @ :15, :40, :03 over next hour confirm row growth