### PR TITLE
chore: §6 retrofit + cron_policy + Supabase advisor cluster 1A/2 + Arias chart partition fix

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -42,7 +42,6 @@
 
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
-| B1-NEXT-7 | A1 + C1 | RLS gap on 3 tables: `cron_pause_state_20260514`, `sg_event_priority_state`, `sg_priority_policy` (rowsecurity=false, 0 policies, anon SELECT grant). Same pattern as Phase-1 `aq_*_map` gap. | Author `<ts>_security_rls_gap_close_3_tables.sql` — enable RLS + add deny-by-default policy |
 | B1-NEXT-11 | Op | Leaked `CRON_SECRET` in git history (commit `5297739`). Value rotated but repo is public → internet-readable. | Operator decides: `git filter-repo` + force-push window, OR accept (rotated, contained blast radius). G-1. |
 
 ### SEC-MED (defense-in-depth)
@@ -54,18 +53,17 @@
 | B1-NEXT-8 | A1 | `_health_check_pg_net_errors()` missing §6 body guard (added by PR #115). | Add guard via CREATE OR REPLACE; preserve return shape |
 | B1-NEXT-18 | Op | Verify Actions secrets populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`). | Operator confirms next session via Settings → Secrets |
 | B1-NEXT-29 | A1 | `refresh_sg_broker_sales_event_metrics(integer)` missing §6 body guard. Hourly cron at `:17`. | Add guard via CREATE OR REPLACE |
-| B1-NEXT-30 | A1 (D2) | `sg_seller_orders_queue(p_pages, p_statuses)` missing §6 body guard. | Add guard via CREATE OR REPLACE |
-| B1-NEXT-31 | A1 | §6 body guard absent on 7 JWT-gated SECDEF RPCs: `get_broker_event_page` (v1/v2/v3), `get_event_sg_listings_full`, `get_event_evo_listings_full`, `get_event_sg_sales_full`, `get_event_cross_source_metrics`. JWT body check IS primary mitigation; guard is 2nd belt. | Add guard via CREATE OR REPLACE per fn (or batch migration) |
+| B1-NEXT-30 | A1 (D2) | `sg_seller_orders_queue(p_pages, p_statuses)` missing §6 body guard + **EXECUTE granted to PUBLIC** (real defense-in-depth bug, not just convention drift). Verified 2026-05-18. | Add guard via CREATE OR REPLACE + REVOKE EXECUTE FROM PUBLIC |
+| B1-NEXT-31 | A1 | §6 body guard absent on 7 JWT-gated SECDEF RPCs: `get_broker_event_page` (v1/v2/v3), `get_event_sg_listings_full`, `get_event_evo_listings_full`, `get_event_sg_sales_full`, `get_event_cross_source_metrics`. JWT body check IS primary mitigation; guard is 2nd belt. **BLOCKED on spec clarification** — literal §6 `current_user NOT IN (service_role, postgres, supabase_admin)` would brick these (anon/authenticated callers via PostgREST). bot_chat question pending B1 response. | Wait for B1 spec; verified `public_exec=false` already in place on all 7 |
 | B1-NEXT-39 | D0 + D1 | `/api/store/search` exposes `we_own` (bool) + `owned_tix` (count). LANE_DISCIPLINE.md §D1 wall rule lists `is_owned` as forbidden. May be intentional storefront-product behavior. bot_chat 308. | If intentional: add carveout to LANE_DISCIPLINE.md §D1. If not: filter columns from `/api/store/search` response in `app.py` |
 
 ### SEC-LOW (hygiene)
 
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
-| B1-NEXT-2 | A1 | Drop dead v1 (7-arg) overload of `match_to_aq_event_id`. **Verify status** — A1 PR #177 may have already dropped this. | `DROP FUNCTION IF EXISTS public.match_to_aq_event_id(text,bigint,text,text,timestamptz,numeric,numeric);` if still present |
 | B1-NEXT-4 | B1 | Evaluate CodeQL / SAST for FastAPI + edge functions. | Research + decision doc |
 | B1-NEXT-6 | B1 | Egress payload review on `*_public` / `/api/store/*` RPCs. (Partial pass via war-games W-3 2026-05-17; rotational.) | Quarterly sweep against war_games_playbook W-3 + W-4 |
-| B1-NEXT-10 | A1 | Migration slot collisions: `20260515300000` (3 files), `20260515320000` (2 files). | Rename to next free slots in a future cleanup PR |
+| B1-NEXT-10 | A1 | Migration slot collisions: `20260515300000` (3 files), `20260515320000` (2 files), `20260515340000` (2 files — caught 2026-05-18, kanban missed it). None applied via `apply_migration` (`schema_migrations` empty for all). | Rename to next free slots in a future cleanup PR. **Risk-check first**: some may have been applied via direct `execute_sql` — verify via function/object presence before rename. |
 | B1-NEXT-15 | Op | Branch-protection `enforce_admins=false` on `main`. | Operator decision. G-6. |
 | B1-NEXT-16 | Op | `required_signatures=false` on `main`. | Operator decision. G-7. |
 | B1-NEXT-17 | Op | Actions `sha_pinning_required=false`. | Operator decision. G-8. |
@@ -78,7 +76,7 @@
 | B1-NEXT-27 | B1 | Cross-bible consistency check (PROJECT_BIBLE.md vs LANE_DISCIPLINE.md vs BOT_HIERARCHY.md). | Periodic full diff |
 | B1-NEXT-28 | B1 (post-MCP) | Slack channel signal-quality metric. | Blocked on B1-NEXT-21 |
 | B1-NEXT-35 | Op | Create scheduled task `b1-war-games-rotation`. Every 4h. | Operator approves Slack MCP tool + cron creation |
-| B1-NEXT-37 | A1 | Backfill `cron_policy` rows for 4 daily collect-listings windowed crons (1-7d/7-30d/30-60d/60d+). | 1 SQL INSERT into `cron_policy` |
+| B1-NEXT-37 | A1 | Backfill `cron_policy` rows for **5** daily collect-listings windowed crons: `0-24h` (1-59/10 schedule, 144 fires/24h), `1-7d` / `7-30d` / `30-60d` / `60d+` (twice-daily, 2 fires/24h). All currently `fire_no_policy`. | 1 SQL INSERT into `cron_policy` (5 rows) |
 | B1-NEXT-40 | Op | **G-9**: `allow_forking: true` on public repo. Forks clone full history including the leaked `CRON_SECRET` commit `5297739`. Compounds G-1. | Operator decision (usually allow_forking stays true; real fix is G-1 history rewrite) |
 | B1-NEXT-44 | Op | **G-14**: Branch protection on `main` — no required approving review count, no CODEOWNERS review required, no dismiss-stale-reviews. Single-operator can push without formal review. | Operator decision — Settings → Branches → Edit rule for `main` |
 | B1-NEXT-45 | Op | **G-15**: `required_conversation_resolution: false`. PRs can merge with unresolved review comments. | Settings → Branches → toggle |

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -50,10 +50,7 @@
 |---|---|---|---|
 | B1-NEXT-3 | B1 | Edge function auth-posture inventory (16 fns). Per-function record of `x-cron-secret` vs open vs JWT-gated. | Author `docs/edge_function_auth_inventory.md` |
 | B1-NEXT-5 | B1 | Vault orphans check — `release_health_check()` row for `get_app_secret` allowlist entries unused by any prod fn/cron/edge-fn. | 1 SQL migration adding a new row to `release_health_check()` |
-| B1-NEXT-8 | A1 | `_health_check_pg_net_errors()` missing §6 body guard (added by PR #115). | Add guard via CREATE OR REPLACE; preserve return shape |
 | B1-NEXT-18 | Op | Verify Actions secrets populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`). | Operator confirms next session via Settings → Secrets |
-| B1-NEXT-29 | A1 | `refresh_sg_broker_sales_event_metrics(integer)` missing §6 body guard. Hourly cron at `:17`. | Add guard via CREATE OR REPLACE |
-| B1-NEXT-30 | A1 (D2) | `sg_seller_orders_queue(p_pages, p_statuses)` missing §6 body guard + **EXECUTE granted to PUBLIC** (real defense-in-depth bug, not just convention drift). Verified 2026-05-18. | Add guard via CREATE OR REPLACE + REVOKE EXECUTE FROM PUBLIC |
 | B1-NEXT-31 | A1 | §6 body guard absent on 7 JWT-gated SECDEF RPCs: `get_broker_event_page` (v1/v2/v3), `get_event_sg_listings_full`, `get_event_evo_listings_full`, `get_event_sg_sales_full`, `get_event_cross_source_metrics`. JWT body check IS primary mitigation; guard is 2nd belt. **BLOCKED on spec clarification** — literal §6 `current_user NOT IN (service_role, postgres, supabase_admin)` would brick these (anon/authenticated callers via PostgREST). bot_chat question pending B1 response. | Wait for B1 spec; verified `public_exec=false` already in place on all 7 |
 | B1-NEXT-39 | D0 + D1 | `/api/store/search` exposes `we_own` (bool) + `owned_tix` (count). LANE_DISCIPLINE.md §D1 wall rule lists `is_owned` as forbidden. May be intentional storefront-product behavior. bot_chat 308. | If intentional: add carveout to LANE_DISCIPLINE.md §D1. If not: filter columns from `/api/store/search` response in `app.py` |
 
@@ -76,7 +73,6 @@
 | B1-NEXT-27 | B1 | Cross-bible consistency check (PROJECT_BIBLE.md vs LANE_DISCIPLINE.md vs BOT_HIERARCHY.md). | Periodic full diff |
 | B1-NEXT-28 | B1 (post-MCP) | Slack channel signal-quality metric. | Blocked on B1-NEXT-21 |
 | B1-NEXT-35 | Op | Create scheduled task `b1-war-games-rotation`. Every 4h. | Operator approves Slack MCP tool + cron creation |
-| B1-NEXT-37 | A1 | Backfill `cron_policy` rows for **5** daily collect-listings windowed crons: `0-24h` (1-59/10 schedule, 144 fires/24h), `1-7d` / `7-30d` / `30-60d` / `60d+` (twice-daily, 2 fires/24h). All currently `fire_no_policy`. | 1 SQL INSERT into `cron_policy` (5 rows) |
 | B1-NEXT-40 | Op | **G-9**: `allow_forking: true` on public repo. Forks clone full history including the leaked `CRON_SECRET` commit `5297739`. Compounds G-1. | Operator decision (usually allow_forking stays true; real fix is G-1 history rewrite) |
 | B1-NEXT-44 | Op | **G-14**: Branch protection on `main` — no required approving review count, no CODEOWNERS review required, no dismiss-stale-reviews. Single-operator can push without formal review. | Operator decision — Settings → Branches → Edit rule for `main` |
 | B1-NEXT-45 | Op | **G-15**: `required_conversation_resolution: false`. PRs can merge with unresolved review comments. | Settings → Branches → toggle |

--- a/supabase/migrations/20260519210000_security_secdef_guard_retrofit_3_fns.sql
+++ b/supabase/migrations/20260519210000_security_secdef_guard_retrofit_3_fns.sql
@@ -1,0 +1,214 @@
+-- 20260519210000_security_secdef_guard_retrofit_3_fns.sql
+--
+-- §6 SECDEF body-guard retrofit on 3 cron-internal functions.
+-- Closes KANBAN.md B1-NEXT-8, B1-NEXT-29, B1-NEXT-30.
+--
+-- WHY:
+--   All 3 functions ship as SECURITY DEFINER with `SET search_path` already set,
+--   but lack the §6 (BOT_HIERARCHY.md) in-body caller guard:
+--     IF current_user NOT IN ('service_role','postgres','supabase_admin') THEN RAISE;
+--
+--   None of the 3 has a legitimate non-cron caller. All cron firings run as
+--   service_role and pass the guard. Verified 2026-05-18:
+--     - _health_check_pg_net_errors:        no fn/cron callers (orphan check fn);
+--                                           release_health_check inlines its own checks.
+--     - refresh_sg_broker_sales_event_metrics: called only by `sg_broker_sales_metrics_refresh_hourly` (:17 cron, service_role).
+--     - sg_seller_orders_queue:             called only by `sg_seller_orders_queue_30min` (:2,:32 cron, service_role).
+--
+-- WHAT:
+--   1. Convert _health_check_pg_net_errors from LANGUAGE sql -> plpgsql so the
+--      guard can RAISE. Body wrapped as RETURN QUERY against the unchanged
+--      SELECT — return shape preserved.
+--   2. Prepend the §6 guard to the other 2 functions verbatim.
+--   3. REVOKE EXECUTE FROM PUBLIC + anon + authenticated for all 3 (cron-internal;
+--      no PostgREST consumer should reach them). GRANT to service_role.
+--      sg_seller_orders_queue currently has public_exec=TRUE — the real
+--      defense-in-depth bug B1-NEXT-30 flagged.
+--
+-- INVARIANTS PRESERVED:
+--   - All 3 signatures unchanged (no overload creation per PROJECT_BIBLE §7
+--     "function signature changes" landmine).
+--   - search_path config unchanged.
+--   - Return types unchanged.
+--   - Volatility (STABLE for #1, default VOLATILE for #2/#3) unchanged.
+--
+-- ROLLBACK:
+--   Re-apply the prior pg_get_functiondef() output for each — captured in this
+--   migration's git diff via the CREATE OR REPLACE delta.
+
+-- ============================================================
+-- 1/3 — _health_check_pg_net_errors()
+-- ============================================================
+-- Convert sql -> plpgsql to support RAISE. Wrap original SELECT in RETURN QUERY.
+
+CREATE OR REPLACE FUNCTION public._health_check_pg_net_errors()
+RETURNS TABLE(check_class text, check_name text, status text, metric numeric, detail text)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION '_health_check_pg_net_errors: caller % not authorized', current_user;
+  END IF;
+
+  RETURN QUERY
+  WITH last_60 AS (
+    SELECT
+      count(*) FILTER (WHERE status_code BETWEEN 200 AND 299 AND NOT timed_out) AS ok,
+      count(*) FILTER (WHERE status_code >= 400 OR timed_out OR status_code IS NULL) AS err,
+      count(*) AS total
+    FROM net._http_response
+    WHERE created > now() - interval '60 minutes'
+  )
+  SELECT
+    'pg_net'::text,
+    'error_rate_60min'::text,
+    CASE
+      WHEN total = 0                    THEN 'ok'
+      WHEN (err::numeric / total) > 0.5 THEN 'fail'
+      WHEN (err::numeric / total) > 0.2 THEN 'warn'
+      ELSE 'ok'
+    END,
+    round(coalesce(err::numeric / nullif(total, 0), 0) * 100, 1),
+    format('%s err / %s total (%s%% — fail >50%%, warn >20%%)',
+           err, total, round(coalesce(err::numeric / nullif(total, 0), 0) * 100, 1))
+  FROM last_60;
+END
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public._health_check_pg_net_errors() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public._health_check_pg_net_errors() FROM anon;
+REVOKE EXECUTE ON FUNCTION public._health_check_pg_net_errors() FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public._health_check_pg_net_errors() TO service_role;
+
+
+-- ============================================================
+-- 2/3 — refresh_sg_broker_sales_event_metrics(integer)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.refresh_sg_broker_sales_event_metrics(p_max_events integer DEFAULT 200)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_now timestamptz := now();
+  v_count int := 0;
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'refresh_sg_broker_sales_event_metrics: caller % not authorized', current_user;
+  END IF;
+
+  WITH deduped AS (
+    SELECT DISTINCT ON (sg_sale_id)
+      sg_event_id, tevo_event_id, sg_sale_id, broadcast_price, sale_at_utc
+    FROM public.seatgeek_sales_snapshots
+    WHERE sale_at_utc > v_now - interval '24 hours'
+    ORDER BY sg_sale_id, pulled_at DESC
+  ),
+  agg AS (
+    SELECT
+      d.sg_event_id,
+      coalesce(
+        max(d.tevo_event_id),
+        (SELECT tevo_event_id FROM public.seatgeek_event_xref WHERE sg_event_id = d.sg_event_id LIMIT 1)
+      ) AS tevo_event_id,
+      count(DISTINCT d.sg_sale_id) AS sold_quantity,
+      round(sum(d.broadcast_price)::numeric, 2) AS sold_gross,
+      min(d.broadcast_price) AS sold_price_min,
+      percentile_cont(0.50) WITHIN GROUP (ORDER BY d.broadcast_price)::numeric AS sold_price_median,
+      round(avg(d.broadcast_price)::numeric, 2) AS sold_price_mean,
+      max(d.broadcast_price) AS sold_price_max
+    FROM deduped d
+    GROUP BY d.sg_event_id
+    HAVING count(DISTINCT d.sg_sale_id) > 0
+    LIMIT p_max_events
+  )
+  INSERT INTO public.seatgeek_event_metrics (
+    sg_event_id, tevo_event_id, captured_at,
+    sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_mean, sold_price_max
+  )
+  SELECT sg_event_id, tevo_event_id, v_now,
+         sold_quantity, sold_gross, sold_price_min, sold_price_median, sold_price_mean, sold_price_max
+  FROM agg
+  WHERE tevo_event_id IS NOT NULL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.refresh_sg_broker_sales_event_metrics(integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.refresh_sg_broker_sales_event_metrics(integer) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.refresh_sg_broker_sales_event_metrics(integer) FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.refresh_sg_broker_sales_event_metrics(integer) TO service_role;
+
+
+-- ============================================================
+-- 3/3 — sg_seller_orders_queue(integer, text)
+-- ============================================================
+-- Pre-state: public_exec=TRUE (real defense-in-depth bug per B1-NEXT-30).
+
+CREATE OR REPLACE FUNCTION public.sg_seller_orders_queue(p_pages integer DEFAULT 1, p_statuses text DEFAULT NULL::text)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_token text := get_app_secret('SEATGEEK_API_TOKEN');
+  v_req_id bigint;
+  v_status text;
+  v_count int := 0;
+  v_statuses text[] := coalesce(
+    string_to_array(p_statuses, ','),
+    ARRAY['open','pending','confirmed','fulfilled']
+  );
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'sg_seller_orders_queue: caller % not authorized', current_user;
+  END IF;
+
+  PERFORM p_pages;
+  FOREACH v_status IN ARRAY v_statuses LOOP
+    SELECT net.http_get(
+      url := 'https://sellerdirect-api.seatgeek.com/orders?per_page=200&status='
+             || trim(v_status) || '&token=' || v_token,
+      timeout_milliseconds := 30000
+    ) INTO v_req_id;
+    INSERT INTO sg_seller_pending(request_id, scope, page, per_page, status_csv)
+    VALUES (v_req_id, 'orders', 1, 200, trim(v_status));
+    v_count := v_count + 1;
+  END LOOP;
+  RETURN v_count;
+END
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.sg_seller_orders_queue(integer, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.sg_seller_orders_queue(integer, text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.sg_seller_orders_queue(integer, text) FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_seller_orders_queue(integer, text) TO service_role;
+
+
+-- ============================================================
+-- Post-apply verification (operator runs after apply_migration)
+-- ============================================================
+-- expected: all 3 rows show has_caller_guard=true, public_exec=false, anon_exec=false, authed_exec=false, service_role_exec=true
+--
+-- WITH fns AS (
+--   SELECT p.oid, p.proname, pg_get_function_identity_arguments(p.oid) AS args,
+--          pg_get_functiondef(p.oid) AS def
+--   FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+--   WHERE n.nspname='public'
+--     AND p.proname IN ('_health_check_pg_net_errors','refresh_sg_broker_sales_event_metrics','sg_seller_orders_queue')
+-- )
+-- SELECT proname, args,
+--        (def ILIKE '%current_user%' AND def ILIKE '%RAISE%') AS has_caller_guard,
+--        has_function_privilege('public', oid, 'EXECUTE')        AS public_exec,
+--        has_function_privilege('anon', oid, 'EXECUTE')          AS anon_exec,
+--        has_function_privilege('authenticated', oid, 'EXECUTE') AS authed_exec,
+--        has_function_privilege('service_role', oid, 'EXECUTE')  AS service_role_exec
+-- FROM fns ORDER BY proname;

--- a/supabase/migrations/20260519240000_cron_policy_collect_listings_backfill.sql
+++ b/supabase/migrations/20260519240000_cron_policy_collect_listings_backfill.sql
@@ -1,0 +1,90 @@
+-- 20260519240000_cron_policy_collect_listings_backfill.sql
+--
+-- Backfill `cron_policy` rows for the 5 collect-listings windowed crons.
+-- Closes KANBAN.md B1-NEXT-37.
+--
+-- WHY:
+--   All 5 crons currently produce `decision=fire_no_policy` in cron_gate_decisions
+--   (default-fire behavior). Adds explicit daily_max_fires + interval limits so the
+--   cron_should_fire gate has explicit ceilings to enforce.
+--
+-- CURRENT STATE (verified 2026-05-18):
+--   collect-listings-0-24h    schedule "1-59/10 * * * *"   144 fires/24h
+--   collect-listings-1-7d     schedule "30 5,17 * * *"       2 fires/24h
+--   collect-listings-7-30d    schedule "20 4,16 * * *"       2 fires/24h
+--   collect-listings-30-60d   schedule "35 4,16 * * *"       2 fires/24h
+--   collect-listings-60d+     schedule "50 4,16 * * *"       2 fires/24h
+--
+-- DESIGN:
+--   - daily_max_fires = ceil(actual + 10% safety margin)
+--   - peak_min_interval_min matches schedule cadence (10 min for hot, 720 min for daily)
+--   - work_check_sql left NULL — these crons are by-design "always sweep"; adding a
+--     work check would be a separate behavior change.
+--   - enabled=true (current behavior — no operational change).
+
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+   work_check_sql, daily_max_fires, enabled, notes, updated_at)
+VALUES
+  ('collect-listings-0-24h',
+   ARRAY[]::int[],          -- no peak distinction; runs every 10 min all day
+   10, 10,
+   NULL,
+   150,                     -- 144 actual + safety margin
+   true,
+   'Hot window: events occurring 0-24h out. Sweeps every 10 min via */10 schedule. Policy ceiling 150/day.',
+   now()),
+
+  ('collect-listings-1-7d',
+   ARRAY[]::int[],
+   720, 720,                -- 12h interval matches twice-daily schedule (05:30 + 17:30)
+   NULL,
+   4,                       -- 2 actual + safety
+   true,
+   'Daily window: 1-7d horizon. Twice daily at 05:30 + 17:30 UTC.',
+   now()),
+
+  ('collect-listings-7-30d',
+   ARRAY[]::int[],
+   720, 720,
+   NULL,
+   4,
+   true,
+   'Daily window: 7-30d horizon. Twice daily at 04:20 + 16:20 UTC.',
+   now()),
+
+  ('collect-listings-30-60d',
+   ARRAY[]::int[],
+   720, 720,
+   NULL,
+   4,
+   true,
+   'Daily window: 30-60d horizon. Twice daily at 04:35 + 16:35 UTC.',
+   now()),
+
+  ('collect-listings-60d+',
+   ARRAY[]::int[],
+   720, 720,
+   NULL,
+   4,
+   true,
+   'Daily window: 60d+ horizon. Twice daily at 04:50 + 16:50 UTC.',
+   now())
+ON CONFLICT (jobname) DO NOTHING;
+
+-- ============================================================
+-- Post-apply verification
+-- ============================================================
+-- expected: 5 rows
+--
+-- SELECT jobname, peak_min_interval_min, daily_max_fires, enabled
+-- FROM public.cron_policy
+-- WHERE jobname LIKE 'collect-listings-%'
+-- ORDER BY jobname;
+--
+-- expected: no rows (gate sees policy now)
+-- SELECT jobname, decision, count(*)
+-- FROM cron_gate_decisions
+-- WHERE jobname LIKE 'collect-listings-%' AND decided_at > now() - interval '1 hour'
+--   AND decision = 'fire_no_policy'
+-- GROUP BY 1,2;

--- a/supabase/migrations/20260519270000_c1_security_invoker_views_phase_a.sql
+++ b/supabase/migrations/20260519270000_c1_security_invoker_views_phase_a.sql
@@ -1,0 +1,63 @@
+-- 20260519270000_c1_security_invoker_views_phase_a.sql
+--
+-- Cluster 1 (Phase A) from C1's Supabase Action Center brief 2026-05-18.
+-- Clears 12 of 13 `security_definer_view` advisor ERRORs on `public.*` views.
+-- Postgres 17 supports `security_invoker` as a view reloption.
+--
+-- DEFERRED (Phase B, separate migration):
+--   `v_event_full_sports` reads `public.listings_snapshots`, which has
+--   ONLY an `anon USING (true)` policy and NO policy for `authenticated`.
+--   Flipping `v_event_full_sports` to invoker would silently empty results
+--   for any authenticated direct-view consumer. Resolving requires either
+--   (a) adding a d0_s4kent_read policy on listings_snapshots (surface
+--   expansion — operator/B1 sign-off needed), or (b) accepting the ERROR.
+--
+-- RISK CHECK (verified 2026-05-18 against prod):
+--   For each of the 12 views, every underlying base table has:
+--     - SELECT granted to both anon and authenticated
+--     - >=1 SELECT policy for both anon and authenticated
+--   So security_invoker flip preserves anon + authenticated read paths.
+--   service_role (which most cron / RPC paths run as) bypasses RLS entirely.
+--
+-- KNOWN BREAK (acceptable):
+--   `coworker_readonly` role has SELECT grants but NO policies on the
+--   base tables. After flip, direct view reads under coworker_readonly
+--   will return empty. C1's brief did not enumerate coworker_readonly as
+--   a watched consumer; operator confirms before apply.
+
+ALTER VIEW public.unified_orders                 SET (security_invoker = on);
+ALTER VIEW public.unified_orders_by_event        SET (security_invoker = on);
+ALTER VIEW public.v_event_full_v2                SET (security_invoker = on);
+ALTER VIEW public.v_event_velocity_windows       SET (security_invoker = on);
+ALTER VIEW public.v_event_price_arbitrage        SET (security_invoker = on);
+ALTER VIEW public.seatgeek_event_latest          SET (security_invoker = on);
+ALTER VIEW public.v_orphan_seatgeek_data         SET (security_invoker = on);
+ALTER VIEW public.v_sg_broker_429_health         SET (security_invoker = on);
+ALTER VIEW public.v_sg_broker_429_starved_events SET (security_invoker = on);
+ALTER VIEW public.v_aq_match_quality             SET (security_invoker = on);
+ALTER VIEW public.espn_injury_snapshot_latest    SET (security_invoker = on);
+ALTER VIEW public.order_status_coverage          SET (security_invoker = on);
+
+-- Phase B will add v_event_full_sports once listings_snapshots policy is settled.
+
+-- ============================================================
+-- Post-apply verification
+-- ============================================================
+-- 1) All 12 views show has_invoker=true:
+-- SELECT c.relname,
+--        coalesce((SELECT bool_or(opt='security_invoker=true')
+--                  FROM unnest(c.reloptions) opt), false) AS has_invoker
+-- FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+-- WHERE n.nspname='public'
+--   AND c.relname IN ('unified_orders','unified_orders_by_event','v_event_full_v2',
+--                     'v_event_velocity_windows','v_event_price_arbitrage','seatgeek_event_latest',
+--                     'v_orphan_seatgeek_data','v_sg_broker_429_health','v_sg_broker_429_starved_events',
+--                     'v_aq_match_quality','espn_injury_snapshot_latest','order_status_coverage');
+--
+-- 2) Sample a representative authed-callable view: should still return rows
+-- SET LOCAL role authenticated;
+-- SET LOCAL request.jwt.claims TO '{"email":"<test>@s4kent.com"}';
+-- SELECT count(*) FROM public.v_event_full_v2 LIMIT 1;
+-- RESET role;
+--
+-- 3) Re-run get_advisors(security): expect 12 fewer `security_definer_view` ERRORs.

--- a/supabase/migrations/20260519300000_c1_d0_read_initplan_fix.sql
+++ b/supabase/migrations/20260519300000_c1_d0_read_initplan_fix.sql
@@ -1,0 +1,48 @@
+-- 20260519300000_c1_d0_read_initplan_fix.sql
+--
+-- Cluster 2 from C1's Supabase Action Center brief 2026-05-18.
+-- Clears 10 `auth_rls_initplan` advisor WARNs.
+--
+-- Current USING clause:
+--   (COALESCE((auth.jwt() ->> 'email'::text), ''::text) ~~ '%@s4kent.com'::text)
+-- Postgres re-evaluates auth.jwt() per row, which the advisor flags.
+--
+-- Fix: wrap auth.jwt() in a sub-SELECT. PG executes the sub-SELECT once
+-- and caches as an InitPlan node — same semantics, ~per-row evaluation cost
+-- collapses to one evaluation per query.
+--
+-- Verified 2026-05-18 against prod: the policy `d0_s4kent_read` exists on
+-- all 10 tables with identical USING clause shape (no per-table semantic drift).
+
+DO $$
+DECLARE
+  t text;
+  tables text[] := ARRAY[
+    'events','event_xref','sg_events_canonical','aq_event_map','aq_venue_map',
+    'aq_performer_map','performer_metadata','venue_assets','cron_policy','cron_gate_decisions'
+  ];
+BEGIN
+  FOREACH t IN ARRAY tables LOOP
+    EXECUTE format('DROP POLICY IF EXISTS d0_s4kent_read ON public.%I', t);
+    EXECUTE format($f$
+      CREATE POLICY d0_s4kent_read ON public.%I
+        FOR SELECT TO authenticated
+        USING (coalesce((select auth.jwt()->>'email'), '') LIKE '%%@s4kent.com')
+    $f$, t);
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- Post-apply verification
+-- ============================================================
+-- 1) All 10 policies show the (select auth.jwt()...) form:
+-- SELECT tablename, qual FROM pg_policies
+-- WHERE schemaname='public' AND policyname='d0_s4kent_read' ORDER BY tablename;
+--
+-- 2) EXPLAIN (ANALYZE, VERBOSE) a representative authenticated query —
+--    InitPlan node should appear ONCE rather than per-row Filter:
+-- EXPLAIN (ANALYZE) SELECT 1 FROM public.events LIMIT 1;
+--    Look for "InitPlan 1 (returns $0)" referencing auth.jwt() rather than
+--    "Filter: (... auth.jwt() ...)" applied per row.
+--
+-- 3) Re-run get_advisors(performance): 10 `auth_rls_initplan` WARNs should clear.

--- a/supabase/migrations/20260519300000_c1_d0_read_initplan_fix.sql
+++ b/supabase/migrations/20260519300000_c1_d0_read_initplan_fix.sql
@@ -14,6 +14,15 @@
 -- Verified 2026-05-18 against prod: the policy `d0_s4kent_read` exists on
 -- all 10 tables with identical USING clause shape (no per-table semantic drift).
 
+-- IDIOM NOTE (applied to prod via fixup migration `c1_d0_read_initplan_fix_v2`
+-- 2026-05-18 17:00 UTC): the advisor lint detects `auth.<function>()` only when the
+-- function call itself is the direct child of a SELECT, not when the entire
+-- `->>` accessor is wrapped. So wrap `auth.jwt()` directly and chain `->>'email'`
+-- off the sub-SELECT result.
+--
+-- Wrong (still flags WARN):   `coalesce((select auth.jwt()->>'email'), '')`
+-- Right (clears WARN):        `coalesce((select auth.jwt())->>'email', '')`
+
 DO $$
 DECLARE
   t text;
@@ -27,7 +36,7 @@ BEGIN
     EXECUTE format($f$
       CREATE POLICY d0_s4kent_read ON public.%I
         FOR SELECT TO authenticated
-        USING (coalesce((select auth.jwt()->>'email'), '') LIKE '%%@s4kent.com')
+        USING (coalesce((select auth.jwt())->>'email', '') LIKE '%%@s4kent.com')
     $f$, t);
   END LOOP;
 END $$;

--- a/supabase/migrations/20260520220000_fix_get_event_chart_injuries_partition.sql
+++ b/supabase/migrations/20260520220000_fix_get_event_chart_injuries_partition.sql
@@ -1,0 +1,329 @@
+-- Migration 20260520220000 · lane:A1 · writes:get_event_chart_extended · reads:(unchanged) · pre:20260519150000
+--
+-- Fix Gabriel Arias notification flood on the Cleveland Guardians @ Phillies chart.
+--
+-- ROOT CAUSE
+--   `public.espn_injuries_snapshots` had 277 rows for athlete_name='Gabriel Arias'
+--   (espn_team_id='5', league='MLB', status='10-Day-IL') with 275 distinct
+--   negative synthetic `athlete_id` values (and 2 NULL ids). ESPN returns a
+--   fresh provisional negative id per poll when no stable athlete id is
+--   available, which both:
+--     (a) defeats `upsert_espn_injury` content-hash dedup → every row inserts
+--         as is_baseline=true;
+--     (b) breaks downstream consumers that PARTITION BY athlete_id.
+--
+--   `get_event_chart_extended` (mig 20260519150000, line 188) used
+--     LAG(status) OVER (PARTITION BY athlete_id ORDER BY captured_at)
+--   so every Arias row sat in its own partition of size 1 → `prev_status`
+--   was always NULL → `status IS DISTINCT FROM prev_status` was always TRUE
+--   → the chart painted ~277 identical "10-Day-IL" markers.
+--
+-- FIX (this migration, RPC-side only)
+--   Partition by stable identity instead of unstable athlete_id:
+--     PARTITION BY espn_league, espn_team_id,
+--                  lower(btrim(coalesce(athlete_name, athlete_id, '')))
+--   - `athlete_name` is stable across captures (277 rows, 1 distinct name).
+--   - Scoping by `(espn_league, espn_team_id)` prevents cross-league
+--     espn_team_id collisions (PROJECT_BIBLE.md §3 landmine: id='28' maps to
+--     BOTH MLB Atlanta + an NHL team).
+--   - `lower(btrim(...))` defends against whitespace/case noise.
+--   - `coalesce(athlete_name, athlete_id, '')` keeps a sensible fallback for
+--     rows that lack a name (e.g. the 2 NULL-name Arias rows still fall into
+--     a single partition keyed on their athlete_id values).
+--   - First-seen NULL→status transition still emits one annotation per
+--     athlete (intended behavior — original code comment at line 207 of
+--     20260519150000).
+--
+-- VERIFIED (dry-run on prod 2026-05-18 against live espn_injuries_snapshots)
+--   Pre-patch  : Arias emits ~184 transitions in 168h window.
+--   Post-patch : Arias emits 1 transition. Other Cleveland athletes still
+--                emit their expected 1 transition each (Shawn Armstrong 3
+--                rows → 1, Andrew Walters 1 row → 1).
+--
+-- DEFERRED (Layer 2 — ingest hardening, separate PR)
+--   `supabase/functions/espn-collect/index.ts:194-200` should treat
+--   `athleteIdRaw < 0` (negative provisional ESPN ids) as "no stable id"
+--   and fall through to the `${team_id}:${slug}` synthetic-id branch.
+--   That change touches several downstream views/RPCs and warrants its
+--   own scoped PR. bot_chat flag to the espn-collect lane owner pending.
+--
+-- INVARIANTS PRESERVED
+--   - Function signature unchanged (no overload risk per PROJECT_BIBLE §7).
+--   - SECDEF + STABLE + search_path + @s4kent.com email gate unchanged.
+--   - REVOKE/GRANT matrix unchanged (idempotent re-grant included for safety).
+--   - All other CTEs (SG listings/sales series, game-state transitions) are
+--     byte-identical to mig 20260519150000.
+
+CREATE OR REPLACE FUNCTION public.get_event_chart_extended(
+  p_event_id        integer,
+  p_chart_hours     integer DEFAULT 168,
+  p_espn_home_team  text    DEFAULT NULL,
+  p_espn_away_team  text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email          text;
+  v_sg_event_id    bigint;
+  v_espn_event_id  text;
+  v_espn_league    text;
+  v_home_team      text := p_espn_home_team;
+  v_away_team      text := p_espn_away_team;
+  v_hours          int  := greatest(1, least(coalesce(p_chart_hours, 168), 4320));
+  v_bucket_secs    int;
+  v_window_start   timestamptz;
+  v_now            timestamptz := now();
+  v_sg_listings    jsonb := '[]'::jsonb;
+  v_sg_listings_own jsonb := '[]'::jsonb;
+  v_sg_listings_ct jsonb := '[]'::jsonb;
+  v_sg_sales       jsonb := '[]'::jsonb;
+  v_sg_sales_ct    jsonb := '[]'::jsonb;
+  v_injuries       jsonb := '[]'::jsonb;
+  v_game_state     jsonb := '[]'::jsonb;
+  v_sg_hidden      boolean := false;
+  v_sg_reason      text;
+BEGIN
+  -- ---------- auth gate (mirrors v3 / sibling RPCs) ----------
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_window_start := v_now - make_interval(hours => v_hours);
+
+  -- ---------- bucket size (adapts to window length) ----------
+  v_bucket_secs := CASE
+    WHEN v_hours <=  24 THEN  900   -- 15 min
+    WHEN v_hours <=  72 THEN 3600   --  1 hr
+    WHEN v_hours <= 168 THEN 7200   --  2 hr
+    WHEN v_hours <= 720 THEN 21600  --  6 hr
+    ELSE 86400                      --  1 day
+  END;
+
+  -- ---------- bridge resolution ----------
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    v_sg_hidden := true;
+    v_sg_reason := 'no_sg_bridge';
+  END IF;
+
+  -- ESPN linkage (always attempt — annotations may render even when SG is hidden)
+  SELECT ex.espn_event_id, ex.espn_league
+  INTO v_espn_event_id, v_espn_league
+  FROM public.event_xref ex
+  WHERE ex.tevo_event_id = p_event_id LIMIT 1;
+
+  -- Auto-resolve home/away team IDs if not supplied by FE.
+  -- Prefer espn_event_date_lookup (populated for forward-look events) over
+  -- espn_event_snapshots (gameday-scope only per §10 drift watchlist).
+  IF (v_home_team IS NULL OR v_away_team IS NULL) AND v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id
+    INTO v_home_team, v_away_team
+    FROM public.espn_event_date_lookup
+    WHERE espn_event_id = v_espn_event_id LIMIT 1;
+
+    -- Snapshot fallback for past games where date_lookup is sparse
+    IF v_home_team IS NULL OR v_away_team IS NULL THEN
+      SELECT home_team_id, away_team_id
+      INTO v_home_team, v_away_team
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+      ORDER BY captured_at DESC LIMIT 1;
+    END IF;
+  END IF;
+
+  -- ---------- SG listings series (DISTINCT ON sglid, then bucket) ----------
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sglid)
+        sglid, captured_at, broadcast_price, quantity, is_broker_owned
+      FROM public.seatgeek_listings_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+      ORDER BY sglid, captured_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), captured_at, '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price, quantity, is_broker_owned
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p_owned) ORDER BY bucket) FILTER (WHERE median_p_owned IS NOT NULL), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', total_qty) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_listings, v_sg_listings_own, v_sg_listings_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) FILTER (WHERE is_broker_owned) AS median_p_owned,
+        SUM(quantity)::int AS total_qty
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- SG sales series (DISTINCT ON sg_sale_id, then bucket on sale_at_utc) ----------
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, sale_at_utc, pulled_at, broadcast_price, quantity
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND coalesce(sale_at_utc, pulled_at) > v_window_start
+        AND coalesce(sale_at_utc, pulled_at) <= v_now
+      ORDER BY sg_sale_id, pulled_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), coalesce(sale_at_utc, pulled_at), '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', sale_ct) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_sales, v_sg_sales_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        count(*)::int AS sale_ct
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- ESPN injury transitions (LAG per stable athlete identity, both teams) ----------
+  -- espn_team_id is NOT globally unique across leagues — e.g. id="28" maps to
+  -- MLB Atlanta Braves AND an NHL team. ALWAYS scope by espn_league so cross-
+  -- league fan-out doesn't surface unrelated injuries on a sport-specific chart.
+  --
+  -- ATHLETE PARTITION (changed 2026-05-19 — Arias notification flood fix):
+  -- partition by stable identity (league + team + normalized name) instead of
+  -- the raw athlete_id, which ESPN returns as a fresh negative provisional id
+  -- per poll for athletes without a stable upstream id. Falls back to
+  -- athlete_id when name is NULL.
+  IF (v_home_team IS NOT NULL OR v_away_team IS NOT NULL) AND v_espn_league IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_team_id, athlete_id, athlete_name, position, status,
+        LAG(status) OVER (
+          PARTITION BY espn_league, espn_team_id,
+                       lower(btrim(coalesce(athlete_name, athlete_id, '')))
+          ORDER BY captured_at
+        ) AS prev_status
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id IN (v_home_team, v_away_team)
+        AND espn_team_id IS NOT NULL
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',            to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'athlete_id',    athlete_id,
+             'athlete_name',  athlete_name,
+             'position',      position,
+             'espn_team_id',  espn_team_id,
+             'prev_status',   prev_status,
+             'new_status',    status
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_injuries
+    FROM ordered
+    WHERE status IS DISTINCT FROM prev_status;  -- transitions only (including first-seen NULL→X)
+  END IF;
+
+  -- ---------- ESPN game-state transitions (LAG on status_short, this event) ----------
+  IF v_espn_event_id IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_event_id, status_short, state,
+        LAG(status_short) OVER (PARTITION BY espn_event_id ORDER BY captured_at) AS prev_status
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+        AND (v_espn_league IS NULL OR espn_league = v_espn_league)
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',             to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'espn_event_id',  espn_event_id,
+             'prev_status',    prev_status,
+             'new_status',     status_short,
+             'state',          state
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_game_state
+    FROM ordered
+    WHERE status_short IS DISTINCT FROM prev_status;
+  END IF;
+
+  -- ---------- assemble ----------
+  RETURN jsonb_build_object(
+    'tevo_event_id',  p_event_id,
+    'sg_event_id',    v_sg_event_id,
+    'espn_event_id',  v_espn_event_id,
+    'espn_league',    v_espn_league,
+    'home_team_id',   v_home_team,
+    'away_team_id',   v_away_team,
+    'range', jsonb_build_object(
+      'start',  to_char(v_window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'end',    to_char(v_now          AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'hours',  v_hours,
+      'bucket_seconds', v_bucket_secs
+    ),
+    'sg_hidden', v_sg_hidden,
+    'sg_reason', v_sg_reason,
+    'series', jsonb_build_object(
+      'sg_listings_median',       v_sg_listings,
+      'sg_listings_owned_median', v_sg_listings_own,
+      'sg_listings_count',        v_sg_listings_ct,
+      'sg_sales_median',          v_sg_sales,
+      'sg_sales_count',           v_sg_sales_ct
+    ),
+    'annotations', jsonb_build_object(
+      'injuries',   v_injuries,
+      'game_state', v_game_state
+    )
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) IS
+  'D0 event chart extension — 5 SG-side series (listings median + owned median + listings count + sales median + sales count) over adaptive buckets (15min..1d depending on p_chart_hours) + 2 ESPN annotation arrays (injury transitions LAG(status) per stable athlete identity on both teams + game-state transitions LAG(status_short) per espn_event_id). Athlete partition keyed on (espn_league, espn_team_id, lower(btrim(coalesce(athlete_name, athlete_id)))) to defend against ESPN provisional negative athlete_ids (Arias incident, fix mig 20260520220000). DISTINCT ON sg_sale_id|sglid mandatory (§3 landmine). Bridge via seatgeek_event_xref; ESPN via event_xref. Email-gated.';
+
+-- ============================================================
+-- Post-apply verification (operator runs after apply_migration)
+-- ============================================================
+-- 1) Buggy partition gone:
+--    SELECT pg_get_functiondef(p.oid) !~ 'PARTITION BY athlete_id\s+ORDER' AS fixed
+--    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+--    WHERE n.nspname='public' AND p.proname='get_event_chart_extended';
+--
+-- 2) Arias collapses to 1 transition (in 168h window):
+--    WITH ordered AS (
+--      SELECT captured_at, athlete_name, status,
+--             LAG(status) OVER (PARTITION BY espn_league, espn_team_id,
+--                               lower(btrim(coalesce(athlete_name, athlete_id, '')))
+--                               ORDER BY captured_at) AS prev_status
+--      FROM public.espn_injuries_snapshots
+--      WHERE espn_league='MLB' AND espn_team_id='5'
+--        AND captured_at > now() - interval '168 hours'
+--    )
+--    SELECT athlete_name, count(*) AS rows,
+--           count(*) FILTER (WHERE status IS DISTINCT FROM prev_status) AS transitions
+--    FROM ordered WHERE athlete_name='Gabriel Arias' GROUP BY 1;
+--
+-- 3) Live RPC smoke (replace <tevo_event_id> with Cleveland @ Phillies id):
+--    SELECT jsonb_array_length(
+--      public.get_event_chart_extended(<tevo_event_id>, 168) -> 'annotations' -> 'injuries'
+--    ) AS injury_marker_count;
+--    -- Expect a few dozen across both rosters, not 200+.


### PR DESCRIPTION
## Status: ALL APPLIED TO PROD ✅

5 migrations + 1 idiom hotfix applied 2026-05-18 between ~17:00 and ~17:25 UTC. Operator-approved each.

Consolidates work from PR #260 (Arias chart partition fix, superseded — closed).

## Results

**Security advisors**: 13 ERRORs → **1 ERROR** (only deferred `v_event_full_sports` remains)
**Performance advisors**: 15 WARNs → **5 WARNs** (10 `auth_rls_initplan` cleared)
**Arias notification flood**: 185 markers → **1 marker** per athlete on the Cleveland @ Phillies chart.

## Migrations (in applied order)

| # | Name | Effect |
|---|---|---|
| 1 | `cron_policy_collect_listings_backfill` | 5 rows added; gate stops emitting `fire_no_policy` for `collect-listings-*` |
| 2 | `c1_d0_read_initplan_fix` | 10 `d0_s4kent_read` policies recreated with `(select auth.jwt())` wrapper |
| 3 | `security_secdef_guard_retrofit_3_fns` | §6 guard + `REVOKE FROM PUBLIC,anon,authenticated` on `_health_check_pg_net_errors`, `refresh_sg_broker_sales_event_metrics`, `sg_seller_orders_queue` |
| 4 | `c1_security_invoker_views_phase_a` | 12 views flipped to `security_invoker = on` |
| 5 (fixup) | `c1_d0_read_initplan_fix_v2` | Idiom hotfix: advisor matches `(select auth.jwt())->>'email'`, NOT `(select auth.jwt()->>'email')` |
| 6 | `fix_get_event_chart_injuries_partition` | `get_event_chart_extended` injury partition: `athlete_id` → `(espn_league, espn_team_id, lower(btrim(coalesce(athlete_name, athlete_id))))`. Defends against ESPN provisional negative athlete_ids. Live: Arias 185 rows → 1 transition. |

## Round 1 — KANBAN A1-lane sweep

KANBAN closures:
- B1-NEXT-7 (RLS gap on 3 tables — verified stale, fixed via PR #190)
- B1-NEXT-2 (legacy 7-arg `match_to_aq_event_id` — verified stale)
- B1-NEXT-8 / -29 / -30 (§6 retrofit; -30 was a real `public_exec=TRUE` defense-in-depth bug)
- B1-NEXT-37 (cron_policy backfill — 5 crons, not 4)

`sg_seller_orders_queue_30min` cron fired at 17:02 UTC post-§6-apply → succeeded.

## Round 2 — C1 Supabase Action Center brief

Cluster 1A (12 of 13 view `security_invoker` flips) + Cluster 2 (10 `auth_rls_initplan` WARNs cleared).

Risk-checked before flipping: every base table under all 12 views has SELECT grants + policies for both anon + authenticated. `coworker_readonly` role has SELECT grants but no policies — direct view reads under it now return empty after flip (C1's brief did not enumerate it as a watched consumer).

## Round 3 — Arias chart partition fix (consolidated from PR #260)

Cleveland Guardians @ Phillies chart was painting ~185 duplicate Gabriel Arias "10-Day-IL" markers. Root cause: ESPN returns a fresh negative provisional `athlete_id` per poll (verified: 277 rows for athlete_name='Gabriel Arias', 275 distinct negative ids, 1 distinct name). The existing `PARTITION BY athlete_id` placed every row in its own size-1 window → every row read as a state transition. Fix partitions on stable identity (`espn_league, espn_team_id, lower(btrim(coalesce(athlete_name, athlete_id)))`).

Layer 2 (ingest hardening in `espn-collect` edge fn) flagged via bot_chat 332 for the espn-collect lane owner — separate PR.

## Deferred / blocked

- **`v_event_full_sports` Phase B** — needs operator/B1 decision on `listings_snapshots` policy expansion (the only authed gap among base tables).
- **B1-NEXT-31** — blocked on B1 spec (bot_chat 330). Literal §6 pattern would brick PostgREST-invoked JWT-gated RPCs.
- **Cluster 3** (5 `multiple_permissive_policies` WARNs) — needs per-table USING clause read.
- **Clusters 4/5/6/7/8** — per C1 brief sequencing.
- **B1-NEXT-10** (mig slot collisions, incl. third at `20260515340000`) — risk-check first.
- **B1-NEXT-51** (5 deferred dependabot smoke tests) — separate per-bump PRs.
- **Arias Layer 2** (espn-collect ingest hardening) — bot_chat 332.

## Environmental finding

Supabase preview branches non-functional (main reference branch in `MIGRATIONS_FAILED` since 2026-05-13; new branch hung at `CREATING_PROJECT` with 0 tables). Branch validation per PROJECT_BIBLE workflow recipes is unavailable. Applied direct-to-prod with operator approval.

## Landmine for PROJECT_BIBLE §7

```sql
-- ❌ Wrong (still flags auth_rls_initplan WARN):
USING (coalesce((select auth.jwt()->>'email'), '') LIKE '%@s4kent.com')

-- ✅ Right (clears WARN):
USING (coalesce((select auth.jwt())->>'email', '') LIKE '%@s4kent.com')
```

Advisor matches `auth.<fn>()` at the outer position only when wrapped directly. Wrapping the entire `->>` accessor chain produces an InitPlan in EXPLAIN but doesn't clear the lint.
