### PR TITLE
fix(d1/store): 20s fetch timeout in api() — kill infinite-spinner stall

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -43,7 +43,33 @@
   }
 
   async function api(path, init) {
-    const r = await fetch(path, init);
+    // 20s default timeout via AbortController. Was unbounded — when the
+    // backend or network stalled (Render free-tier cold-start dragging
+    // past 30s, supabase latency spike, transient connection hang), the
+    // promise never resolved and the UI sat on "Loading…" indefinitely.
+    // loadCatalog's PR #141 loadComplete gate compounds the symptom: the
+    // spinner stays until either then() or catch() fires. With the
+    // timeout, a stall surfaces an AbortError through the existing catch
+    // path → user sees the Retry button instead of an infinite spinner.
+    // Per-call override: pass `init.timeout` in ms.
+    const userInit = init || {};
+    const timeoutMs = Number.isFinite(userInit.timeout) ? userInit.timeout : 20000;
+    const controller = new AbortController();
+    const fetchInit = { ...userInit, signal: userInit.signal || controller.signal };
+    delete fetchInit.timeout;
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let r;
+    try {
+      r = await fetch(path, fetchInit);
+    } catch (e) {
+      clearTimeout(timer);
+      if (e && (e.name === "AbortError" || e.code === 20)) {
+        const tag = String(path).split("?")[0].replace(/^\/api\/store\//, "");
+        throw new Error(`timeout ${tag}: server didn't respond within ${Math.round(timeoutMs / 1000)}s`);
+      }
+      throw e;
+    }
+    clearTimeout(timer);
     if (!r.ok) {
       const body = await r.text();
       let msg = body;


### PR DESCRIPTION
## Symptom

Operator reported `/store` stuck on "Loading available events…" with the progress bar still active, no error / Retry surfaced, search bar typing accepted but unresponsive. Screenshot: search input has `knicks`, status pill says "Loading available events…", no grid, no error.

## Root cause

`api()` (`static/store/store.js:45`) called `fetch()` with **no timeout**. When the network or backend stalls (Render dyno restart mid-request, slow LEM matview, transient connection hang), the promise never resolves AND never rejects — so the existing `.catch()` path that surfaces the Retry button is never reached.

PR #141's `loadComplete` gate compounds the symptom on purpose: the spinner deliberately stays visible until either `.then()` or `.catch()` fires. Without a timeout, "neither fires" is a stable state.

## Fix

Wrap `fetch()` in an AbortController with a 20s default timeout (generous — even Render free-tier cold starts complete in 12-15s). Per-call override via `init.timeout` in ms.

On timeout: AbortError → tagged message → existing catch path → Retry button:

```
timeout home: server didn't respond within 20s
[Retry]
```

Same UX the catch path already renders for HTTP errors. Endpoint tag preserved for the debugger's quick scan.

## Verification

Data path is **healthy** server-side (probed via Supabase MCP just now):

- `latest_event_metrics`: 385 owned rows · 204 fresh in last 24h · latest captured 21:21 UTC
- `events` table: 283 future events with owned inventory

So this isn't a data problem — purely a client-side resilience fix that should have been there from the start. If the request was hanging because of a Render-side issue, the Retry button gives the user a recovery path and tells them where (`home`) it died.

## Diff

```
 static/store/store.js | 28 +++++++++++++++++++++++++++-
 1 file changed, 27 insertions(+), 1 deletion(-)
```

Pure D1 lane. No backend change. Live TEvo `/v9/ticket_groups` pull on event-detail unaffected (different code path; hits `app.py` server-side, not `api()`).

## Test plan

- [x] `node --check static/store/store.js` clean
- [ ] CI: pytest
- [ ] Manual smoke after merge:
  - [ ] Hard-refresh `/store` cold — verify catalog still loads on the happy path
  - [ ] DevTools network → throttle to "Offline" → reload `/store` — verify Retry button appears within ~20s with `timeout home:` message
  - [ ] Click Retry — verify it re-fires the request and recovers on next pass
  - [ ] DevTools network → throttle to "Slow 3G" → reload — verify normal recovery (under 20s budget)

## Coordination

- D1 lane only
- Companion-but-independent of PR #264 (carveout doc) and PR #265 (quick-pricing). All three can land in any order; no merge dependencies
- Sign-off pause active through 2026-05-22 (bot_chat 170) → ships under CI gate alone


---
_Generated by [Claude Code](https://claude.ai/code/session_01YTqt7DDgLwBvhjcwqGgVsX)_