### PR TITLE
docs(b1): Phase 3 — GitHub Discussions seeded (5 posts in 6 default categories)

### DIFF
--- a/docs/github_discussions_seed_2026-05-18.md
+++ b/docs/github_discussions_seed_2026-05-18.md
@@ -258,12 +258,18 @@ Category IDs:
 
 After post: B1 captures the discussion URLs in a follow-up commit to this file under each post heading.
 
-## URLs (filled post-publish)
+## URLs (published 2026-05-18)
 
 | Category | Post title | URL |
 |---|---|---|
-| Announcements | Welcome to Terminal-2 — read this first | _(pending publish)_ |
-| Ideas | RFC flow — propose changes here before writing code | _(pending publish)_ |
-| General | [coord] Cross-lane coordination — when bot_chat is too short | _(pending publish)_ |
-| Q&A | FAQ — common questions about Terminal-2 | _(pending publish)_ |
-| Show and tell | 🎉 Recent ships (May 2026) — terminal v3 + multi-bot governance | _(pending publish)_ |
+| Announcements | Welcome to Terminal-2 — read this first | [#231](https://github.com/JulianS4K/Terminal-2/discussions/231) |
+| Ideas | RFC flow — propose changes here before writing code | [#232](https://github.com/JulianS4K/Terminal-2/discussions/232) |
+| General | [coord] Cross-lane coordination — when bot_chat is too short | [#233](https://github.com/JulianS4K/Terminal-2/discussions/233) |
+| Q&A | FAQ — common questions about Terminal-2 | [#234](https://github.com/JulianS4K/Terminal-2/discussions/234) |
+| Show and tell | 🎉 Recent ships (May 2026) — terminal v3 + multi-bot governance | [#235](https://github.com/JulianS4K/Terminal-2/discussions/235) |
+
+## Operator follow-ups (optional)
+
+1. **Pin the welcome post** (#231) — discussion pinning is web-UI-only (`pinDiscussion` GraphQL mutation doesn't exist; REST endpoint 404s). To pin: go to [discussion #231](https://github.com/JulianS4K/Terminal-2/discussions/231) → "..." menu → "Pin discussion".
+2. **Add Coordination + Decisions categories** if you want the originally-proposed 8-category structure rather than the 6 defaults. Settings → Discussions → "New category".
+3. **Run a Poll** in the Polls category when an operator decision needs multi-choice input (B1 will draft the poll body when an example comes up).

--- a/docs/github_discussions_seed_2026-05-18.md
+++ b/docs/github_discussions_seed_2026-05-18.md
@@ -1,0 +1,269 @@
+# GitHub Discussions seed content — Terminal-2
+
+**Owner**: B1 (Security Manager · Phase 3 of `docs/github_features_plan.md`)
+**Posted**: 2026-05-18 via GraphQL `createDiscussion` mutation
+**Categories**: 6 defaults (Announcements / General / Ideas / Polls / Q&A / Show and tell)
+
+Operator's directive 2026-05-17 enabled Discussions tab. B1 seeds these 6 categories with one welcome/anchor post each so visitors land on content, not an empty tab.
+
+> The 2 categories originally proposed (Coordination + Decisions) are not in GitHub's default set. They get folded into General (Coordination uses `[coord]` prefix) + Announcements (Decisions use `[DECISION]` prefix) respectively. Operator can add the 2 categories later via Settings → Discussions if desired.
+
+---
+
+## 📢 Announcements — "Welcome to Terminal-2 Discussions"
+
+Posted to: `Announcements` (slug `announcements`)
+
+**Title**: `Welcome to Terminal-2 — read this first`
+
+**Body**:
+
+```markdown
+Terminal-2 is a multi-bot orchestrated ticket-trading intelligence + retail platform. FastAPI + Supabase + Render. This Discussions tab is the place for **async, long-form, threaded** conversation. For transactional cross-bot coordination, the canonical channel is the `public.bot_chat` table inside Supabase.
+
+## Where to find things
+
+| Need | Go to |
+|---|---|
+| **What can I do?** Hard rules + lane scope + SQL macros | [`PROJECT_BIBLE.md`](../blob/main/PROJECT_BIBLE.md) |
+| **What's open right now?** Severity-sorted ledger | [`KANBAN.md §🟢 OPEN`](../blob/main/KANBAN.md) |
+| **What exists?** Tables/views/crons/edge-fn inventory | [`RESOURCES_BIBLE.md`](../blob/main/RESOURCES_BIBLE.md) |
+| **Who can push where?** | [`BOT_HIERARCHY.md`](../blob/main/BOT_HIERARCHY.md) |
+| **Report a security issue** | [Security Advisories (private)](../security/advisories/new) — DO NOT open a public issue for security |
+| **Report a bug** | [Issues → "Bug report"](../issues/new?template=bug.yml) |
+
+## How to use Discussions
+
+- 📢 **Announcements** (this category) — Operator broadcasts, decision records, major-change notices. `[DECISION]` prefix marks operator decision records.
+- 💡 **Ideas** — Pre-implementation RFCs. Use this for design proposals before code lands.
+- 🤝 **General** — Cross-lane coordination too long for bot_chat. `[coord]` prefix marks coordination threads.
+- ❓ **Q&A** — Knowledge base. Search past questions before re-asking.
+- 🎯 **Show and tell** — Demos of shipped features.
+- 🗳️ **Polls** — Operator-side multi-choice decisions.
+
+## Conventions
+
+- One topic per thread. Don't bury new questions inside answered ones.
+- Cross-link to `KANBAN.md §🟢 OPEN` row IDs when discussing open work.
+- Cross-link to PRs / commits / bot_chat row IDs for traceability.
+
+Welcome.
+```
+
+---
+
+## 💡 Ideas — "How to propose a feature or architecture change"
+
+Posted to: `Ideas` (slug `ideas`)
+
+**Title**: `RFC flow — propose changes here before writing code`
+
+**Body**:
+
+```markdown
+## When to use Ideas (vs Issues vs bot_chat)
+
+| Surface | Use case |
+|---|---|
+| **Discussions → Ideas** (here) | Anything that needs **conversation BEFORE code**: architectural shifts, new lanes, schema migrations affecting >1 table, deprecating an RPC, framework changes. The discussion produces a decision; the decision drives the PR. |
+| **Issues** | Concrete, scoped feature requests with a clear "done" definition. |
+| **`bot_chat` `event_type='question'`** | Transactional cross-lane asks during active work. |
+
+## Light RFC template
+
+When you start a new Idea, copy this scaffold into the body:
+
+```
+**Problem**: What's broken / missing / painful? Concrete examples.
+
+**Proposed**: What we'd do. Be specific — file paths, function names, schema changes.
+
+**Alternatives considered**: What else we ruled out + why.
+
+**Impact**:
+- Files touched:
+- Migrations:
+- Cross-lane writes (per `LANE_DISCIPLINE.md`):
+- Reversibility:
+- Smoke harness expected to change: yes/no
+
+**Open questions**: things the discussion should resolve.
+```
+
+The operator (or A1) lands the resolution as a top-level comment with `[DECISION: ship | hold | reject]`. The thread closes when implementation PR merges.
+
+## Past examples to learn from
+
+- The testing-unified architecture (PR #168) — folded D0 + D1 + D2 onto one Render service
+- The `match_to_aq_event_id` overload drop (PR #177) — sequencing-regression lesson
+- The KANBAN §🟢 OPEN closure protocol (PR #209) — coordination-pattern decision
+
+Start a new thread when you have something to propose.
+```
+
+---
+
+## 🤝 General — "Cross-lane coordination here"
+
+Posted to: `General` (slug `general`)
+
+**Title**: `[coord] Cross-lane coordination — when bot_chat is too short`
+
+**Body**:
+
+```markdown
+`bot_chat` rows are great for transactional asks ("@A1 — please apply migration X"). But sometimes a coordination thread runs longer:
+
+- Multi-message back-and-forth between D0/D1/D2 about table ownership
+- Design conversation with 3+ participants
+- "Who owns this surface now that the D-tier reorg happened?"
+
+For those, **post here with `[coord]` prefix**. The thread is durable, searchable, and stays out of the high-traffic bot_chat firehose.
+
+## Conventions
+
+- Title format: `[coord] <topic>` — the prefix makes filtered views easy
+- @-mention the affected lanes in the body (e.g., `cc @D0 @D1`) — note GitHub @-mention only works for users, not bot lanes. Use lane names anyway for grep
+- Cross-link the originating `bot_chat` row IDs
+- When resolved, the operator (or originating bot) posts `[RESOLVED]` as a top-level comment + locks the thread
+
+## What does NOT go here
+
+- Security findings — those go to `bot_chat` `event_type='flag'` + `KANBAN.md §🟢 OPEN`
+- Bug reports — those go to GitHub Issues
+- Feature proposals — those go to Discussions → Ideas
+- Code review — those go on the PR itself
+```
+
+---
+
+## ❓ Q&A — Seed FAQ
+
+Posted to: `Q&A` (slug `q-a`)
+
+**Title**: `FAQ — common questions about Terminal-2`
+
+**Body**:
+
+```markdown
+Quick-reference for questions that come up repeatedly. Each Q&A here is a top-level Discussion you can search; longer answers might warrant their own thread.
+
+## Q: Why is `seatgeek_sales_snapshots.tevo_event_id` mostly null?
+
+A: SG firehose tables don't carry TEvo IDs natively. Cross-source matching is done lazily via `aq_event_map` + `seatgeek_event_xref`. Always query by `sg_event_id` for SG-side data. PR #178 backfilled 87% of historical rows; new rows are born populated where xref exists (mig 20260517160000). See `PROJECT_BIBLE.md §3` column landmines.
+
+## Q: Why are migrations sometimes applied to prod before the PR exists?
+
+A: 2026-05-13 lockdown protocol — author files first, prod-apply via MCP `apply_migration` is gated separately on operator authorization. Idempotent migrations that A1 has authority over can be applied first, then codified in a PR (with "Already applied to prod" annotation in the migration header). See `MIGRATION_CONVENTIONS.md` + `docs/release-discipline.md`.
+
+## Q: What's the difference between `bot_chat`, KANBAN, this Discussions tab, and Slack?
+
+A: 4-surface map:
+- **`bot_chat`** (Supabase table) — durable, append-only, transactional cross-bot coordination
+- **`KANBAN.md §🟢 OPEN`** (repo file) — current actionable work, severity-sorted, fixing bot deletes their row when shipped
+- **GitHub Discussions** (this tab) — async, long-form, threaded, for design/decision/RFC work
+- **Slack** (`#terminal-2-alerts` + `#terminal-2-admin` + `#terminal-2-d0`) — operator-facing real-time signal
+
+When in doubt: `bot_chat` for short, Discussions for long, KANBAN for state.
+
+## Q: What's a "lane"?
+
+A: Terminal-2 has ~10 specialized bot roles ("lanes"): A1 admin, B1 security, C1 canonical, D0 terminal FE, D1 storefront, D2 orders, D3 broadway scraper, D4 ticketing infra, E1 external markets. Each lane has its own write surface per `LANE_DISCIPLINE.md`. Cross-lane writes need coordination via `bot_chat` or PR comment.
+
+## Q: How do I report a security vulnerability?
+
+A: **NOT** via a public issue. Use [Private Vulnerability Reporting](../security/advisories/new). See `.github/SECURITY.md` for the full policy + response SLA.
+
+---
+
+Have another question? Open a new Q&A thread.
+```
+
+---
+
+## 🎯 Show and tell — Recent ships
+
+Posted to: `Show and tell` (slug `show-and-tell`)
+
+**Title**: `🎉 Recent ships (May 2026) — terminal v3 + multi-bot governance`
+
+**Body**:
+
+```markdown
+Highlights from the May 2026 sprint:
+
+## D0 Terminal frontend
+- **PR #196** — event-page tab navigation + 3 full-list tabs + Last Snapshot panel
+- **PR #205** — uncapped 3 full-list tabs + new CROSS-SOURCE METRICS panel
+- **PR #203** — performer 2-mode + venue page + ESPN context tab
+- **PR #202** — full movers table + SG sales column + Blind Spots panel
+- **PR #186** — event-page v3: 9 enrichment panels (operator audit followup)
+
+## A1 admin / SG bridge
+- **PR #168** — testing-unified architecture (D0 + D1 + D2 mount on one Render service)
+- **PR #177** — cross-source venue map + active TEvo search bridge + 2 OPS hotfixes
+- **PR #178** — 87% backfill of `seatgeek_sales_snapshots.tevo_event_id`
+- **PR #206** — 5 per-event metrics gaps fixed (sentiment + competitors + sections + cost cleanup + owned dist)
+
+## B1 security / governance
+- **PR #176** — cron heartbeat detector in `release_health_check()`
+- **PR #209** — KANBAN §🟢 OPEN consolidated live ledger + closure-by-deletion protocol
+- **PR #217** — GitHub capabilities audit (11 new findings + 27 unutilized features catalogued)
+- **PR #219** — GitHub fullest-utilization Phase 1: SECURITY.md + 4 quality workflows + Issue templates
+- **PR #229** — 6 G-N findings closed post operator Phase 2 quick wins
+
+## What this enables
+
+- Operator can see broker-level event detail across SG / TEvo / TickPick / Vivid in one view
+- Bots' security drift caught + closed within hours of detection (B1 detect → A1 fix loop)
+- Public-facing repo hygiene: Dependabot active, PVR live, Discussions tab open
+
+Shipping continues. Watch `KANBAN.md §🟢 OPEN` for what's next.
+```
+
+---
+
+## 🗳️ Polls — (skipped, no active poll)
+
+Polls category exists but no current decision needs a poll. B1 will post one when an operator-side multi-choice decision arises (e.g., "Cron heartbeat threshold: 2x median, 3x, or 5x?" if we revisit PR #176's defaults).
+
+---
+
+## Posting protocol (B1 ops)
+
+Each post above is sent via GraphQL:
+
+```graphql
+mutation {
+  createDiscussion(input:{
+    repositoryId: "<repo_id>",
+    categoryId: "<category_id>",
+    title: "<title>",
+    body: "<body>"
+  }) {
+    discussion { number url }
+  }
+}
+```
+
+Repo ID: `R_kgDOSMegnc` (retrieved via `gh api graphql -f query='query{repository(owner:"JulianS4K",name:"Terminal-2"){id}}'`)
+
+Category IDs:
+- Announcements: `DIC_kwDOSMegnc4C9SEq`
+- General: `DIC_kwDOSMegnc4C9SEr`
+- Ideas: `DIC_kwDOSMegnc4C9SEt`
+- Q&A: `DIC_kwDOSMegnc4C9SEs`
+- Show and tell: `DIC_kwDOSMegnc4C9SEu`
+- Polls: `DIC_kwDOSMegnc4C9SEv` (not used in this seed)
+
+After post: B1 captures the discussion URLs in a follow-up commit to this file under each post heading.
+
+## URLs (filled post-publish)
+
+| Category | Post title | URL |
+|---|---|---|
+| Announcements | Welcome to Terminal-2 — read this first | _(pending publish)_ |
+| Ideas | RFC flow — propose changes here before writing code | _(pending publish)_ |
+| General | [coord] Cross-lane coordination — when bot_chat is too short | _(pending publish)_ |
+| Q&A | FAQ — common questions about Terminal-2 | _(pending publish)_ |
+| Show and tell | 🎉 Recent ships (May 2026) — terminal v3 + multi-bot governance | _(pending publish)_ |


### PR DESCRIPTION
## Summary

Phase 3 of `docs/github_features_plan.md` — operator enabled Discussions tab 2026-05-18; B1 seeded 5 anchor posts so visitors land on content, not an empty tab.

## Published

| Category | Post | URL |
|---|---|---|
| 📢 Announcements | Welcome to Terminal-2 — read this first | [#231](https://github.com/JulianS4K/Terminal-2/discussions/231) |
| 💡 Ideas | RFC flow — propose changes here before writing code | [#232](https://github.com/JulianS4K/Terminal-2/discussions/232) |
| 🤝 General | [coord] Cross-lane coordination — when bot_chat is too short | [#233](https://github.com/JulianS4K/Terminal-2/discussions/233) |
| ❓ Q&A | FAQ — common questions about Terminal-2 | [#234](https://github.com/JulianS4K/Terminal-2/discussions/234) |
| 🎯 Show and tell | 🎉 Recent ships (May 2026) — terminal v3 + multi-bot governance | [#235](https://github.com/JulianS4K/Terminal-2/discussions/235) |

Polls category seeded with no post — no current operator decision needs a poll. The 2 categories originally proposed (Coordination + Decisions) folded into General (`[coord]` prefix) + Announcements (`[DECISION]` prefix). Operator can add as separate categories later via Settings → Discussions if desired.

## How posting worked

Via GraphQL `createDiscussion` mutation (5 posts, sequential). Each post is short (~150-250 words), cross-links to PROJECT_BIBLE / KANBAN / SECURITY.md, and explains WHEN to use each category vs bot_chat vs Issues.

## What this enables

- **First-time visitors** land on substantive content explaining the multi-bot system, where to find things, and how to contribute (instead of "no discussions here yet")
- **Future RFCs** have a structured home (Ideas category) instead of scattering across `docs/audit-*.md`
- **Q&A is searchable** — recurring questions (why is `sg_event_id` null? when do migrations apply before PR?) now have canonical answers
- **Cross-lane coord** has a longer-form home than `bot_chat` for multi-message threads

## Operator follow-ups (optional, web-UI-only)

1. Pin #231 (welcome post) — discussion pinning isn't API-accessible; only Settings → discussion → "..." menu
2. Add Coordination + Decisions categories if you want the 8-category structure
3. Run a Poll when an operator multi-choice decision arises (B1 drafts on request)

## Files

- `docs/github_discussions_seed_2026-05-18.md` — the source-of-truth content + URLs

## Next Phase 3 work (after this lands)

Per `docs/github_features_plan.md` §Phase 3 — still pending operator-action:
- **Wiki**: operator clicks "Create first page" in the Wiki tab → B1 seeds 7 pages (Home, Bot directory, Architecture, Glossary, New-bot bootstrap, Operator runbooks, FAQ)
- **Projects**: operator creates "Terminal-2 Open Work" project board → B1 populates custom fields + 6 views + automation + Issues mirroring KANBAN §🟢 OPEN
- **Releases**: operator decides on first version tag (`v0.1.0-beta`?) → B1 cuts the tag with auto-drafted release notes
- **CodeQL**: operator enables Code scanning → B1 authors `codeql.yml` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)