### PR TITLE
feat(governance): GitHub fullest-utilization Phase 1 — 12 files for Security/Issues/Actions tabs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Terminal-2
+
+Terminal-2 is a multi-bot orchestrated ticket-trading intelligence platform. The contributor population is:
+
+- **Internal bots** (A1, B1, C1, D0, D1, D2, D3, D4, E1) — most commits land via this path
+- **Human operator** (`@JulianS4K`) — sole approver / sole pusher to `main`
+- **Outside contributors** — rare, but welcomed for security disclosures + bug reports
+
+## If you're a bot
+
+Read these in order:
+
+1. [`PROJECT_BIBLE.md`](../PROJECT_BIBLE.md) — operating playbook (hard rules, lane scope, SQL macros, column-name landmines)
+2. [`KANBAN.md §🟢 OPEN`](../KANBAN.md) — what's actionable right now (severity-sorted)
+3. [`CLAUDE.md`](../CLAUDE.md) — security rules + 2026-05-13 lockdown
+4. [`LANE_DISCIPLINE.md`](../LANE_DISCIPLINE.md) — your write surface
+5. [`MIGRATION_CONVENTIONS.md`](../MIGRATION_CONVENTIONS.md) — if authoring migrations
+6. [`docs/<your-lane>_operating_constraints.md`](../docs/) — your self-contract
+
+## If you're a human contributor
+
+### Reporting bugs
+
+1. For **security** vulnerabilities: see [`SECURITY.md`](SECURITY.md) — use Private Vulnerability Reporting, do NOT open a public issue.
+2. For **non-security** bugs: open a GitHub Issue using the "Bug report" template. Include reproduction steps + expected vs actual behavior + which hosted surface (terminal / storefront / dashboard).
+
+### Proposing features
+
+Open a GitHub Issue with the "Feature request" template. For larger architectural proposals, open a GitHub Discussion in the "Ideas" category (when enabled) instead — it allows threaded conversation before code lands.
+
+### Pull request flow
+
+We don't accept code PRs from outside contributors in the general case (single-operator product). If you have a focused fix:
+
+1. Fork the repo
+2. Branch off `main` with prefix `external/<your-handle>-<slug>`
+3. Follow [`MIGRATION_CONVENTIONS.md`](../MIGRATION_CONVENTIONS.md) if your change touches `supabase/migrations/`
+4. Open a PR using the [PR template](PULL_REQUEST_TEMPLATE.md)
+5. CI must pass (`forbidden-paths-check`, `secret-scan`, `pytest`)
+6. Wait for `@JulianS4K` review — turnaround ~1 week
+
+Note: PRs that touch backend code (`app.py`, `supabase/*`, `*_client.py`) require CODEOWNERS review per [`.github/CODEOWNERS`](CODEOWNERS).
+
+## Code style
+
+- Python: follow existing patterns in `app.py`; no formal `black`/`ruff` enforcement currently
+- SQL: lowercase keywords are fine; column names match the table they read from (see `PROJECT_BIBLE.md §3` landmines)
+- TypeScript (edge functions): match the style of `supabase/functions/_shared/cron-auth.ts`
+
+## Commit messages
+
+Format: `<type>(<lane>): <short imperative>` per [`docs/pr_governance.md`](../docs/pr_governance.md).
+
+Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+
+Lane shorthand: `a1`, `b1`, `c1`, `d0`, `d1`, `d2`, `security`, `bibles`, `governance`.
+
+Example: `chore(security): GitHub capabilities audit 2026-05-17 — 11 new findings`
+
+## Communication
+
+- **Cross-lane coordination**: `bot_chat` table (Supabase) — durable, append-only
+- **Long-form decisions / RFC**: GitHub Discussions → "Ideas" or "Decisions" category (when enabled)
+- **Operator broadcasts**: bot_chat `event_type='broadcast'` OR Slack `#terminal-2-alerts` (per [`CLAUDE.md §4`](../CLAUDE.md))
+
+## Code of conduct
+
+Be excellent to each other. This project is single-operator-led; disagreements get resolved by the operator. No tolerance for harassment, doxxing, or deliberately misleading bot behavior (impersonation).

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,65 @@
+name: 🐛 Bug report
+description: Non-security bug in code, data, or hosted surface. For security issues, use Private Vulnerability Reporting (see "Security vulnerability" link).
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for **functional bugs** — broken UI, wrong data, crashes, performance regressions. For security vulnerabilities, do NOT use this template; use [Private Vulnerability Reporting](https://github.com/JulianS4K/Terminal-2/security/advisories/new) instead.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - D0 Terminal (broker view)
+        - D1 Storefront (consumer retail)
+        - D2 Dashboard (orders)
+        - Edge function (Supabase)
+        - Backend API (FastAPI /api/*)
+        - Database / SQL
+        - CI / GitHub Actions
+        - Documentation
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: One paragraph. Be specific.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. Open https://...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: when
+    attributes:
+      label: When did this start? (commit SHA, PR #, or approximate timestamp UTC)
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Extra context (logs, screenshots, related PRs/migrations)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Security vulnerability (private)
+    url: https://github.com/JulianS4K/Terminal-2/security/advisories/new
+    about: Report a vulnerability privately via GitHub Security Advisories. Do NOT open a public issue for security.
+  - name: 💬 Discussion / RFC / Idea
+    url: https://github.com/JulianS4K/Terminal-2/discussions
+    about: For design proposals or open-ended questions, use Discussions (when enabled) instead of Issues.
+  - name: 📋 Operational state (bots only)
+    url: https://github.com/JulianS4K/Terminal-2/blob/main/KANBAN.md
+    about: Bots — check KANBAN §🟢 OPEN for what's currently actionable. Don't file Issues for things already there.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,56 @@
+name: 💡 Feature request
+description: Propose new functionality. For larger architectural changes, use Discussions → Ideas instead.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For **architectural** proposals (touching multiple lanes, governance, or RFC-level scope), open a [Discussion](https://github.com/JulianS4K/Terminal-2/discussions) under "Ideas" instead. Issues are best for focused, scoped features.
+
+  - type: dropdown
+    id: lane
+    attributes:
+      label: Affected lane (best guess)
+      options:
+        - A1 Admin
+        - B1 Security
+        - C1 Canonical
+        - D0 Terminal FE
+        - D1 Storefront
+        - D2 Dashboard
+        - D3 Broadway scraper
+        - D4 Ticketing infra
+        - E1 External markets
+        - Cross-cutting / unsure
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: User-facing or operational pain — be concrete.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+
+  - type: textarea
+    id: success
+    attributes:
+      label: What does success look like?
+      description: How will we know it works?
+    validations:
+      required: false

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+This repository is public. If you find a vulnerability in Terminal-2 or its hosted services (`vibepass-storefront-test.onrender.com`, `vibepass-terminal-test.onrender.com`, `d2-orders-dashboard.onrender.com`), report it via one of:
+
+1. **GitHub Private Vulnerability Reporting** (preferred): https://github.com/JulianS4K/Terminal-2/security/advisories/new
+2. **Email** (encrypted): julian@s4kent.com — include "SECURITY" in the subject line. PGP key on request.
+
+Please include:
+- A description of the issue + impact
+- Reproduction steps (commands, payloads, URLs)
+- Affected component (`app.py` route, Supabase RPC, edge function, etc.)
+- Any related CVE / disclosure timeline you're working with
+
+## Response SLA
+
+- **Acknowledgement**: within 72 hours
+- **Initial triage**: within 7 days (severity assessment + mitigation plan)
+- **Fix or workaround**: within 30 days for SEC-CRIT/HIGH (per `docs/b1_operating_constraints.md` severity matrix)
+
+## Supported versions
+
+This is a continuously-deployed monorepo. The only supported version is the current `main` branch. Production deployments auto-deploy on `main` push via Render.
+
+## Scope
+
+In-scope for this policy:
+
+- Code under `app.py`, `supabase/migrations/*`, `supabase/functions/*`, `*_client.py`
+- Hosted Render services (`vibepass-storefront-test`, `vibepass-terminal-test`, `d2-orders-dashboard`)
+- Edge functions deployed to Supabase project `hzrizjeaxlqcxfrtczpq`
+- Authentication / authorization paths (Supabase Auth + `@s4kent.com` email gate + Apps Script `APPSCRIPT_INGEST_SECRET` + cron `CRON_SECRET`)
+
+Out of scope:
+
+- Third-party services (TEvo, SeatGeek, TickPick, Vivid, SeatData, ESPN, NWS) — report directly to the upstream
+- Issues already documented in [`KANBAN.md §🟢 OPEN`](../KANBAN.md) under B1-NEXT-N (defense-in-depth follow-ups; not exploitable today)
+- Social engineering / phishing of repo collaborators
+- Denial-of-service via rate-limit exhaustion (we use rate limiting; abuse → block)
+
+## Internal coordination
+
+For Terminal-2 bots: security findings flow through:
+
+1. `bot_chat` with `event_type IN ('p0_security', 'flag')` — durable, B1 owns resolution
+2. [`KANBAN.md §🟢 OPEN`](../KANBAN.md) — operating ledger (severity-sorted, fixing bot deletes their row when shipping)
+3. `docs/security-audit-<date>-<topic>.md` — long-form post-mortems
+4. [`docs/b1_open_findings.md`](../docs/b1_open_findings.md) — superseded by KANBAN §🟢 OPEN as of 2026-05-17
+
+See [`docs/b1_operating_constraints.md`](../docs/b1_operating_constraints.md) for B1's full charter + severity matrix.
+
+## Hall of fame
+
+We acknowledge reporters who follow responsible disclosure (with permission). To opt in, mention "publish my name" in your report.
+
+_None yet — be the first._

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Dependabot configuration — version + security updates
+#
+# Activates when operator enables Dependabot in Settings → Code security
+# (currently disabled — see docs/git_repo_security_posture.md G-2).
+#
+# B1-NEXT-49 / G-19 — file authored 2026-05-17 to be ready when operator
+# enables. Until then it sits inert. Re-confirm schedule rhythm with operator
+# before enabling — weekly is a reasonable default; daily for high-churn deps.
+
+version: 2
+updates:
+
+  # Python dependencies (FastAPI app + clients)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "level:admin"
+      - "dependencies"
+    reviewers:
+      - "JulianS4K"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # Group minor + patch updates per package family — reduces PR noise.
+    groups:
+      patches:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+    # Allow security updates outside the group + window.
+    allow:
+      - dependency-type: "all"
+
+  # GitHub Actions versions (workflow files)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    labels:
+      - "level:admin"
+      - "ci"
+    reviewers:
+      - "JulianS4K"
+    commit-message:
+      prefix: "chore(ci-deps)"
+
+  # Note: Deno (Supabase edge functions) is NOT supported by Dependabot.
+  # Edge function deps are pinned via import URLs (e.g.,
+  # `https://deno.land/std@0.224.0/`) — B1 manually audits via per-session
+  # sweep step 12 (git posture) + secret-scan workflow.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,71 @@
+# Path-based PR labeler config — pairs with .github/workflows/labeler.yml
+#
+# When a PR touches files matching a pattern, the listed labels are applied.
+# Branch-prefix labeling (a1/* → level:admin) is handled in workflows/labeler.yml.
+
+"area:migrations":
+  - changed-files:
+      - any-glob-to-any-file: "supabase/migrations/**/*.sql"
+
+"area:edge-functions":
+  - changed-files:
+      - any-glob-to-any-file: "supabase/functions/**/*"
+
+"area:backend":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app.py"
+          - "*_client.py"
+          - "requirements.txt"
+          - "Procfile"
+
+"area:terminal-fe":
+  - changed-files:
+      - any-glob-to-any-file: "static/terminal/**/*"
+
+"area:storefront":
+  - changed-files:
+      - any-glob-to-any-file: "static/store/**/*"
+
+"area:dashboard":
+  - changed-files:
+      - any-glob-to-any-file: "d2_dashboard/**/*"
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**/*.md"
+          - "*.md"
+
+"area:bibles":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "PROJECT_BIBLE.md"
+          - "RESOURCES_BIBLE.md"
+          - "CLAUDE.md"
+          - "BOT_HIERARCHY.md"
+          - "LANE_DISCIPLINE.md"
+          - "MIGRATION_CONVENTIONS.md"
+          - "SYNC_PROTOCOL.md"
+          - "SCHEMA.md"
+          - "CRON_HIERARCHY.md"
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**/*"
+          - ".github/CODEOWNERS"
+          - "scripts/**/*"
+          - "bin/**/*"
+
+"area:tests":
+  - changed-files:
+      - any-glob-to-any-file: "tests/**/*"
+
+"area:design":
+  - changed-files:
+      - any-glob-to-any-file: "design/**/*"
+
+"area:kanban":
+  - changed-files:
+      - any-glob-to-any-file: "KANBAN.md"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,44 @@
+# Dependency review — block PRs that add vulnerable / unwanted deps
+#
+# Authored 2026-05-17 (B1-NEXT-47 / G-17). Activates when Dependabot security
+# alerts are enabled (B1-NEXT-12 / G-2 — currently disabled). Until then, this
+# workflow runs but has nothing to compare against — it will pass trivially.
+#
+# Behavior post-enable:
+# - Diffs new vs. base dependencies on every PR
+# - Fails if any added dep has a known vuln >= 'moderate' severity
+# - Fails on disallowed licenses (e.g., AGPL — we're proprietary internal)
+
+name: Dependency Review
+
+on:
+  pull_request:
+    paths:
+      - "requirements.txt"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/**/*.yml"
+
+permissions:
+  contents: read
+  pull-requests: write   # for summary comment
+
+jobs:
+  review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          # Comment on the PR with the diff summary
+          comment-summary-in-pr: on-failure
+          # Disallow licenses incompatible with our proprietary stance.
+          # Leave deny-licenses empty initially — re-tighten after first false-positives
+          # are triaged. Common dangerous-for-proprietary licenses to consider:
+          # GPL-2.0, GPL-3.0, AGPL-3.0, SSPL-1.0
+          deny-licenses: ""

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,60 @@
+# PR auto-labeler — labels PRs by branch prefix + touched paths
+#
+# Authored 2026-05-17. Reduces manual labeling burden + makes filter views
+# (GitHub Projects, Issues search) more reliable.
+#
+# Config: .github/labeler.yml (path-based rules).
+# Branch-prefix rules: handled inline below via 'pr-labeler' action.
+
+name: PR Auto-Label
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  path-labels:
+    name: Label by changed paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+  branch-prefix-labels:
+    name: Label by branch prefix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply lane label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            // Map: branch-prefix → label
+            const rules = [
+              [/^a1\//,        'level:admin'],
+              [/^claude\/b1-/, 'level:security'],
+              [/^claude\/c1-/, 'level:supervisor'],
+              [/^claude\/d0-/, 'level:primary-sales'],  // Terminal FE consolidated
+              [/^claude\/d1-/, 'level:primary-sales'],  // Storefront
+              [/^claude\/d2-/, 'level:secondary-sales'],
+              [/^claude\/d3-/, 'level:data-collection'],
+              [/^external\//,  'help wanted'],
+            ];
+            const labelsToAdd = [];
+            for (const [re, label] of rules) {
+              if (re.test(branch)) labelsToAdd.push(label);
+            }
+            if (labelsToAdd.length === 0) return;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: labelsToAdd,
+            });
+            console.log(`Added labels: ${labelsToAdd.join(', ')}`);

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,59 @@
+# PR title format check — enforces `<type>(<lane>): <short imperative>`
+#
+# Authored 2026-05-17. Matches docs/pr_governance.md commit-message format.
+# Catches PRs with generic titles like "Update KANBAN" before merge.
+
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check format
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            // Format: <type>(<lane>): <message>
+            // type: feat|fix|chore|docs|refactor|test|perf|style|build|ci|revert
+            // lane: a1|b1|c1|d0|d1|d2|d3|d4|e1|security|bibles|governance|deps|ci-deps|admin|bridge|d0/event|d0/home|d0/terminal|store|sg|sg/cron|sg/sales|sg/metrics|sg-bridge|unified-shell|metrics|d2|d2-* (loose: any [a-z0-9/-]+)
+            const re = /^(feat|fix|chore|docs|refactor|test|perf|style|build|ci|revert)\(([a-z0-9/_-]+)\):\s+.{5,}$/;
+            if (!re.test(title)) {
+              const msg = [
+                `❌ PR title does not match the required format.`,
+                ``,
+                `**Format**: \`<type>(<lane>): <short imperative>\``,
+                ``,
+                `**Examples**:`,
+                `- \`chore(security): GitHub capabilities audit\``,
+                `- \`feat(d0/event): tab navigation + Last Snapshot panel\``,
+                `- \`fix(admin): drop dead match_to_aq_event_id 7-arg overload\``,
+                ``,
+                `**Allowed types**: feat, fix, chore, docs, refactor, test, perf, style, build, ci, revert`,
+                ``,
+                `**Common lanes**: a1, b1, c1, d0, d1, d2, d3, d4, e1, security, bibles, governance, deps, ci-deps, sg, store`,
+                ``,
+                `See docs/pr_governance.md for the full convention.`,
+                ``,
+                `Current title: \`${title}\``,
+              ].join('\n');
+              core.setFailed(msg);
+              // Post a comment so the author sees the failure inline
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: msg,
+              });
+            } else {
+              console.log(`✅ Title matches format: ${title}`);
+            }

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,62 @@
+# OSSF Scorecard — weekly automated repo-security scoring
+#
+# Authored 2026-05-17 (B1-NEXT-48 / G-18). Posts results to GitHub
+# code-scanning so they surface in the Security tab + commit/PR checks.
+# Also publishes a JSON report uploadable as a workflow artifact.
+#
+# What it checks (16 default checks): branch protection, code review, CI tests,
+# dangerous workflow patterns, dependency update tool, fuzzing, license,
+# maintained, packaging, pinned dependencies, SAST, security policy, signed
+# releases, token permissions, vulnerabilities, webhooks.
+#
+# https://github.com/ossf/scorecard
+
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 12 * * 1"   # Monday 12:00 UTC
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for uploading SARIF to code-scanning
+      security-events: write
+      # Needed for the action to read repo settings
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true   # Public results: shown on https://scorecard.dev/
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload artifact (raw JSON)
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30

--- a/docs/github_features_plan.md
+++ b/docs/github_features_plan.md
@@ -1,0 +1,323 @@
+# GitHub Features Plan — Terminal-2
+
+**Owner**: B1 (Security Manager) · **Status**: 2026-05-17 — initial proposal, awaiting operator decisions on Discussions / Projects / Wiki enable
+
+Operator directive 2026-05-17: *"use git to its fullest extent including using discussions tab, projects tab, wiki tab and securities and quality tab and others that may assist in quality and productivity."*
+
+This doc maps every GitHub surface to a concrete proposed use within Terminal-2's multi-bot operation, plus the operator-action needed to enable each one. Phase 1 (files in this PR) lands without operator settings changes; Phase 2/3 wait on operator enable.
+
+---
+
+## Surface-by-surface plan
+
+### 🔒 Security tab — ENABLED (partially utilized) → fully utilize
+
+**What it is**: GitHub's centralized view of all security signals: SECURITY.md policy, secret-scanning alerts, code-scanning alerts (CodeQL), Dependabot alerts, security advisories.
+
+**Current state**: secret-scanning + push-protection ENABLED; everything else disabled.
+
+**Phase 1 (this PR)**:
+- ✅ Added [`.github/SECURITY.md`](../.github/SECURITY.md) — vulnerability disclosure policy + response SLA + scope
+- ✅ Added [`.github/dependabot.yml`](../.github/dependabot.yml) — inert until operator enables (G-2)
+- ✅ Added [`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml) — inert until operator enables (G-2)
+- ✅ Added [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml) — OSSF Scorecard, weekly cron, results to code-scanning + public scorecard.dev
+
+**Phase 2 (operator must enable in Settings → Code security)**:
+1. Dependabot security updates (G-2 / B1-NEXT-12)
+2. Dependabot security alerts (companion)
+3. Secret scanning non-provider patterns (G-3 / B1-NEXT-13)
+4. Secret scanning validity checks (G-4 / B1-NEXT-14)
+5. Private Vulnerability Reporting (G-16 / B1-NEXT-46) — so SECURITY.md's "preferred" channel works
+6. CodeQL (G-5 / B1-NEXT-4) — adds a 4th workflow `codeql.yml` (B1 authors after operator OK)
+
+**Phase 3 (after Phase 2 lands)**:
+- Repository Security Advisories — draft CVE entries when first vuln surfaces (per-incident, no setup)
+- Surface scorecard.dev badge in README
+- Tie B1 sweep step 14 (code-scanning alerts) to the new CodeQL alerts
+
+---
+
+### 💬 Discussions tab — DISABLED → enable
+
+**What it is**: Async threaded conversations, separate from Issues. Categorized. Searchable.
+
+**Current state**: `has_discussions: false` (disabled).
+
+**Why enable for Terminal-2**: bot_chat handles transactional cross-lane coordination. Discussions can handle:
+- Long-form decisions / RFCs (currently scattered across `docs/audit-*.md`)
+- Operator broadcasts that should be discoverable later (currently scattered between bot_chat broadcasts and Slack)
+- Cross-bot knowledge base (Q&A — searchable past questions, replaces re-asking)
+
+**Phase 2 — operator enables** (Settings → General → Features → Discussions)
+
+**Phase 3 — B1 seeds these categories**:
+
+| Category | Format | Purpose | Example seed posts |
+|---|---|---|---|
+| 📢 **Announcements** | Announcement | Operator → all bots, durable broadcasts. Pinnable. | "Multi-bot reorg 2026-05-15", "Testing-unified architecture (PR #168)" |
+| 💡 **Ideas** | Open-ended | RFC-style proposals before code lands. Discussion ≠ commitment to ship. | "Should we add a Kalshi integration?", "Move D0 to its own service post-beta?" |
+| 🤝 **Coordination** | Open-ended | Cross-lane design discussion too long for bot_chat. | "How should D1 and D2 share the `evo_orders` table for storefront returns?" |
+| 📊 **Decisions** | Open-ended | Operator decisions with rationale. Replaces some `docs/audit-*.md`. | "Why we picked Render over Railway", "Why allow_forking stays true" |
+| ❓ **Q&A** | Q&A (mark answer) | Knowledge base. Bots and humans search past questions. | "Why is sg_event_id 0% populated on listings_snapshots?" |
+| 🎯 **Show and tell** | Show and tell | Bot demos / completed features for human visibility. | "D0 event-page v3 — 9 enrichment panels", "B1 cron heartbeat detector" |
+| 🗳️ **Polls** | Poll | Operator-side multi-choice decisions. | "Cron heartbeat threshold: 2x median, 3x, or 5x?" |
+| 💬 **General** | Open-ended | Misc | (catch-all) |
+
+**Seed content B1 prepares** (one-shot when Discussions go live):
+- `docs/seed/discussions/announcements_pinned_overview.md` — pinned "Read me first" overview
+- `docs/seed/discussions/decisions_*.md` — 3-5 historical decisions converted from `docs/audit-*.md`
+
+---
+
+### 📋 Projects tab — ENABLED (empty) → populate
+
+**What it is**: Projects v2 — kanban / table / roadmap views over Issues + PRs with custom fields.
+
+**Current state**: `has_projects: true` but no projects exist.
+
+**Why use for Terminal-2**: KANBAN.md `§🟢 OPEN` is the source-of-truth (markdown, append-only). A GitHub Project mirrors it as a VISUAL board with auto-flow. The two coexist:
+- KANBAN.md = canonical, structured, search-by-text, populates manually
+- Project = visual, filtered views, auto-close on PR merge, drag-and-drop
+
+**Phase 2 — operator creates a Project**:
+1. Repo → Projects tab → New project → "Board" template
+2. Name: "Terminal-2 Open Work"
+3. Configure custom fields (B1 documents below)
+4. Configure automation (auto-add new issues + auto-close on PR merge)
+5. Set visibility (probably "Public" to match repo, "Private" if operator prefers)
+
+**Phase 3 — B1 populates**:
+
+**Custom fields** to add:
+| Field | Type | Values |
+|---|---|---|
+| Lane | Single select | A1, B1, C1, D0, D1, D2, D3, D4, E1, Operator |
+| Severity | Single select | SEC-CRIT, SEC-HIGH, SEC-MED, SEC-LOW, OPS, Product |
+| Status | Single select | Triage, In Progress, Blocked, Ready for Review, Done |
+| Blocked on | Text | (free-form, e.g., "G-2 Dependabot enable") |
+| KANBAN ID | Text | B1-NEXT-N or other lane's ID |
+| Originating PR | Number | PR number that surfaced this |
+
+**Views** (saved query configs):
+1. **By severity** (board) — columns: SEC-CRIT / HIGH / MED / LOW / OPS
+2. **By lane** (board) — columns: A1 / B1 / C1 / D-tier / Operator
+3. **By status** (board) — columns: Triage → In Progress → Blocked → Ready for Review → Done
+4. **Operator-only** (table) — filter: Lane=Operator
+5. **My queue** (table) — filter: Assignee=@me
+6. **Roadmap** (timeline) — by `Originating PR` date
+
+**Automation rules** (built-in):
+- New Issue → auto-add to project, default Status=Triage
+- PR opened with `closes #N` → linked issue moves to "Ready for Review"
+- PR merged → linked issue moves to "Done"
+- Issue closed → Status=Done
+
+**B1 syncing protocol**:
+- For each row in KANBAN §🟢 OPEN, B1 creates a matching Issue with the same ID in title (e.g., "B1-NEXT-43: Author SECURITY.md disclosure policy")
+- Issue body links to the KANBAN row
+- Issue auto-adds to project via automation
+- When fixing bot ships PR with `closes #N`, both Issue + KANBAN row close (KANBAN row deleted per existing protocol; Issue closed by GitHub)
+
+---
+
+### 📖 Wiki tab — ENABLED (empty) → populate
+
+**What it is**: Git-backed markdown wiki. Separate repo (`Terminal-2.wiki.git`). Sidebar navigation.
+
+**Current state**: `has_wiki: true` but empty.
+
+**Why use for Terminal-2**: Some content benefits from being detached from `main` (no CI on every change, no review gate). Good candidates:
+- New-bot onboarding flow (read-frequently, edit-rarely)
+- Architecture diagrams + glossary
+- Operator runbooks (recovery procedures, deploy steps)
+- FAQ — "Why did we do X?"
+
+**Caveats**:
+- Wiki is PUBLIC because repo is public. **Don't put secrets, internal IPs, vault names, or speculative roadmap there.**
+- No CI / no review — anyone with write access can edit. CODEOWNERS doesn't apply.
+
+**Phase 2 — operator initializes the wiki**:
+1. Click the Wiki tab
+2. Create the first page (auto-creates the `.wiki.git` repo)
+
+**Phase 3 — B1 seeds these pages**:
+
+| Wiki page | Purpose | Source content |
+|---|---|---|
+| **Home** | Sidebar TOC + project overview | Adapted from README.md |
+| **Bot directory** | One page per bot (A1, B1, ...) with role + lane + write surface | Synthesized from `LANE_DISCIPLINE.md` + each bot's `*_operating_constraints.md` |
+| **Architecture** | Component diagram, data flow, hosted services | From PROJECT_BIBLE.md §2 + RESOURCES_BIBLE.md §1 |
+| **Glossary** | A→Z definitions: AQ, broker firehose, listings_snapshots, etc. | Mined from migration headers + bibles |
+| **New-bot bootstrap** | First-session checklist | Pointer to PROJECT_BIBLE.md + KANBAN §🟢 OPEN + this wiki Home |
+| **Operator runbooks** | Recovery procedures: "Edge function failing", "Cron silent for >24h", "Render service red" | Synthesized from existing runbooks |
+| **TEvo gotchas (full)** | Extended version of PROJECT_BIBLE.md §3 with examples | Aggregated from migration comments |
+| **FAQ** | "Why did we ____?" — operator/A1 decision rationale | Mined from audit docs + commit messages |
+
+**Update cadence**: B1 syncs wiki monthly (lower priority than bibles). Major architectural changes trigger a wiki refresh PR.
+
+---
+
+### 🐛 Issues tab — ENABLED (lightly used) → expand
+
+**What it is**: Standard issue tracker. Labels, milestones, assignees, projects, linked PRs.
+
+**Current state**: `has_issues: true`. Labels exist (`bug`, `enhancement`, `level:admin` ... `level:data-collection`, etc.). Few issues filed historically — bots use bot_chat instead.
+
+**Why expand**:
+- External contributors / users need an inbound channel (Issues are public-facing; bot_chat isn't)
+- Long-running tasks (e.g., "Implement real-purchase checkout") work better as Issues with milestones than bot_chat threads
+- Issues link bidirectionally to PRs (`closes #N`) for traceability
+
+**Phase 1 (this PR)**:
+- ✅ Added [`.github/ISSUE_TEMPLATE/bug.yml`](../.github/ISSUE_TEMPLATE/bug.yml)
+- ✅ Added [`.github/ISSUE_TEMPLATE/feature.yml`](../.github/ISSUE_TEMPLATE/feature.yml)
+- ✅ Added [`.github/ISSUE_TEMPLATE/config.yml`](../.github/ISSUE_TEMPLATE/config.yml) — disables blank issues, links to Security/Discussions/KANBAN
+
+**Phase 2 — B1 creates 1 Issue per row in KANBAN §🟢 OPEN**:
+- Tagged with `level:*` label per lane
+- Body links to KANBAN §🟢 OPEN row + relevant docs
+- Adds to "Terminal-2 Open Work" project (Phase 3 of Projects tab)
+- When PR ships, `closes #N` removes the KANBAN row + closes the Issue
+
+**Phase 3** — Milestones for sprint planning:
+- "Beta launch" milestone — pulls all blocker Issues into one view
+- "Q3 2026" / monthly cadence milestones for non-blocker work
+
+---
+
+### 🚀 Actions tab — ENABLED (4 workflows) → 8 workflows + improvements
+
+**What it is**: CI / scheduled workflows.
+
+**Current state**: 4 active — `forbidden-paths-check.yml`, `sync-check.yml`, `tests.yml`, `secret-scan.yml`.
+
+**Phase 1 (this PR — 4 new workflows)**:
+- ✅ [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml) — weekly OSSF Scorecard
+- ✅ [`.github/workflows/labeler.yml`](../.github/workflows/labeler.yml) — auto-label PRs (paths + branch prefix)
+- ✅ [`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml) — block PRs adding vulnerable deps (inert until G-2)
+- ✅ [`.github/workflows/pr-title-lint.yml`](../.github/workflows/pr-title-lint.yml) — enforce `<type>(<lane>): <msg>` format
+
+**Phase 2 (after operator enables CodeQL)**:
+- `.github/workflows/codeql.yml` — SAST scanning, results to Security tab
+
+**Phase 3 (nice-to-have)**:
+- `release-drafter.yml` — auto-draft release notes from merged PRs
+- `stale.yml` — close abandoned issues/PRs (low priority — bots squash-merge fast)
+
+---
+
+### 🏷️ Releases / Tags — UNUSED → use for production checkpoints
+
+**What it is**: Git tags + release notes published on the Releases page.
+
+**Current state**: No tags, no releases.
+
+**Why use**:
+- Anchor "what's in production right now" — currently you can't quickly answer "what was running on 2026-05-15?" without `git log`
+- Operator can hand-cut releases as production-freeze checkpoints
+- Release notes auto-generated from merged PRs (with `release-drafter` workflow)
+
+**Phase 2 — operator cuts the first tag**:
+```bash
+git tag -a v0.1.0-beta -m "Pre-launch beta — multi-bot orchestration, testing-unified architecture"
+git push origin v0.1.0-beta
+```
+
+**Phase 3 — B1 authors `release-drafter.yml`** that auto-drafts the next release on every merge to main.
+
+---
+
+### 📊 Insights tab — READ-ONLY → integrate into B1 sweep
+
+**What it is**: Code frequency, contributors, traffic (clones + visitors), pulse, dependency graph, network, forks.
+
+**Current state**: All available; not actively monitored.
+
+**Phase 2 — B1 integrates into per-session sweep**:
+- New sweep step 21: "Insights anomaly check" — manual web-view of Traffic + Forks tabs; flag if visitor count >10× baseline or new fork from an unknown account
+- Set up a weekly digest scheduled task (B1) that posts to `#terminal-2-alerts` if Pulse shows >50% drop in commit activity or >2x increase in fork count
+
+---
+
+### 🔧 Other capabilities being utilized
+
+| Capability | Current | Plan |
+|---|---|---|
+| Branch protection on `main` | ENABLED | Tighten per G-14/G-15 (operator decision) |
+| CODEOWNERS | ENABLED | Keep as-is (`@JulianS4K` owns everything) |
+| PR template | ENABLED | Already comprehensive (per `docs/pr_governance.md`) |
+| Topics + description | EMPTY | Operator adds: `ticket-trading`, `fastapi`, `supabase`, `multi-bot`, `claude-code` + 1-line description |
+| GitHub Pages | NOT IN USE | Defer — wiki covers public-facing docs needs |
+| Sponsors / FUNDING.yml | NOT APPLICABLE | Single-operator proprietary |
+| Co-pilot integration | Operator-side | (No repo-level config) |
+
+---
+
+## Cumulative operator-action checklist
+
+**Quick wins (~10 minutes total, all in Settings)**:
+
+1. Settings → Code security:
+   - Enable Dependabot security updates
+   - Enable secret-scanning non-provider patterns
+   - Enable secret-scanning validity checks
+   - Enable Private Vulnerability Reporting
+   - Enable Code scanning → CodeQL → "Default" setup (or wait for B1 to author `codeql.yml`)
+
+2. Settings → General → Features:
+   - Toggle Discussions ON
+   - Decide on Wiki: keep ON (B1 will seed) or OFF (defer)
+   - Decide on Projects: keep ON (B1 will create board)
+   - Toggle "Automatically delete head branches" ON (closes G-10)
+
+3. Settings → General → Pull Requests:
+   - Toggle "Always suggest updating pull request branches" ON
+   - Decide: allow auto-merge?
+
+4. Settings → General → repo metadata:
+   - Add 1-line description
+   - Add topics: `ticket-trading`, `fastapi`, `supabase`, `multi-bot`, `claude-code`
+
+5. Repo → Projects tab → New project → "Board" template → name "Terminal-2 Open Work"
+
+6. Repo → Wiki tab → Create first page (auto-initializes the wiki repo)
+
+7. Repo → Discussions tab (after step 1) → "Get started" → enable + B1's proposed categories
+
+**After operator quick wins** — B1 follow-up PRs:
+- B1 authors `.github/workflows/codeql.yml` (after CodeQL enabled)
+- B1 seeds Discussions categories + first few posts
+- B1 seeds Wiki pages (Home, Bot directory, Architecture, Glossary, Runbooks, FAQ)
+- B1 creates Issues mirroring KANBAN §🟢 OPEN rows + auto-adds them to the Project
+- B1 cuts first `v0.1.0-beta` tag with release notes
+
+---
+
+## Files added in this PR (Phase 1)
+
+```
+.github/
+├── SECURITY.md                          ← Security tab
+├── CONTRIBUTING.md                      ← Issues tab + new-contributor onboarding
+├── dependabot.yml                       ← Security tab (inert until G-2)
+├── labeler.yml                          ← PR labeler config
+├── ISSUE_TEMPLATE/
+│   ├── bug.yml
+│   ├── feature.yml
+│   └── config.yml
+└── workflows/
+    ├── scorecard.yml                    ← OSSF Scorecard weekly
+    ├── labeler.yml                      ← PR auto-label by paths + branch prefix
+    ├── dependency-review.yml            ← Block vulnerable deps in PRs (inert until G-2)
+    └── pr-title-lint.yml                ← Enforce PR title format
+
+docs/
+└── github_features_plan.md              ← This doc
+```
+
+---
+
+**Refresh cadence**: B1 updates this doc when:
+- Operator enables one of the Phase 2 items (mark complete inline)
+- New GitHub feature releases that's worth evaluating
+- Quarterly review (next: 2026-08)

--- a/docs/markdown_inventory.md
+++ b/docs/markdown_inventory.md
@@ -74,6 +74,7 @@ Catalogue of every tracked `.md` file in the repo, grouped by audience/purpose. 
 | [`docs/markdown_inventory.md`](markdown_inventory.md) | **This doc** — every `.md` file catalogued | Per-session sweep step 17 (new); quarterly full re-cat |
 | [`docs/security-runbook-2026-05-11.md`](security-runbook-2026-05-11.md) | Security incident response playbook | When new playbook step is added |
 | [`docs/war_games_playbook.md`](war_games_playbook.md) | 10 adversarial scenarios (W-1..W-10) with read-only probe templates for idle-time rotation | When new scenario surface emerges; rotate scenarios per sweep step 19 |
+| [`docs/github_features_plan.md`](github_features_plan.md) | Roadmap for utilizing all GitHub surfaces (Security tab, Discussions, Projects, Wiki, Issues, Actions, Releases, Insights). Phase 1 files in this PR; Phase 2/3 wait on operator enable | Quarterly review + when operator enables a Phase 2 item |
 
 ## §5 — Active operational state 📋
 


### PR DESCRIPTION
## Summary

Operator directive 2026-05-17: *"use git to its fullest extent including discussions tab, projects tab, wiki tab and securities and quality tab and others that may assist in quality and productivity."*

**Phase 1** ships 12 files that activate immediately — no operator settings changes required. Phase 2 (operator quick wins, ~10 min) + Phase 3 (B1 seeds content) are documented in [`docs/github_features_plan.md`](docs/github_features_plan.md).

## Files added (12)

```
.github/
├── SECURITY.md                          ← Security tab (vuln policy)
├── CONTRIBUTING.md                      ← bot-onboarding + external-contributor flow
├── dependabot.yml                       ← Dependabot (inert until G-2 enable)
├── labeler.yml                          ← path-based labeler config
├── ISSUE_TEMPLATE/
│   ├── bug.yml                          ← structured bug reports
│   ├── feature.yml                      ← feature requests
│   └── config.yml                       ← disable blank issues, link to Security/Discussions/KANBAN
└── workflows/
    ├── scorecard.yml                    ← OSSF Scorecard weekly, results → Security tab
    ├── labeler.yml                      ← auto-label PRs by paths + branch prefix
    ├── dependency-review.yml            ← block vulnerable deps (inert until G-2)
    └── pr-title-lint.yml                ← enforce `<type>(<lane>): <msg>` format

docs/
└── github_features_plan.md              ← unified proposal: surface-by-surface plan
```

## Activates immediately

| Workflow | Trigger | Effect |
|---|---|---|
| `scorecard.yml` | Weekly Mon 12:00 UTC + push to main | Scores repo against 16 OSSF checks; results in Security tab |
| `labeler.yml` | Every PR | Auto-labels by `area:*` (paths) + `level:*` (branch prefix) |
| `pr-title-lint.yml` | Every PR open/edit | Fails if title doesn't match `<type>(<lane>): <msg>` |
| `dependency-review.yml` | PRs touching `requirements.txt` / `package.json` / workflows | Trivial pass until Dependabot enabled, then blocks vulnerable deps |

## Phase 1 closes

| ID | What |
|---|---|
| G-12 / B1-NEXT-43 | SECURITY.md disclosure policy authored |
| G-18 / B1-NEXT-48 | OSSF Scorecard workflow live |

Partially prepares:
- G-17 / B1-NEXT-47 — dependency-review workflow in place, activates when Dependabot enabled
- G-19 / B1-NEXT-49 — `dependabot.yml` in place, activates when Dependabot enabled

## Phase 2 — operator quick wins (~10 min via Settings UI)

Detailed in [`docs/github_features_plan.md`](docs/github_features_plan.md):
1. **Settings → Code security**: Dependabot security updates + secret-scanning non-provider + validity-checks + Private Vulnerability Reporting + CodeQL "Default" setup
2. **Settings → General → Features**: Discussions ON, decide Wiki + Projects, "Automatically delete head branches" ON
3. **Settings → General → metadata**: 1-line description + topics (`ticket-trading`, `fastapi`, `supabase`, `multi-bot`, `claude-code`)
4. **Repo → Projects tab**: Create "Terminal-2 Open Work" board
5. **Repo → Wiki tab**: First page click → initializes `.wiki.git` repo

## Phase 3 — B1 seeds content (post Phase 2)

| Surface | Seed content B1 prepares |
|---|---|
| Discussions | 8 categories (Announcements, Ideas, Coordination, Decisions, Q&A, Show and tell, Polls, General) + 3-5 historical decisions from `docs/audit-*.md` |
| Projects | Custom fields (Lane, Severity, Status, Blocked on, KANBAN ID, Originating PR) + 6 views + automation rules + Issues mirroring KANBAN §🟢 OPEN |
| Wiki | 7 pages: Home, Bot directory, Architecture, Glossary, New-bot bootstrap, Operator runbooks, FAQ |
| Releases | First `v0.1.0-beta` tag with auto-drafted release notes |
| Workflows | `codeql.yml` (after CodeQL enabled) |

## Coordination with open PRs

- [PR #217](https://github.com/JulianS4K/Terminal-2/pull/217) (capabilities audit) added B1-NEXT-43, B1-NEXT-47, B1-NEXT-48, B1-NEXT-49 to KANBAN §🟢 OPEN. This PR ships the fixes for B1-NEXT-43 (SECURITY.md) + B1-NEXT-48 (scorecard) + prepares B1-NEXT-47 + B1-NEXT-49. Once both PRs land, follow-up will delete the closed rows from §🟢 OPEN per the closure protocol.

## Test plan

- [ ] CI green (forbidden-paths-check, scan, pytest)
- [ ] Workflow validation: `scorecard.yml` parses (will run on next Mon or push to main)
- [ ] Workflow validation: `labeler.yml` runs on this PR — labels appear (`area:ci`, `area:docs`, `level:security`)
- [ ] Workflow validation: `pr-title-lint.yml` passes on this PR (title matches format)
- [ ] After merge: confirm SECURITY.md surfaces in repo Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)