### PR TITLE
chore(security): close 6 G-N findings post operator Phase 2 quick wins

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -52,15 +52,11 @@
 | B1-NEXT-3 | B1 | Edge function auth-posture inventory (16 fns). Per-function record of `x-cron-secret` vs open vs JWT-gated. | Author `docs/edge_function_auth_inventory.md` |
 | B1-NEXT-5 | B1 | Vault orphans check — `release_health_check()` row for `get_app_secret` allowlist entries unused by any prod fn/cron/edge-fn. | 1 SQL migration adding a new row to `release_health_check()` |
 | B1-NEXT-8 | A1 | `_health_check_pg_net_errors()` missing §6 body guard (added by PR #115). | Add guard via CREATE OR REPLACE; preserve return shape |
-| B1-NEXT-12 | Op | `dependabot_security_updates` is disabled. | Settings → Code security → Enable. G-2. |
-| B1-NEXT-13 | Op | `secret_scanning_non_provider_patterns` disabled. | Operator settings toggle. G-3. |
-| B1-NEXT-14 | Op | `secret_scanning_validity_checks` disabled. | Operator settings toggle. G-4. |
 | B1-NEXT-18 | Op | Verify Actions secrets populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`). | Operator confirms next session via Settings → Secrets |
 | B1-NEXT-29 | A1 | `refresh_sg_broker_sales_event_metrics(integer)` missing §6 body guard. Hourly cron at `:17`. | Add guard via CREATE OR REPLACE |
 | B1-NEXT-30 | A1 (D2) | `sg_seller_orders_queue(p_pages, p_statuses)` missing §6 body guard. | Add guard via CREATE OR REPLACE |
 | B1-NEXT-31 | A1 | §6 body guard absent on 7 JWT-gated SECDEF RPCs: `get_broker_event_page` (v1/v2/v3), `get_event_sg_listings_full`, `get_event_evo_listings_full`, `get_event_sg_sales_full`, `get_event_cross_source_metrics`. JWT body check IS primary mitigation; guard is 2nd belt. | Add guard via CREATE OR REPLACE per fn (or batch migration) |
 | B1-NEXT-39 | D0 + D1 | `/api/store/search` exposes `we_own` (bool) + `owned_tix` (count). LANE_DISCIPLINE.md §D1 wall rule lists `is_owned` as forbidden. May be intentional storefront-product behavior. bot_chat 308. | If intentional: add carveout to LANE_DISCIPLINE.md §D1. If not: filter columns from `/api/store/search` response in `app.py` |
-| B1-NEXT-43 | B1 | **G-12**: No `SECURITY.md` security disclosure policy. Public repo + no vuln-reporting channel = researchers open public GitHub issues with vulnerabilities. | Author `.github/SECURITY.md`: reporting channel = GitHub PVR (after B1-NEXT-46) or bot_chat |
 
 ### SEC-LOW (hygiene)
 
@@ -84,14 +80,8 @@
 | B1-NEXT-35 | Op | Create scheduled task `b1-war-games-rotation`. Every 4h. | Operator approves Slack MCP tool + cron creation |
 | B1-NEXT-37 | A1 | Backfill `cron_policy` rows for 4 daily collect-listings windowed crons (1-7d/7-30d/30-60d/60d+). | 1 SQL INSERT into `cron_policy` |
 | B1-NEXT-40 | Op | **G-9**: `allow_forking: true` on public repo. Forks clone full history including the leaked `CRON_SECRET` commit `5297739`. Compounds G-1. | Operator decision (usually allow_forking stays true; real fix is G-1 history rewrite) |
-| B1-NEXT-41 | Op | **G-10**: `delete_branch_on_merge: false`. B1 manually pruned 14 orphan branches 2026-05-17. Hygiene. | Settings → General → "Automatically delete head branches" |
-| B1-NEXT-42 | Op | **G-11**: `has_wiki: true`, `has_projects: true`, `has_downloads: true` — enabled but unused. Attack surface (wiki spam, public visibility). | Settings → General → Features → disable unused |
 | B1-NEXT-44 | Op | **G-14**: Branch protection on `main` — no required approving review count, no CODEOWNERS review required, no dismiss-stale-reviews. Single-operator can push without formal review. | Operator decision — Settings → Branches → Edit rule for `main` |
 | B1-NEXT-45 | Op | **G-15**: `required_conversation_resolution: false`. PRs can merge with unresolved review comments. | Settings → Branches → toggle |
-| B1-NEXT-46 | Op | **G-16**: Private Vulnerability Reporting (PVR) not enabled. Public repo with no private channel for security researchers. | Settings → Code security → "Private vulnerability reporting" |
-| B1-NEXT-47 | B1 (blocked on G-2) | **G-17**: No `actions/dependency-review-action` in CI. Blocks PRs adding vulnerable deps once Dependabot enabled. | Add `.github/workflows/dependency-review.yml` after B1-NEXT-12 lands |
-| B1-NEXT-48 | B1 | **G-18**: No OSSF Scorecard workflow. Automated repo-security scoring + badge. | Add `.github/workflows/scorecard.yml` |
-| B1-NEXT-49 | B1 (blocked on G-2) | **G-19**: No `.github/dependabot.yml` for version updates. | Add weekly pip + gh-actions schedule after B1-NEXT-12 lands |
 
 ### Operator-only (settings / lockdown-gated applies)
 

--- a/docs/git_repo_security_posture.md
+++ b/docs/git_repo_security_posture.md
@@ -1,6 +1,6 @@
 # Git Repo Security Posture — Terminal-2
 
-**Owner**: B1 (Security Manager) · **Last full sweep**: 2026-05-17 (expanded — capabilities audit) · **Update cadence**: per-session sweep step 12 + 14 (see [`b1_operating_constraints.md`](b1_operating_constraints.md))
+**Owner**: B1 (Security Manager) · **Last full sweep**: 2026-05-18 (post Phase 2 operator quick wins — 6 findings closed) · **Update cadence**: per-session sweep step 12 + 14 (see [`b1_operating_constraints.md`](b1_operating_constraints.md))
 
 Living snapshot of GitHub repo security + maintenance configuration. B1 diffs current `gh api` output against this doc to catch regressions AND to track which GitHub capabilities are utilized vs available.
 
@@ -15,9 +15,9 @@ Original sweep G-1 through G-8 unchanged from 2026-05-15 baseline. Expanded with
 | # | Severity | Finding | Action |
 |---|---|---|---|
 | G-1 | SEC-HIGH | Repo `visibility: public` AND historic `CRON_SECRET` literal in commit `5297739` (now-rotated, but readable on the internet). | [B1-NEXT-11]. Operator decides `git filter-repo` window. |
-| G-2 | SEC-MED | `dependabot_security_updates: disabled` | [B1-NEXT-12]. Operator-only (Settings → Code security). |
-| G-3 | SEC-MED | `secret_scanning_non_provider_patterns: disabled` | [B1-NEXT-13]. Operator-only. |
-| G-4 | SEC-MED | `secret_scanning_validity_checks: disabled` | [B1-NEXT-14]. Operator-only. |
+| G-2 | SEC-MED | ~~`dependabot_security_updates: disabled`~~ ✅ **CLOSED 2026-05-18** — operator enabled. 0 open alerts on first scan. |
+| G-3 | SEC-MED | `secret_scanning_non_provider_patterns: disabled` — **DEFERRED 2026-05-18**: requires GitHub Advanced Security (GHAS) on individual public repos. Push protection (free tier) + gitleaks CI cover the gap. Reopen if repo moves to org with GHAS. |
+| G-4 | SEC-MED | `secret_scanning_validity_checks: disabled` — **DEFERRED 2026-05-18**: same GHAS-paid gate as G-3. |
 | G-5 | SEC-MED | No CodeQL / code-scanning analysis (`code-scanning/alerts` returns 404). | [B1-NEXT-4]. Decision deferred. |
 | G-6 | SEC-LOW | `enforce_admins: false` — admin can bypass branch protection. | [B1-NEXT-15]. Operator-only. |
 | G-7 | SEC-LOW | `required_signatures: false` — commits not GPG-signed. | [B1-NEXT-16]. |
@@ -28,16 +28,16 @@ Original sweep G-1 through G-8 unchanged from 2026-05-15 baseline. Expanded with
 | # | Severity | Finding | Action |
 |---|---|---|---|
 | G-9 | SEC-LOW | `allow_forking: true` on public repo. Forks clone full history including the leaked `CRON_SECRET` commit `5297739`. Compounds G-1. | [B1-NEXT-40]. Operator decision — typically allow_forking stays true unless concerned about derivative works; the real fix is G-1 history-rewrite. |
-| G-10 | SEC-LOW | `delete_branch_on_merge: false`. B1 manually deleted 14 orphan merged branches 2026-05-17. Hygiene issue, not security. | [B1-NEXT-41]. Operator-only toggle (Settings → General → "Automatically delete head branches"). |
-| G-11 | SEC-LOW | `has_wiki: true`, `has_projects: true`, `has_downloads: true` — all enabled but never used. Unused features = attack surface (spam, public-visibility leakage via wiki). | [B1-NEXT-42]. Operator decision. Disable unused. |
-| G-12 | SEC-MED | No `SECURITY.md` security disclosure policy. Public repo + no vuln-reporting channel = researchers open public issues with vulnerabilities. | [B1-NEXT-43]. B1 can author. Files at `.github/SECURITY.md` or repo root. |
+| G-10 | SEC-LOW | ~~`delete_branch_on_merge: false`~~ ✅ **CLOSED 2026-05-18** — operator enabled. |
+| G-11 | SEC-LOW | `has_wiki/projects/downloads: true` — **SUPERSEDED 2026-05-18** by operator "use to fullest extent" directive. Wiki + Projects now intentionally enabled. Discussions added (was false → true). Downloads stays on (no operational impact). |
+| G-12 | SEC-MED | ~~No `SECURITY.md` security disclosure policy.~~ ✅ **CLOSED 2026-05-18** by [PR #219](https://github.com/JulianS4K/Terminal-2/pull/219) — `.github/SECURITY.md` published. |
 | G-13 | SEC-LOW | No `LICENSE` file. Public repo without license = full copyright reserved (US default). Proprietary code; intentional. README footer should call this out. | Document, no action. |
 | G-14 | SEC-LOW | Branch protection — `required_approving_review_count` not set, CODEOWNERS review not required, `dismiss_stale_reviews` not set. Currently any user with push access (only `JulianS4K`) can merge to `main` without explicit review. | [B1-NEXT-44]. Operator decision — single-operator profile may or may not require formal review gate. |
 | G-15 | SEC-LOW | `required_conversation_resolution: false` on branch protection. PRs can merge with unresolved review comments. | [B1-NEXT-45]. Operator-only. |
-| G-16 | SEC-LOW | No private vulnerability reporting enabled. Public repo with no PVR = no private channel for researchers. | [B1-NEXT-46]. Operator-only (Settings → Code security → Private vulnerability reporting). |
-| G-17 | SEC-LOW | No `actions/dependency-review-action` in CI. With Dependabot enabled, this workflow blocks PRs that add vulnerable deps. | [B1-NEXT-47]. Blocked on G-2 (Dependabot enable). B1 can author once Dependabot lives. |
-| G-18 | SEC-LOW | No OSSF Scorecard workflow. Automated repo-security scoring (`.github/workflows/scorecard.yml`). | [B1-NEXT-48]. B1 can author. |
-| G-19 | SEC-LOW | No `.github/dependabot.yml` for version updates. Even with security updates disabled, version updates can run separately. | [B1-NEXT-49]. Blocked on G-2 enable decision. |
+| G-16 | SEC-LOW | ~~No private vulnerability reporting enabled.~~ ✅ **CLOSED 2026-05-18** — operator enabled. SECURITY.md "preferred" link now resolves. |
+| G-17 | SEC-LOW | ~~No `actions/dependency-review-action` in CI.~~ ✅ **CLOSED 2026-05-18** by [PR #219](https://github.com/JulianS4K/Terminal-2/pull/219) + Dependabot enable (G-2). Workflow now active on PRs touching `requirements.txt` / `workflows/*`. |
+| G-18 | SEC-LOW | ~~No OSSF Scorecard workflow.~~ ✅ **CLOSED 2026-05-18** by [PR #219](https://github.com/JulianS4K/Terminal-2/pull/219) — `.github/workflows/scorecard.yml` runs Mondays 12:00 UTC. |
+| G-19 | SEC-LOW | ~~No `.github/dependabot.yml` for version updates.~~ ✅ **CLOSED 2026-05-18** by [PR #219](https://github.com/JulianS4K/Terminal-2/pull/219) + Dependabot enable (G-2). Weekly pip + gh-actions schedule active. |
 
 No SEC-CRIT findings.
 

--- a/docs/github_features_plan.md
+++ b/docs/github_features_plan.md
@@ -1,6 +1,6 @@
 # GitHub Features Plan — Terminal-2
 
-**Owner**: B1 (Security Manager) · **Status**: 2026-05-17 — initial proposal, awaiting operator decisions on Discussions / Projects / Wiki enable
+**Owner**: B1 (Security Manager) · **Status**: 2026-05-18 — Phase 2 operator quick wins partially landed (4 of 7 toggles); Phase 3 content seeding now unblocked for Discussions + PVR-backed Security tab
 
 Operator directive 2026-05-17: *"use git to its fullest extent including using discussions tab, projects tab, wiki tab and securities and quality tab and others that may assist in quality and productivity."*
 
@@ -22,13 +22,13 @@ This doc maps every GitHub surface to a concrete proposed use within Terminal-2'
 - ✅ Added [`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml) — inert until operator enables (G-2)
 - ✅ Added [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml) — OSSF Scorecard, weekly cron, results to code-scanning + public scorecard.dev
 
-**Phase 2 (operator must enable in Settings → Code security)**:
-1. Dependabot security updates (G-2 / B1-NEXT-12)
-2. Dependabot security alerts (companion)
-3. Secret scanning non-provider patterns (G-3 / B1-NEXT-13)
-4. Secret scanning validity checks (G-4 / B1-NEXT-14)
-5. Private Vulnerability Reporting (G-16 / B1-NEXT-46) — so SECURITY.md's "preferred" channel works
-6. CodeQL (G-5 / B1-NEXT-4) — adds a 4th workflow `codeql.yml` (B1 authors after operator OK)
+**Phase 2 (operator must enable in Settings → Code security)** — **STATUS as of 2026-05-18**:
+1. ✅ Dependabot security updates (G-2 / B1-NEXT-12) — **ENABLED 2026-05-18**, 0 open alerts on first scan
+2. ✅ Dependabot security alerts — companion to #1
+3. ⏸️ Secret scanning non-provider patterns (G-3 / B1-NEXT-13) — **DEFERRED** (GHAS-paid feature, not available on free individual public repo)
+4. ⏸️ Secret scanning validity checks (G-4 / B1-NEXT-14) — **DEFERRED** (same GHAS gate)
+5. ✅ Private Vulnerability Reporting (G-16 / B1-NEXT-46) — **ENABLED 2026-05-18**, SECURITY.md PVR link now resolves
+6. 🟡 CodeQL (G-5 / B1-NEXT-4) — pending operator decision; adds `codeql.yml` workflow when chosen
 
 **Phase 3 (after Phase 2 lands)**:
 - Repository Security Advisories — draft CVE entries when first vuln surfaces (per-incident, no setup)
@@ -48,7 +48,7 @@ This doc maps every GitHub surface to a concrete proposed use within Terminal-2'
 - Operator broadcasts that should be discoverable later (currently scattered between bot_chat broadcasts and Slack)
 - Cross-bot knowledge base (Q&A — searchable past questions, replaces re-asking)
 
-**Phase 2 — operator enables** (Settings → General → Features → Discussions)
+**Phase 2 — operator enables** (Settings → General → Features → Discussions) — ✅ **ENABLED 2026-05-18**, tab now live
 
 **Phase 3 — B1 seeds these categories**:
 
@@ -255,34 +255,33 @@ git push origin v0.1.0-beta
 
 ## Cumulative operator-action checklist
 
-**Quick wins (~10 minutes total, all in Settings)**:
+**Quick wins** — STATUS as of 2026-05-18:
 
 1. Settings → Code security:
-   - Enable Dependabot security updates
-   - Enable secret-scanning non-provider patterns
-   - Enable secret-scanning validity checks
-   - Enable Private Vulnerability Reporting
-   - Enable Code scanning → CodeQL → "Default" setup (or wait for B1 to author `codeql.yml`)
+   - ✅ Dependabot security updates (enabled 2026-05-18)
+   - ⏸️ Secret-scanning non-provider patterns (DEFERRED — GHAS-paid)
+   - ⏸️ Secret-scanning validity checks (DEFERRED — GHAS-paid)
+   - ✅ Private Vulnerability Reporting (enabled 2026-05-18)
+   - 🟡 CodeQL → "Default" setup (pending operator decision)
 
 2. Settings → General → Features:
-   - Toggle Discussions ON
-   - Decide on Wiki: keep ON (B1 will seed) or OFF (defer)
-   - Decide on Projects: keep ON (B1 will create board)
-   - Toggle "Automatically delete head branches" ON (closes G-10)
+   - ✅ Discussions ON (enabled 2026-05-18)
+   - ✅ Wiki kept ON per fullest-extent directive (B1 will seed)
+   - ✅ Projects kept ON per fullest-extent directive (B1 will create board)
+   - ✅ Automatically delete head branches (enabled 2026-05-18)
 
 3. Settings → General → Pull Requests:
-   - Toggle "Always suggest updating pull request branches" ON
-   - Decide: allow auto-merge?
+   - 🟡 "Always suggest updating pull request branches" — pending operator
+   - 🟡 Allow auto-merge — pending operator decision
 
 4. Settings → General → repo metadata:
-   - Add 1-line description
-   - Add topics: `ticket-trading`, `fastapi`, `supabase`, `multi-bot`, `claude-code`
+   - ⏸️ Description + topics — SKIPPED 2026-05-18 (operator noted UI didn't surface these fields)
 
-5. Repo → Projects tab → New project → "Board" template → name "Terminal-2 Open Work"
+5. 🟡 Repo → Projects tab → New project "Terminal-2 Open Work" — pending operator
 
-6. Repo → Wiki tab → Create first page (auto-initializes the wiki repo)
+6. 🟡 Repo → Wiki tab → Create first page — pending operator
 
-7. Repo → Discussions tab (after step 1) → "Get started" → enable + B1's proposed categories
+7. ✅ Repo → Discussions tab — operator enabled 2026-05-18, B1 to seed categories
 
 **After operator quick wins** — B1 follow-up PRs:
 - B1 authors `.github/workflows/codeql.yml` (after CodeQL enabled)


### PR DESCRIPTION
## Summary

Operator landed 4 of 7 Phase 2 quick-win toggles 2026-05-18 + my PR #219 closed 2 more. This PR enacts the §🟢 OPEN closure protocol — fixing-bot DELETES rows from the ledger when work ships.

## Verification

Confirmed via gh api:

| Setting | API value |
|---|---|
| `dependabot_security_updates.status` | `enabled` |
| `delete_branch_on_merge` | `true` |
| `private-vulnerability-reporting.enabled` | `true` |
| `has_discussions` | `true` |
| `dependabot/alerts?state=open` | `0` (clean baseline) |

## Rows deleted from KANBAN §🟢 OPEN (10 total)

### Closed by operator (Phase 2 quick wins)
- **B1-NEXT-12 / G-2** — Dependabot security updates enabled
- **B1-NEXT-41 / G-10** — Auto-delete head branches enabled
- **B1-NEXT-46 / G-16** — Private Vulnerability Reporting enabled
- **B1-NEXT-42 / G-11** — Superseded by fullest-extent directive: Discussions ON, Wiki+Projects kept ON intentionally

### Closed by PR #219 (workflows shipped + activated by Dependabot enable)
- **B1-NEXT-43 / G-12** — \`.github/SECURITY.md\` authored
- **B1-NEXT-47 / G-17** — \`dependency-review.yml\` now active
- **B1-NEXT-48 / G-18** — \`scorecard.yml\` runs Mondays 12:00 UTC
- **B1-NEXT-49 / G-19** — \`dependabot.yml\` activated by G-2 enable

### Deferred (deleted with annotation in posture doc)
- **B1-NEXT-13 / G-3** — Secret scanning non-provider patterns: GHAS-paid, not on free individual public repo. Push protection + gitleaks CI cover the gap.
- **B1-NEXT-14 / G-4** — Secret scanning validity checks: same GHAS gate.

## Skipped (operator note)

Quick win #7 (repo description + topics) — operator reported the UI didn't surface those fields. Left open in \`docs/github_features_plan.md\` §"Cumulative operator-action checklist" for a retry pass.

## Remaining §🟢 OPEN snapshot

- SEC-HIGH: 2 (RLS gap on 3 tables; leaked CRON_SECRET history rewrite)
- SEC-MED: 9 (was 12, -3)
- SEC-LOW: 16 (was 22, -6)
- Operator-only: 3 (unchanged — pending migration applies + bot_chat aging triage)
- OPS: empty (other lanes self-populate)

## Files

- \`KANBAN.md\` — 10 rows removed from §🟢 OPEN (historical entries in B1-NEXT queue archive section preserved per closure protocol)
- \`docs/git_repo_security_posture.md\` — G-2/10/11/12/16/17/18/19 marked CLOSED inline; G-3/4 marked DEFERRED with GHAS rationale
- \`docs/github_features_plan.md\` — Phase 2 quick-wins status updated (✅/⏸️/🟡 per item)

## Next steps (B1 follow-ups)

1. Seed Discussions categories (8 categories + welcome posts) — operator enabled the tab; B1 can populate now
2. Initialize Wiki + seed 7 pages (operator must create the first page to initialize \`.wiki.git\`)
3. Create "Terminal-2 Open Work" project board (operator creates, B1 populates)
4. Cut first \`v0.1.0-beta\` release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)