### PR TITLE
fix(ci): forbidden-paths-check — `[bot]` brackets broke grep -wq author match

### DIFF
--- a/.github/workflows/forbidden-paths-check.yml
+++ b/.github/workflows/forbidden-paths-check.yml
@@ -60,7 +60,11 @@ jobs:
       - name: Check forbidden paths
         run: |
           AUTHOR="${{ github.event.pull_request.user.login }}"
-          if echo "$OWNERS" | grep -wq "$AUTHOR"; then
+          # Bash glob compare instead of `grep -wq`: GitHub bot logins contain
+          # bracket chars (e.g. `dependabot[bot]`) which grep interprets as a
+          # regex character class. Space-padded substring match is literal +
+          # word-boundary-safe (no overlap between, say, `bot` and `dependabot`).
+          if [[ " $OWNERS " == *" $AUTHOR "* ]]; then
             echo "Author $AUTHOR is an owner — backend writes allowed."
             exit 0
           fi


### PR DESCRIPTION
## Summary

Follow-up to PR #239. The author-match in `forbidden-paths-check.yml` uses `grep -wq "\$AUTHOR"`, which interprets the `[bot]` suffix in bot logins as a regex character class. So `dependabot[bot]` in OWNERS never matched the AUTHOR string, and dependabot PRs continued to fail after PR #239 merged.

## Repro (after PR #239 merge, on PR #224)

```
OWNERS: JulianS4K dependabot[bot] github-actions[bot]
AUTHOR: dependabot[bot]
→ grep -wq returns no match → falls through to "Non-owner author" path
→ requirements.txt flagged → check fails
```

## Fix

Bash glob compare with space padding:

```bash
if [[ " $OWNERS " == *" $AUTHOR "* ]]; then
```

- Literal-string match (brackets are just chars)
- Word-boundary-safe via the leading/trailing spaces (no overlap between e.g. `bot` substring and `dependabot[bot]`)
- No regex metacharacter issues

## Test plan

- [x] Verified locally: `bash -c '[[ " JulianS4K dependabot[bot] github-actions[bot] " == *" dependabot[bot] "* ]] && echo ok'` → `ok`
- [ ] After merge: rebase the 4 remaining open dependabot PRs (#223, #224, #226, #227); CI should pass `check` and unblock them

## Worth noting

This is the same class of issue as the others today — bot identity not accounted for at integration boundaries. Candidate for a PROJECT_BIBLE.md §7 macro note about literal-vs-regex matching in CI shell scripts. Deferring the docs update to a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)