### PR TITLE
feat(metrics): populate event_metrics.owned_p25/p75/p90 in collect-listings edge fn

### DIFF
--- a/supabase/functions/collect-listings/index.ts
+++ b/supabase/functions/collect-listings/index.ts
@@ -313,7 +313,13 @@ function computeEventMetrics(rows: ListingRow[], eventId: number, capturedAt: st
   const ownedTicketsCount = ownedSeats.reduce((s, r) => s + (r.quantity || 0), 0);
   const ownedGroupsCount = ownedSeats.length;
   const ownedShare = ticketsCount > 0 ? ownedTicketsCount / ticketsCount : null;
+  // PR #206 PR-5 (mig 20260518060000) — owned distribution columns. Mirrors the
+  // retail_* percentile pattern but filtered to is_owned rows. Falls through to
+  // null when ownedRetail is empty (no owned seats on this capture).
   const ownedMedianRetail = percentile(ownedRetail, 0.5);
+  const ownedP25         = percentile(ownedRetail, 0.25);
+  const ownedP75         = percentile(ownedRetail, 0.75);
+  const ownedP90         = percentile(ownedRetail, 0.9);
 
   return {
     event_id: eventId,
@@ -344,6 +350,9 @@ function computeEventMetrics(rows: ListingRow[], eventId: number, capturedAt: st
     owned_tickets_count: ownedTicketsCount,
     owned_share: round4(ownedShare),
     owned_median_retail: round2(ownedMedianRetail),
+    owned_p25: round2(ownedP25),
+    owned_p75: round2(ownedP75),
+    owned_p90: round2(ownedP90),
   };
 }
 


### PR DESCRIPTION
Writer-side completion of PR #206 PR-5 (mig 20260518060000).

The migration added 3 owned distribution columns to `event_metrics` but left them at NULL pending the writer-side change. This patches `supabase/functions/collect-listings/index.ts` to populate them.

## Patch

In `computeEventMetrics()`:
```ts
const ownedP25 = percentile(ownedRetail, 0.25);
const ownedP75 = percentile(ownedRetail, 0.75);
const ownedP90 = percentile(ownedRetail, 0.9);
// ... and emit in the return object:
owned_p25: round2(ownedP25),
owned_p75: round2(ownedP75),
owned_p90: round2(ownedP90),
```

Mirrors the existing `retail_p25/p75/p90` pattern exactly. Same input array (`ownedRetail` = retail_price values where `is_owned`), same TS percentile() helper, same round2() wrapper.

NULL-safe: percentile() returns null when ownedRetail is empty. Upsert key `(event_id, captured_at)` unchanged.

## Deploy

Edge function redeploy required:
```
supabase functions deploy collect-listings
```

Once live, new event_metrics rows populated from next collect cycle. Historical rows stay NULL (no backfill — would require re-reading listings_snapshots).

## Test plan

After deploy:
```sql
SELECT count(*) FILTER (WHERE owned_p25 IS NOT NULL) AS pop,
       count(*) AS total
FROM event_metrics WHERE captured_at > now() - interval '15 minutes';
```
Should show owned_p25 populated for events with owned seats.