### PR TITLE
feat(d0/event): chart expansion — 5 SG series + ESPN injury/state annotations

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -14,6 +14,11 @@
   let CHART_HOURS = DEFAULT_HOURS;
   let _chartInstance = null;
   let _lastPayload = null;
+  // Chart-extension state cache (mig 20260519150000 / get_event_chart_extended):
+  // fetched in parallel with v3; merges 5 SG series + 2 ESPN annotation arrays
+  // into the chart whenever it lands. Same state-machine pattern as splits/zones.
+  let _chartExtState = { payload: undefined };
+  let _chartExtAlerts = []; // cached for re-renders after extended payload arrives
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
@@ -37,6 +42,7 @@
     loadCrossSourceMetrics(eventId).catch(e => console.error('[crossSource]', e));
     loadWeatherLocalized(eventId).catch(e => console.error('[weatherLocalized]', e));
     loadSgZonesSplits(eventId).catch(e => console.error('[sgZonesSplits]', e));
+    loadChartExtended(eventId).catch(e => console.error('[chartExtended]', e));
     await loadAndRender(eventId);
   }
 
@@ -105,6 +111,10 @@
       if (lbl) lbl.textContent = sel.options[sel.selectedIndex].textContent;
       const aw = document.getElementById('alertsWindow');
       if (aw) aw.textContent = sel.options[sel.selectedIndex].textContent;
+      // Drop stale extended payload so series don't render mismatched windows
+      _chartExtState.payload = undefined;
+      // Re-fire both fetches; renderChart re-runs when each lands
+      loadChartExtended(eventId).catch(e => console.error('[chartExtended]', e));
       await loadAndRender(eventId);
     });
   }
@@ -423,17 +433,38 @@
     host.innerHTML = '';
     if (!chart || !window.uPlot) return;
 
+    // Cache alerts for re-renders triggered by extended-payload arrival
+    _chartExtAlerts = alerts || [];
+
+    // Merge the SG-side series from _chartExtState (lands in parallel — may be
+    // undefined on first paint; chart redraws when it arrives). Reading via
+    // the cache instead of an explicit arg matches the splits/zones pattern.
+    const ext = _chartExtState.payload || null;
+    const extSeries = (ext && ext.series) || {};
+    const sgListMed   = extSeries.sg_listings_median       || [];
+    const sgListOwnMed= extSeries.sg_listings_owned_median || [];
+    const sgListCt    = extSeries.sg_listings_count        || [];
+    const sgSaleMed   = extSeries.sg_sales_median          || [];
+    const sgSaleCt    = extSeries.sg_sales_count           || [];
+
     const seriesSpecs = [
-      { key: 'prices_owned',    label: 'Owned median',    color: '#fbbf24', scale: 'y',   width: 2,   dash: null },
-      { key: 'prices_market',   label: 'Market median',   color: '#737373', scale: 'y',   width: 1.5, dash: [4, 4] },
-      { key: 'prices_nonowned', label: 'Non-owned median',color: '#a78bfa', scale: 'y',   width: 1.5, dash: [6, 3] },
-      { key: 'counts_owned',    label: 'Owned qty',       color: '#60a5fa', scale: 'qty', width: 1,   dash: null, fill: 'rgba(96,165,250,0.08)' },
-      { key: 'counts_market',   label: 'Market qty',      color: '#94a3b8', scale: 'qty', width: 1,   dash: [2, 2] },
+      // TEvo (existing 5)
+      { key: 'prices_owned',    label: 'TEvo Owned',     color: '#fbbf24', scale: 'y',   width: 2,   dash: null,    data: chart.prices_owned },
+      { key: 'prices_market',   label: 'TEvo Market',    color: '#737373', scale: 'y',   width: 1.5, dash: [4, 4],  data: chart.prices_market },
+      { key: 'prices_nonowned', label: 'TEvo Non-owned', color: '#a78bfa', scale: 'y',   width: 1.5, dash: [6, 3],  data: chart.prices_nonowned },
+      { key: 'counts_owned',    label: 'TEvo Owned qty', color: '#60a5fa', scale: 'qty', width: 1,   dash: null,    fill: 'rgba(96,165,250,0.08)', data: chart.counts_owned },
+      { key: 'counts_market',   label: 'TEvo Mkt qty',   color: '#94a3b8', scale: 'qty', width: 1,   dash: [2, 2],  data: chart.counts_market },
+      // SG (new 5, from extended RPC payload)
+      { key: 'sg_list_med',     label: 'SG list med',    color: '#22d3ee', scale: 'y',   width: 1.5, dash: null,    data: sgListMed },
+      { key: 'sg_own_med',      label: 'SG owned med',   color: '#fb7185', scale: 'y',   width: 1.5, dash: [3, 3],  data: sgListOwnMed },
+      { key: 'sg_sale_med',     label: 'SG sale med',    color: '#84cc16', scale: 'y',   width: 1.5, dash: [5, 2],  data: sgSaleMed },
+      { key: 'sg_list_ct',      label: 'SG list qty',    color: '#22d3ee', scale: 'qty', width: 1,   dash: [2, 2],  data: sgListCt },
+      { key: 'sg_sale_ct',      label: 'SG sale ct',     color: '#84cc16', scale: 'sgct',width: 1.5, dash: null,    data: sgSaleCt, points: { show: true, size: 4 } },
     ];
 
     // Build unified time axis
     const tset = new Set();
-    seriesSpecs.forEach(s => (chart[s.key] || []).forEach(p => tset.add(p.t)));
+    seriesSpecs.forEach(s => (s.data || []).forEach(p => tset.add(p.t)));
     const ts = [...tset].sort();
     const xs = ts.map(t => Math.round(new Date(t).getTime() / 1000));
     const idx = new Map(ts.map((t, i) => [t, i]));
@@ -443,7 +474,7 @@
       return arr;
     };
 
-    const data = [xs, ...seriesSpecs.map(s => project(chart[s.key]))];
+    const data = [xs, ...seriesSpecs.map(s => project(s.data))];
 
     // Pick a tick-friendly width (re-render on resize)
     const rect = host.getBoundingClientRect();
@@ -453,24 +484,36 @@
     const opts = {
       width: w, height: h,
       cursor: { drag: { x: true, y: false } },
-      scales: { x: { time: true }, y: {}, qty: {} },
+      scales: { x: { time: true }, y: {}, qty: {}, sgct: {} },
       axes: [
         { stroke: 'var(--muted)', grid: { stroke: 'var(--line-2)', width: 1 } },
         { scale: 'y',   stroke: 'var(--muted)', grid: { stroke: 'var(--line-2)', width: 1 },
           values: (u, v) => v.map(x => x === null ? '' : '$' + Math.round(x)) },
         { scale: 'qty', side: 1, stroke: 'var(--muted)', grid: { show: false },
           values: (u, v) => v.map(x => x === null ? '' : Math.round(x)) },
+        // Hidden axis: sg sale count shares the right-side gutter implicitly via
+        // its own scale (sgct), but we don't draw a separate axis to keep the
+        // chart visually clean. uPlot still scales it correctly.
       ],
       series: [
         { label: 'time' },
         ...seriesSpecs.map(s => ({
           label: s.label, stroke: s.color, width: s.width, scale: s.scale,
           spanGaps: true, dash: s.dash || undefined, fill: s.fill || undefined,
+          points: s.points || undefined,
         })),
       ],
       hooks: {
         draw: [
           (u) => drawAlertsMarkers(u, alerts || []),
+          (u) => drawInjuryMarkers(u, ext && ext.annotations && ext.annotations.injuries),
+          (u) => drawGameStateMarkers(u, ext && ext.annotations && ext.annotations.game_state),
+        ],
+        ready: [
+          (u) => renderAnnotationTooltips(u, host, ext && ext.annotations),
+        ],
+        setSize: [
+          (u) => renderAnnotationTooltips(u, host, ext && ext.annotations),
         ],
       },
     };
@@ -482,7 +525,7 @@
       let resizeTimer;
       window.addEventListener('resize', () => {
         clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(() => renderChart(chart, alerts), 200);
+        resizeTimer = setTimeout(() => renderChart(chart, _chartExtAlerts), 200);
       });
     }
   }
@@ -519,18 +562,114 @@
     return '#60a5fa';
   }
 
+  // Injury transition canvas marker — small "+" near top of chart, magenta.
+  // Same canvas-px coordinate convention as drawAlertsMarkers (canPos=true).
+  function drawInjuryMarkers(u, injuries) {
+    if (!injuries || !injuries.length || !u.ctx) return;
+    const ctx = u.ctx;
+    ctx.save();
+    ctx.strokeStyle = '#ec4899'; // pink/magenta — distinct from yellow/red alert palette
+    ctx.lineWidth = 2;
+    injuries.forEach(a => {
+      if (!a.at) return;
+      const tSec = Math.round(new Date(a.at).getTime() / 1000);
+      const x = u.valToPos(tSec, 'x', true);
+      if (x < u.bbox.left || x > u.bbox.left + u.bbox.width) return;
+      const y = u.bbox.top + 14;
+      // small cross
+      ctx.beginPath();
+      ctx.moveTo(x - 3, y); ctx.lineTo(x + 3, y);
+      ctx.moveTo(x, y - 3); ctx.lineTo(x, y + 3);
+      ctx.stroke();
+    });
+    ctx.restore();
+  }
+
+  // Game-state transition canvas marker — small square near top of chart, teal.
+  function drawGameStateMarkers(u, states) {
+    if (!states || !states.length || !u.ctx) return;
+    const ctx = u.ctx;
+    ctx.save();
+    ctx.fillStyle = '#14b8a6'; // teal
+    states.forEach(s => {
+      if (!s.at) return;
+      const tSec = Math.round(new Date(s.at).getTime() / 1000);
+      const x = u.valToPos(tSec, 'x', true);
+      if (x < u.bbox.left || x > u.bbox.left + u.bbox.width) return;
+      const y = u.bbox.top + 26;
+      ctx.fillRect(x - 3, y - 3, 6, 6);
+    });
+    ctx.restore();
+  }
+
+  // DOM-overlay tooltips for annotations (canvas can't host hover tooltips natively).
+  // Sibling absolute-positioned dots over the chart canvas; native title= attribute
+  // for hover text. Cheap + zero plugin deps. Re-run on uPlot ready + setSize.
+  function renderAnnotationTooltips(u, host, annotations) {
+    if (!annotations) return;
+    let overlay = host.querySelector('.chart-anno-host');
+    if (!overlay) {
+      // Ensure host is positioned for absolute children
+      const cs = window.getComputedStyle(host);
+      if (cs.position === 'static') host.style.position = 'relative';
+      overlay = document.createElement('div');
+      overlay.className = 'chart-anno-host';
+      host.appendChild(overlay);
+    }
+    overlay.innerHTML = '';
+    const inj = annotations.injuries || [];
+    const gs  = annotations.game_state || [];
+    const addDot = (t, kind, tip) => {
+      const tSec = Math.round(new Date(t).getTime() / 1000);
+      // canPos=false → CSS pixels (matches DOM coordinate space)
+      const x = u.valToPos(tSec, 'x');
+      if (x < u.bbox.left || x > u.bbox.left + u.bbox.width) return;
+      const yOffset = kind === 'inj' ? 12 : 24;
+      const dot = document.createElement('div');
+      dot.className = 'chart-anno-dot anno-' + kind;
+      dot.style.left = (x - 5) + 'px';
+      dot.style.top = (u.bbox.top + yOffset - 5) + 'px';
+      dot.title = tip;
+      overlay.appendChild(dot);
+    };
+    inj.forEach(a => addDot(a.at, 'inj',
+      `${a.athlete_name || a.athlete_id || '?'} (${a.position || '?'} · team ${a.espn_team_id || '?'}): ${a.prev_status || '—'} → ${a.new_status || '—'}`));
+    gs.forEach(s => addDot(s.at, 'gs',
+      `Game state: ${s.prev_status || '—'} → ${s.new_status || '—'}${s.state ? ' (' + s.state + ')' : ''}`));
+  }
+
   function renderChartLegend() {
     const el = document.getElementById('chartLegend');
     if (!el) return;
+    const ext = _chartExtState.payload;
+    const hasSg = ext && !ext.sg_hidden;
     const items = [
-      ['#fbbf24', 'Owned'],
-      ['#737373', 'Market'],
-      ['#a78bfa', 'Non-owned'],
-      ['#60a5fa', 'Owned qty'],
-      ['#94a3b8', 'Mkt qty'],
+      ['#fbbf24', 'TEvo Owned'],
+      ['#737373', 'TEvo Mkt'],
+      ['#a78bfa', 'TEvo Non-own'],
+      ['#60a5fa', 'TEvo Own qty'],
+      ['#94a3b8', 'TEvo Mkt qty'],
     ];
-    el.innerHTML = items.map(([c, l]) =>
-      `<span><i style="background:${c}"></i> ${l}</span>`).join('');
+    if (hasSg) {
+      items.push(
+        ['#22d3ee', 'SG list med'],
+        ['#fb7185', 'SG owned med'],
+        ['#84cc16', 'SG sale med'],
+        ['#22d3ee', 'SG list qty', 'dashed'],
+        ['#84cc16', 'SG sale ct'],
+      );
+    }
+    let html = items.map(([c, l, mod]) =>
+      `<span><i style="background:${c}${mod === 'dashed' ? ';opacity:.5' : ''}"></i> ${l}</span>`).join('');
+    if (ext && (
+      (ext.annotations && ext.annotations.injuries && ext.annotations.injuries.length) ||
+      (ext.annotations && ext.annotations.game_state && ext.annotations.game_state.length)
+    )) {
+      html += '<span class="legend-sep">|</span>';
+      html += '<span><i class="anno-inj-i"></i> Injury</span>';
+      html += '<span><i class="anno-gs-i"></i> State</span>';
+    }
+    el.innerHTML = html;
   }
 
   // ---------- Splits ----------
@@ -2125,6 +2264,42 @@
     }
     setZonesSg(sgZones);
     setSplitsSg(sgSplits);
+  }
+
+  // ---------- Chart Extended (mig 20260519150000 / get_event_chart_extended) ----------
+  // Fetches 5 SG-side series + 2 ESPN annotation arrays in parallel with v3.
+  // On arrival, updates _chartExtState and re-renders the chart (which reads
+  // the cache and merges the new series + draws annotation markers).
+  // No-ops gracefully if the RPC isn't deployed yet (errors silenced).
+  async function loadChartExtended(eventId) {
+    const res = await rpcOrNull('get_event_chart_extended', {
+      p_event_id: eventId,
+      p_chart_hours: CHART_HOURS,
+    });
+    if (res.error) {
+      // 42883 = function not deployed (early/staged rollout) → no-op
+      if (res.error.code === '42883' || /does not exist/i.test(res.error.message || '')) {
+        return;
+      }
+      console.error('[chartExtended]', res.error);
+      return;
+    }
+    setChartExtended(res.data || null);
+  }
+
+  function setChartExtended(payload) {
+    _chartExtState.payload = payload;
+    // Trigger chart re-render IFF the TEvo-side payload is already in.
+    // adaptChart is idempotent; re-using the cached payload's chart_data.
+    if (_lastPayload && _lastPayload.chart_data) {
+      try {
+        const chart = adaptChart(_lastPayload.chart_data);
+        renderChart(chart, _chartExtAlerts);
+        renderChartLegend();
+      } catch (e) {
+        console.error('[setChartExtended re-render]', e);
+      }
+    }
   }
 
   // ---------- Last event snapshot (Overview tab) ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -137,14 +137,62 @@ main.wrap {
   font-family: var(--mono); font-size: 11px; color: var(--muted);
   text-transform: uppercase; letter-spacing: 0.5px;
 }
-#chart .legend { display: flex; gap: 12px; }
+#chart .legend { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
 #chart .legend span { display: flex; align-items: center; gap: 4px; }
 #chart .legend i {
   width: 10px; height: 2px; display: inline-block;
 }
+#chart .legend .legend-sep {
+  color: var(--line-2); padding: 0 4px;
+}
+/* Annotation legend icons (mig 20260519150000) — small + cross for injury,
+   small square for game-state. Different from series swatches. */
+#chart .legend i.anno-inj-i {
+  width: 10px; height: 10px; background: transparent;
+  border: 0; position: relative;
+}
+#chart .legend i.anno-inj-i::before,
+#chart .legend i.anno-inj-i::after {
+  content: ""; position: absolute; background: #ec4899;
+}
+#chart .legend i.anno-inj-i::before { left: 4px; top: 0; width: 2px; height: 10px; }
+#chart .legend i.anno-inj-i::after  { left: 0; top: 4px; width: 10px; height: 2px; }
+#chart .legend i.anno-gs-i {
+  width: 8px; height: 8px; background: #14b8a6;
+}
 #chart .uplot { background: transparent; }
 #chart .uplot text { fill: var(--muted) !important; font-family: var(--mono) !important; font-size: 10px !important; }
 #chart .u-axis { color: var(--muted); }
+
+/* Chart annotation overlay (mig 20260519150000) — sibling DOM layer for
+   hover tooltips over canvas-drawn marker dots. Pointer events restricted
+   to the dots so they don't block uPlot cursor interactions. */
+.chart-anno-host {
+  position: absolute; left: 0; top: 0; width: 100%; height: 100%;
+  pointer-events: none;
+}
+.chart-anno-dot {
+  position: absolute; width: 10px; height: 10px;
+  pointer-events: auto; cursor: help;
+  border-radius: 50%;
+}
+.chart-anno-dot.anno-inj {
+  background: rgba(236, 72, 153, 0.0);
+  /* the canvas already draws a + marker; this dot is purely the hover hit-target */
+  border: 1px solid transparent;
+}
+.chart-anno-dot.anno-inj:hover {
+  background: rgba(236, 72, 153, 0.18);
+  border-color: rgba(236, 72, 153, 0.6);
+}
+.chart-anno-dot.anno-gs {
+  background: rgba(20, 184, 166, 0.0);
+  border: 1px solid transparent;
+}
+.chart-anno-dot.anno-gs:hover {
+  background: rgba(20, 184, 166, 0.18);
+  border-color: rgba(20, 184, 166, 0.6);
+}
 
 /* ---------- Zones table ---------- */
 

--- a/supabase/migrations/20260519150000_get_event_chart_extended_rpc.sql
+++ b/supabase/migrations/20260519150000_get_event_chart_extended_rpc.sql
@@ -1,0 +1,268 @@
+-- Migration 20260519150000 · lane:A1 · writes:get_event_chart_extended · reads:seatgeek_listings_snapshots,seatgeek_sales_snapshots,seatgeek_event_xref,espn_injuries_snapshots,espn_event_snapshots,event_xref · pre:20260519140000 · auth:operator-approved 2026-05-19
+--
+-- D0 Event-page chart expansion (5 → 10 lines + 2 annotation overlays).
+--
+-- Existing chart (event_metrics_series in v3 payload) already gives:
+--   prices_owned / prices_market / prices_nonowned (TEvo medians)
+--   counts_owned / counts_market (TEvo inventory)
+--
+-- This RPC adds SG-side series (deduped per bucket) + ESPN annotation
+-- arrays (transition events, not series — LAG() per athlete or per game):
+--
+--   series.sg_listings_median       SG listings broadcast_price median per bucket
+--   series.sg_listings_owned_median is_broker_owned=true subset
+--   series.sg_listings_count        SUM(quantity) per bucket
+--   series.sg_sales_median          SG sales broadcast_price median per bucket
+--   series.sg_sales_count           COUNT(*) of deduped sales per bucket
+--
+--   annotations.injuries     [ {at, athlete_id, athlete_name, position, espn_team_id, prev_status, new_status} ]
+--   annotations.game_state   [ {at, espn_event_id, prev_status, new_status, state} ]
+--
+-- Bucket size adapts to window so the chart stays legible:
+--   ≤24h → 15min · ≤72h → 1h · ≤168h → 2h · ≤720h → 6h · >720h → 1d
+--
+-- ESPN home/away team IDs may be passed by FE (from v3 espn payload) or
+-- auto-resolved from event_xref → espn_event_snapshots latest row.
+--
+-- SG dedupe per PROJECT_BIBLE.md §3 landmine: DISTINCT ON (sg_sale_id) /
+-- (sglid) ORDER BY pulled_at|captured_at DESC. Each logical row may appear
+-- 11-23x in raw firehose; aggregates without DISTINCT ON overcount.
+--
+-- Per A1 SECDEF pattern (PRs #196/#205/#210): SECDEF + @s4kent.com gate +
+-- REVOKE PUBLIC + GRANT anon/authenticated. STABLE.
+
+CREATE OR REPLACE FUNCTION public.get_event_chart_extended(
+  p_event_id        integer,
+  p_chart_hours     integer DEFAULT 168,
+  p_espn_home_team  text    DEFAULT NULL,
+  p_espn_away_team  text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email          text;
+  v_sg_event_id    bigint;
+  v_espn_event_id  text;
+  v_espn_league    text;
+  v_home_team      text := p_espn_home_team;
+  v_away_team      text := p_espn_away_team;
+  v_hours          int  := greatest(1, least(coalesce(p_chart_hours, 168), 4320));
+  v_bucket_secs    int;
+  v_window_start   timestamptz;
+  v_now            timestamptz := now();
+  v_sg_listings    jsonb := '[]'::jsonb;
+  v_sg_listings_own jsonb := '[]'::jsonb;
+  v_sg_listings_ct jsonb := '[]'::jsonb;
+  v_sg_sales       jsonb := '[]'::jsonb;
+  v_sg_sales_ct    jsonb := '[]'::jsonb;
+  v_injuries       jsonb := '[]'::jsonb;
+  v_game_state     jsonb := '[]'::jsonb;
+  v_sg_hidden      boolean := false;
+  v_sg_reason      text;
+BEGIN
+  -- ---------- auth gate (mirrors v3 / sibling RPCs) ----------
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_window_start := v_now - make_interval(hours => v_hours);
+
+  -- ---------- bucket size (adapts to window length) ----------
+  v_bucket_secs := CASE
+    WHEN v_hours <=  24 THEN  900   -- 15 min
+    WHEN v_hours <=  72 THEN 3600   --  1 hr
+    WHEN v_hours <= 168 THEN 7200   --  2 hr
+    WHEN v_hours <= 720 THEN 21600  --  6 hr
+    ELSE 86400                      --  1 day
+  END;
+
+  -- ---------- bridge resolution ----------
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    v_sg_hidden := true;
+    v_sg_reason := 'no_sg_bridge';
+  END IF;
+
+  -- ESPN linkage (always attempt — annotations may render even when SG is hidden)
+  SELECT ex.espn_event_id, ex.espn_league
+  INTO v_espn_event_id, v_espn_league
+  FROM public.event_xref ex
+  WHERE ex.tevo_event_id = p_event_id LIMIT 1;
+
+  -- Auto-resolve home/away team IDs if not supplied by FE.
+  -- Prefer espn_event_date_lookup (populated for forward-look events) over
+  -- espn_event_snapshots (gameday-scope only per §10 drift watchlist).
+  IF (v_home_team IS NULL OR v_away_team IS NULL) AND v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id
+    INTO v_home_team, v_away_team
+    FROM public.espn_event_date_lookup
+    WHERE espn_event_id = v_espn_event_id LIMIT 1;
+
+    -- Snapshot fallback for past games where date_lookup is sparse
+    IF v_home_team IS NULL OR v_away_team IS NULL THEN
+      SELECT home_team_id, away_team_id
+      INTO v_home_team, v_away_team
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+      ORDER BY captured_at DESC LIMIT 1;
+    END IF;
+  END IF;
+
+  -- ---------- SG listings series (DISTINCT ON sglid, then bucket) ----------
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sglid)
+        sglid, captured_at, broadcast_price, quantity, is_broker_owned
+      FROM public.seatgeek_listings_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+      ORDER BY sglid, captured_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), captured_at, '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price, quantity, is_broker_owned
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p_owned) ORDER BY bucket) FILTER (WHERE median_p_owned IS NOT NULL), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', total_qty) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_listings, v_sg_listings_own, v_sg_listings_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) FILTER (WHERE is_broker_owned) AS median_p_owned,
+        SUM(quantity)::int AS total_qty
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- SG sales series (DISTINCT ON sg_sale_id, then bucket on sale_at_utc) ----------
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, sale_at_utc, pulled_at, broadcast_price, quantity
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND coalesce(sale_at_utc, pulled_at) > v_window_start
+        AND coalesce(sale_at_utc, pulled_at) <= v_now
+      ORDER BY sg_sale_id, pulled_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), coalesce(sale_at_utc, pulled_at), '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', sale_ct) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_sales, v_sg_sales_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        count(*)::int AS sale_ct
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- ESPN injury transitions (LAG per athlete, both teams) ----------
+  -- espn_team_id is NOT globally unique across leagues — e.g. id="28" maps to
+  -- MLB Atlanta Braves AND an NHL team. ALWAYS scope by espn_league so cross-
+  -- league fan-out doesn't surface unrelated injuries on a sport-specific chart.
+  IF (v_home_team IS NOT NULL OR v_away_team IS NOT NULL) AND v_espn_league IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_team_id, athlete_id, athlete_name, position, status,
+        LAG(status) OVER (PARTITION BY athlete_id ORDER BY captured_at) AS prev_status
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id IN (v_home_team, v_away_team)
+        AND espn_team_id IS NOT NULL
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',            to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'athlete_id',    athlete_id,
+             'athlete_name',  athlete_name,
+             'position',      position,
+             'espn_team_id',  espn_team_id,
+             'prev_status',   prev_status,
+             'new_status',    status
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_injuries
+    FROM ordered
+    WHERE status IS DISTINCT FROM prev_status;  -- transitions only (including first-seen NULL→X)
+  END IF;
+
+  -- ---------- ESPN game-state transitions (LAG on status_short, this event) ----------
+  IF v_espn_event_id IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_event_id, status_short, state,
+        LAG(status_short) OVER (PARTITION BY espn_event_id ORDER BY captured_at) AS prev_status
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+        AND (v_espn_league IS NULL OR espn_league = v_espn_league)
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',             to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'espn_event_id',  espn_event_id,
+             'prev_status',    prev_status,
+             'new_status',     status_short,
+             'state',          state
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_game_state
+    FROM ordered
+    WHERE status_short IS DISTINCT FROM prev_status;
+  END IF;
+
+  -- ---------- assemble ----------
+  RETURN jsonb_build_object(
+    'tevo_event_id',  p_event_id,
+    'sg_event_id',    v_sg_event_id,
+    'espn_event_id',  v_espn_event_id,
+    'espn_league',    v_espn_league,
+    'home_team_id',   v_home_team,
+    'away_team_id',   v_away_team,
+    'range', jsonb_build_object(
+      'start',  to_char(v_window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'end',    to_char(v_now          AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'hours',  v_hours,
+      'bucket_seconds', v_bucket_secs
+    ),
+    'sg_hidden', v_sg_hidden,
+    'sg_reason', v_sg_reason,
+    'series', jsonb_build_object(
+      'sg_listings_median',       v_sg_listings,
+      'sg_listings_owned_median', v_sg_listings_own,
+      'sg_listings_count',        v_sg_listings_ct,
+      'sg_sales_median',          v_sg_sales,
+      'sg_sales_count',           v_sg_sales_ct
+    ),
+    'annotations', jsonb_build_object(
+      'injuries',   v_injuries,
+      'game_state', v_game_state
+    )
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) IS
+  'D0 event chart extension — 5 SG-side series (listings median + owned median + listings count + sales median + sales count) over adaptive buckets (15min..1d depending on p_chart_hours) + 2 ESPN annotation arrays (injury transitions LAG(status) per athlete on both teams + game-state transitions LAG(status_short) per espn_event_id). DISTINCT ON sg_sale_id|sglid mandatory (§3 landmine). Bridge via seatgeek_event_xref; ESPN via event_xref. Email-gated.';


### PR DESCRIPTION
## Summary

Expands the event-page chart from 5 TEvo-only series to **10 series + 2 annotation overlays**, per operator's chart-expansion plan.

### New migration `20260519150000_get_event_chart_extended_rpc.sql`

`get_event_chart_extended(p_event_id, p_chart_hours DEFAULT 168, p_espn_home_team text DEFAULT NULL, p_espn_away_team text DEFAULT NULL)`

| Output key | Source | Notes |
|---|---|---|
| `series.sg_listings_median` | `seatgeek_listings_snapshots` DISTINCT ON `sglid` | `percentile_cont(0.5)` on `broadcast_price` per bucket |
| `series.sg_listings_owned_median` | same, `is_broker_owned=true` subset | filter inside aggregate |
| `series.sg_listings_count` | same | `SUM(quantity)` per bucket |
| `series.sg_sales_median` | `seatgeek_sales_snapshots` DISTINCT ON `sg_sale_id` | bucket on `sale_at_utc`/`pulled_at` |
| `series.sg_sales_count` | same | `count(*)` per bucket |
| `annotations.injuries` | `espn_injuries_snapshots` LAG(status) | **league-scoped** (espn_team_id collides cross-league) |
| `annotations.game_state` | `espn_event_snapshots` LAG(status_short) | per espn_event_id |

Variable bucket interval (15min/1h/2h/6h/1d) adapts to `p_chart_hours`. Auto-resolves home/away teams from `espn_event_date_lookup` (forward-look) → `espn_event_snapshots` (gameday fallback) if FE doesn't pass them. SECDEF + email gate. Returns `sg_hidden:true` for TEvo-only events; annotations still attempted via ESPN linkage.

### FE — `event.js`

- New parallel loader `loadChartExtended` in `init()` (same pattern as `loadSgZonesSplits`)
- State cache `_chartExtState = { payload }` — re-render-on-arrival merges new series + annotations
- `renderChart` extended: 10 series, 3 scales (`y`, `qty`, `sgct`), 2 new canvas hook overlays (`drawInjuryMarkers`, `drawGameStateMarkers`)
- DOM-overlay tooltips: sibling `.chart-anno-host` with `title=""` hover text (cheap, zero plugin deps)
- Range selector re-fires both v3 + extended fetch so bucket adapts to new window
- Legend extended conditionally (SG block only when bridge exists; annotation block only when ≥1 transition)

### FE — `style.css`

- Palette: cyan SG listings, rose SG owned, lime SG sales; magenta + cross for injuries, teal square for game-state
- Legend flex-wrap for 10 items
- Annotation hover hit-targets + tinted hover highlight

## Performance (warm cache, smoke against event 3222197 — 6,099 SG listings + 128 SG sales over 7d)

| Window | Latency |
|---|---|
| 24h | 64ms |
| 168h | 308ms |
| 720h | 317ms |

All under operator's 500ms / 1s targets.

## Landmines avoided (PROJECT_BIBLE.md §3)

- **`sg_sale_id` / `sglid` DISTINCT ON** mandatory before any aggregate (11-23× overcount otherwise)
- **`espn_team_id` cross-league collision** — id="28" is BOTH MLB Atlanta Braves AND an NHL team. RPC now scopes by `espn_league` to avoid surfacing the wrong sport's injuries
- **`espn_event_snapshots` is gameday-scope only** (§10 drift watchlist) — use `espn_event_date_lookup` for forward-look team resolution

## Test plan

- [x] Smoke: MLB Braves-Marlins surfaces 12 league-scoped injury transitions
- [x] Smoke: MLS LAFC-Nashville: 19 listings buckets / 36 sales buckets / 0 injuries (sparse MLS pipe)
- [x] Smoke: TEvo-only no-SG event → `sg_hidden:true` cleanly
- [x] Smoke: 24h/168h/720h windows adapt buckets to 900/7200/21600s
- [x] Smoke: cross-league espn_team_id "28" collision filtered correctly by `espn_league`
- [ ] Browser smoke @ `event.html?event=3172845` once deployed: verify SG series render, injury dots appear with hover tooltips, range selector flips re-fire both fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)