### PR TITLE
feat(d0/event): chart redesign to 3-pane stacked (TradingView/Bloomberg style)

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -138,7 +138,13 @@
           </select>
         </div>
       </div>
-      <div id="chartHost"></div>
+      <!-- 3-pane stacked layout (PR redesign 2026-05-18) — replaces single
+           chartHost. Price 60% / Inventory 20% / Volume 20%. uPlot instances
+           share X-axis via cursor.sync. -->
+      <div id="chartHostPrice" class="chart-pane chart-pane-price"></div>
+      <div id="chartHostInv"   class="chart-pane chart-pane-inv"></div>
+      <div id="chartHostVol"   class="chart-pane chart-pane-vol"></div>
+      <div id="chartTooltip" class="chart-tooltip" hidden></div>
     </section>
 
     <section id="sg-broker-sales">

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -12,13 +12,21 @@
   const T = window.Terminal;
   const DEFAULT_HOURS = 168;
   let CHART_HOURS = DEFAULT_HOURS;
-  let _chartInstance = null;
+  // PR redesign 2026-05-18: 3-pane stacked chart (TradingView/Bloomberg style).
+  // Price (60%) + Inventory (20%) + Volume bars (20%), X-axis synchronized via
+  // uPlot cursor.sync. Each pane is an independent uPlot instance.
+  let _chartInstances = { price: null, inv: null, vol: null };
   let _lastPayload = null;
   // Chart-extension state cache (mig 20260519150000 / get_event_chart_extended):
   // fetched in parallel with v3; merges 5 SG series + 2 ESPN annotation arrays
   // into the chart whenever it lands. Same state-machine pattern as splits/zones.
   let _chartExtState = { payload: undefined };
   let _chartExtAlerts = []; // cached for re-renders after extended payload arrives
+  // Legend toggle state (session-scope; persists across re-renders).
+  // Maps series-key → boolean (true = visible). Defaults to true on first sight.
+  const _chartVisible = new Map();
+  // Series spec cache so tooltip can read from all 3 panes at a given idx.
+  let _chartLastBuild = null;
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
@@ -426,81 +434,128 @@
     return 'neg';
   }
 
-  // ---------- Chart (8 series + event_alerts markers) ----------
+  // ---------- Chart — 3-pane stacked (Price / Inventory / Volume bars) ----------
+  //
+  // TradingView/Bloomberg-style stacked layout (operator redesign 2026-05-18).
+  // Replaces the single-pane multi-scale chart that PR #237 grew to 10 series.
+  // Each pane is an independent uPlot instance; X-axis synced via cursor.sync.
+  //
+  //   Price (60%)     — 6 medians ($-axis) + ESPN/alert annotations
+  //   Inventory (20%) — 3 ticket-count lines (integer axis)
+  //   Volume (20%)    — SG sale-count bars (histogram)
+  //
+  // Series specs carry a `pane` field so the tooltip + legend can route
+  // visibility across the right instance.
 
   function renderChart(chart, alerts) {
-    const host = document.getElementById('chartHost');
-    host.innerHTML = '';
+    const hostPrice = document.getElementById('chartHostPrice');
+    const hostInv   = document.getElementById('chartHostInv');
+    const hostVol   = document.getElementById('chartHostVol');
+    if (!hostPrice || !hostInv || !hostVol) {
+      // Backwards-compat: legacy single-host page → no-op so we don't crash
+      // on environments still serving the pre-redesign HTML.
+      const legacy = document.getElementById('chartHost');
+      if (legacy) legacy.innerHTML = '<div class="empty">chart redesigned to 3-pane; reload</div>';
+      return;
+    }
+    hostPrice.innerHTML = '';
+    hostInv.innerHTML   = '';
+    hostVol.innerHTML   = '';
     if (!chart || !window.uPlot) return;
 
-    // Cache alerts for re-renders triggered by extended-payload arrival
     _chartExtAlerts = alerts || [];
 
-    // Merge the SG-side series from _chartExtState (lands in parallel — may be
-    // undefined on first paint; chart redraws when it arrives). Reading via
-    // the cache instead of an explicit arg matches the splits/zones pattern.
+    // Merge SG-side series from extended-RPC cache (parallel fetch — may be
+    // undefined on first paint; setChartExtended triggers a re-render).
     const ext = _chartExtState.payload || null;
     const extSeries = (ext && ext.series) || {};
-    const sgListMed   = extSeries.sg_listings_median       || [];
-    const sgListOwnMed= extSeries.sg_listings_owned_median || [];
-    const sgListCt    = extSeries.sg_listings_count        || [];
-    const sgSaleMed   = extSeries.sg_sales_median          || [];
-    const sgSaleCt    = extSeries.sg_sales_count           || [];
 
-    const seriesSpecs = [
-      // TEvo (existing 5)
-      { key: 'prices_owned',    label: 'TEvo Owned',     color: '#fbbf24', scale: 'y',   width: 2,   dash: null,    data: chart.prices_owned },
-      { key: 'prices_market',   label: 'TEvo Market',    color: '#737373', scale: 'y',   width: 1.5, dash: [4, 4],  data: chart.prices_market },
-      { key: 'prices_nonowned', label: 'TEvo Non-owned', color: '#a78bfa', scale: 'y',   width: 1.5, dash: [6, 3],  data: chart.prices_nonowned },
-      { key: 'counts_owned',    label: 'TEvo Owned qty', color: '#60a5fa', scale: 'qty', width: 1,   dash: null,    fill: 'rgba(96,165,250,0.08)', data: chart.counts_owned },
-      { key: 'counts_market',   label: 'TEvo Mkt qty',   color: '#94a3b8', scale: 'qty', width: 1,   dash: [2, 2],  data: chart.counts_market },
-      // SG (new 5, from extended RPC payload)
-      { key: 'sg_list_med',     label: 'SG list med',    color: '#22d3ee', scale: 'y',   width: 1.5, dash: null,    data: sgListMed },
-      { key: 'sg_own_med',      label: 'SG owned med',   color: '#fb7185', scale: 'y',   width: 1.5, dash: [3, 3],  data: sgListOwnMed },
-      { key: 'sg_sale_med',     label: 'SG sale med',    color: '#84cc16', scale: 'y',   width: 1.5, dash: [5, 2],  data: sgSaleMed },
-      { key: 'sg_list_ct',      label: 'SG list qty',    color: '#22d3ee', scale: 'qty', width: 1,   dash: [2, 2],  data: sgListCt },
-      { key: 'sg_sale_ct',      label: 'SG sale ct',     color: '#84cc16', scale: 'sgct',width: 1.5, dash: null,    data: sgSaleCt, points: { show: true, size: 4 } },
+    // Series specs, grouped by pane. `key` is the toggle id, `pane` is the
+    // instance that owns the series, `scale` is the within-pane axis tag.
+    const specs = [
+      // ---- PRICE PANE (6 medians) ----
+      { key: 'prices_owned',    label: 'TEvo Owned',     color: '#fbbf24', pane: 'price', scale: 'y', width: 2,   dash: null,    data: chart.prices_owned },
+      { key: 'prices_market',   label: 'TEvo Market',    color: '#737373', pane: 'price', scale: 'y', width: 1.5, dash: [4, 4],  data: chart.prices_market },
+      { key: 'prices_nonowned', label: 'TEvo Non-owned', color: '#a78bfa', pane: 'price', scale: 'y', width: 1.5, dash: [6, 3],  data: chart.prices_nonowned },
+      { key: 'sg_list_med',     label: 'SG list med',    color: '#22d3ee', pane: 'price', scale: 'y', width: 1.5, dash: null,    data: extSeries.sg_listings_median       || [] },
+      { key: 'sg_own_med',      label: 'SG owned med',   color: '#fb7185', pane: 'price', scale: 'y', width: 1.5, dash: [3, 3],  data: extSeries.sg_listings_owned_median || [] },
+      { key: 'sg_sale_med',     label: 'SG sale med',    color: '#84cc16', pane: 'price', scale: 'y', width: 1.5, dash: [5, 2],  data: extSeries.sg_sales_median          || [] },
+      // ---- INVENTORY PANE (3 qty lines) ----
+      { key: 'counts_owned',    label: 'TEvo Owned qty', color: '#60a5fa', pane: 'inv',   scale: 'y', width: 1.5, dash: null,    fill: 'rgba(96,165,250,0.08)', data: chart.counts_owned },
+      { key: 'counts_market',   label: 'TEvo Mkt qty',   color: '#94a3b8', pane: 'inv',   scale: 'y', width: 1,   dash: [2, 2],  data: chart.counts_market },
+      { key: 'sg_list_ct',      label: 'SG list qty',    color: '#22d3ee', pane: 'inv',   scale: 'y', width: 1.5, dash: null,    data: extSeries.sg_listings_count        || [] },
+      // ---- VOLUME PANE (1 bar series) ----
+      { key: 'sg_sale_ct',      label: 'SG sale ct',     color: '#84cc16', pane: 'vol',   scale: 'y', width: 1,   dash: null,    bars: true, data: extSeries.sg_sales_count   || [] },
     ];
 
-    // Build unified time axis
+    // Unified time axis built from the union of ALL series — keeps cursor.sync
+    // alignments correct even when SG series have a sparser bucket density.
     const tset = new Set();
-    seriesSpecs.forEach(s => (s.data || []).forEach(p => tset.add(p.t)));
+    specs.forEach(s => (s.data || []).forEach(p => tset.add(p.t)));
     const ts = [...tset].sort();
     const xs = ts.map(t => Math.round(new Date(t).getTime() / 1000));
-    const idx = new Map(ts.map((t, i) => [t, i]));
+    const idxByT = new Map(ts.map((t, i) => [t, i]));
     const project = (s) => {
       const arr = new Array(ts.length).fill(null);
-      (s || []).forEach(p => { const i = idx.get(p.t); if (i != null) arr[i] = p.v; });
+      (s || []).forEach(p => { const i = idxByT.get(p.t); if (i != null) arr[i] = p.v; });
       return arr;
     };
+    specs.forEach(s => { s.projected = project(s.data); });
 
-    const data = [xs, ...seriesSpecs.map(s => project(s.data))];
+    // Stash for the cross-pane tooltip + legend re-renders.
+    _chartLastBuild = { specs, xs };
 
-    // Pick a tick-friendly width (re-render on resize)
-    const rect = host.getBoundingClientRect();
-    const w = Math.max(800, rect.width || host.clientWidth || 1200);
-    const h = Math.max(280, (rect.height || 320) - 20);
+    // Render each pane (returns the uPlot instance or null if no series).
+    _chartInstances.price = renderPanePrice(hostPrice, specs, xs, alerts, ext);
+    _chartInstances.inv   = renderPaneInv  (hostInv,   specs, xs);
+    _chartInstances.vol   = renderPaneVol  (hostVol,   specs, xs);
 
+    // Single resize listener — rebuilds all 3 panes (debounced)
+    if (!hostPrice.__resizeWired) {
+      hostPrice.__resizeWired = true;
+      let resizeTimer;
+      window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => renderChart(chart, _chartExtAlerts), 200);
+      });
+    }
+  }
+
+  // Shared axis styling — canvas-drawn so we set fonts/strokes directly.
+  // The old `#chart .uplot text { fill }` CSS doesn't apply because uPlot
+  // draws axis labels on canvas, not SVG.
+  const AXIS_FONT = '11px ui-monospace, SFMono-Regular, Menlo, monospace';
+  const AXIS_STROKE = '#a3a3a3';     // lighter than --muted so it's readable on #0a0a0a
+  const AXIS_GRID = '#262626';
+  const AXIS_TICKS = '#404040';
+  const X_AXIS = {
+    stroke: AXIS_STROKE, font: AXIS_FONT,
+    grid: { stroke: AXIS_GRID, width: 1 },
+    ticks: { stroke: AXIS_TICKS, size: 6 },
+  };
+
+  function renderPanePrice(host, specs, xs, alerts, ext) {
+    const paneSpecs = specs.filter(s => s.pane === 'price');
+    const data = [xs, ...paneSpecs.map(s => s.projected)];
+    const { w, h } = paneSize(host);
     const opts = {
       width: w, height: h,
-      cursor: { drag: { x: true, y: false } },
-      scales: { x: { time: true }, y: {}, qty: {}, sgct: {} },
+      cursor: { drag: { x: true, y: false }, sync: { key: 'evt-chart', setSeries: false } },
+      scales: { x: { time: true }, y: {} },
       axes: [
-        { stroke: 'var(--muted)', grid: { stroke: 'var(--line-2)', width: 1 } },
-        { scale: 'y',   stroke: 'var(--muted)', grid: { stroke: 'var(--line-2)', width: 1 },
-          values: (u, v) => v.map(x => x === null ? '' : '$' + Math.round(x)) },
-        { scale: 'qty', side: 1, stroke: 'var(--muted)', grid: { show: false },
-          values: (u, v) => v.map(x => x === null ? '' : Math.round(x)) },
-        // Hidden axis: sg sale count shares the right-side gutter implicitly via
-        // its own scale (sgct), but we don't draw a separate axis to keep the
-        // chart visually clean. uPlot still scales it correctly.
+        X_AXIS,
+        { scale: 'y', stroke: AXIS_STROKE, font: AXIS_FONT,
+          grid: { stroke: AXIS_GRID, width: 1 },
+          ticks: { stroke: AXIS_TICKS, size: 6 },
+          values: (u, v) => v.map(x => x == null ? '' : '$' + Math.round(x)),
+          size: 56 },
       ],
       series: [
         { label: 'time' },
-        ...seriesSpecs.map(s => ({
-          label: s.label, stroke: s.color, width: s.width, scale: s.scale,
+        ...paneSpecs.map(s => ({
+          label: s.label, stroke: s.color, width: s.width, scale: 'y',
           spanGaps: true, dash: s.dash || undefined, fill: s.fill || undefined,
-          points: s.points || undefined,
+          show: _chartVisible.get(s.key) !== false,
         })),
       ],
       hooks: {
@@ -515,19 +570,144 @@
         setSize: [
           (u) => renderAnnotationTooltips(u, host, ext && ext.annotations),
         ],
+        setCursor: [
+          (u) => updateChartTooltip(u),
+        ],
       },
     };
+    return new window.uPlot(opts, data, host);
+  }
 
-    _chartInstance = new window.uPlot(opts, data, host);
+  function renderPaneInv(host, specs, xs) {
+    const paneSpecs = specs.filter(s => s.pane === 'inv');
+    const data = [xs, ...paneSpecs.map(s => s.projected)];
+    const { w, h } = paneSize(host);
+    const opts = {
+      width: w, height: h,
+      cursor: { drag: { x: true, y: false }, sync: { key: 'evt-chart', setSeries: false } },
+      scales: { x: { time: true }, y: {} },
+      axes: [
+        X_AXIS,
+        { scale: 'y', stroke: AXIS_STROKE, font: AXIS_FONT,
+          grid: { stroke: AXIS_GRID, width: 1 },
+          ticks: { stroke: AXIS_TICKS, size: 6 },
+          values: (u, v) => v.map(x => x == null ? '' : Math.round(x)),
+          size: 56 },
+      ],
+      series: [
+        { label: 'time' },
+        ...paneSpecs.map(s => ({
+          label: s.label, stroke: s.color, width: s.width, scale: 'y',
+          spanGaps: true, dash: s.dash || undefined, fill: s.fill || undefined,
+          show: _chartVisible.get(s.key) !== false,
+        })),
+      ],
+      hooks: {
+        setCursor: [(u) => updateChartTooltip(u)],
+      },
+    };
+    return new window.uPlot(opts, data, host);
+  }
 
-    if (!host.__resizeWired) {
-      host.__resizeWired = true;
-      let resizeTimer;
-      window.addEventListener('resize', () => {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(() => renderChart(chart, _chartExtAlerts), 200);
-      });
+  function renderPaneVol(host, specs, xs) {
+    const paneSpecs = specs.filter(s => s.pane === 'vol');
+    const data = [xs, ...paneSpecs.map(s => s.projected)];
+    const { w, h } = paneSize(host);
+    // uPlot built-in bars factory: width = 60% of bucket spacing, max 32px,
+    // min 1px. Cheap, no plugin needed.
+    const barsPath = window.uPlot.paths.bars
+      ? window.uPlot.paths.bars({ size: [0.6, 32, 1] })
+      : undefined;
+    const opts = {
+      width: w, height: h,
+      cursor: { drag: { x: true, y: false }, sync: { key: 'evt-chart', setSeries: false } },
+      scales: { x: { time: true }, y: { range: (u, dataMin, dataMax) => [0, Math.max(dataMax || 1, 1)] } },
+      axes: [
+        X_AXIS,
+        { scale: 'y', stroke: AXIS_STROKE, font: AXIS_FONT,
+          grid: { stroke: AXIS_GRID, width: 1 },
+          ticks: { stroke: AXIS_TICKS, size: 6 },
+          values: (u, v) => v.map(x => x == null ? '' : Math.round(x)),
+          size: 56 },
+      ],
+      series: [
+        { label: 'time' },
+        ...paneSpecs.map(s => ({
+          label: s.label, stroke: s.color, fill: s.color, width: s.width, scale: 'y',
+          paths: s.bars ? barsPath : undefined,
+          points: { show: false },
+          show: _chartVisible.get(s.key) !== false,
+        })),
+      ],
+      hooks: {
+        setCursor: [(u) => updateChartTooltip(u)],
+      },
+    };
+    return new window.uPlot(opts, data, host);
+  }
+
+  function paneSize(host) {
+    const rect = host.getBoundingClientRect();
+    const w = Math.max(400, rect.width || host.clientWidth || 1200);
+    // Subtract a small budget for the host's own padding; uPlot wants exact px.
+    const h = Math.max(40, Math.floor(rect.height || host.clientHeight || 120));
+    return { w, h };
+  }
+
+  // Cross-pane tooltip — reads value at the cursor idx from all 3 instances
+  // and renders a compact floating table anchored to the cursor X position.
+  function updateChartTooltip(srcInstance) {
+    const tip = document.getElementById('chartTooltip');
+    if (!tip) return;
+    const build = _chartLastBuild;
+    if (!build || !srcInstance || !srcInstance.cursor) return;
+    const idx = srcInstance.cursor.idx;
+    if (idx == null || idx < 0 || idx >= build.xs.length) {
+      tip.hidden = true;
+      return;
     }
+    const tSec = build.xs[idx];
+    const ts = new Date(tSec * 1000);
+    const rows = [];
+    build.specs.forEach(s => {
+      if (_chartVisible.get(s.key) === false) return; // hidden by legend toggle
+      const v = s.projected[idx];
+      if (v == null) return;
+      const fmt = s.pane === 'price'
+        ? '$' + Math.round(v)
+        : Math.round(v).toString();
+      rows.push(
+        `<div class="tt-row"><i style="background:${s.color}"></i>` +
+        `<span class="tt-label">${escapeHtml(s.label)}</span>` +
+        `<span class="tt-val">${fmt}</span></div>`
+      );
+    });
+    if (!rows.length) {
+      tip.hidden = true;
+      return;
+    }
+    // Format compact local time
+    const tStr = ts.toLocaleString(undefined, {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+    tip.innerHTML = `<div class="tt-time">${escapeHtml(tStr)}</div>` + rows.join('');
+    // Position: anchor to the cursor X on the source instance, clamp to chart bounds
+    const chartHost = document.getElementById('chart');
+    if (!chartHost) return;
+    const chartRect = chartHost.getBoundingClientRect();
+    const srcCanvas = srcInstance.root;
+    const srcRect = srcCanvas.getBoundingClientRect();
+    const px = (srcInstance.cursor.left || 0) + (srcRect.left - chartRect.left);
+    // Render to measure, then position with overflow-protection
+    tip.style.left = '0px';
+    tip.style.top  = '0px';
+    tip.hidden = false;
+    const tipWidth = tip.offsetWidth;
+    const maxLeft = chartRect.width - tipWidth - 8;
+    const desiredLeft = px + 12;
+    const finalLeft = Math.max(8, Math.min(desiredLeft, maxLeft));
+    tip.style.left = finalLeft + 'px';
+    tip.style.top  = '36px';  // below the chart title bar
   }
 
   function drawAlertsMarkers(u, alerts) {
@@ -641,35 +821,61 @@
   function renderChartLegend() {
     const el = document.getElementById('chartLegend');
     if (!el) return;
+    const build = _chartLastBuild;
     const ext = _chartExtState.payload;
     const hasSg = ext && !ext.sg_hidden;
-    const items = [
-      ['#fbbf24', 'TEvo Owned'],
-      ['#737373', 'TEvo Mkt'],
-      ['#a78bfa', 'TEvo Non-own'],
-      ['#60a5fa', 'TEvo Own qty'],
-      ['#94a3b8', 'TEvo Mkt qty'],
-    ];
-    if (hasSg) {
-      items.push(
-        ['#22d3ee', 'SG list med'],
-        ['#fb7185', 'SG owned med'],
-        ['#84cc16', 'SG sale med'],
-        ['#22d3ee', 'SG list qty', 'dashed'],
-        ['#84cc16', 'SG sale ct'],
-      );
+
+    // Build clickable series swatches from the spec list. Each swatch toggles
+    // the matching series on its pane via uPlot.setSeries({show}).
+    let html = '';
+    if (build && build.specs && build.specs.length) {
+      const visibleSpecs = build.specs.filter(s => hasSg || !s.key.startsWith('sg_'));
+      // Group by pane in legend for visual clarity: Price → Inv → Vol
+      const order = { price: 0, inv: 1, vol: 2 };
+      const sorted = [...visibleSpecs].sort((a, b) => order[a.pane] - order[b.pane]);
+      html = sorted.map(s => {
+        const isOn = _chartVisible.get(s.key) !== false;
+        const opa = isOn ? '1' : '0.35';
+        return `<span class="legend-item" data-key="${escapeHtml(s.key)}" data-pane="${s.pane}" style="opacity:${opa};cursor:pointer" title="Click to toggle">` +
+               `<i style="background:${s.color}"></i> ${escapeHtml(s.label)}</span>`;
+      }).join('');
+    } else {
+      // Fallback static legend pre-first-render
+      const items = [
+        ['#fbbf24', 'TEvo Owned'], ['#737373', 'TEvo Mkt'], ['#a78bfa', 'TEvo Non-own'],
+        ['#60a5fa', 'TEvo Own qty'], ['#94a3b8', 'TEvo Mkt qty'],
+      ];
+      html = items.map(([c, l]) =>
+        `<span><i style="background:${c}"></i> ${escapeHtml(l)}</span>`).join('');
     }
-    let html = items.map(([c, l, mod]) =>
-      `<span><i style="background:${c}${mod === 'dashed' ? ';opacity:.5' : ''}"></i> ${l}</span>`).join('');
+
     if (ext && (
       (ext.annotations && ext.annotations.injuries && ext.annotations.injuries.length) ||
       (ext.annotations && ext.annotations.game_state && ext.annotations.game_state.length)
     )) {
       html += '<span class="legend-sep">|</span>';
-      html += '<span><i class="anno-inj-i"></i> Injury</span>';
-      html += '<span><i class="anno-gs-i"></i> State</span>';
+      html += '<span class="legend-anno"><i class="anno-inj-i"></i> Injury</span>';
+      html += '<span class="legend-anno"><i class="anno-gs-i"></i> State</span>';
     }
     el.innerHTML = html;
+
+    // Wire click handlers (idempotent — innerHTML wipes prior listeners).
+    el.querySelectorAll('.legend-item').forEach(node => {
+      node.addEventListener('click', () => {
+        const key = node.getAttribute('data-key');
+        const pane = node.getAttribute('data-pane');
+        const cur = _chartVisible.get(key) !== false; // default true
+        _chartVisible.set(key, !cur);
+        // Find the series index on the target pane and toggle
+        const inst = _chartInstances[pane];
+        if (inst && _chartLastBuild) {
+          const paneSpecs = _chartLastBuild.specs.filter(s => s.pane === pane);
+          const idx = paneSpecs.findIndex(s => s.key === key);
+          if (idx >= 0) inst.setSeries(idx + 1 /* +1 for time series */, { show: !cur });
+        }
+        renderChartLegend(); // refresh opacity
+      });
+    });
   }
 
   // ---------- Splits ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -119,23 +119,20 @@ main.wrap {
 .kpi-value.neg  { color: var(--neg); }
 .kpi-sub { color: var(--muted); font-family: var(--mono); font-size: 11px; }
 
-/* ---------- Chart ---------- */
+/* ---------- Chart — 3-pane stacked redesign (operator redesign 2026-05-18) ---------- */
 
 #chart {
   grid-column: 1 / -1;
   background: var(--panel);
   border: 1px solid var(--line);
   padding: 8px;
-  /* Flex column so chart-title (now wraps the 10-series legend post-PR #237)
-     takes natural height and #chartHost absorbs the remainder. Without
-     this, the canvas — sized at rect.height - 20 in renderChart — plus a
-     wrapped title overflows the 320px fixed container and bleeds below
-     into #sg-broker-sales. */
+  /* Flex column: chart-title (auto height) + 3 panes (flex-weighted 6:2:2)
+     + floating tooltip. min-height bumped from 420 → 540 to give the new
+     stacked layout enough vertical room. */
   display: flex;
   flex-direction: column;
-  height: 40vh;
-  min-height: 420px;   /* up from 320 — accommodates ~10-series wrapped legend */
-  position: relative;  /* needed for absolute .chart-anno-host overlay */
+  min-height: 540px;
+  position: relative;  /* anchor for .chart-anno-host + .chart-tooltip */
 }
 #chart .chart-title {
   display: flex; justify-content: space-between; align-items: flex-start;
@@ -146,21 +143,33 @@ main.wrap {
   text-transform: uppercase; letter-spacing: 0.5px;
   flex: 0 0 auto;
 }
-#chart #chartHost {
-  flex: 1 1 auto;
-  min-height: 0;    /* required for flex children that contain a canvas */
+/* Stacked panes. flex weights 6:2:2 = price 60%, inv 20%, vol 20% of remaining
+   vertical space. min-height:0 required for flex children that contain a
+   canvas (otherwise the canvas pushes the parent past the flex allotment). */
+#chart .chart-pane {
+  min-height: 0;
   position: relative;
+  overflow: hidden;
 }
+#chart .chart-pane-price { flex: 6 1 0; }
+#chart .chart-pane-inv   { flex: 2 1 0; border-top: 1px solid var(--line-2); }
+#chart .chart-pane-vol   { flex: 2 1 0; border-top: 1px solid var(--line-2); }
+#chart .chart-pane canvas { display: block; }
+
+/* Legend — now clickable swatches per series. Toggling dims the swatch + hides
+   the series via uPlot.setSeries({show:false}). Annotation icons unchanged. */
 #chart .legend { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
 #chart .legend span { display: flex; align-items: center; gap: 4px; }
+#chart .legend .legend-item { transition: opacity 80ms ease; user-select: none; }
+#chart .legend .legend-item:hover { opacity: 1 !important; text-decoration: underline; text-decoration-style: dotted; }
+#chart .legend .legend-anno { cursor: default; }
 #chart .legend i {
   width: 10px; height: 2px; display: inline-block;
 }
 #chart .legend .legend-sep {
   color: var(--line-2); padding: 0 4px;
 }
-/* Annotation legend icons (mig 20260519150000) — small + cross for injury,
-   small square for game-state. Different from series swatches. */
+/* Annotation legend icons — small + cross for injury, small square for state. */
 #chart .legend i.anno-inj-i {
   width: 10px; height: 10px; background: transparent;
   border: 0; position: relative;
@@ -174,9 +183,46 @@ main.wrap {
 #chart .legend i.anno-gs-i {
   width: 8px; height: 8px; background: #14b8a6;
 }
+
+/* uPlot draws axis labels via canvas (not SVG), so the old
+   `#chart .uplot text { fill: ... }` rule was a no-op — axis text rendered
+   in default dark-gray, invisible on #0a0a0a background. Axis colors are
+   now set programmatically via opts.axes[*].stroke + .font in renderChart. */
 #chart .uplot { background: transparent; }
-#chart .uplot text { fill: var(--muted) !important; font-family: var(--mono) !important; font-size: 10px !important; }
-#chart .u-axis { color: var(--muted); }
+
+/* Cross-pane tooltip — floats above all 3 panes, anchored to cursor X. */
+.chart-tooltip {
+  position: absolute;
+  z-index: 5;
+  background: rgba(15, 15, 15, 0.96);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #e5e5e5;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  min-width: 160px;
+  max-width: 260px;
+}
+.chart-tooltip[hidden] { display: none; }
+.chart-tooltip .tt-time {
+  color: var(--muted);
+  font-size: 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--line-2);
+  padding-bottom: 3px;
+}
+.chart-tooltip .tt-row {
+  display: flex; align-items: center; gap: 6px;
+  line-height: 1.4;
+}
+.chart-tooltip .tt-row i {
+  width: 10px; height: 2px; flex: 0 0 auto;
+}
+.chart-tooltip .tt-label { flex: 1 1 auto; color: var(--muted); }
+.chart-tooltip .tt-val   { flex: 0 0 auto; color: #f5f5f5; font-weight: 500; }
 
 /* Chart annotation overlay (mig 20260519150000) — sibling DOM layer for
    hover tooltips over canvas-drawn marker dots. Pointer events restricted


### PR DESCRIPTION
## Summary

Replaces the post-PR-#237 single-pane chart that fought 10 series on 2 visible Y-scales (with a hidden `sgct` scale silently rendering sales-count spikes through the price band). Operator screenshot showed it unreadable.

**New layout — 3 stacked uPlot instances, X-axis synced via `cursor.sync`:**

| Pane | Height | Content |
|---|---|---|
| **Price** | 60% | 6 medians on `$`-axis (TEvo Owned/Market/Non-owned + SG list/owned/sale med). ESPN injury crosses + game-state squares + event_alerts triangles attach to this pane only. |
| **Inventory** | 20% | 3 ticket-count lines (integer axis): TEvo Owned qty (filled), TEvo Mkt qty (dashed), SG list qty. |
| **Volume** | 20% | SG sale count as histogram **bars** via `uPlot.paths.bars({size:[0.6,32,1]})` — no more line-through-price-band confusion. |

## Fixes alongside the redesign

1. **Axis labels now visible** — set `font` + `stroke` directly in `opts.axes[*]`. uPlot draws axis text on canvas, not SVG, so the old `#chart .uplot text { fill }` CSS rule was a no-op — text rendered default dark-gray, invisible on `#0a0a0a`. Now programmatic via AXIS_FONT + AXIS_STROKE constants.
2. **Hover tooltip** — single floating `.chart-tooltip` absolute-positioned inside `#chart`. `setCursor` hook on all 3 panes triggers `updateChartTooltip` which reads values at the cursor idx across all panes. Renders compact time + per-series color swatch + value table. Anchors to cursor X, clamps to bounds.
3. **Clickable legend toggles** — each swatch carries `data-key` + `data-pane`. Click flips `_chartVisible` Map + calls `uPlot.setSeries(idx, {show})` on the matching pane. Hidden = opacity 0.35.
4. **Annotations price-pane only** — `drawAlertsMarkers` / `drawInjuryMarkers` / `drawGameStateMarkers` + DOM `.chart-anno-host` overlay live exclusively on `_chartInstances.price`.

## No migration change

RPC payload shape (`v3.chart_data` + `get_event_chart_extended.series`/`.annotations`) unchanged. FE-only.

## Files

- `static/terminal/event.js` — `renderChart` rewrite (3 new pane functions + tooltip + legend toggles + state machine for `_chartInstances`)
- `static/terminal/event.html` — single `#chartHost` → 3 host divs + `#chartTooltip`
- `static/terminal/style.css` — `#chart` min-height 420→540, flex column 6:2:2 weighted panes, drop broken `.uplot text` rule, add `.chart-tooltip` + `.chart-pane` styles

## Test plan

- [x] DOM check passes: 3 host divs + tooltip div present
- [x] CSS layout: flex 6:2:2, panes have `min-height:0` for canvas children
- [x] uPlot v1.6.31 supports `cursor.sync` + `paths.bars` natively (no plugins)
- [ ] Browser smoke on live deploy: 3 panes render proportionally, axis labels readable, tooltip works on hover, legend toggles hide series, annotations only on price pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)