### PR TITLE
fix(d0/event): #chart container overflow into #sg-broker-sales

### DIFF
--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -126,16 +126,30 @@ main.wrap {
   background: var(--panel);
   border: 1px solid var(--line);
   padding: 8px;
+  /* Flex column so chart-title (now wraps the 10-series legend post-PR #237)
+     takes natural height and #chartHost absorbs the remainder. Without
+     this, the canvas — sized at rect.height - 20 in renderChart — plus a
+     wrapped title overflows the 320px fixed container and bleeds below
+     into #sg-broker-sales. */
+  display: flex;
+  flex-direction: column;
   height: 40vh;
-  min-height: 320px;
+  min-height: 420px;   /* up from 320 — accommodates ~10-series wrapped legend */
+  position: relative;  /* needed for absolute .chart-anno-host overlay */
 }
 #chart .chart-title {
-  display: flex; justify-content: space-between; align-items: center;
+  display: flex; justify-content: space-between; align-items: flex-start;
   padding: 0 8px 8px;
   border-bottom: 1px solid var(--line-2);
   margin-bottom: 8px;
   font-family: var(--mono); font-size: 11px; color: var(--muted);
   text-transform: uppercase; letter-spacing: 0.5px;
+  flex: 0 0 auto;
+}
+#chart #chartHost {
+  flex: 1 1 auto;
+  min-height: 0;    /* required for flex children that contain a canvas */
+  position: relative;
 }
 #chart .legend { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
 #chart .legend span { display: flex; align-items: center; gap: 4px; }


### PR DESCRIPTION
## Problem

Operator reported chart components overlapping the section below.

Forensic confirmed via DOM bounding-box inspection: \`#chart\` is fixed at \`height: 40vh; min-height: 320px\`. After PR #237 expanded the chart legend from 5 to 10 series + 2 annotation icons, \`.chart-title\` flex-wraps to 2 rows (~60px instead of ~30px). Combined with the canvas (sized at \`rect.height - 20 = 300px\` in \`renderChart\`), the total content is ~360px — 40px more than the container. The canvas bleeds below the \`#chart\` panel border into \`#sg-broker-sales\`.

## Fix

\`#chart\` becomes a flex column: title takes natural height, \`#chartHost\` absorbs the remainder.

\`\`\`css
#chart {
  display: flex;
  flex-direction: column;
  min-height: 420px;   /* up from 320 — accommodates wrapping legend */
  position: relative;  /* formalized for the absolute .chart-anno-host */
}
#chart .chart-title { flex: 0 0 auto; align-items: flex-start; }
#chart #chartHost { flex: 1 1 auto; min-height: 0; position: relative; }
\`\`\`

The \`min-height: 0\` on the flex child is the standard fix for flex children containing a canvas — without it the canvas would never shrink below its intrinsic size.

## Verification

Local browser preview at \`event.html?event=3091413\`:
- \`#chart\` computed: \`display: flex\`, \`flex-direction: column\`, \`height: 420px\`, \`min-height: 420px\`, \`position: relative\` ✓
- \`#chartHost\` computed: \`flex: 1 1 auto\`, \`min-height: 0px\`, observed height **354px** ✓
- \`.chart-title\` height 32px (single row on localhost — full 10-series legend doesn't paint without auth) ✓
- DOM stack-overlap check across all 15 Overview sections returned 0 real overlaps (only false-positive flags for \`#alerts | #competing-events\` and \`#recent-listings | #performer-espn\` which are intentional side-by-side grid pairs at the same row)

In prod with the chart canvas painted + 10-series legend wrapping the title to ~60px, the canvas now gets ~320px in the 420px container — fits cleanly without overflow.

## Related

- PR #237 — added the 5 SG series + 2 annotation icons that pushed the legend over the threshold
- No migration change; CSS-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)