### PR TITLE
chore(ci): Dependabot ignore rules for 5 deferred major bumps (audit followup)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,15 @@ updates:
     # Allow security updates outside the group + window.
     allow:
       - dependency-type: "all"
+    # Pin majors held by operator 2026-05-18 (B1 triage in PR #239 description).
+    # Each entry blocks the version range until the operator explicitly unblocks
+    # after smoke-testing the major bump. Security advisories override `ignore`
+    # — vulnerable versions still get PRs.
+    ignore:
+      - dependency-name: "anthropic"
+        versions: [">=1.0"]
+        # anthropic v1.0 = major API redesign. Hold until anthropic_client.py
+        # is audited for v1 compatibility. Original PR #225 closed.
 
   # GitHub Actions versions (workflow files)
   - package-ecosystem: "github-actions"
@@ -59,6 +68,27 @@ updates:
       # Dependabot produces "chore(github-actions): ..." cleanly.
       prefix: "chore"
       include: "scope"
+    # Pin majors held by operator 2026-05-18 (B1 triage in PR #239 description).
+    # Each entry blocks the version range until the operator explicitly unblocks
+    # after smoke-testing the major bump.
+    ignore:
+      - dependency-name: "actions/upload-artifact"
+        versions: [">=5"]
+        # v5 introduced breaking change: artifacts can no longer be merged
+        # automatically. v6 + v7 inherit. Stay on v4 until workflow logic is
+        # updated. Original PR #220 closed.
+      - dependency-name: "actions/github-script"
+        versions: [">=8"]
+        # v8 switched to Node 22 + script API changes. Need ecosystem test.
+        # Original PR #221 closed.
+      - dependency-name: "actions/labeler"
+        versions: [">=6"]
+        # v6 changed config schema (sync-labels parameter moved). labeler.yml
+        # uses v5 syntax. Test before bumping. Original PR #222 closed.
+      - dependency-name: "github/codeql-action"
+        versions: [">=4"]
+        # v4 has migration notes; scorecard.yml uses v3 upload-sarif. Hold
+        # until CodeQL workflow is authored (B1-NEXT-4). Original PR #240 closed.
 
   # Note: Deno (Supabase edge functions) is NOT supported by Dependabot.
   # Edge function deps are pinned via import URLs (e.g.,

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -82,6 +82,7 @@
 | B1-NEXT-40 | Op | **G-9**: `allow_forking: true` on public repo. Forks clone full history including the leaked `CRON_SECRET` commit `5297739`. Compounds G-1. | Operator decision (usually allow_forking stays true; real fix is G-1 history rewrite) |
 | B1-NEXT-44 | Op | **G-14**: Branch protection on `main` — no required approving review count, no CODEOWNERS review required, no dismiss-stale-reviews. Single-operator can push without formal review. | Operator decision — Settings → Branches → Edit rule for `main` |
 | B1-NEXT-45 | Op | **G-15**: `required_conversation_resolution: false`. PRs can merge with unresolved review comments. | Settings → Branches → toggle |
+| B1-NEXT-51 | A1 (B1 assists) | 5 deferred major-version bumps (held in `.github/dependabot.yml` ignore rules 2026-05-18): `anthropic>=1.0`, `actions/upload-artifact>=5`, `actions/github-script>=8`, `actions/labeler>=6`, `github/codeql-action>=4`. Each needs smoke-test before operator unblocks. Original Dependabot PRs were #220/#221/#222/#225/#240 (all closed). | One smoke-test PR per bump (or batch). Remove the corresponding `ignore:` block after each lands. |
 
 ### Operator-only (settings / lockdown-gated applies)
 


### PR DESCRIPTION
## Summary

Audit follow-up to PR #239 / Dependabot triage 2026-05-18. Operator + A1 correctly **closed** 5 major-version Dependabot PRs per B1's triage table:

| PR | Bump | Closed |
|---|---|---|
| #220 | actions/upload-artifact v4 → v7 | ✅ |
| #221 | actions/github-script v7 → v9 | ✅ |
| #222 | actions/labeler v5 → v6 | ✅ |
| #225 | anthropic 0.40 → 0.102 | ✅ |
| #240 | github/codeql-action v3 → v4 | ✅ |

Workflow files retain safe pins (`@v4`, `@v7`, `@v5`, `@v3` respectively).

## Problem

Without `ignore:` rules, Dependabot **re-opens these same 5 PRs every Monday** when the weekly schedule runs. A1 faces the same triage choice weekly. PR noise + cognitive load.

## Fix

Added `ignore:` blocks in `.github/dependabot.yml` for both Python + GitHub Actions ecosystems. Each entry blocks the specific version range and includes a `# comment` explaining why it's held + original PR reference.

## What `ignore:` does NOT block

**Security advisories override ignore.** If `anthropic 0.50` (still in the ignored range `>=1.0` — wait, that's already not in the ignore range; let me reread).

Actually the ignore rule is `versions: [">=1.0"]` for anthropic, which means: don't propose any version >= 1.0. If a vulnerability lands in `anthropic 0.50` (in the allowed range), Dependabot still files the security PR. Only the **version-update** type is suppressed.

This is the intended behavior — we want security advisories regardless.

## Unblocking later

When operator decides to test a held major:

1. Smoke-test the bump in a feature branch (e.g., bump anthropic locally + run pytest + smoke `anthropic_client.py` integration)
2. If safe: remove the corresponding `ignore:` block in `dependabot.yml`
3. Dependabot re-opens the PR (or operator merges the local test PR)
4. Delete B1-NEXT-51 entry as the held majors land

## Files

- `.github/dependabot.yml` — 5 ignore entries added under the 2 `updates:` blocks (3 GitHub Actions + 1 Python + 1 CodeQL)
- `KANBAN.md §🟢 OPEN` — B1-NEXT-51 tracks the 5 deferred majors

## Test plan

- [ ] CI passes on this PR (the ignore rules are config-only; no runtime impact until next Monday)
- [ ] Next Monday 09:00 ET: Dependabot's weekly run should NOT re-open #220/#221/#222/#225/#240-equivalent PRs
- [ ] If Dependabot still proposes them, the `ignore:` syntax was wrong — investigate via `Insights → Dependency graph → Dependabot → last-run logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)