### PR TITLE
feat(d1/event): quick-pricing rollup — from-price by quantity + by section

### DIFF
--- a/static/store/event.html
+++ b/static/store/event.html
@@ -102,6 +102,18 @@
           </button>
         </nav>
 
+        <!-- Quick pricing: "at-a-glance" view of what's available by
+             quantity-bucket (1 / 2 / 3 / 4 / 5+) and by section. Computed
+             client-side from the same listings the server returns — no
+             extra fetch, no broker-internal fields. Re-renders whenever
+             renderListings() runs so filter changes update the rollup.
+             Hidden when the seats list is empty (parking tab also leaves
+             this strip hidden). -->
+        <aside id="quickPricing" class="quick-pricing" hidden aria-label="Quick pricing">
+          <div id="qpBuckets" class="qp-buckets" role="group" aria-label="From-price by quantity"></div>
+          <div id="qpSections" class="qp-sections" hidden aria-label="By section"></div>
+        </aside>
+
         <!-- Inline filters drive the page view AND the share URL. URL is the
              source of truth: every change updates ?zones=&section=&min_price=
              &max_price=&min_qty= via replaceState and re-fetches the listings.

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -1038,10 +1038,131 @@
     }
     listEl.addEventListener("click", onReserveDelegatedClick);
 
+    // ---- Quick pricing rollup (from-price by quantity + by section) ----
+    // Computed client-side from the same listings array the server returns.
+    // No new fetch, no broker-internal fields. Re-runs from renderListings()
+    // so filter changes update the rollup. Buckets a listing into every
+    // quantity tier its `splits` array exposes (TEvo ticket_groups.splits is
+    // the allowed split sizes; absent → fall back to available_quantity).
+    function _qpBucketFor(n) {
+      if (n === 1) return "singles";
+      if (n === 2) return "pairs";
+      if (n === 3) return "triples";
+      if (n === 4) return "quads";
+      if (n >= 5) return "five_plus";
+      return null;
+    }
+    function _qpBucketsFromListing(l) {
+      const fromSplits = Array.isArray(l.splits) && l.splits.length
+        ? l.splits
+        : [Number(l.available_quantity || 0)];
+      const set = new Set();
+      fromSplits.forEach((s) => {
+        const b = _qpBucketFor(Number(s) || 0);
+        if (b) set.add(b);
+      });
+      return Array.from(set);
+    }
+    function renderQuickPricing(listings) {
+      const host = $("#quickPricing");
+      const bucketsHost = $("#qpBuckets");
+      const sectionsHost = $("#qpSections");
+      if (!host || !bucketsHost || !sectionsHost) return;
+      bucketsHost.replaceChildren();
+      sectionsHost.replaceChildren();
+      if (!listings || !listings.length) {
+        host.hidden = true;
+        return;
+      }
+
+      // Quantity buckets: groups offering + min retail_price for each.
+      const order = ["singles", "pairs", "triples", "quads", "five_plus"];
+      const labels = { singles: "1", pairs: "2", triples: "3", quads: "4", five_plus: "5+" };
+      const agg = {};
+      order.forEach((b) => { agg[b] = { groups: 0, min_price: null }; });
+      for (const l of listings) {
+        const px = Number(l.retail_price);
+        if (!Number.isFinite(px) || px <= 0) continue;
+        for (const b of _qpBucketsFromListing(l)) {
+          agg[b].groups += 1;
+          if (agg[b].min_price == null || px < agg[b].min_price) agg[b].min_price = px;
+        }
+      }
+      const anyBucket = order.some((b) => agg[b].groups > 0);
+      if (anyBucket) {
+        order.forEach((b) => {
+          const cell = document.createElement("div");
+          cell.className = "qp-bucket";
+          if (!agg[b].groups) cell.classList.add("empty");
+          const qty = document.createElement("div");
+          qty.className = "qp-qty";
+          qty.textContent = labels[b];
+          const price = document.createElement("div");
+          price.className = "qp-price";
+          price.textContent = agg[b].min_price != null ? `from ${fmtMoney(agg[b].min_price)}` : "—";
+          const grp = document.createElement("div");
+          grp.className = "qp-meta muted";
+          grp.textContent = agg[b].groups
+            ? `${agg[b].groups} listing${agg[b].groups === 1 ? "" : "s"}`
+            : "none";
+          cell.append(qty, price, grp);
+          bucketsHost.append(cell);
+        });
+      }
+
+      // Section rollup: top 10 sections by listings count.
+      const bySection = new Map();
+      for (const l of listings) {
+        const sec = (l.section == null || l.section === "") ? "—" : String(l.section);
+        const px = Number(l.retail_price);
+        const tix = Number(l.available_quantity) || 0;
+        const cur = bySection.get(sec) || { section: sec, listings: 0, tickets: 0, min_price: null };
+        cur.listings += 1;
+        cur.tickets += tix;
+        if (Number.isFinite(px) && px > 0 && (cur.min_price == null || px < cur.min_price)) {
+          cur.min_price = px;
+        }
+        bySection.set(sec, cur);
+      }
+      const top = Array.from(bySection.values())
+        .sort((a, b) => b.listings - a.listings || (a.min_price ?? Infinity) - (b.min_price ?? Infinity))
+        .slice(0, 10);
+      if (top.length > 1) {
+        const hdr = document.createElement("div");
+        hdr.className = "qp-sections-hdr muted";
+        hdr.textContent = `By section · top ${top.length}`;
+        sectionsHost.append(hdr);
+        const ul = document.createElement("ul");
+        ul.className = "qp-sec-list";
+        top.forEach((r) => {
+          const li = document.createElement("li");
+          li.className = "qp-sec";
+          const name = document.createElement("span");
+          name.className = "qp-sec-name";
+          name.textContent = `Sec ${r.section}`;
+          const meta = document.createElement("span");
+          meta.className = "qp-sec-meta muted";
+          meta.textContent = `${r.listings} · ${r.tickets} tix`;
+          const price = document.createElement("span");
+          price.className = "qp-sec-price";
+          price.textContent = r.min_price != null ? `from ${fmtMoney(r.min_price)}` : "—";
+          li.append(name, meta, price);
+          ul.append(li);
+        });
+        sectionsHost.append(ul);
+        sectionsHost.hidden = false;
+      } else {
+        sectionsHost.hidden = true;
+      }
+
+      host.hidden = !(anyBucket || top.length > 1);
+    }
+
     // ---- Listings rendering (server already filtered) ----
     function renderListings() {
       listCount.textContent = `${allListings.length}`;
       listEl.replaceChildren();
+      renderQuickPricing(allListings);
       if (!allListings.length) {
         noListings.hidden = false;
         return;
@@ -1223,6 +1344,9 @@
           // only on the Seats tab; parking list flips inverse.
           if (filterBar) filterBar.hidden = !seats;
           $("#listings").hidden = !seats;
+          const qp = $("#quickPricing");
+          if (qp && !seats) qp.hidden = true;
+          else if (qp && seats) renderQuickPricing(allListings);
           const noMatch = $("#noListings");
           if (noMatch && !seats) noMatch.hidden = true;
           parkUl.hidden = seats;

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -491,6 +491,85 @@ a { color: inherit; }
 /* Parking-list rows reuse .row styles but trim some seat-only ornaments. */
 .parking-list .parking-row { /* same .row grid; no overrides needed today */ }
 
+/* ----- Quick pricing rollup (event detail, between tabs and filter bar) -----
+   Computed client-side from the listings array. Two stacked blocks:
+     1. .qp-buckets — 5-cell row of from-price by quantity (1/2/3/4/5+).
+     2. .qp-sections — top-10 sections by listings count + from-price.
+   Hidden by JS when there's no seat data or the Parking tab is active. */
+.quick-pricing {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.qp-buckets {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+}
+.qp-bucket {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 8px 6px;
+  text-align: center;
+  background: rgba(255,255,255,0.015);
+}
+.qp-bucket.empty { opacity: 0.45; }
+.qp-bucket .qp-qty {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 2px;
+}
+.qp-bucket .qp-price {
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--accent-2);
+  line-height: 1.1;
+}
+.qp-bucket.empty .qp-price { color: var(--muted); font-weight: 600; }
+.qp-bucket .qp-meta { font-size: 11px; margin-top: 2px; }
+
+.qp-sections-hdr {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.qp-sec-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.qp-sec {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255,255,255,0.02);
+  font-size: 12px;
+}
+.qp-sec-name { font-weight: 700; }
+.qp-sec-meta { font-size: 11px; }
+.qp-sec-price { color: var(--accent-2); font-weight: 700; }
+
+/* Narrow viewports: collapse the 5-cell bucket row into 2 columns so the
+   "from $X" price stays readable. Mirrors the catalog responsive break. */
+@media (max-width: 560px) {
+  .qp-buckets { grid-template-columns: repeat(3, 1fr); }
+  .qp-bucket .qp-price { font-size: 14px; }
+}
+
 /* Inline filter-bar error pill — surfaces when applyFiltersAndFetch
    catches. Mirrors search-dropdown error tone so the bad-state vocabulary
    is consistent. Per D1 UX audit 2026-05-12 fix #5. */


### PR DESCRIPTION
## Summary

D0-pattern borrow #1 of N. Surfaces an "at-a-glance" pricing strip on `/store/event/{id}` so a shopper sees from-price by quantity and by section without scrolling the listings list.

**No backend change.** Pure client-side derivation from the listings array `/api/store/events/{id}` already returns. Live TEvo `/v9/ticket_groups` pull is unchanged.

## What it looks like

Between the Seats/Parking tabs and the filter bar:

```
┌──────────────────────────────────────────────────────────────────┐
│  ┌────────┬────────┬────────┬────────┬─────────┐                  │
│  │   1    │   2    │   3    │   4    │   5+    │   ← qp-buckets   │
│  │ from   │ from   │   —    │ from   │ from    │                  │
│  │ $150   │ $145   │        │ $135   │ $120    │                  │
│  │12 list.│28 list.│  none  │14 list.│ 8 list. │                  │
│  └────────┴────────┴────────┴────────┴─────────┘                  │
│                                                                    │
│  BY SECTION · TOP 10                          ← qp-sections        │
│  [Sec 117 · 5 · 14 tix · from $185]                                │
│  [Sec 224 · 3 · 8 tix · from $90]                                  │
│  [Sec 308 · 3 · 6 tix · from $75]   ...                            │
└──────────────────────────────────────────────────────────────────┘
```

Both blocks re-render from `renderListings()` so filter changes (zone, section, min/max price, min_qty) update the rollup in lockstep. Parking tab hides the strip — parking doesn't bucket meaningfully.

## Source pattern

Borrowed visual structure from `static/terminal/event.js` `buildTevoSplitsTable` (line 943) + `buildTevoZonesTable` (line 1052), trimmed to storefront-safe fields:

- ❌ Dropped: "ours vs market" split, broker deltas, wholesale references, owned_share, owned_listings, market median deltas
- ✅ Kept: from-price by qty bucket, listings count, section roll-up

The data shown is whatever the user can already see one click deeper into the listings list — this just surfaces it without scrolling.

## Files touched

D1 lane only (`static/store/*`):

```
 static/store/event.html  | +12 lines   new <aside id="quickPricing"> container
 static/store/store.js    | +124 lines  renderQuickPricing() + bucket helpers
 static/store/style.css   | +79 lines   .quick-pricing / .qp-buckets / .qp-sec
```

## Bucket logic

Each TEvo ticket group's `splits` array (allowed split sizes) is walked once; the listing contributes to every bucket it can be split into. `splits` empty → fall back to `available_quantity`. Bucket from-price is `min(retail_price)` across listings offering that bucket.

```js
function _qpBucketFor(n) {
  if (n === 1) return 'singles';
  if (n === 2) return 'pairs';
  if (n === 3) return 'triples';
  if (n === 4) return 'quads';
  if (n >= 5) return 'five_plus';
  return null;
}
```

Section rollup: `groupBy(section)`, top 10 by listings count, tie-break by from-price ascending.

## Test plan

- [x] `node --check static/store/store.js` clean
- [x] `git diff` shows D1 lane only (no app.py, no migrations)
- [ ] Pytest in CI
- [ ] Manual smoke after merge: load `/store/event/{id}` on a multi-section event, verify (a) buckets reflect the splits-array shape of returned ticket groups, (b) section chips refresh when applying zone/price filters, (c) Parking tab toggle hides the strip cleanly
- [ ] Regression check: empty-listings state (filters that match nothing) hides the whole `<aside>` instead of showing an empty pricing row

## Coordination

- D1 lane only; no cross-lane writes
- Companion to PR #264 (the LANE_DISCIPLINE.md `we_own`/`owned_tix` carveout). This PR doesn't use any of those carved-out fields — the data here is per-listing pricing, not aggregate inventory position
- Sign-off pause active through 2026-05-22 (bot_chat 170) → ships under CI gate alone


---
_Generated by [Claude Code](https://claude.ai/code/session_01YTqt7DDgLwBvhjcwqGgVsX)_