### PR TITLE
feat(d0/event): page redesign — hero weather, dual-source zones/splits, merged orders + broker tab, localized NWS alerts

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -29,6 +29,11 @@
         <div class="badges" id="evBadges"></div>
       </div>
       <div class="hero-side">
+        <div id="hero-weather" hidden>
+          <div class="hw-temp"><span id="hwTemp">—</span><span class="hw-unit">°F</span><span id="hwKindBadge" class="hw-kind" hidden>climo</span></div>
+          <div class="hw-summary" id="hwSummary">—</div>
+          <div class="hw-meta"><span id="hwPrecip">—</span> · <span id="hwWind">—</span></div>
+        </div>
         <div class="coverage" id="coverage">
           <span class="lbl">COVERAGE</span>
           <span class="light" data-src="tevo"     title="TEvo"></span>
@@ -53,9 +58,7 @@
       <button class="event-tab" data-tab="evo-listings" role="tab" aria-selected="false">EVO Listings <span class="tab-count" id="tabCountEvoListings"></span></button>
       <button class="event-tab" data-tab="sg-sales" role="tab" aria-selected="false">SG Sales <span class="tab-count" id="tabCountSgSales"></span></button>
       <span class="event-tabs-sep" aria-hidden="true">|</span>
-      <button class="event-tab" data-tab="evo-orders" role="tab" aria-selected="false">Our TEvo Orders <span class="tab-count" id="tabCountEvoOrders"></span></button>
-      <button class="event-tab" data-tab="sg-seller-orders" role="tab" aria-selected="false">Our SG Sales <span class="tab-count" id="tabCountSgSellerOrders"></span></button>
-      <button class="event-tab" data-tab="cross-broker" role="tab" aria-selected="false">TP + Vivid <span class="tab-count" id="tabCountCrossBroker"></span></button>
+      <button class="event-tab" data-tab="our-orders" role="tab" aria-selected="false">Our Orders <span class="tab-count" id="tabCountOurOrders"></span></button>
     </nav>
 
     <div class="tab-pane active" id="paneOverview" role="tabpanel">
@@ -143,24 +146,14 @@
       <div id="sgBrokerSalesBody"></div>
     </section>
 
-    <section id="sg-listings-summary">
-      <div class="panel-title">SG LISTINGS — COST DISTRIBUTION</div>
-      <div id="sgListingsSummaryBody"></div>
-    </section>
-
     <section id="splits">
       <div class="panel-title">SPLITS — DENSITY · LAST 24H</div>
-      <div id="splitsBody"></div>
+      <div class="dual-src" id="splitsBody"></div>
     </section>
 
     <section id="zones">
       <div class="panel-title">ZONES — LATEST SNAPSHOT</div>
-      <div id="zonesBody"></div>
-    </section>
-
-    <section id="sales-tape">
-      <div class="panel-title">SALES TAPE — SEATGEEK · LAST 20</div>
-      <div id="salesTapeBody"></div>
+      <div class="dual-src" id="zonesBody"></div>
     </section>
 
     <section id="espn">
@@ -179,14 +172,17 @@
       <div id="weatherBody"></div>
     </section>
 
-    <section id="order-strip">
-      <div class="panel-title">ORDERS — EVO STATE MIX</div>
-      <div id="ordersBody"></div>
+    <section id="sales-tape">
+      <div class="panel-title">SALES TAPE — SEATGEEK · LAST 20</div>
+      <div id="salesTapeBody"></div>
     </section>
 
-    <section id="cross-source-orders">
-      <div class="panel-title">CROSS-SOURCE ORDERS — TICKPICK + VIVID</div>
-      <div id="crossSourceOrdersBody"></div>
+    <section id="all-orders">
+      <div class="panel-title row">
+        <span>ORDERS — ALL SOURCES (EVO + TickPick + Vivid)</span>
+        <span class="muted small" id="allOrdersCount"></span>
+      </div>
+      <div id="allOrdersBody"></div>
     </section>
 
     <section id="alerts">
@@ -254,7 +250,8 @@
       </section>
     </div>
 
-    <div class="tab-pane" id="paneEvoOrders" role="tabpanel" hidden>
+    <!-- "Our Orders" merged tab — fires 3 parallel RPCs on first activate -->
+    <div class="tab-pane" id="paneOurOrders" role="tabpanel" hidden>
       <section id="evo-orders-full">
         <div class="panel-title row">
           <span>OUR TEVO ORDERS — FULL (evo_orders ⨯ items, newest first)</span>
@@ -262,9 +259,7 @@
         </div>
         <div id="evoOrdersFullBody"><div class="empty">Click the tab to load.</div></div>
       </section>
-    </div>
 
-    <div class="tab-pane" id="paneSgSellerOrders" role="tabpanel" hidden>
       <section id="sg-seller-orders-full">
         <div class="panel-title row">
           <span>OUR SG SALES — SellerDirect orders (our account)</span>
@@ -272,9 +267,7 @@
         </div>
         <div id="sgSellerOrdersFullBody"><div class="empty">Click the tab to load.</div></div>
       </section>
-    </div>
 
-    <div class="tab-pane" id="paneCrossBroker" role="tabpanel" hidden>
       <section id="cross-broker-full">
         <div class="panel-title row">
           <span>TICKPICK + VIVID — combined cross-marketplace orders</span>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -31,10 +31,12 @@
     wireRangeSelector(eventId);
     wireTabs(eventId);
     wireSalesWindow(eventId);
-    // Cross-source metrics RPC is independent of the v3 / Path A fetch
-    // — fire it in parallel so it renders even when fetchPayload fails
-    // (localhost dev without Path A API + without Path C auth).
+    // Path-C-only enrichment RPCs fire in parallel — render even when
+    // fetchPayload (Path A / Path C v3) fails. PR #205 cross-source +
+    // PR redesign localized weather + SG zones/splits all independent.
     loadCrossSourceMetrics(eventId).catch(e => console.error('[crossSource]', e));
+    loadWeatherLocalized(eventId).catch(e => console.error('[weatherLocalized]', e));
+    loadSgZonesSplits(eventId).catch(e => console.error('[sgZonesSplits]', e));
     await loadAndRender(eventId);
   }
 
@@ -62,23 +64,26 @@
       safe('kpiGrid',    () => renderKPIGrid(chart, data.sg_side_by_side, data.velocity));
       safe('chart',      () => renderChart(chart, data.event_alerts));
       safe('chartLegend',() => renderChartLegend());
-      safe('splits',     () => renderSplits(data.splits));
-      safe('zones',      () => renderZones(zones, data.zone_deltas));
+      // Splits + Zones — TEvo side rendered now; SG side merged in by loadSgZonesSplits.
+      safe('splits',     () => renderSplits(data.splits, null));
+      safe('zones',      () => renderZones(zones, data.zone_deltas, null));
       safe('salesTape',  () => renderSalesTape(data.sales_tape, bridge));
       safe('espn',       () => renderEspn(data.espn));
-      safe('weather',    () => renderWeather(data.weather));
-      safe('orders',     () => renderOrders(orders, data.cross_source_orders));
+      // Weather now lazy-loaded via loadWeatherLocalized (drops global-alert path).
+      safe('allOrders',  () => renderAllOrders(orders, data.cross_source_orders));
       safe('coverage',   () => renderCoverage(cadences, overview, data.freshness, bridge));
       safe('freshness',  () => renderFreshness(data.freshness));
       safe('alerts',     () => renderAlerts(data.event_alerts));
-      // v3 enrichments (PR pending)
+      // v3 enrichments
       safe('sgBrokerSales',    () => renderSgBrokerSales(data.sg_broker_sales));
-      safe('sgListingsSummary',() => renderSgListingsSummary(data.sg_listings_summary, data.sg_side_by_side));
       safe('velocityChips',    () => renderVelocityChips(data.velocity));
       safe('competingEvents',  () => renderCompetingEvents(data.competing_events));
       safe('recentListings',   () => renderRecentListings(data.recent_listings));
       safe('performerEspn',    () => renderPerformerEspn(data.performer_espn_context, data.performer));
       safe('lastSnapshot',     () => renderLastSnapshot(data.chart_data));
+      // Cross-source panel: re-render now that we have v3's sg_broker_sales
+      // available (overrides sold_price_median for "Realized sale median" row).
+      safe('crossSourceRerender', () => rerenderCrossSourceWithV3(data));
     } catch (e) {
       handleRpcError(e);
     }
@@ -527,24 +532,37 @@
 
   // ---------- Splits ----------
 
-  function renderSplits(splits) {
+  // Renders TEvo splits + SG splits side-by-side. sgSplits comes from
+  // get_event_sg_zones_splits and is bucketed identically.
+  function renderSplits(splits, sgSplits) {
     const body = document.getElementById('splitsBody');
+    if (!body) return;
     body.innerHTML = '';
-    if (!splits) {
-      body.innerHTML = '<div class="empty">no splits data</div>';
-      return;
-    }
+    // Left col — TEvo
+    const left = document.createElement('div');
+    left.className = 'dual-src-col';
+    left.innerHTML = '<div class="dual-src-hdr">TEvo</div>';
+    left.appendChild(buildTevoSplitsTable(splits));
+    // Right col — SG
+    const right = document.createElement('div');
+    right.className = 'dual-src-col';
+    right.innerHTML = '<div class="dual-src-hdr">SG</div>';
+    right.appendChild(buildSgSplitsTable(sgSplits));
+    body.appendChild(left);
+    body.appendChild(right);
+  }
+
+  function buildTevoSplitsTable(splits) {
+    const wrap = document.createElement('div');
+    if (!splits) { wrap.innerHTML = '<div class="empty">no TEvo splits data</div>'; return wrap; }
     const owned = splits.owned || {};
     const market = splits.market || {};
     const buckets = ['singles', 'pairs', 'triples', 'quads', 'five_plus'];
     const totalOwnedTg = sumTg(owned);
     const totalMarketTg = sumTg(market);
-
     if (totalOwnedTg === 0 && totalMarketTg === 0) {
-      body.innerHTML = '<div class="empty">no recent TEvo listings (last 24h) — possibly stale collector</div>';
-      return;
+      wrap.innerHTML = '<div class="empty">no recent TEvo listings (last 24h)</div>'; return wrap;
     }
-
     const tbl = document.createElement('table');
     tbl.className = 'splits-tbl';
     tbl.innerHTML = `
@@ -556,13 +574,10 @@
         <th class="num">Mkt TG</th>
         <th class="num">Mkt tix</th>
         <th class="num">Mkt avg $</th>
-      </tr></thead>
-      <tbody></tbody>
-    `;
+      </tr></thead><tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
     buckets.forEach(b => {
-      const ob = owned[b] || {};
-      const mb = market[b] || {};
+      const ob = owned[b] || {}; const mb = market[b] || {};
       if (!ob.tg_count && !mb.tg_count) return;
       const tr = document.createElement('tr');
       tr.innerHTML = `
@@ -572,11 +587,46 @@
         <td class="num ours">${fmtPxCell(ob.avg_px)}</td>
         <td class="num">${fmtIntCell(mb.tg_count)}</td>
         <td class="num">${fmtIntCell(mb.tix_count)}</td>
-        <td class="num">${fmtPxCell(mb.avg_px)}</td>
-      `;
+        <td class="num">${fmtPxCell(mb.avg_px)}</td>`;
       tb.appendChild(tr);
     });
-    body.appendChild(tbl);
+    wrap.appendChild(tbl);
+    return wrap;
+  }
+
+  function buildSgSplitsTable(sgSplits) {
+    const wrap = document.createElement('div');
+    if (sgSplits === undefined) { wrap.innerHTML = '<div class="empty">loading SG…</div>'; return wrap; }
+    if (sgSplits === null || sgSplits.hidden) {
+      const reason = sgSplits && sgSplits.reason === 'no_sg_bridge' ? 'no SG bridge for this event' : 'SG unavailable';
+      wrap.innerHTML = `<div class="empty">${escapeHtml(reason)}</div>`; return wrap;
+    }
+    const buckets = ['singles','pairs','triples','quads','five_plus'];
+    const splits = sgSplits.splits || {};
+    const nonEmpty = buckets.some(b => splits[b]);
+    if (!nonEmpty) { wrap.innerHTML = '<div class="empty">no recent SG listings (last 24h)</div>'; return wrap; }
+    const tbl = document.createElement('table');
+    tbl.className = 'splits-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Split</th>
+        <th class="num">Groups</th>
+        <th class="num">Tickets</th>
+        <th class="num">Avg $</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    buckets.forEach(b => {
+      const r = splits[b]; if (!r) return;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="split-name">${labelForBucket(b)}</td>
+        <td class="num">${fmtIntCell(r.groups)}</td>
+        <td class="num">${fmtIntCell(r.tickets)}</td>
+        <td class="num">${fmtPxCell(r.avg_price)}</td>`;
+      tb.appendChild(tr);
+    });
+    wrap.appendChild(tbl);
+    return wrap;
   }
 
   function labelForBucket(b) {
@@ -591,23 +641,30 @@
 
   // ---------- Zones (carried from v1) ----------
 
-  function renderZones(zones, deltas) {
+  // TEvo zones + SG zones (per-section rollup) side-by-side.
+  function renderZones(zones, deltas, sgZones) {
     const body = document.getElementById('zonesBody');
+    if (!body) return;
     body.innerHTML = '';
-    if (!zones) {
-      body.innerHTML = '<div class="empty">zones unavailable</div>';
-      return;
-    }
+    const left = document.createElement('div');
+    left.className = 'dual-src-col';
+    left.innerHTML = '<div class="dual-src-hdr">TEvo (zones)</div>';
+    left.appendChild(buildTevoZonesTable(zones, deltas));
+    const right = document.createElement('div');
+    right.className = 'dual-src-col';
+    right.innerHTML = '<div class="dual-src-hdr">SG (sections)</div>';
+    right.appendChild(buildSgZonesTable(sgZones));
+    body.appendChild(left);
+    body.appendChild(right);
+  }
+
+  function buildTevoZonesTable(zones, deltas) {
+    const wrap = document.createElement('div');
+    if (!zones) { wrap.innerHTML = '<div class="empty">zones unavailable</div>'; return wrap; }
     const rows = zones.zones || [];
-    if (!rows.length) {
-      body.innerHTML = '<div class="empty">no zone data</div>';
-      return;
-    }
-    // Build a delta lookup by zone name (v3 enrichment)
+    if (!rows.length) { wrap.innerHTML = '<div class="empty">no zone data</div>'; return wrap; }
     const deltaByZone = {};
-    if (Array.isArray(deltas)) {
-      deltas.forEach(d => { if (d && d.zone) deltaByZone[d.zone] = d; });
-    }
+    if (Array.isArray(deltas)) deltas.forEach(d => { if (d && d.zone) deltaByZone[d.zone] = d; });
     const tbl = document.createElement('table');
     tbl.innerHTML = `
       <thead><tr>
@@ -641,7 +698,45 @@
         <td class="num ours">${ourPct}</td>`;
       tb.appendChild(tr);
     });
-    body.appendChild(tbl);
+    wrap.appendChild(tbl);
+    return wrap;
+  }
+
+  function buildSgZonesTable(sgZones) {
+    const wrap = document.createElement('div');
+    if (sgZones === undefined) { wrap.innerHTML = '<div class="empty">loading SG…</div>'; return wrap; }
+    if (sgZones === null || sgZones.hidden) {
+      const reason = sgZones && sgZones.reason === 'no_sg_bridge' ? 'no SG bridge for this event' : 'SG unavailable';
+      wrap.innerHTML = `<div class="empty">${escapeHtml(reason)}</div>`; return wrap;
+    }
+    const rows = sgZones.zones || [];
+    if (!rows.length) { wrap.innerHTML = '<div class="empty">no SG section data (last 24h)</div>'; return wrap; }
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Section</th>
+        <th class="num">Listings</th>
+        <th class="num">Tickets</th>
+        <th class="num">Min</th>
+        <th class="num">Median</th>
+        <th class="num">Max</th>
+        <th class="num">Owned</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.slice(0, 30).forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="zone-name">${escapeHtml(r.section || '—')}</td>
+        <td class="num">${T.fmtNum(r.listings)}</td>
+        <td class="num">${T.fmtNum(r.tickets)}</td>
+        <td class="num">${r.min != null ? '$' + T.fmtNum(Math.round(r.min)) : '—'}</td>
+        <td class="num">${r.median != null ? '$' + T.fmtNum(Math.round(r.median)) : '—'}</td>
+        <td class="num">${r.max != null ? '$' + T.fmtNum(Math.round(r.max)) : '—'}</td>
+        <td class="num ${r.owned_listings > 0 ? 'ours' : ''}">${T.fmtNum(r.owned_listings)}</td>`;
+      tb.appendChild(tr);
+    });
+    wrap.appendChild(tbl);
+    return wrap;
   }
 
   // ---------- Sales tape (SG, deduped already by RPC) ----------
@@ -762,139 +857,207 @@
     return 'inj-p';
   }
 
-  // ---------- Weather ----------
+  // ---------- Weather (localized via get_event_weather_localized) ----------
+  //
+  // Renders the full weather panel + the compact hero card. RPC returns:
+  //   forecast: { temp_f, summary, precip_pct, precip_in, wind_mph,
+  //               weather_kind, days_to_event, is_indoor }
+  //   alerts:   [{ alert_id, severity, urgency, alert_event, headline,
+  //                area_desc, onset_at, expires_at, matched_zone_kind }]
+  // weather_kind in {'none','forecast_indoor','forecast_outdoor','climatology_outdoor'}.
 
-  function renderWeather(w) {
+  function renderWeather(d) {
     const section = document.getElementById('weather');
     const body = document.getElementById('weatherBody');
     const subtitle = document.getElementById('weatherSubtitle');
     if (!body) return;
-    if (!w || w.hidden) {
-      section.style.display = 'none';
+    body.innerHTML = '';
+    const f = (d && d.forecast) || null;
+    const alerts = (d && d.alerts) || [];
+    if (!f && !alerts.length) {
+      if (section) section.style.display = 'none';
       return;
     }
-    section.style.display = '';
-    body.innerHTML = '';
-    if (subtitle) subtitle.textContent = w.event_at ? `event ${T.fmtDate(w.event_at)}` : '';
-
-    const fc = w.forecast || [];
-    const obs = w.recent_obs || [];
-    const alerts = w.nws_alerts || [];
-
-    if (fc.length) {
+    if (section) section.style.display = '';
+    if (subtitle) {
+      const dte = (f && f.days_to_event != null) ? `T-${f.days_to_event}d` : '';
+      const kind = (f && f.weather_kind && f.weather_kind !== 'none') ? f.weather_kind.replace(/_/g, ' ') : '';
+      subtitle.textContent = [dte, kind].filter(Boolean).join(' · ');
+    }
+    // Single forecast strip — single row card derived from the resolved
+    // top-level fcst columns on v_event_weather_with_fallback.
+    if (f && f.weather_kind !== 'none') {
       const fcWrap = document.createElement('div');
       fcWrap.className = 'wx-forecast';
-      fcWrap.innerHTML = '<div class="wx-sublabel">FORECAST · NEAREST TO EVENT TIME</div>';
+      const kindLbl = f.weather_kind === 'climatology_outdoor'
+        ? 'CLIMATOLOGY FALLBACK · OUTDOOR'
+        : f.weather_kind === 'forecast_indoor'
+        ? 'FORECAST · INDOOR (no outdoor signal)'
+        : 'FORECAST · OUTDOOR';
+      fcWrap.innerHTML = `<div class="wx-sublabel">${kindLbl}</div>`;
       const row = document.createElement('div');
       row.className = 'wx-row';
-      fc.forEach(f => {
-        const cell = document.createElement('div');
-        cell.className = 'wx-cell';
-        cell.innerHTML = `
-          <div class="wx-time">${shortHour(f.observed_at)}</div>
-          <div class="wx-temp">${f.temp_f != null ? Math.round(f.temp_f) + '°' : '—'}</div>
-          <div class="wx-precip">${f.precip_pct != null ? Math.round(f.precip_pct) + '%' : '—'} ${f.precip_in != null ? `· ${f.precip_in.toFixed(2)}"` : ''}</div>
-          <div class="wx-wind">${f.wind_mph != null ? Math.round(f.wind_mph) + ' mph' : '—'}${f.gust_mph != null ? ` · g${Math.round(f.gust_mph)}` : ''}</div>
-          <div class="wx-summary">${escapeHtml(f.weather_summary || '')}</div>
-        `;
-        row.appendChild(cell);
-      });
+      const cell = document.createElement('div');
+      cell.className = 'wx-cell';
+      cell.innerHTML = `
+        <div class="wx-temp">${f.temp_f != null ? Math.round(f.temp_f) + '°' : '—'}</div>
+        <div class="wx-precip">${f.precip_pct != null ? Math.round(f.precip_pct) + '%' : '—'}${f.precip_in != null ? ` · ${Number(f.precip_in).toFixed(2)}"` : ''}</div>
+        <div class="wx-wind">${f.wind_mph != null ? Math.round(f.wind_mph) + ' mph' : '—'}</div>
+        <div class="wx-summary">${escapeHtml(f.summary || '')}</div>`;
+      row.appendChild(cell);
       fcWrap.appendChild(row);
       body.appendChild(fcWrap);
     }
-
-    if (obs.length) {
-      const obsWrap = document.createElement('div');
-      obsWrap.className = 'wx-obs';
-      obsWrap.innerHTML = `<div class="wx-sublabel">RECENT OBSERVATIONS (${obs.length})</div>`;
-      const ul = document.createElement('ul');
-      obs.forEach(o => {
-        const li = document.createElement('li');
-        li.innerHTML = `<span class="muted">${T.fmtDate(o.observed_at)}</span> ${o.temp_f != null ? Math.round(o.temp_f) + '°F' : '—'} · ${o.precip_pct != null ? o.precip_pct + '% precip' : '—'} · ${escapeHtml(o.weather_summary || '')}`;
-        ul.appendChild(li);
-      });
-      obsWrap.appendChild(ul);
-      body.appendChild(obsWrap);
-    }
-
     if (alerts.length) {
       const aw = document.createElement('div');
       aw.className = 'wx-alerts';
-      aw.innerHTML = `<div class="wx-sublabel">NWS ALERTS (${alerts.length})</div>`;
+      aw.innerHTML = `<div class="wx-sublabel">NWS ALERTS (${alerts.length}) · venue-scoped</div>`;
       const ul = document.createElement('ul');
       alerts.forEach(a => {
         const li = document.createElement('li');
-        li.innerHTML = `<strong>${escapeHtml(a.event || '')}</strong> <span class="muted">${escapeHtml(a.severity || '')} · expires ${T.fmtDate(a.expires_at)}</span> — ${escapeHtml(a.headline || '')}`;
+        const sev = String(a.severity || '').toLowerCase();
+        const sevCls = (sev === 'extreme' || sev === 'severe') ? 'neg' : (sev === 'moderate' ? 'warn' : 'muted');
+        li.innerHTML = `<strong>${escapeHtml(a.alert_event || '')}</strong> <span class="${sevCls}">${escapeHtml(a.severity || '')}</span> · <span class="muted">expires ${T.fmtDate(a.expires_at)}</span> — ${escapeHtml(a.headline || '')} <span class="muted small">[${escapeHtml(a.matched_zone_kind || '')}]</span>`;
         ul.appendChild(li);
       });
       aw.appendChild(ul);
       body.appendChild(aw);
+    } else {
+      const noneEl = document.createElement('div');
+      noneEl.className = 'muted small';
+      noneEl.style.marginTop = '8px';
+      noneEl.textContent = 'no active NWS alerts for venue';
+      body.appendChild(noneEl);
     }
   }
 
-  function shortHour(iso) {
-    if (!iso) return '—';
-    try {
-      const d = new Date(iso);
-      return d.toLocaleString(undefined, { weekday: 'short', hour: 'numeric' });
-    } catch (_) { return iso; }
+  function renderHeroWeather(forecast) {
+    const host = document.getElementById('hero-weather');
+    if (!host) return;
+    if (!forecast || forecast.weather_kind === 'none' || forecast.weather_kind === 'forecast_indoor' || forecast.temp_f == null) {
+      host.setAttribute('hidden', '');
+      return;
+    }
+    host.removeAttribute('hidden');
+    const tEl = document.getElementById('hwTemp');
+    const sEl = document.getElementById('hwSummary');
+    const pEl = document.getElementById('hwPrecip');
+    const wEl = document.getElementById('hwWind');
+    const kEl = document.getElementById('hwKindBadge');
+    if (tEl) tEl.textContent = Math.round(forecast.temp_f);
+    if (sEl) sEl.textContent = forecast.summary || '—';
+    if (pEl) pEl.textContent = forecast.precip_pct != null ? Math.round(forecast.precip_pct) + '% precip' : '—';
+    if (wEl) wEl.textContent = forecast.wind_mph != null ? Math.round(forecast.wind_mph) + ' mph' : '—';
+    if (kEl) {
+      if (forecast.weather_kind === 'climatology_outdoor') {
+        kEl.removeAttribute('hidden');
+        kEl.textContent = 'climo';
+      } else {
+        kEl.setAttribute('hidden', '');
+      }
+    }
   }
 
-  // ---------- Orders strip ----------
+  // ---------- All Orders (unified — EVO + TickPick + Vivid) ----------
+  //
+  // Replaces the legacy #order-strip (EVO state-mix bar) + #cross-source-orders
+  // (TP+Vivid separate panel). Single sortable table with a Source column.
+  // Shows ALL order states (pending/accepted/completed/rejected/etc.), not
+  // just pending. Sorted by created_at DESC, capped 30.
 
-  function renderOrders(orders, crossSource) {
-    const body = document.getElementById('ordersBody');
+  function renderAllOrders(orders, crossSource) {
+    const body = document.getElementById('allOrdersBody');
+    const countEl = document.getElementById('allOrdersCount');
+    if (!body) return;
+    const rows = [];
+    // EVO line-items
+    const items   = (orders && orders.items) || [];
+    const ordList = (orders && orders.orders) || [];
+    const stateById = new Map(ordList.map(o => [o.evo_order_id, o]));
+    items.forEach(it => {
+      const o = stateById.get(it.evo_order_id) || {};
+      rows.push({
+        source: 'evo',
+        order_id: it.evo_order_id,
+        status: o.state || 'unknown',
+        section: it.ticket_group_section || it.section,
+        row:     it.ticket_group_row     || it.row,
+        quantity: it.quantity,
+        total:    it.price != null && it.quantity != null ? Number(it.price) * Number(it.quantity) : null,
+        created_at: o.evo_created_at || o.evo_updated_at || it.pulled_at,
+      });
+    });
+    // TickPick
+    ((crossSource && crossSource.tickpick) || []).forEach(o => {
+      rows.push({
+        source: 'tickpick',
+        order_id: o.tp_order_id || o.order_id,
+        status: o.status || o.order_status || 'unknown',
+        section: o.section, row: o.row,
+        quantity: o.quantity,
+        total: o.total,
+        created_at: o.ordered_at,
+      });
+    });
+    // Vivid
+    ((crossSource && crossSource.vivid) || []).forEach(o => {
+      rows.push({
+        source: 'vivid',
+        order_id: o.vivid_order_id || o.order_id,
+        status: o.status || 'unknown',
+        section: o.section, row: o.row,
+        quantity: o.quantity,
+        total: o.total,
+        created_at: o.ordered_at,
+      });
+    });
+    rows.sort((a, b) => {
+      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return tb - ta;
+    });
+    if (countEl) {
+      const evoN = rows.filter(r => r.source === 'evo').length;
+      const tpN  = rows.filter(r => r.source === 'tickpick').length;
+      const vvN  = rows.filter(r => r.source === 'vivid').length;
+      const parts = [];
+      if (evoN) parts.push(`EVO ${evoN}`);
+      if (tpN)  parts.push(`TP ${tpN}`);
+      if (vvN)  parts.push(`Vivid ${vvN}`);
+      if (rows.length) parts.push(`· ${rows.length} total`);
+      countEl.textContent = parts.join(' · ');
+    }
     body.innerHTML = '';
-    if (!orders) {
-      body.innerHTML = '<div class="empty">orders unavailable</div>';
-      renderCrossSourceOrders(crossSource);  // still surface tickpick/vivid if present
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no orders for this event from any source</div>';
       return;
     }
-    if (!orders.summary || orders.summary.total_items === 0) {
-      body.innerHTML = '<div class="empty">no EVO orders for this event</div>';
-      renderCrossSourceOrders(crossSource);
-      return;
-    }
-    const byState = orders.summary.by_state || {};
-    const stateOrder = ['pending', 'accepted', 'completed', 'rejected', 'pending_sub', 'unknown'];
-
-    const bar = document.createElement('div');
-    bar.className = 'order-bar';
-    stateOrder.forEach(st => {
-      const n = byState[st] || 0;
-      if (!n) return;
-      const seg = document.createElement('div');
-      seg.className = 'seg ' + st;
-      seg.style.flex = String(n);
-      seg.textContent = n >= 3 ? n : '';
-      seg.title = `${st}: ${n}`;
-      bar.appendChild(seg);
+    const tbl = document.createElement('table');
+    tbl.className = 'orders-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Source</th><th>Order</th><th>Status</th>
+        <th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">Total</th>
+        <th>Created</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.slice(0, 30).forEach(r => {
+      const tr = document.createElement('tr');
+      const statusCls = r.status ? 'status-' + String(r.status).toLowerCase().replace(/[^a-z0-9]+/g, '-') : '';
+      const srcCls = 'src-' + r.source;
+      tr.innerHTML = `
+        <td><span class="src-pill ${srcCls}">${escapeHtml(r.source)}</span></td>
+        <td>${escapeHtml(String(r.order_id || '—'))}</td>
+        <td><span class="status-pill ${statusCls}">${escapeHtml(r.status || '—')}</span></td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${T.fmtNum(r.quantity)}</td>
+        <td class="num">${r.total != null ? '$' + T.fmtNum(Math.round(r.total)) : '—'}</td>
+        <td class="muted">${T.fmtDate(r.created_at)}</td>`;
+      tb.appendChild(tr);
     });
-    body.appendChild(bar);
-
-    const legend = document.createElement('div');
-    legend.className = 'order-legend';
-    stateOrder.forEach(st => {
-      const n = byState[st] || 0;
-      if (!n) return;
-      const row = document.createElement('div');
-      row.className = 'row ' + st;
-      row.innerHTML = `<span class="lbl">${st}</span><span class="num">${n}</span>`;
-      legend.appendChild(row);
-    });
-    body.appendChild(legend);
-
-    const summary = document.createElement('div');
-    summary.className = 'order-summary';
-    summary.innerHTML = `
-      <span class="lbl">items</span><span class="val">${T.fmtNum(orders.summary.total_items)}</span>
-      <span class="lbl">tickets sold</span><span class="val">${T.fmtNum(orders.summary.tickets_sold)}</span>
-      <span class="lbl">gross sold</span><span class="val">$${T.fmtNum(orders.summary.gross_sold, { max: 0 })}</span>
-      <span class="lbl">last update</span><span class="val">${T.fmtDate(orders.summary.last_update_at)}</span>
-    `;
-    // v3: surface tickpick/vivid orders for this event AFTER EVO rendering
-    setTimeout(() => renderCrossSourceOrders(crossSource), 0);
-    body.appendChild(summary);
+    body.appendChild(tbl);
   }
 
   // ---------- Coverage + freshness ----------
@@ -1113,34 +1276,10 @@
       </div>`;
   }
 
-  // ---------- SG listings summary (cost distribution) ----------
-  function renderSgListingsSummary(m, sxs) {
-    const section = document.getElementById('sg-listings-summary');
-    const body = document.getElementById('sgListingsSummaryBody');
-    if (!body) return;
-    if (!m || m.hidden) {
-      if (section) section.style.display = 'none';
-      return;
-    }
-    if (section) section.style.display = '';
-    // Optional 24h-ago delta from sxs.d24h_ago for cost_median
-    const prev = sxs && !sxs.hidden && sxs.d24h_ago ? sxs.d24h_ago : null;
-    const dPct = (prev && prev.cost_median && m.cost_median)
-      ? ((m.cost_median / prev.cost_median - 1) * 100) : null;
-    body.innerHTML = `
-      <div class="kpi-strip">
-        <div class="kpi-strip-cell"><span class="kpi-lbl">LISTINGS</span><span class="kpi-val">${T.fmtNum(m.listings_count)}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">TIX</span><span class="kpi-val">${T.fmtNum(m.tickets_count)}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">COST MIN</span><span class="kpi-val">${m.cost_min != null ? '$' + T.fmtNum(Math.round(m.cost_min)) : '—'}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">P25</span><span class="kpi-val">${m.cost_p25 != null ? '$' + T.fmtNum(Math.round(m.cost_p25)) : '—'}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">MEDIAN</span><span class="kpi-val">${m.cost_median != null ? '$' + T.fmtNum(Math.round(m.cost_median)) : '—'}${dPct != null ? `<span class="kpi-sg ${dPct >= 0 ? 'pos' : 'neg'}">${dPct >= 0 ? '+' : ''}${dPct.toFixed(1)}% d24h</span>` : ''}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">P75</span><span class="kpi-val">${m.cost_p75 != null ? '$' + T.fmtNum(Math.round(m.cost_p75)) : '—'}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">P90</span><span class="kpi-val">${m.cost_p90 != null ? '$' + T.fmtNum(Math.round(m.cost_p90)) : '—'}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">MAX</span><span class="kpi-val">${m.cost_max != null ? '$' + T.fmtNum(Math.round(m.cost_max)) : '—'}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">FILL</span><span class="kpi-val">${m.fill_rate != null ? (m.fill_rate * 100).toFixed(0) + '%' : '—'}</span></div>
-        <div class="kpi-strip-cell"><span class="kpi-lbl">SECTIONS</span><span class="kpi-val">${T.fmtNum(m.unique_sections)}</span></div>
-      </div>`;
-  }
+  // (renderSgListingsSummary removed — deprecated cost_* fields per operator
+  // metrics inventory; CROSS-SOURCE METRICS panel covers the SG ask
+  // distribution via listings_all_* from PR #204.)
+
 
   // ---------- Velocity chips (inline strip) ----------
   function renderVelocityChips(v) {
@@ -1222,36 +1361,9 @@
     body.appendChild(tbl);
   }
 
-  // ---------- Cross-source orders (TickPick + Vivid) ----------
-  function renderCrossSourceOrders(cs) {
-    const body = document.getElementById('crossSourceOrdersBody');
-    const section = document.getElementById('cross-source-orders');
-    if (!body) return;
-    const tp = (cs && cs.tickpick) || [];
-    const vv = (cs && cs.vivid) || [];
-    if (!tp.length && !vv.length) {
-      if (section) section.style.display = 'none';
-      return;
-    }
-    if (section) section.style.display = '';
-    function rowsHtml(rows, source) {
-      if (!rows.length) return '';
-      return rows.slice(0, 10).map(o => {
-        const total = o.total != null ? '$' + T.fmtNum(o.total, { max: 2 }) : '—';
-        const sec = escapeHtml(o.section || '—');
-        const row = escapeHtml(o.row || '—');
-        return `<tr><td><span class="src-pill src-${source}">${source}</span></td><td>${escapeHtml(o.status || '—')}</td><td class="num">${T.fmtNum(o.quantity)}</td><td class="num">${total}</td><td>${sec} / ${row}</td><td class="muted">${T.fmtDate(o.ordered_at)}</td></tr>`;
-      }).join('');
-    }
-    body.innerHTML = `
-      <div class="cross-src-meta muted small">
-        TickPick: ${tp.length} orders · Vivid: ${vv.length} orders (top 10 each)
-      </div>
-      <table class="cross-src-tbl">
-        <thead><tr><th>Src</th><th>Status</th><th class="num">Qty</th><th class="num">Total</th><th>Sec/Row</th><th>Ordered</th></tr></thead>
-        <tbody>${rowsHtml(tp, 'tickpick')}${rowsHtml(vv, 'vivid')}</tbody>
-      </table>`;
-  }
+  // (renderCrossSourceOrders removed — folded into renderAllOrders which
+  // unifies EVO + TickPick + Vivid into a single sortable table.)
+
 
   // ---------- Performer ESPN context (next 5 games) ----------
   function renderPerformerEspn(ctx, performer) {
@@ -1328,7 +1440,7 @@
   // ============================================================
   const _tabState = { loaded: {
     'sg-listings': false, 'evo-listings': false, 'sg-sales': false,
-    'evo-orders': false, 'sg-seller-orders': false, 'cross-broker': false,
+    'our-orders': false,
   } };
 
   function wireTabs(eventId) {
@@ -1345,12 +1457,16 @@
         await loadEvoListingsFull(eventId);
       } else if (tabId === 'sg-sales' && !_tabState.loaded['sg-sales']) {
         await loadSgSalesFull(eventId);
-      } else if (tabId === 'evo-orders' && !_tabState.loaded['evo-orders']) {
-        await loadEvoOrdersFull(eventId);
-      } else if (tabId === 'sg-seller-orders' && !_tabState.loaded['sg-seller-orders']) {
-        await loadSgSellerOrdersFull(eventId);
-      } else if (tabId === 'cross-broker' && !_tabState.loaded['cross-broker']) {
-        await loadCrossBrokerFull(eventId);
+      } else if (tabId === 'our-orders' && !_tabState.loaded['our-orders']) {
+        // Merged tab — fire all 3 broker-order RPCs in parallel, render each
+        // into its own stacked sub-section inside #paneOurOrders.
+        _tabState.loaded['our-orders'] = true;
+        await Promise.all([
+          loadEvoOrdersFull(eventId),
+          loadSgSellerOrdersFull(eventId),
+          loadCrossBrokerFull(eventId),
+        ]);
+        updateOurOrdersTabCount();
       }
     });
   }
@@ -1362,13 +1478,11 @@
       b.setAttribute('aria-selected', on ? 'true' : 'false');
     });
     const paneIds = {
-      'overview':         'paneOverview',
-      'sg-listings':      'paneSgListings',
-      'evo-listings':     'paneEvoListings',
-      'sg-sales':         'paneSgSales',
-      'evo-orders':       'paneEvoOrders',
-      'sg-seller-orders': 'paneSgSellerOrders',
-      'cross-broker':     'paneCrossBroker',
+      'overview':     'paneOverview',
+      'sg-listings':  'paneSgListings',
+      'evo-listings': 'paneEvoListings',
+      'sg-sales':     'paneSgSales',
+      'our-orders':   'paneOurOrders',
     };
     Object.entries(paneIds).forEach(([id, paneId]) => {
       const pane = document.getElementById(paneId);
@@ -1381,6 +1495,17 @@
         pane.classList.remove('active');
       }
     });
+  }
+
+  // Aggregate the 3 sub-section counts into the merged Our Orders tab chip.
+  function updateOurOrdersTabCount() {
+    const chip = document.getElementById('tabCountOurOrders');
+    if (!chip) return;
+    const evo  = parseInt(document.getElementById('tabCountEvoOrders')?.textContent || '0', 10) || 0;
+    const sg   = parseInt(document.getElementById('tabCountSgSellerOrders')?.textContent || '0', 10) || 0;
+    const xb   = parseInt(document.getElementById('tabCountCrossBroker')?.textContent || '0', 10) || 0;
+    const total = evo + sg + xb;
+    chip.textContent = total ? String(total) : '';
   }
 
   function wireSalesWindow(eventId) {
@@ -1866,12 +1991,19 @@
     renderCrossSourceMetrics(res.data || {}, performance.now() - t0);
   }
 
-  function renderCrossSourceMetrics(d, ms) {
+  // Cache the last cross-source payload so we can re-render when v3 data
+  // arrives later and we want to override sold_price_median with the v3
+  // sg_broker_sales aggregate (which is what the SG BROKER SALES — AGGREGATE
+  // panel renders, ensuring both panels show the same number).
+  let _lastCrossSource = null;
+
+  function renderCrossSourceMetrics(d, ms, overrides) {
+    _lastCrossSource = d;
     const body = document.getElementById('crossSourceBody');
     const meta = document.getElementById('crossSourceMeta');
     if (!body) return;
-    const rows = d.rows || [];
-    const hasSg = d.sg_event_id != null;
+    const rows = (d && d.rows) || [];
+    const hasSg = d && d.sg_event_id != null;
     if (meta) {
       const parts = [`${ms != null ? ms.toFixed(0) + 'ms' : ''}`];
       if (hasSg) parts.unshift(`sg_event_id ${d.sg_event_id}`);
@@ -1882,6 +2014,9 @@
       body.innerHTML = '<div class="empty">no metrics available</div>';
       return;
     }
+    // Override "Realized sale median" SG cell with v3 sg_broker_sales aggregate
+    // when available (the SG BROKER SALES — AGGREGATE panel's source of truth).
+    const realizedOverride = overrides && overrides.realized_sale_median_sg;
     function fmtVal(v, isMoney) {
       if (v === null || v === undefined) return '<span class="dim">—</span>';
       const n = Number(v);
@@ -1890,7 +2025,6 @@
       return T.fmtNum(n);
     }
     function deltaPct(tevo, sg) {
-      // SG vs TEvo — positive means SG higher than TEvo
       if (tevo === null || tevo === undefined || sg === null || sg === undefined) return null;
       const t = Number(tevo), s = Number(sg);
       if (!Number.isFinite(t) || !Number.isFinite(s) || t === 0) return null;
@@ -1915,15 +2049,65 @@
     const tb = tbl.querySelector('tbody');
     rows.forEach(r => {
       const tr = document.createElement('tr');
+      let sgVal = r.sg;
+      if (r.label === 'Realized sale median' && realizedOverride != null) sgVal = realizedOverride;
       tr.innerHTML = `
         <td>${escapeHtml(r.label || '')}</td>
         <td class="num">${fmtVal(r.tevo, r.is_money)}</td>
-        <td class="num">${fmtVal(r.sg, r.is_money)}</td>
-        <td class="num">${deltaCell(r.tevo, r.sg)}</td>`;
+        <td class="num">${fmtVal(sgVal, r.is_money)}</td>
+        <td class="num">${deltaCell(r.tevo, sgVal)}</td>`;
       tb.appendChild(tr);
     });
     body.innerHTML = '';
     body.appendChild(tbl);
+  }
+
+  // Called after v3 RPC payload arrives — re-renders the cross-source panel
+  // using the v3 sg_broker_sales.median_sale_price as the canonical
+  // "Realized sale median" value (matches SG BROKER SALES — AGGREGATE).
+  function rerenderCrossSourceWithV3(data) {
+    if (!_lastCrossSource) return;
+    const med = data && data.sg_broker_sales && data.sg_broker_sales.median_sale_price;
+    renderCrossSourceMetrics(_lastCrossSource, null, {
+      realized_sale_median_sg: med != null ? Number(med) : null,
+    });
+  }
+
+  // ---------- Localized weather + NWS alerts (mig 20260519000000) ----------
+  async function loadWeatherLocalized(eventId) {
+    const res = await rpcOrNull('get_event_weather_localized', { p_event_id: eventId });
+    if (res.error) {
+      console.error('[weatherLocalized] RPC error:', res.error.message);
+      // Hide hero card; full panel will still show whatever the v3 payload provides.
+      const host = document.getElementById('hero-weather');
+      if (host) host.setAttribute('hidden', '');
+      return;
+    }
+    const d = res.data || {};
+    renderHeroWeather(d.forecast);
+    renderWeather(d);
+  }
+
+  // ---------- SG zones + splits (mig 20260519010000) ----------
+  // When the RPC resolves, re-render Splits + Zones with SG data merged in.
+  // TEvo side is pulled from the cached _lastPayload (set by loadAndRender).
+  async function loadSgZonesSplits(eventId) {
+    const res = await rpcOrNull('get_event_sg_zones_splits', { p_event_id: eventId });
+    let sgZones, sgSplits;
+    if (res.error) {
+      sgZones  = { hidden: true, reason: 'rpc_error' };
+      sgSplits = { hidden: true, reason: 'rpc_error' };
+    } else {
+      const d = res.data || {};
+      if (d.hidden) { sgZones = d; sgSplits = d; }
+      else { sgZones = { zones: d.zones || [] }; sgSplits = { splits: d.splits || {} }; }
+    }
+    const data = _lastPayload || {};
+    const tevoZones  = data.zones || {};
+    const tevoDeltas = data.zone_deltas || null;
+    const tevoSplits = data.splits || null;
+    renderZones(tevoZones, tevoDeltas, sgZones);
+    renderSplits(tevoSplits, sgSplits);
   }
 
   // ---------- Last event snapshot (Overview tab) ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -851,14 +851,12 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 .wrap.event #cross-source-metrics { grid-column: 1 / -1; }
 .wrap.event #chart              { grid-column: 1 / -1; padding: 12px 8px; }
 .wrap.event #sg-broker-sales    { grid-column: 1 / -1; }
-.wrap.event #sg-listings-summary{ grid-column: 1 / -1; }
-.wrap.event #splits             { grid-column: 1 / 7; }
-.wrap.event #zones              { grid-column: 7 / 13; }
+.wrap.event #splits             { grid-column: 1 / -1; }
+.wrap.event #zones              { grid-column: 1 / -1; }
 .wrap.event #sales-tape         { grid-column: 1 / -1; }
 .wrap.event #espn               { grid-column: 1 / -1; }
 .wrap.event #weather            { grid-column: 1 / -1; }
-.wrap.event #order-strip        { grid-column: 1 / 7; }
-.wrap.event #cross-source-orders{ grid-column: 7 / 13; }
+.wrap.event #all-orders         { grid-column: 1 / -1; }
 .wrap.event #alerts             { grid-column: 1 / 7; }
 .wrap.event #competing-events   { grid-column: 7 / 13; }
 .wrap.event #recent-listings    { grid-column: 1 / 7; }
@@ -1464,3 +1462,109 @@ body[data-page="login"] {
   text-align: center;
 }
 .ts-empty.err { color: var(--neg); }
+
+/* ---------- Event redesign (post-PR #206) ---------- */
+
+/* Hero weather card — compact top-right of hero side-rail */
+#hero-weather {
+  display: flex; flex-direction: column;
+  align-items: flex-end;
+  padding: 6px 10px;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  font-family: var(--mono);
+  margin-bottom: 6px;
+  min-width: 140px;
+}
+#hero-weather .hw-temp {
+  font-size: 24px; font-weight: 700; color: var(--accent);
+  display: flex; align-items: baseline; gap: 4px;
+}
+#hero-weather .hw-temp .hw-unit { font-size: 12px; color: var(--muted); }
+#hero-weather .hw-temp .hw-kind {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 9px;
+  color: var(--warn);
+  border: 1px solid var(--warn);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+#hero-weather .hw-summary { color: var(--text); font-size: 11px; margin-top: 2px; }
+#hero-weather .hw-meta    { color: var(--muted); font-size: 10px; margin-top: 2px; }
+
+/* Dual-source side-by-side container (used by Splits + Zones panels) */
+.dual-src {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.dual-src-col {
+  min-width: 0;
+}
+.dual-src-hdr {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding-bottom: 4px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--line);
+}
+
+/* Unified Orders panel — EVO + TickPick + Vivid in one table */
+.orders-tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono); font-size: 11px;
+}
+.orders-tbl thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--line);
+}
+.orders-tbl tbody td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--line-2);
+  color: var(--text);
+}
+.orders-tbl tbody tr:hover td { background: var(--shade); }
+.orders-tbl .num { text-align: right; }
+.src-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  border-radius: 2px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.src-pill.src-evo      { color: var(--accent); border-color: var(--accent); }
+.src-pill.src-tickpick { color: var(--info);   border-color: var(--info); }
+.src-pill.src-vivid    { color: #c084fc;       border-color: #c084fc; }
+.status-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  border-radius: 2px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.status-pill.status-pending     { color: var(--info); border-color: var(--info); }
+.status-pill.status-accepted,
+.status-pill.status-completed,
+.status-pill.status-confirmed   { color: var(--pos); border-color: var(--pos); }
+.status-pill.status-rejected,
+.status-pill.status-cancelled,
+.status-pill.status-pending-sub { color: var(--neg); border-color: var(--neg); }
+
+/* Our Orders merged tab — 3 stacked sub-sections */
+#paneOurOrders > section + section { margin-top: 12px; }

--- a/supabase/migrations/20260519000000_event_page_weather_localized_rpc.sql
+++ b/supabase/migrations/20260519000000_event_page_weather_localized_rpc.sql
@@ -1,0 +1,92 @@
+-- Migration 20260519000000 · lane:D0 (author) → A1 (apply) · writes:get_event_weather_localized · reads:v_event_weather_with_fallback,v_event_nws_alerts · pre:20260518040000 · auth:operator-approved 2026-05-19
+--
+-- D0 — venue-localized weather + NWS alerts for the event page.
+-- Replaces the v3 RPC `weather` payload's behavior of returning ALL
+-- alerts unfiltered.
+--
+-- Per A1 audit (bot_chat #309): v_event_weather_with_fallback exposes
+-- fallback-aware top-level cols (temp_f/precip_in/precip_pct/wind_mph/
+-- weather_summary) — no fcst_*/climo_* branching needed. weather_kind
+-- column signals source: 'none' / 'forecast_indoor' / 'forecast_outdoor'
+-- / 'climatology_outdoor'. v_event_nws_alerts filters alerts to the
+-- event's venue via UGC zone match (matched_zone_kind tells us which
+-- of county/forecast/fire-weather zone matched).
+
+CREATE OR REPLACE FUNCTION public.get_event_weather_localized(p_event_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email    text;
+  v_forecast jsonb;
+  v_alerts   jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- Forecast row from v_event_weather_with_fallback (one row per event).
+  SELECT to_jsonb(f) INTO v_forecast
+  FROM (
+    SELECT
+      tevo_event_id,
+      venue_id,
+      venue_name,
+      is_indoor,
+      occurs_at_local,
+      days_to_event,
+      weather_kind,
+      temp_f,
+      weather_summary       AS summary,
+      precip_pct,
+      precip_in,
+      wind_mph,
+      latitude,
+      longitude
+    FROM public.v_event_weather_with_fallback
+    WHERE tevo_event_id = p_event_id
+    LIMIT 1
+  ) f;
+
+  -- Localized NWS alerts via v_event_nws_alerts (auto-scoped to venue UGC zones).
+  SELECT coalesce(jsonb_agg(to_jsonb(a) ORDER BY a.severity_rank, a.expires_at DESC NULLS LAST), '[]'::jsonb)
+  INTO v_alerts
+  FROM (
+    SELECT
+      alert_id,
+      alert_event,
+      severity,
+      urgency,
+      certainty,
+      headline,
+      area_desc,
+      onset_at,
+      expires_at,
+      matched_zone_kind,
+      ugc_code,
+      -- For server-side ORDER BY: Extreme=1, Severe=2, Moderate=3, Minor=4, Unknown=5
+      CASE lower(coalesce(severity, ''))
+        WHEN 'extreme'  THEN 1
+        WHEN 'severe'   THEN 2
+        WHEN 'moderate' THEN 3
+        WHEN 'minor'    THEN 4
+        ELSE 5
+      END AS severity_rank
+    FROM public.v_event_nws_alerts
+    WHERE tevo_event_id = p_event_id
+  ) a;
+
+  RETURN jsonb_build_object(
+    'event_id',  p_event_id,
+    'forecast',  v_forecast,
+    'alerts',    v_alerts
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_weather_localized(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_weather_localized(integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_weather_localized(integer) IS
+  'D0 event Overview — venue-localized weather forecast (v_event_weather_with_fallback) + NWS alerts (v_event_nws_alerts, filtered to event venue UGC zones). Replaces the v3 RPC weather payloads global-alert behavior. Email-gated.';

--- a/supabase/migrations/20260519010000_event_page_sg_zones_splits_rpc.sql
+++ b/supabase/migrations/20260519010000_event_page_sg_zones_splits_rpc.sql
@@ -1,0 +1,133 @@
+-- Migration 20260519010000 · lane:D0 (author) → A1 (apply) · writes:get_event_sg_zones_splits · reads:seatgeek_listings_snapshots,seatgeek_event_xref · pre:20260519000000 · auth:operator-approved 2026-05-19
+--
+-- D0 — SG-side zones (per-section rollup) + splits (per-quantity bucket)
+-- so the event Overview tab Zones + Splits panels can render TEvo vs SG
+-- side-by-side.
+--
+-- Source: seatgeek_listings_snapshots 24h window, deduped on sglid
+-- (PROJECT_BIBLE §3 — content-hash table requires DISTINCT ON).
+-- Scoped on sg_event_id (idx_sg_listings_sg_event_id_time).
+-- Bridge via seatgeek_event_xref.
+--
+-- Per-zone: min/median/max broadcast_price + listings count + tickets count.
+-- Per-split: bucket on quantity (1, 2, 3, 4+) — groups + tickets + avg price.
+
+CREATE OR REPLACE FUNCTION public.get_event_sg_zones_splits(p_event_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_zones       jsonb;
+  v_splits      jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref
+  WHERE tevo_event_id = p_event_id
+  LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'sg_event_id', null,
+                              'zones', '[]'::jsonb, 'splits', '{}'::jsonb);
+  END IF;
+
+  -- Dedupe 24h SG listings on sglid first (mandatory). Use broadcast_price
+  -- as primary signal; retail_price_all_in as fallback when null.
+  WITH deduped AS (
+    SELECT DISTINCT ON (sglid)
+      sglid, section, quantity,
+      coalesce(broadcast_price, retail_price_all_in) AS price,
+      is_broker_owned
+    FROM public.seatgeek_listings_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND captured_at > now() - interval '24 hours'
+      AND section IS NOT NULL
+    ORDER BY sglid, captured_at DESC
+  )
+  SELECT
+    coalesce(jsonb_agg(jsonb_build_object(
+      'section',  section,
+      'listings', listings,
+      'tickets',  tickets,
+      'min',      min_p,
+      'median',   median_p,
+      'max',      max_p,
+      'owned_listings', owned_listings
+    ) ORDER BY median_p DESC NULLS LAST), '[]'::jsonb)
+  INTO v_zones
+  FROM (
+    SELECT
+      section,
+      COUNT(*)                                AS listings,
+      COALESCE(SUM(quantity), 0)::int         AS tickets,
+      MIN(price)                              AS min_p,
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY price) AS median_p,
+      MAX(price)                              AS max_p,
+      COUNT(*) FILTER (WHERE is_broker_owned) AS owned_listings
+    FROM deduped
+    WHERE price IS NOT NULL
+    GROUP BY section
+  ) z;
+
+  -- Splits — bucket on quantity. Same deduped source.
+  WITH deduped AS (
+    SELECT DISTINCT ON (sglid)
+      sglid, quantity,
+      coalesce(broadcast_price, retail_price_all_in) AS price
+    FROM public.seatgeek_listings_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND captured_at > now() - interval '24 hours'
+    ORDER BY sglid, captured_at DESC
+  ),
+  bucketed AS (
+    SELECT
+      CASE
+        WHEN quantity = 1 THEN 'singles'
+        WHEN quantity = 2 THEN 'pairs'
+        WHEN quantity = 3 THEN 'triples'
+        WHEN quantity = 4 THEN 'quads'
+        WHEN quantity >= 5 THEN 'five_plus'
+        ELSE NULL
+      END AS bucket,
+      quantity, price
+    FROM deduped
+    WHERE quantity IS NOT NULL
+  )
+  SELECT
+    jsonb_object_agg(bucket, jsonb_build_object(
+      'groups',    groups,
+      'tickets',   tickets,
+      'avg_price', avg_price
+    ))
+  INTO v_splits
+  FROM (
+    SELECT
+      bucket,
+      COUNT(*)                  AS groups,
+      COALESCE(SUM(quantity),0) AS tickets,
+      AVG(price)                AS avg_price
+    FROM bucketed
+    WHERE bucket IS NOT NULL
+    GROUP BY bucket
+  ) b;
+
+  RETURN jsonb_build_object(
+    'sg_event_id', v_sg_event_id,
+    'zones',       v_zones,
+    'splits',      coalesce(v_splits, '{}'::jsonb),
+    'hidden',      false
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_zones_splits(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_zones_splits(integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_sg_zones_splits(integer) IS
+  'D0 event Overview — SG zones (per-section rollup) + splits (per-quantity bucket) over 24h deduped firehose. DISTINCT ON sglid. Bridge via seatgeek_event_xref. Email-gated.';


### PR DESCRIPTION
## Summary

Operator-driven event-page redesign bundling 9 asks + 2 new SECDEF RPCs.

### What's new

- **Hero weather card** — compact top-right card on the event hero shows the forecast for the event date when available. Hidden for indoor venues / missing data. `climo` badge for fallback rows.
- **Localized NWS alerts** — new `get_event_weather_localized` RPC sources alerts from `v_event_nws_alerts` (auto-filters via venue UGC zones). Replaces the legacy global-alert behavior. Matched zone kind shown per alert.
- **Section reorder on Overview**:
  `KPI → Last Snapshot → Cross-Source Metrics → Chart → SG Broker Sales → Splits (TEvo|SG) → Zones (TEvo|SG) → ESPN → Weather → Sales Tape → All Orders → Alerts → Competing → Recent Listings → Performer ESPN`
- **Splits + Zones dual-source** — side-by-side TEvo | SG panels. SG side from new `get_event_sg_zones_splits` RPC. Zones = per-section rollup; Splits = quantity-bucket distribution. TEvo-only events get `no SG bridge` empty state on the SG side.
- **Merged Orders panel** — `ORDERS — EVO STATE MIX` + `CROSS-SOURCE ORDERS — TICKPICK + VIVID` collapsed into one `#all-orders` table. Unified sortable rows with Source pill (EVO/TickPick/Vivid), state pill color-coded, all states (not just pending), sorted by created_at DESC, capped 30.
- **Merged "Our Orders" tab** — 3 broker tabs (Our TEvo Orders / Our SG Sales / TP + Vivid) collapsed into one tab. On first activate fires 3 RPCs in parallel, renders 3 stacked sub-sections. Tab nav goes 7 → 5 tabs.
- **Realized sale median alignment** — cross-source panel's SG cell for "Realized sale median" now sources from v3 `sg_broker_sales.median_sale_price` (A1 PR #191 inline scoped aggregate, same source as `SG BROKER SALES — AGGREGATE` panel). Both panels show the same number.
- **Removed** `SG LISTINGS — COST DISTRIBUTION` panel + `renderSgListingsSummary` (deprecated `cost_*` fields per operator metrics inventory; `CROSS-SOURCE METRICS` already shows SG ask distribution via `listings_all_*`).

### Migrations

`20260519000000_event_page_weather_localized_rpc.sql` — `get_event_weather_localized(p_event_id)`. Reads `v_event_weather_with_fallback` (fallback-aware top-level cols `temp_f / precip_in / precip_pct / wind_mph / weather_summary` + `weather_kind` source indicator) + `v_event_nws_alerts`. Server-orders alerts by severity rank.

`20260519010000_event_page_sg_zones_splits_rpc.sql` — `get_event_sg_zones_splits(p_event_id)`. `DISTINCT ON (sglid)` over 24h SG snapshot, scoped on `sg_event_id` (`idx_sg_listings_sg_event_id_time`). Returns zones + splits in one round-trip. `{hidden:true, reason:'no_sg_bridge'}` for unlinked events.

Both RPCs: canonical v3 SECDEF pattern (`@s4kent.com` gate, `REVOKE PUBLIC + GRANT anon/auth`, `search_path` locked, STABLE). Additive — leaves v3 RPC untouched.

### A1 pre-flight audit corrections (bot_chat #309) — baked in

- `weather_kind` column (not `is_climo_fallback`) — direct source-indicator field
- Use top-level fallback-aware cols, skip `fcst_*`/`climo_*` branching entirely
- `v_event_nws_alerts` already filters per venue — no manual UGC join needed

### Verification

Local browser preview (`event.html?event=3091413`):
- ✓ Section order matches spec (verified via DOM `paneOverview > section` enumeration)
- ✓ `#sg-listings-summary`, `#order-strip`, `#cross-source-orders` all removed from DOM
- ✓ `#hero-weather`, `#all-orders`, `#sg-broker-sales` present
- ✓ Tab nav shows 5 tabs (overview / sg-listings / evo-listings / sg-sales / our-orders)
- ✓ Splits + Zones each render 2 dual-src columns with graceful empty states
- ✓ Click "our-orders" → 3 stacked sub-sections render (evo-orders-full, sg-seller-orders-full, cross-broker-full)
- ✓ Localhost (no Path C auth): hero weather hidden, RPC failures degrade in-pane

### Test plan (A1 smoke pre-merge per bot_chat #299 process note)

- [ ] `get_event_weather_localized(3091413)` returns forecast + ≥0 alerts; <100ms
- [ ] `get_event_weather_localized(<event in alerted region>)` filters alerts to event venue
- [ ] `get_event_sg_zones_splits(3091413)` returns 10-30 zones + 5 splits buckets; <250ms
- [ ] `get_event_sg_zones_splits(<TEvo-only event>)` returns `{hidden:true, reason:'no_sg_bridge'}`
- [ ] Indoor venue event (e.g. MSG): hero weather hidden; full panel shows "FORECAST · INDOOR" subtitle
- [ ] Click "Our Orders" tab → all 3 sub-sections render with parallel-fetched data

## Related

- bot_chat #309 — A1 pre-flight audit (all 3 corrections baked in)
- PR #205 — CROSS-SOURCE METRICS (PR replaces the panel's `sold_price_median` SG cell with v3 `sg_broker_sales.median_sale_price` for alignment)
- PR #199 — 3 broker-account RPCs (still alive — only the FE tab structure consolidates)
- PR #204 — `listings_all_*` / `listings_owned_*` columns (consumed by `CROSS-SOURCE METRICS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)