### PR TITLE
feat(d0/chart): event-alert markers OFF by default + toggle

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -132,6 +132,9 @@
         <div class="chart-controls">
           <span class="legend" id="chartPriceLegend"></span>
           <span class="velocity-strip" id="velocityChips"></span>
+          <label class="alerts-toggle" title="Show event alert markers on the chart">
+            <input type="checkbox" id="chartPriceAlertsToggle" /> Alerts
+          </label>
           <select id="chartPriceRange" class="range-select" aria-label="Price chart range">
             <option value="6">6h</option>
             <option value="24">24h</option>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -30,6 +30,12 @@
   let _chartExtStateInv   = { payload: undefined };
   // Alerts cached for the price chart's annotation overlay re-renders.
   let _chartExtAlerts = [];
+  // Alerts markers on the price chart are OFF by default (operator request 2026-05-18 —
+  // arbitrage_opportunity fires ~17 alerts per cron tick, stacking to a dark vertical
+  // bar that dominates the chart). Toggle via #chartPriceAlertsToggle; persisted in
+  // localStorage so the preference survives reloads.
+  const _ALERTS_LS_KEY = 'd0_chart_show_alerts';
+  let _showAlerts = (typeof localStorage !== 'undefined' && localStorage.getItem(_ALERTS_LS_KEY) === '1');
   // Legend toggle state (session-scope, shared map — keys are globally unique).
   const _chartVisible = new Map();
   // Per-chart build caches so each tooltip can read its own series at cursor.idx.
@@ -51,6 +57,7 @@
 
     wireRangeSelectorPrice(eventId);
     wireRangeSelectorInv(eventId);
+    wireAlertsToggle();
     wireTabs(eventId);
     wireSalesWindow(eventId);
     // Path-C-only enrichment RPCs fire in parallel — render even when
@@ -148,6 +155,18 @@
       // Then fetch fresh SG series for the new window — re-renders on arrival
       loadChartExtended('price', eventId, _chartPriceHours)
         .catch(e => console.error('[chartExt price]', e));
+    });
+  }
+
+  function wireAlertsToggle() {
+    const cb = document.getElementById('chartPriceAlertsToggle');
+    if (!cb) return;
+    cb.checked = _showAlerts;
+    cb.addEventListener('change', () => {
+      _showAlerts = !!cb.checked;
+      try { localStorage.setItem(_ALERTS_LS_KEY, _showAlerts ? '1' : '0'); } catch (_) {}
+      const inst = _chartInstances.price;
+      if (inst && typeof inst.redraw === 'function') inst.redraw(false, true);
     });
   }
 
@@ -587,7 +606,9 @@
       ],
       hooks: {
         draw: [
-          (u) => drawAlertsMarkers(u, alerts || []),
+          // Read _showAlerts at draw time so the toggle takes effect via redraw()
+          // without rebuilding the chart instance.
+          (u) => drawAlertsMarkers(u, _showAlerts ? (_chartExtAlerts || []) : []),
           (u) => drawInjuryMarkers(u, ext && ext.annotations && ext.annotations.injuries),
           (u) => drawGameStateMarkers(u, ext && ext.annotations && ext.annotations.game_state),
         ],

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1077,6 +1077,14 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 }
 .range-select:focus { outline: none; border-color: var(--accent); }
 
+/* Alerts toggle inside price chart controls — off by default per operator 2026-05-18 */
+.alerts-toggle {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: 11px; color: var(--muted);
+  cursor: pointer; user-select: none;
+}
+.alerts-toggle input[type="checkbox"] { cursor: pointer; }
+
 /* Splits panel */
 #splits .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
 .splits-tbl { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 12px; }


### PR DESCRIPTION
## Summary

Event-alert markers on the price chart are now **OFF by default** with a checkbox toggle in `.chart-controls` to re-enable. Preference persisted in `localStorage` (`d0_chart_show_alerts` = `'0'`/`'1'`).

## Why

`drawAlertsMarkers` paints one full-height vertical line per `event_alerts` row at its `fired_at` timestamp. The `arbitrage_opportunity` rule fires one row per arb'd section per cron tick — verified ~17 alerts/fire on the Cleveland @ Phillies May 22 event today. Since all 17 share the same `fired_at`, they stack on the same x-pixel and the 35% alpha compounds into a dark vertical bar that dominates the chart.

## What

FE-only, no DB/RPC changes:

**`static/terminal/event.html`** (price chart's `.chart-controls`):
```html
<label class="alerts-toggle" title="Show event alert markers on the chart">
  <input type="checkbox" id="chartPriceAlertsToggle" /> Alerts
</label>
```

**`static/terminal/event.js`**:
- Module-level `_showAlerts` (initial value from `localStorage`, default `false`).
- Draw hook reads `_showAlerts ? (_chartExtAlerts || []) : []` at draw time instead of closure-capturing the `alerts` param, so the toggle takes effect via `uPlot.redraw()` without rebuilding the chart instance.
- New `wireAlertsToggle()` wired in `init()` alongside the range selectors. On change: flip flag, persist to `localStorage`, redraw price chart.

**`static/terminal/style.css`**: 6 lines of `.alerts-toggle` styling to match the `.range-select` look.

## Behavior

- First visit: alerts hidden. Triangle + vertical line markers do not draw.
- Tick the checkbox: markers render immediately (next `redraw()` cycle, < 1 frame).
- Untick: markers vanish; choice persists across reloads and across event pages.
- Inventory chart: unaffected (alerts were only painted on the price chart).
- Injury (pink `+`) and game-state (teal square) annotations: unchanged.
- The Event Alerts list panel below the chart is unaffected — alerts still show there.

## Test plan

- [ ] Load any event page; chart renders without the heavy vertical bars from arb-cron fires.
- [ ] Tick the Alerts checkbox; vertical lines appear at each `fired_at`.
- [ ] Reload the page; checkbox state persists.
- [ ] Untick + reload; markers stay hidden.

## Not in scope (follow-up options if user wants further reduction)

- Dedupe alerts by `fired_at` so 17 stacked alerts paint as ONE line (regardless of toggle).
- Severity filter — only `medium`/`high`/`critical` paint; collapse `info` to the panel.
- Server-side: change `arbitrage_opportunity` to emit one summary row per fire with sections in payload, instead of 17 rows per fire.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_