### PR TITLE
chore(a1): consolidate blindspot tracker + sales rewire + matcher + d0/d1 fixes

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -52,7 +52,6 @@
 | B1-NEXT-5 | B1 | Vault orphans check — `release_health_check()` row for `get_app_secret` allowlist entries unused by any prod fn/cron/edge-fn. | 1 SQL migration adding a new row to `release_health_check()` |
 | B1-NEXT-18 | Op | Verify Actions secrets populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`). | Operator confirms next session via Settings → Secrets |
 | B1-NEXT-31 | A1 | §6 body guard absent on 7 JWT-gated SECDEF RPCs: `get_broker_event_page` (v1/v2/v3), `get_event_sg_listings_full`, `get_event_evo_listings_full`, `get_event_sg_sales_full`, `get_event_cross_source_metrics`. JWT body check IS primary mitigation; guard is 2nd belt. **BLOCKED on spec clarification** — literal §6 `current_user NOT IN (service_role, postgres, supabase_admin)` would brick these (anon/authenticated callers via PostgREST). bot_chat question pending B1 response. | Wait for B1 spec; verified `public_exec=false` already in place on all 7 |
-| B1-NEXT-39 | D0 + D1 | `/api/store/search` exposes `we_own` (bool) + `owned_tix` (count). LANE_DISCIPLINE.md §D1 wall rule lists `is_owned` as forbidden. May be intentional storefront-product behavior. bot_chat 308. | If intentional: add carveout to LANE_DISCIPLINE.md §D1. If not: filter columns from `/api/store/search` response in `app.py` |
 
 ### SEC-LOW (hygiene)
 

--- a/LANE_DISCIPLINE.md
+++ b/LANE_DISCIPLINE.md
@@ -161,10 +161,20 @@ D0 has full workspace-wide Render permissions, parity with A1. All `mcp__render_
 **Must filter from any client response:**
 - `wholesale_price`, `wholesale_min`, `wholesale_*`
 - `brokerage_id`, `brokerage_name`, `office_id`, `office_name`
-- `is_owned`, `is_ancillary` provenance flags that reveal S4K's inventory position
+- `is_owned`, `is_ancillary` provenance flags that reveal S4K's inventory position (see storefront carveout below)
 - TEvo signing tokens, API tokens, secrets from vault
 - Raw broker_* table rows
 - Any column not whitelisted by a `*_public` RPC
+
+**Storefront-product carveout (`/api/store/*` only, codified 2026-05-18 from B1 war-games W-3 / bot_chat 308):**
+
+The storefront is a "100% we-own catalog" by product design — every event surfaced is one S4K holds inventory for, with no "browse market" fallthrough (see `store_events()` docstring in `app.py`). Under this model the following fields are **intentionally exposed** on `/api/store/*` responses and power the retail availability UX ("X tix · Y listings" badge in `static/store/store.js`, buyable-vs-browse split):
+
+- `we_own` (bool) — drives result prioritization in `/api/store/search`
+- `owned_tix` / `owned_tickets_count` (int) — inventory-availability count
+- `owned_groups_count` (int) — listings count for the same event
+
+These are retail-availability signals (analogous to "5 tickets left" on any consumer ticket marketplace), not wholesale-side broker flags. The broader `is_owned` / `is_ancillary` rule above still applies to terminal / portfolio / broker API responses where the field carries wholesale-position semantics.
 
 **Filter pattern:** call public-RPC → response only contains retail-safe fields → serialize that to client. Never dump raw broker rows. RULE 7 (retail product = S4K-owned only) applies: listings exposed must be filtered to S4K-owned where applicable.
 

--- a/static/store/event.html
+++ b/static/store/event.html
@@ -102,6 +102,18 @@
           </button>
         </nav>
 
+        <!-- Quick pricing: "at-a-glance" view of what's available by
+             quantity-bucket (1 / 2 / 3 / 4 / 5+) and by section. Computed
+             client-side from the same listings the server returns — no
+             extra fetch, no broker-internal fields. Re-renders whenever
+             renderListings() runs so filter changes update the rollup.
+             Hidden when the seats list is empty (parking tab also leaves
+             this strip hidden). -->
+        <aside id="quickPricing" class="quick-pricing" hidden aria-label="Quick pricing">
+          <div id="qpBuckets" class="qp-buckets" role="group" aria-label="From-price by quantity"></div>
+          <div id="qpSections" class="qp-sections" hidden aria-label="By section"></div>
+        </aside>
+
         <!-- Inline filters drive the page view AND the share URL. URL is the
              source of truth: every change updates ?zones=&section=&min_price=
              &max_price=&min_qty= via replaceState and re-fetches the listings.

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -43,7 +43,33 @@
   }
 
   async function api(path, init) {
-    const r = await fetch(path, init);
+    // 20s default timeout via AbortController. Was unbounded — when the
+    // backend or network stalled (Render free-tier cold-start dragging
+    // past 30s, supabase latency spike, transient connection hang), the
+    // promise never resolved and the UI sat on "Loading…" indefinitely.
+    // loadCatalog's PR #141 loadComplete gate compounds the symptom: the
+    // spinner stays until either then() or catch() fires. With the
+    // timeout, a stall surfaces an AbortError through the existing catch
+    // path → user sees the Retry button instead of an infinite spinner.
+    // Per-call override: pass `init.timeout` in ms.
+    const userInit = init || {};
+    const timeoutMs = Number.isFinite(userInit.timeout) ? userInit.timeout : 20000;
+    const controller = new AbortController();
+    const fetchInit = { ...userInit, signal: userInit.signal || controller.signal };
+    delete fetchInit.timeout;
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let r;
+    try {
+      r = await fetch(path, fetchInit);
+    } catch (e) {
+      clearTimeout(timer);
+      if (e && (e.name === "AbortError" || e.code === 20)) {
+        const tag = String(path).split("?")[0].replace(/^\/api\/store\//, "");
+        throw new Error(`timeout ${tag}: server didn't respond within ${Math.round(timeoutMs / 1000)}s`);
+      }
+      throw e;
+    }
+    clearTimeout(timer);
     if (!r.ok) {
       const body = await r.text();
       let msg = body;

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -1038,10 +1038,131 @@
     }
     listEl.addEventListener("click", onReserveDelegatedClick);
 
+    // ---- Quick pricing rollup (from-price by quantity + by section) ----
+    // Computed client-side from the same listings array the server returns.
+    // No new fetch, no broker-internal fields. Re-runs from renderListings()
+    // so filter changes update the rollup. Buckets a listing into every
+    // quantity tier its `splits` array exposes (TEvo ticket_groups.splits is
+    // the allowed split sizes; absent → fall back to available_quantity).
+    function _qpBucketFor(n) {
+      if (n === 1) return "singles";
+      if (n === 2) return "pairs";
+      if (n === 3) return "triples";
+      if (n === 4) return "quads";
+      if (n >= 5) return "five_plus";
+      return null;
+    }
+    function _qpBucketsFromListing(l) {
+      const fromSplits = Array.isArray(l.splits) && l.splits.length
+        ? l.splits
+        : [Number(l.available_quantity || 0)];
+      const set = new Set();
+      fromSplits.forEach((s) => {
+        const b = _qpBucketFor(Number(s) || 0);
+        if (b) set.add(b);
+      });
+      return Array.from(set);
+    }
+    function renderQuickPricing(listings) {
+      const host = $("#quickPricing");
+      const bucketsHost = $("#qpBuckets");
+      const sectionsHost = $("#qpSections");
+      if (!host || !bucketsHost || !sectionsHost) return;
+      bucketsHost.replaceChildren();
+      sectionsHost.replaceChildren();
+      if (!listings || !listings.length) {
+        host.hidden = true;
+        return;
+      }
+
+      // Quantity buckets: groups offering + min retail_price for each.
+      const order = ["singles", "pairs", "triples", "quads", "five_plus"];
+      const labels = { singles: "1", pairs: "2", triples: "3", quads: "4", five_plus: "5+" };
+      const agg = {};
+      order.forEach((b) => { agg[b] = { groups: 0, min_price: null }; });
+      for (const l of listings) {
+        const px = Number(l.retail_price);
+        if (!Number.isFinite(px) || px <= 0) continue;
+        for (const b of _qpBucketsFromListing(l)) {
+          agg[b].groups += 1;
+          if (agg[b].min_price == null || px < agg[b].min_price) agg[b].min_price = px;
+        }
+      }
+      const anyBucket = order.some((b) => agg[b].groups > 0);
+      if (anyBucket) {
+        order.forEach((b) => {
+          const cell = document.createElement("div");
+          cell.className = "qp-bucket";
+          if (!agg[b].groups) cell.classList.add("empty");
+          const qty = document.createElement("div");
+          qty.className = "qp-qty";
+          qty.textContent = labels[b];
+          const price = document.createElement("div");
+          price.className = "qp-price";
+          price.textContent = agg[b].min_price != null ? `from ${fmtMoney(agg[b].min_price)}` : "—";
+          const grp = document.createElement("div");
+          grp.className = "qp-meta muted";
+          grp.textContent = agg[b].groups
+            ? `${agg[b].groups} listing${agg[b].groups === 1 ? "" : "s"}`
+            : "none";
+          cell.append(qty, price, grp);
+          bucketsHost.append(cell);
+        });
+      }
+
+      // Section rollup: top 10 sections by listings count.
+      const bySection = new Map();
+      for (const l of listings) {
+        const sec = (l.section == null || l.section === "") ? "—" : String(l.section);
+        const px = Number(l.retail_price);
+        const tix = Number(l.available_quantity) || 0;
+        const cur = bySection.get(sec) || { section: sec, listings: 0, tickets: 0, min_price: null };
+        cur.listings += 1;
+        cur.tickets += tix;
+        if (Number.isFinite(px) && px > 0 && (cur.min_price == null || px < cur.min_price)) {
+          cur.min_price = px;
+        }
+        bySection.set(sec, cur);
+      }
+      const top = Array.from(bySection.values())
+        .sort((a, b) => b.listings - a.listings || (a.min_price ?? Infinity) - (b.min_price ?? Infinity))
+        .slice(0, 10);
+      if (top.length > 1) {
+        const hdr = document.createElement("div");
+        hdr.className = "qp-sections-hdr muted";
+        hdr.textContent = `By section · top ${top.length}`;
+        sectionsHost.append(hdr);
+        const ul = document.createElement("ul");
+        ul.className = "qp-sec-list";
+        top.forEach((r) => {
+          const li = document.createElement("li");
+          li.className = "qp-sec";
+          const name = document.createElement("span");
+          name.className = "qp-sec-name";
+          name.textContent = `Sec ${r.section}`;
+          const meta = document.createElement("span");
+          meta.className = "qp-sec-meta muted";
+          meta.textContent = `${r.listings} · ${r.tickets} tix`;
+          const price = document.createElement("span");
+          price.className = "qp-sec-price";
+          price.textContent = r.min_price != null ? `from ${fmtMoney(r.min_price)}` : "—";
+          li.append(name, meta, price);
+          ul.append(li);
+        });
+        sectionsHost.append(ul);
+        sectionsHost.hidden = false;
+      } else {
+        sectionsHost.hidden = true;
+      }
+
+      host.hidden = !(anyBucket || top.length > 1);
+    }
+
     // ---- Listings rendering (server already filtered) ----
     function renderListings() {
       listCount.textContent = `${allListings.length}`;
       listEl.replaceChildren();
+      renderQuickPricing(allListings);
       if (!allListings.length) {
         noListings.hidden = false;
         return;
@@ -1223,6 +1344,9 @@
           // only on the Seats tab; parking list flips inverse.
           if (filterBar) filterBar.hidden = !seats;
           $("#listings").hidden = !seats;
+          const qp = $("#quickPricing");
+          if (qp && !seats) qp.hidden = true;
+          else if (qp && seats) renderQuickPricing(allListings);
           const noMatch = $("#noListings");
           if (noMatch && !seats) noMatch.hidden = true;
           parkUl.hidden = seats;

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -491,6 +491,85 @@ a { color: inherit; }
 /* Parking-list rows reuse .row styles but trim some seat-only ornaments. */
 .parking-list .parking-row { /* same .row grid; no overrides needed today */ }
 
+/* ----- Quick pricing rollup (event detail, between tabs and filter bar) -----
+   Computed client-side from the listings array. Two stacked blocks:
+     1. .qp-buckets — 5-cell row of from-price by quantity (1/2/3/4/5+).
+     2. .qp-sections — top-10 sections by listings count + from-price.
+   Hidden by JS when there's no seat data or the Parking tab is active. */
+.quick-pricing {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.qp-buckets {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+}
+.qp-bucket {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 8px 6px;
+  text-align: center;
+  background: rgba(255,255,255,0.015);
+}
+.qp-bucket.empty { opacity: 0.45; }
+.qp-bucket .qp-qty {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 2px;
+}
+.qp-bucket .qp-price {
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--accent-2);
+  line-height: 1.1;
+}
+.qp-bucket.empty .qp-price { color: var(--muted); font-weight: 600; }
+.qp-bucket .qp-meta { font-size: 11px; margin-top: 2px; }
+
+.qp-sections-hdr {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.qp-sec-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.qp-sec {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255,255,255,0.02);
+  font-size: 12px;
+}
+.qp-sec-name { font-weight: 700; }
+.qp-sec-meta { font-size: 11px; }
+.qp-sec-price { color: var(--accent-2); font-weight: 700; }
+
+/* Narrow viewports: collapse the 5-cell bucket row into 2 columns so the
+   "from $X" price stays readable. Mirrors the catalog responsive break. */
+@media (max-width: 560px) {
+  .qp-buckets { grid-template-columns: repeat(3, 1fr); }
+  .qp-bucket .qp-price { font-size: 14px; }
+}
+
 /* Inline filter-bar error pill — surfaces when applyFiltersAndFetch
    catches. Mirrors search-dropdown error tone so the bad-state vocabulary
    is consistent. Per D1 UX audit 2026-05-12 fix #5. */

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -132,6 +132,9 @@
         <div class="chart-controls">
           <span class="legend" id="chartPriceLegend"></span>
           <span class="velocity-strip" id="velocityChips"></span>
+          <label class="alerts-toggle" title="Show event alert markers on the chart">
+            <input type="checkbox" id="chartPriceAlertsToggle" /> Alerts
+          </label>
           <select id="chartPriceRange" class="range-select" aria-label="Price chart range">
             <option value="6">6h</option>
             <option value="24">24h</option>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -30,6 +30,12 @@
   let _chartExtStateInv   = { payload: undefined };
   // Alerts cached for the price chart's annotation overlay re-renders.
   let _chartExtAlerts = [];
+  // Alerts markers on the price chart are OFF by default (operator request 2026-05-18 —
+  // arbitrage_opportunity fires ~17 alerts per cron tick, stacking to a dark vertical
+  // bar that dominates the chart). Toggle via #chartPriceAlertsToggle; persisted in
+  // localStorage so the preference survives reloads.
+  const _ALERTS_LS_KEY = 'd0_chart_show_alerts';
+  let _showAlerts = (typeof localStorage !== 'undefined' && localStorage.getItem(_ALERTS_LS_KEY) === '1');
   // Legend toggle state (session-scope, shared map — keys are globally unique).
   const _chartVisible = new Map();
   // Per-chart build caches so each tooltip can read its own series at cursor.idx.
@@ -51,6 +57,7 @@
 
     wireRangeSelectorPrice(eventId);
     wireRangeSelectorInv(eventId);
+    wireAlertsToggle();
     wireTabs(eventId);
     wireSalesWindow(eventId);
     // Path-C-only enrichment RPCs fire in parallel — render even when
@@ -148,6 +155,18 @@
       // Then fetch fresh SG series for the new window — re-renders on arrival
       loadChartExtended('price', eventId, _chartPriceHours)
         .catch(e => console.error('[chartExt price]', e));
+    });
+  }
+
+  function wireAlertsToggle() {
+    const cb = document.getElementById('chartPriceAlertsToggle');
+    if (!cb) return;
+    cb.checked = _showAlerts;
+    cb.addEventListener('change', () => {
+      _showAlerts = !!cb.checked;
+      try { localStorage.setItem(_ALERTS_LS_KEY, _showAlerts ? '1' : '0'); } catch (_) {}
+      const inst = _chartInstances.price;
+      if (inst && typeof inst.redraw === 'function') inst.redraw(false, true);
     });
   }
 
@@ -587,7 +606,9 @@
       ],
       hooks: {
         draw: [
-          (u) => drawAlertsMarkers(u, alerts || []),
+          // Read _showAlerts at draw time so the toggle takes effect via redraw()
+          // without rebuilding the chart instance.
+          (u) => drawAlertsMarkers(u, _showAlerts ? (_chartExtAlerts || []) : []),
           (u) => drawInjuryMarkers(u, ext && ext.annotations && ext.annotations.injuries),
           (u) => drawGameStateMarkers(u, ext && ext.annotations && ext.annotations.game_state),
         ],

--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -21,6 +21,8 @@
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
     wireMoversControls();
+    // Blind spots fires its own RPC, independent of /api/broker/movers — runs in parallel.
+    renderBlindSpots().catch(e => console.error('[blindSpots]', e));
     load();
   }
 
@@ -37,7 +39,6 @@
           events.owned_value_winners, events.owned_value_losers,
         ]);
         renderCoverage(state.rows);
-        renderBlindSpots(state.rows);
         renderMovers();
         renderOwnedEvents(state.rows);
       })
@@ -80,62 +81,114 @@
 
   // ---------- Blind spots panel — SG selling, we're not ----------
   //
-  // Filter: sg_sales_window >= BLIND_SPOT_MIN_SG_SALES AND cur_owned_tix == 0.
-  // Operator can't capture revenue on inventory they don't hold; surface the
-  // gap so they can investigate (procure, contact buyer, or list elsewhere).
-  // The window matches the mover window selector — at 24h the chip threshold
-  // is "5 SG sales in 24h"; at 7d it's "5 SG sales in 7d". Threshold 5 is a
-  // tuning placeholder.
+  // Calls get_blind_spots_sg_selling(p_min_score) RPC (mig 20260520370000).
+  // Composite 0-4 score across:
+  //   1. listings shrinking >= 5% over 48h
+  //   2. price rising       >= 10% over 48h
+  //   3. sales accelerating >= 30% (last 24h vs prior 24h)
+  //   4. sales clearing at/above current ask
+  // Surfaces events scoring >= 3/4. Pool: ~3,150 unmatched US SG events
+  // polled at 12h cadence (TRACK_BLINDSPOT tier).
+  //
+  // Replaces the prior heuristic (sg_sales_window >= 5 AND cur_owned_tix == 0
+  // pulled from /api/broker/movers) — that surfaced matched events with SG
+  // activity but doesn't cover the unmatched-US cohort the new tracker targets.
 
-  const BLIND_SPOT_MIN_SG_SALES = 5;
-  const BLIND_SPOT_MAX_ROWS     = 20;
+  const BLIND_SPOT_MIN_SCORE = 3;
+  const BLIND_SPOT_MAX_ROWS  = 20;
 
-  function renderBlindSpots(rows) {
+  async function renderBlindSpots() {
     const body = document.getElementById('blindSpotsBody');
     const countEl = document.getElementById('blindSpotsCount');
     if (!body) return;
-    const candidates = rows
-      .filter(r => (+r.sg_sales_window || 0) >= BLIND_SPOT_MIN_SG_SALES
-                && (+r.cur_owned_tix || 0) === 0)
-      .sort((a, b) => {
-        const sa = +a.sg_sales_window || 0;
-        const sb = +b.sg_sales_window || 0;
-        if (sb !== sa) return sb - sa;
-        return (+b.cur_market_tix || 0) - (+a.cur_market_tix || 0);
-      });
-    const n = candidates.length;
+
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+
+    body.innerHTML = '<div class="empty">loading…</div>';
+
+    let rows;
+    try {
+      const res = await Auth.client.rpc('get_blind_spots_sg_selling',
+        { p_min_score: BLIND_SPOT_MIN_SCORE });
+      if (res.error) throw new Error(res.error.message || 'RPC error');
+      rows = res.data || [];
+    } catch (e) {
+      body.innerHTML = '<div class="empty">error: ' + escapeHtml(e.message) + '</div>';
+      if (countEl) countEl.textContent = '';
+      return;
+    }
+
+    const n = rows.length;
     if (countEl) countEl.textContent = n
       ? `${n} event${n === 1 ? '' : 's'} (showing top ${Math.min(n, BLIND_SPOT_MAX_ROWS)})`
       : '';
+
     if (!n) {
-      body.innerHTML = '<div class="empty">no SG-only sales activity above threshold ✓</div>';
+      body.innerHTML =
+        '<div class="empty">no SG-selling signals at score &ge; ' + BLIND_SPOT_MIN_SCORE +
+        '/4 (48h baseline accumulating)</div>';
       return;
     }
+
     const tbl = document.createElement('table');
     tbl.className = 'blind-spots-tbl';
     tbl.innerHTML = `
       <thead><tr>
-        <th>Event</th><th>Performer</th><th>Venue</th>
+        <th>Event</th><th>Venue</th>
         <th class="num">T-days</th>
-        <th class="num">SG sales</th>
-        <th class="num">Mkt qty</th>
-        <th class="num">Mkt median</th>
+        <th class="num" title="Composite 0-4 across listings drop + price rise + sales accel + sales above ask">Score</th>
+        <th class="num" title="DISTINCT sg_sale_id in last 24h">Sales 24h</th>
+        <th class="num" title="Sales velocity: last 24h vs prior 24h">Vel %</th>
+        <th class="num">Listings</th>
+        <th class="num" title="48h delta on distinct sglid count">L Δ%</th>
+        <th class="num">Med px</th>
+        <th class="num" title="48h delta on median listing price">P Δ%</th>
+        <th class="num" title="Median sale 24h vs current median ask">Sale/Ask</th>
+        <th class="num" title="Sales 24h / Listings now">Clear</th>
       </tr></thead>
       <tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
-    candidates.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
-      const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
+
+    rows.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
+      const d = T.daysUntil(r.sg_datetime_utc);
       const tr = document.createElement('tr');
+
+      // Event cell links to event.html if we have a TEvo bridge, else plain text.
+      const eventLabel = r.tevo_event_id
+        ? `<a href="event.html?event=${r.tevo_event_id}">${escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id))}</a>`
+        : escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id));
+
+      // Score cell — hover reveals which signals are lit.
+      const signalsTitle = [
+        (r.signal_listings_drop  ? '✓' : '✗') + ' listings shrinking ≥ 5%',
+        (r.signal_price_rise     ? '✓' : '✗') + ' price rising ≥ 10%',
+        (r.signal_sales_accel    ? '✓' : '✗') + ' sales accelerating ≥ 30%',
+        (r.signal_sales_above_ask? '✓' : '✗') + ' sales clearing at/above ask'
+      ].join(' · ');
+
+      const pct = v => (v == null ? '—' : T.fmtPct(v));
+      const cls = (cond, on, off) => cond ? on : (off || '');
+
       tr.innerHTML = `
-        <td><a href="event.html?event=${r.event_id}">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
-        <td>${escapeHtml(r.performer_name || '—')}</td>
-        <td>${escapeHtml(r.venue_name || '—')}</td>
+        <td>${eventLabel}</td>
+        <td>${escapeHtml(r.sg_venue_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
-        <td class="num warn">${T.fmtNum(+r.sg_sales_window || 0)}</td>
-        <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>
-        <td class="num">${r.cur_market_med ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>`;
+        <td class="num" title="${signalsTitle}"><strong>${r.selling_score}/4</strong></td>
+        <td class="num">${r.sales_24h_count || 0}</td>
+        <td class="num ${cls(r.sales_velocity_pct > 0, 'pos', r.sales_velocity_pct < 0 ? 'neg' : '')}">${pct(r.sales_velocity_pct)}</td>
+        <td class="num">${r.listings_now}</td>
+        <td class="num ${cls(r.listings_pct_delta < 0, 'neg', r.listings_pct_delta > 0 ? 'pos' : '')}">${pct(r.listings_pct_delta)}</td>
+        <td class="num">${r.median_now ? '$' + T.fmtNum(Math.round(+r.median_now)) : '—'}</td>
+        <td class="num ${cls(r.price_pct_delta > 0, 'pos', r.price_pct_delta < 0 ? 'neg' : '')}">${pct(r.price_pct_delta)}</td>
+        <td class="num ${cls(r.sale_vs_listing_pct > 0, 'pos', r.sale_vs_listing_pct < 0 ? 'neg' : '')}">${pct(r.sale_vs_listing_pct)}</td>
+        <td class="num">${r.clearing_ratio != null ? T.fmtNum(Math.round(r.clearing_ratio * 100)) + '%' : '—'}</td>`;
       tb.appendChild(tr);
     });
+
     body.innerHTML = '';
     body.appendChild(tbl);
   }

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -18,6 +18,8 @@
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
     wireControls();
+    // Blind spots is independent of /api/broker/movers — fires its own RPC.
+    renderBlindSpots().catch(e => console.error('[blindSpots]', e));
     load();
   }
 
@@ -69,63 +71,106 @@
     return Array.from(seen.values());
   }
 
-  // Blind-spot threshold matches home.js — sg_sales >= N AND owned_tix = 0
-  // surfaces inventory we don't hold during active SG demand.
-  const BLIND_SPOT_MIN_SG_SALES = 5;
-  const BLIND_SPOT_MAX_ROWS     = 20;
+  // Blind spots — calls get_blind_spots_sg_selling RPC (mig 20260520370000).
+  // Same RPC + render shape as home.js. See home.js comment block for design.
+  const BLIND_SPOT_MIN_SCORE = 3;
+  const BLIND_SPOT_MAX_ROWS  = 20;
 
-  function renderBlindSpots() {
+  async function renderBlindSpots() {
     const body = document.getElementById('blindSpotsBody');
     const countEl = document.getElementById('blindSpotsCount');
     if (!body) return;
-    const candidates = state.rows
-      .filter(r => (+r.sg_sales_window || 0) >= BLIND_SPOT_MIN_SG_SALES
-                && (+r.cur_owned_tix || 0) === 0)
-      .sort((a, b) => {
-        const sa = +a.sg_sales_window || 0;
-        const sb = +b.sg_sales_window || 0;
-        if (sb !== sa) return sb - sa;
-        return (+b.cur_market_tix || 0) - (+a.cur_market_tix || 0);
-      });
-    const n = candidates.length;
+
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+
+    body.innerHTML = '<div class="empty">loading…</div>';
+
+    let rows;
+    try {
+      const res = await Auth.client.rpc('get_blind_spots_sg_selling',
+        { p_min_score: BLIND_SPOT_MIN_SCORE });
+      if (res.error) throw new Error(res.error.message || 'RPC error');
+      rows = res.data || [];
+    } catch (e) {
+      body.innerHTML = '<div class="empty">error: ' + escapeHtml(e.message) + '</div>';
+      if (countEl) countEl.textContent = '';
+      return;
+    }
+
+    const n = rows.length;
     if (countEl) countEl.textContent = n
       ? `${n} event${n === 1 ? '' : 's'} (showing top ${Math.min(n, BLIND_SPOT_MAX_ROWS)})`
       : '';
+
     if (!n) {
-      body.innerHTML = '<div class="empty">no SG-only sales activity above threshold ✓</div>';
+      body.innerHTML =
+        '<div class="empty">no SG-selling signals at score &ge; ' + BLIND_SPOT_MIN_SCORE +
+        '/4 (48h baseline accumulating)</div>';
       return;
     }
+
     const tbl = document.createElement('table');
     tbl.className = 'blind-spots-tbl';
     tbl.innerHTML = `
       <thead><tr>
-        <th>Event</th><th>Performer</th><th>Venue</th>
+        <th>Event</th><th>Venue</th>
         <th class="num">T-days</th>
-        <th class="num">SG sales</th>
-        <th class="num">Mkt qty</th>
-        <th class="num">Mkt median</th>
+        <th class="num" title="Composite 0-4 across listings drop + price rise + sales accel + sales above ask">Score</th>
+        <th class="num" title="DISTINCT sg_sale_id in last 24h">Sales 24h</th>
+        <th class="num" title="Sales velocity: last 24h vs prior 24h">Vel %</th>
+        <th class="num">Listings</th>
+        <th class="num" title="48h delta on distinct sglid count">L Δ%</th>
+        <th class="num">Med px</th>
+        <th class="num" title="48h delta on median listing price">P Δ%</th>
+        <th class="num" title="Median sale 24h vs current median ask">Sale/Ask</th>
+        <th class="num" title="Sales 24h / Listings now">Clear</th>
       </tr></thead>
       <tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
-    candidates.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
-      const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
+
+    rows.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
+      const d = T.daysUntil(r.sg_datetime_utc);
       const tr = document.createElement('tr');
+
+      const eventLabel = r.tevo_event_id
+        ? `<a href="event.html?event=${r.tevo_event_id}">${escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id))}</a>`
+        : escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id));
+
+      const signalsTitle = [
+        (r.signal_listings_drop  ? '✓' : '✗') + ' listings shrinking ≥ 5%',
+        (r.signal_price_rise     ? '✓' : '✗') + ' price rising ≥ 10%',
+        (r.signal_sales_accel    ? '✓' : '✗') + ' sales accelerating ≥ 30%',
+        (r.signal_sales_above_ask? '✓' : '✗') + ' sales clearing at/above ask'
+      ].join(' · ');
+
+      const pct = v => (v == null ? '—' : T.fmtPct(v));
+      const cls = (cond, on, off) => cond ? on : (off || '');
+
       tr.innerHTML = `
-        <td><a href="event.html?event=${r.event_id}">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
-        <td>${escapeHtml(r.performer_name || '—')}</td>
-        <td>${escapeHtml(r.venue_name || '—')}</td>
+        <td>${eventLabel}</td>
+        <td>${escapeHtml(r.sg_venue_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
-        <td class="num warn">${T.fmtNum(+r.sg_sales_window || 0)}</td>
-        <td class="num">${T.fmtNum(+r.cur_market_tix || 0)}</td>
-        <td class="num">${r.cur_market_med ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>`;
+        <td class="num" title="${signalsTitle}"><strong>${r.selling_score}/4</strong></td>
+        <td class="num">${r.sales_24h_count || 0}</td>
+        <td class="num ${cls(r.sales_velocity_pct > 0, 'pos', r.sales_velocity_pct < 0 ? 'neg' : '')}">${pct(r.sales_velocity_pct)}</td>
+        <td class="num">${r.listings_now}</td>
+        <td class="num ${cls(r.listings_pct_delta < 0, 'neg', r.listings_pct_delta > 0 ? 'pos' : '')}">${pct(r.listings_pct_delta)}</td>
+        <td class="num">${r.median_now ? '$' + T.fmtNum(Math.round(+r.median_now)) : '—'}</td>
+        <td class="num ${cls(r.price_pct_delta > 0, 'pos', r.price_pct_delta < 0 ? 'neg' : '')}">${pct(r.price_pct_delta)}</td>
+        <td class="num ${cls(r.sale_vs_listing_pct > 0, 'pos', r.sale_vs_listing_pct < 0 ? 'neg' : '')}">${pct(r.sale_vs_listing_pct)}</td>
+        <td class="num">${r.clearing_ratio != null ? T.fmtNum(Math.round(r.clearing_ratio * 100)) + '%' : '—'}</td>`;
       tb.appendChild(tr);
     });
+
     body.innerHTML = '';
     body.appendChild(tbl);
   }
 
   function render() {
-    renderBlindSpots();
     const body = document.getElementById('moversBody');
     const filtered = state.segment === 'owned'
       ? state.rows.filter(r => (+r.cur_owned_tix || 0) > 0)

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1077,6 +1077,14 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 }
 .range-select:focus { outline: none; border-color: var(--accent); }
 
+/* Alerts toggle inside price chart controls — off by default per operator 2026-05-18 */
+.alerts-toggle {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: 11px; color: var(--muted);
+  cursor: pointer; user-select: none;
+}
+.alerts-toggle input[type="checkbox"] { cursor: pointer; }
+
 /* Splits panel */
 #splits .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
 .splits-tbl { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 12px; }

--- a/supabase/migrations/20260520250000_fix_get_event_chart_listings_per_bucket_dedup.sql
+++ b/supabase/migrations/20260520250000_fix_get_event_chart_listings_per_bucket_dedup.sql
@@ -1,0 +1,362 @@
+-- Migration 20260520250000 · lane:A1 · writes:get_event_chart_extended · reads:(unchanged) · pre:20260520220000
+--
+-- Fix the listings-series chart collapse on D0 event-page charts.
+--
+-- ROOT CAUSE
+--   `get_event_chart_extended` (PR #237 / mig 20260519150000) dedupes the SG
+--   listings firehose GLOBALLY across the chart window before bucketing:
+--
+--     WITH deduped AS (
+--       SELECT DISTINCT ON (sglid)
+--         sglid, captured_at, broadcast_price, quantity, is_broker_owned
+--       FROM public.seatgeek_listings_snapshots
+--       WHERE sg_event_id = v_sg_event_id ...
+--       ORDER BY sglid, captured_at DESC
+--     )
+--
+--   `seatgeek_listings_snapshots` is a FULL-INVENTORY firehose (each pull
+--   re-inserts every active sglid). A listing active for N days appears in N
+--   pulls. The global DISTINCT ON keeps only the row with the latest
+--   captured_at per sglid — so a long-lived listing contributes EXACTLY ONE
+--   data point to the chart, in the bucket where it was LAST seen.
+--
+--   Consequence: early-window buckets only contain listings that
+--   disappeared during that bucket. The chart line collapses to single-digit
+--   counts/totals in early buckets even when ~480 listings were active
+--   throughout. The latest bucket inflates with the listings whose most
+--   recent appearance happens to be there. Users see a "massive drop" that
+--   is purely a rendering artifact.
+--
+-- VERIFIED ON PROD (read-only dry-run 2026-05-18 vs sg_event_id 17693982,
+-- Cleveland Guardians at Philadelphia Phillies May 22, COOL tier, 168h window):
+--
+--   Bucket          | Buggy (global)        | Fixed (per-bucket)
+--   ----------------+-----------------------+-------------------------
+--   05-16 18:00     |   6 sglids /   25 tix |  488 sglids / 2126 tix
+--   05-16 22:00     |   7 sglids /   20 tix |  482 sglids / 2092 tix
+--   05-17 00:00     |   7 sglids /   26 tix |  475 sglids / 2072 tix
+--   05-17 14:00     | 152 sglids /  690 tix |  467 sglids / 2029 tix
+--   05-18 00:00     | 345 sglids / 1461 tix |  350 sglids / 1478 tix
+--   05-18 02:00     |   9 sglids /   32 tix |    9 sglids /   32 tix
+--
+--   True trajectory: ~480 sglids for 24h, with a real ~25% reduction in the
+--   05-17 14:00 → 05-18 00:00 window. The latest bucket (05-18 02:00 = 9)
+--   is a SEPARATE concern — see "NOT FIXED IN THIS MIGRATION" below.
+--
+-- FIX
+--   Replace global DISTINCT ON with per-bucket DISTINCT ON. Each bucket gets
+--   the latest captured_at row per sglid WITHIN THE BUCKET, so a long-lived
+--   listing contributes a data point to EVERY bucket where it was active.
+--
+--     WITH deduped AS (
+--       SELECT DISTINCT ON (date_bin(...), sglid)
+--         date_bin(...) AS bucket,
+--         sglid, captured_at, broadcast_price, quantity, is_broker_owned
+--       FROM ...
+--       ORDER BY date_bin(...), sglid, captured_at DESC
+--     )
+--
+--   The downstream `bucketed` CTE collapses to a direct GROUP BY on bucket
+--   (since the bucket column is already computed in `deduped`).
+--
+-- SALES-SIDE — INTENTIONALLY UNCHANGED
+--   The sales CTE keeps global DISTINCT ON (sg_sale_id), which is CORRECT
+--   for that data shape. A sale is a point event with one true sale_at_utc
+--   timestamp; the bible §3 11–23× firehose duplication factor refers to
+--   the SAME sale being re-emitted in every poll. Global DISTINCT ON
+--   selects the canonical version (latest pulled_at) and the sale falls
+--   in exactly ONE bucket via its sale_at_utc. Per-bucket dedup on sales
+--   would be a no-op at best and incorrect at worst (it would let the
+--   same sale appear in multiple buckets if different pulls happened to
+--   land in different buckets).
+--
+--   Verified (sample 5 sg_sale_ids): each has exactly 1 distinct sale_at_utc
+--   and 1 distinct broadcast_price across 25 re-captures.
+--
+-- NOT FIXED IN THIS MIGRATION (separate concerns, flagged for follow-up)
+--   1. The 05-18 02:45 pull returned only 9 listings (rows_persisted=9 in
+--      sg_broker_pending, with two -429 rate-limited fires preceding it).
+--      No sales recorded between 00:34 → 02:45, so this isn't natural
+--      attrition. Could be a real upstream API hiccup or a query-param
+--      drift. The raw HTTP response was pruned (net._http_response GC)
+--      before inspection. After this migration applies, the chart will
+--      correctly show 9 only in the latest bucket and ~480 in prior
+--      buckets, which is the right behavior — the chart can only paint
+--      what the firehose captured.
+--   2. The 12h gap between 05-17 03:00 and 05-17 14:00 with no pulls is
+--      tier-policy expected for a COOL event (24 polls/day) plus burst-cap
+--      collisions on the 5-min sg_priority_* schedule. Not a bug.
+--
+-- INVARIANTS PRESERVED
+--   - Function signature unchanged (no overload risk per PROJECT_BIBLE §7).
+--   - SECDEF + STABLE + search_path + @s4kent.com email gate unchanged.
+--   - REVOKE/GRANT matrix unchanged.
+--   - Injury partition fix from mig 20260520220000 preserved.
+--   - Sales-series CTE byte-identical.
+--   - Game-state CTE byte-identical.
+--   - Bucket size adaptive logic unchanged.
+
+CREATE OR REPLACE FUNCTION public.get_event_chart_extended(
+  p_event_id        integer,
+  p_chart_hours     integer DEFAULT 168,
+  p_espn_home_team  text    DEFAULT NULL,
+  p_espn_away_team  text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email          text;
+  v_sg_event_id    bigint;
+  v_espn_event_id  text;
+  v_espn_league    text;
+  v_home_team      text := p_espn_home_team;
+  v_away_team      text := p_espn_away_team;
+  v_hours          int  := greatest(1, least(coalesce(p_chart_hours, 168), 4320));
+  v_bucket_secs    int;
+  v_window_start   timestamptz;
+  v_now            timestamptz := now();
+  v_sg_listings    jsonb := '[]'::jsonb;
+  v_sg_listings_own jsonb := '[]'::jsonb;
+  v_sg_listings_ct jsonb := '[]'::jsonb;
+  v_sg_sales       jsonb := '[]'::jsonb;
+  v_sg_sales_ct    jsonb := '[]'::jsonb;
+  v_injuries       jsonb := '[]'::jsonb;
+  v_game_state     jsonb := '[]'::jsonb;
+  v_sg_hidden      boolean := false;
+  v_sg_reason      text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_window_start := v_now - make_interval(hours => v_hours);
+
+  v_bucket_secs := CASE
+    WHEN v_hours <=  24 THEN  900   -- 15 min
+    WHEN v_hours <=  72 THEN 3600   --  1 hr
+    WHEN v_hours <= 168 THEN 7200   --  2 hr
+    WHEN v_hours <= 720 THEN 21600  --  6 hr
+    ELSE 86400                      --  1 day
+  END;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    v_sg_hidden := true;
+    v_sg_reason := 'no_sg_bridge';
+  END IF;
+
+  SELECT ex.espn_event_id, ex.espn_league
+  INTO v_espn_event_id, v_espn_league
+  FROM public.event_xref ex
+  WHERE ex.tevo_event_id = p_event_id LIMIT 1;
+
+  IF (v_home_team IS NULL OR v_away_team IS NULL) AND v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id
+    INTO v_home_team, v_away_team
+    FROM public.espn_event_date_lookup
+    WHERE espn_event_id = v_espn_event_id LIMIT 1;
+
+    IF v_home_team IS NULL OR v_away_team IS NULL THEN
+      SELECT home_team_id, away_team_id
+      INTO v_home_team, v_away_team
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+      ORDER BY captured_at DESC LIMIT 1;
+    END IF;
+  END IF;
+
+  -- ---------- SG listings series (per-bucket DISTINCT ON sglid) ----------
+  -- Dedupe sglid INSIDE each bucket, not globally. A listing active across
+  -- multiple buckets must contribute one data point per bucket; the global
+  -- DISTINCT ON used pre-mig-20260520250000 collapsed long-lived listings
+  -- to a single bucket (their LAST appearance), causing early-window buckets
+  -- to look near-empty even when ~480 listings were active throughout.
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (
+               date_bin(make_interval(secs => v_bucket_secs), captured_at, '2000-01-01'::timestamptz),
+               sglid
+             )
+        date_bin(make_interval(secs => v_bucket_secs), captured_at, '2000-01-01'::timestamptz) AS bucket,
+        sglid, captured_at, broadcast_price, quantity, is_broker_owned
+      FROM public.seatgeek_listings_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+      ORDER BY
+        date_bin(make_interval(secs => v_bucket_secs), captured_at, '2000-01-01'::timestamptz),
+        sglid,
+        captured_at DESC
+    ),
+    bucketed AS (
+      SELECT bucket, broadcast_price, quantity, is_broker_owned
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p_owned) ORDER BY bucket) FILTER (WHERE median_p_owned IS NOT NULL), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', total_qty) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_listings, v_sg_listings_own, v_sg_listings_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) FILTER (WHERE is_broker_owned) AS median_p_owned,
+        SUM(quantity)::int AS total_qty
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- SG sales series (DISTINCT ON sg_sale_id, then bucket on sale_at_utc) ----------
+  -- INTENTIONALLY GLOBAL DEDUP: sales are point events. Each sg_sale_id has
+  -- exactly 1 true sale_at_utc; bible §3 11-23x firehose dedup applies. The
+  -- sale falls into exactly one bucket via its sale_at_utc. Per-bucket dedup
+  -- would be a no-op or incorrect here.
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, sale_at_utc, pulled_at, broadcast_price, quantity
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND coalesce(sale_at_utc, pulled_at) > v_window_start
+        AND coalesce(sale_at_utc, pulled_at) <= v_now
+      ORDER BY sg_sale_id, pulled_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), coalesce(sale_at_utc, pulled_at), '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', sale_ct) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_sales, v_sg_sales_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        count(*)::int AS sale_ct
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- ESPN injury transitions (LAG per stable athlete identity, both teams) ----------
+  -- Injury partition fix from mig 20260520220000 (Arias notification flood) preserved.
+  IF (v_home_team IS NOT NULL OR v_away_team IS NOT NULL) AND v_espn_league IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_team_id, athlete_id, athlete_name, position, status,
+        LAG(status) OVER (
+          PARTITION BY espn_league, espn_team_id,
+                       lower(btrim(coalesce(athlete_name, athlete_id, '')))
+          ORDER BY captured_at
+        ) AS prev_status
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id IN (v_home_team, v_away_team)
+        AND espn_team_id IS NOT NULL
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',            to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'athlete_id',    athlete_id,
+             'athlete_name',  athlete_name,
+             'position',      position,
+             'espn_team_id',  espn_team_id,
+             'prev_status',   prev_status,
+             'new_status',    status
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_injuries
+    FROM ordered
+    WHERE status IS DISTINCT FROM prev_status;
+  END IF;
+
+  -- ---------- ESPN game-state transitions ----------
+  IF v_espn_event_id IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_event_id, status_short, state,
+        LAG(status_short) OVER (PARTITION BY espn_event_id ORDER BY captured_at) AS prev_status
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+        AND (v_espn_league IS NULL OR espn_league = v_espn_league)
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',             to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'espn_event_id',  espn_event_id,
+             'prev_status',    prev_status,
+             'new_status',     status_short,
+             'state',          state
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_game_state
+    FROM ordered
+    WHERE status_short IS DISTINCT FROM prev_status;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'tevo_event_id',  p_event_id,
+    'sg_event_id',    v_sg_event_id,
+    'espn_event_id',  v_espn_event_id,
+    'espn_league',    v_espn_league,
+    'home_team_id',   v_home_team,
+    'away_team_id',   v_away_team,
+    'range', jsonb_build_object(
+      'start',  to_char(v_window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'end',    to_char(v_now          AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'hours',  v_hours,
+      'bucket_seconds', v_bucket_secs
+    ),
+    'sg_hidden', v_sg_hidden,
+    'sg_reason', v_sg_reason,
+    'series', jsonb_build_object(
+      'sg_listings_median',       v_sg_listings,
+      'sg_listings_owned_median', v_sg_listings_own,
+      'sg_listings_count',        v_sg_listings_ct,
+      'sg_sales_median',          v_sg_sales,
+      'sg_sales_count',           v_sg_sales_ct
+    ),
+    'annotations', jsonb_build_object(
+      'injuries',   v_injuries,
+      'game_state', v_game_state
+    )
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) IS
+  'D0 event chart extension — 5 SG-side series + 2 ESPN annotation arrays. LISTINGS series use PER-BUCKET DISTINCT ON sglid (mig 20260520250000); SALES series use GLOBAL DISTINCT ON sg_sale_id (point-event semantics). Athlete partition keyed on (espn_league, espn_team_id, lower(btrim(coalesce(athlete_name, athlete_id)))) to defend against ESPN provisional negative athlete_ids (mig 20260520220000). Email-gated.';
+
+-- ============================================================
+-- Post-apply verification (operator runs after apply_migration)
+-- ============================================================
+-- 1) Old global-dedup pattern gone for LISTINGS, sales-side unchanged:
+--    SELECT pg_get_functiondef(p.oid) ~ 'DISTINCT ON \(\s*date_bin\(make_interval\(secs => v_bucket_secs\)' AS listings_per_bucket,
+--           pg_get_functiondef(p.oid) ~ 'DISTINCT ON \(sg_sale_id\)' AS sales_global_dedup_preserved
+--    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+--    WHERE n.nspname='public' AND p.proname='get_event_chart_extended';
+--    -- expect: listings_per_bucket=true, sales_global_dedup_preserved=true
+--
+-- 2) Live: re-fetch chart for the Cleveland @ Phillies May 22 event
+--    (tevo_event_id=3101466) over 168h. Listings buckets that previously
+--    showed single-digit counts should now show ~470-490.
+--    SELECT jsonb_array_length(public.get_event_chart_extended(3101466, 168)
+--           -> 'series' -> 'sg_listings_count') AS bucket_count;
+--    -- expect: several non-trivial values, max bucket value ~480 instead of ~345
+--
+-- 3) Performance smoke: 168h window with adaptive 2h buckets on a busy event
+--    should run within the v3 RPC's ~308ms baseline. Per-bucket dedup
+--    expands the dedupe key cardinality (bucket × sglid) but the sg_event_id
+--    + captured_at filter scoping keeps the working set small.

--- a/supabase/migrations/20260520260000_matcher_cron_aliases_classify_365d.sql
+++ b/supabase/migrations/20260520260000_matcher_cron_aliases_classify_365d.sql
@@ -1,0 +1,270 @@
+-- Migration 20260520260000 · lane:A1 · writes:cross_source_venue_map,sg_classify_events,cron · pre:20260520220000
+--
+-- Three-in-one: matcher cron + 4 venue aliases + classify window 60d → 365d.
+--
+-- WHY (analysis 2026-05-18):
+--   1. 1,294 future US SG events are unmapped to TEvo. Investigation showed:
+--      - Most are real upstream-TEvo coverage gaps (TEvo doesn't carry the
+--        far-future MLB/MLS games SG knows about). The search bridge
+--        (sg_to_tevo_search_bridge_30min, 48 fires/24h, 444 matches in 7d)
+--        is already filling these in as TEvo's API surfaces them.
+--      - 4 venues exist in cross_source_venue_map with empty sg_aliases,
+--        blocking the local matcher from bridging events at those venues
+--        even when TEvo HAS the game.
+--      - The local matcher (auto_match_sg_canonical_v3) has NO cron schedule.
+--        It works perfectly when called manually but only runs implicitly
+--        via match_listings_to_sg_30min (listings-side, different path).
+--      - sg_classify_events has a hard "+ 60 days" upper bound on the date
+--        window. Result: 1,052 of the 1,294 unmapped US future events are
+--        NOT in priority_state at all → invisible to the polling pipeline
+--        → no time-series capture → can't power a movers tracker.
+--
+-- WHAT:
+--   A. UPDATE cross_source_venue_map.sg_aliases for 4 venues that have a
+--      TEvo entry but no SG alias populated. Unlocks the local matcher for
+--      events at these venues:
+--        414   Dodger Stadium                        → ["Uniqlo Field at Dodger Stadium"]
+--        1343  Moda Center at the Rose Quarter       → ["Moda Center"]
+--        5194  Nationals Park                        → ["Nationals Park"]
+--        34957 Gateway Center Arena at College Park  → ["Gateway Center Arena at College Park"]
+--
+--   B. CREATE OR REPLACE sg_classify_events with date window upper bound
+--      expanded from `+60 days` to `+365 days`. All other gates and the
+--      tier-policy ELSE lookup are byte-identical. Unmatched future US
+--      events automatically land in OBSERVE tier (requires_owned=false,
+--      0-720h via policy) for events ≤ 30d out, or fall to SKIP for further
+--      future (sort_order 8). The 30d–365d range covers the bulk of MLB
+--      late-season + NCAA football season tracking the operator wants.
+--
+--      Cost: classify reads 4,191 future events (vs ~1,500 before) plus
+--      24h listings_snapshots aggregates. Function should stay well under
+--      cron statement_timeout.
+--
+--   C. cron.schedule 'auto_match_sg_canonical_v3_hourly' at :07. Wraps the
+--      matcher with the standard cron_should_fire policy gate. Picks up
+--      new SG canonical events as they're ingested and auto-bridges them
+--      to TEvo when both sides have the event.
+--      Cost: matcher iterates events with tevo_event_id IS NULL AND
+--      sg_event_date >= current_date - 30. ~2,200 events today, scans
+--      drops as bridging catches up.
+--
+--   D. INSERT cron_policy row for the new cron with sane limits.
+--
+-- INVARIANTS PRESERVED:
+--   - sg_classify_events signature, return type, and policy-lookup ELSE
+--     clause byte-identical to mig 20260520210000 except the date window.
+--   - Existing crons (sg_to_tevo_search_bridge_30min, match_listings_to_sg_30min,
+--     sg_classify_events_5min) untouched.
+--   - cross_source_venue_map: append-only to sg_aliases via jsonb_build_array.
+--     Other venue rows untouched.
+--
+-- POST-APPLY WORK (operator may want to run these once, NOT in this migration):
+--   SELECT public.sg_classify_events();          -- bring 365d-window events into priority_state
+--   SELECT public.auto_match_sg_canonical_v3();  -- bridge any newly-alias-resolvable events
+
+-- ============================================================
+-- A. Venue alias fills (4 rows)
+-- ============================================================
+UPDATE public.cross_source_venue_map
+   SET sg_aliases = jsonb_build_array('Uniqlo Field at Dodger Stadium'),
+       updated_at = now()
+ WHERE tevo_venue_id = 414
+   AND jsonb_array_length(coalesce(sg_aliases, '[]'::jsonb)) = 0;
+
+UPDATE public.cross_source_venue_map
+   SET sg_aliases = jsonb_build_array('Moda Center'),
+       updated_at = now()
+ WHERE tevo_venue_id = 1343
+   AND jsonb_array_length(coalesce(sg_aliases, '[]'::jsonb)) = 0;
+
+UPDATE public.cross_source_venue_map
+   SET sg_aliases = jsonb_build_array('Nationals Park'),
+       updated_at = now()
+ WHERE tevo_venue_id = 5194
+   AND jsonb_array_length(coalesce(sg_aliases, '[]'::jsonb)) = 0;
+
+UPDATE public.cross_source_venue_map
+   SET sg_aliases = jsonb_build_array('Gateway Center Arena at College Park'),
+       updated_at = now()
+ WHERE tevo_venue_id = 34957
+   AND jsonb_array_length(coalesce(sg_aliases, '[]'::jsonb)) = 0;
+
+
+-- ============================================================
+-- B. sg_classify_events: expand date window 60d → 365d
+-- ============================================================
+-- All gates + ELSE clause byte-identical to mig 20260520210000. Only the
+-- date-window upper bound changes (line marked "WINDOW EXPANSION").
+
+CREATE OR REPLACE FUNCTION public.sg_classify_events()
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_updated int := 0;
+BEGIN
+  WITH listings_by_tevo AS (
+    SELECT event_id AS tevo_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '24 hours'
+      AND event_id IS NOT NULL
+    GROUP BY event_id
+  ),
+  listings_by_aq AS (
+    SELECT aq_short_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '24 hours'
+      AND aq_short_event_id IS NOT NULL
+    GROUP BY aq_short_event_id
+  ),
+  event_metrics AS (
+    SELECT c.sg_event_id, c.sg_event_name, c.sg_venue_name, c.sg_datetime_utc,
+           a.aq_short_event_id,
+           coalesce(c.tevo_event_id,
+                    (SELECT x.tevo_event_id FROM public.seatgeek_event_xref x
+                     WHERE x.sg_event_id = c.sg_event_id LIMIT 1)) AS tevo_event_id,
+           EXTRACT(epoch FROM (c.sg_datetime_utc - v_now)) / 3600 AS hours_to_event,
+           coalesce(lt.owned_cnt,    la.owned_cnt,    0) AS owned_cnt,
+           coalesce(lt.listings_cnt, la.listings_cnt, 0) AS listings_cnt
+    FROM public.sg_events_canonical c
+    -- LATERAL with deterministic preference for non-SYS aq ids: aq_event_map has
+    -- rows with multiple aq_short_event_ids per sg_event_id (SYS-* synthetic +
+    -- real aq id pairs for some NFL events). Plain LEFT JOIN duped rows into
+    -- the INSERT, hitting "ON CONFLICT cannot affect row a second time" — was
+    -- failing 12 of 72 sg_classify_events_5min fires pre-fix.
+    LEFT JOIN LATERAL (
+      SELECT aq_short_event_id
+      FROM public.aq_event_map
+      WHERE sg_event_id = c.sg_event_id
+      ORDER BY (aq_short_event_id LIKE 'SYS-%') ASC, aq_short_event_id
+      LIMIT 1
+    ) a ON true
+    LEFT JOIN listings_by_tevo lt ON lt.tevo_event_id = c.tevo_event_id
+    LEFT JOIN listings_by_aq   la ON la.aq_short_event_id = a.aq_short_event_id
+    WHERE c.sg_datetime_utc IS NOT NULL
+      -- WINDOW EXPANSION (mig 20260520260000): was '+ 60 days', now '+ 365 days'
+      -- to bring far-future US events into priority_state so polling pipeline
+      -- captures their time-series for the movers tracker.
+      AND c.sg_datetime_utc BETWEEN v_now - interval '6 hours' AND v_now + interval '365 days'
+  ),
+  classified AS (
+    SELECT em.*,
+      CASE
+        WHEN em.sg_event_name ~* '(cancelled|if necessary)' THEN 'SKIP'
+        WHEN em.sg_event_name ~* '(\(date tbd\)|^TBD at )'
+             AND em.tevo_event_id IS NULL THEN 'SKIP'
+        -- WATCH threshold scaled to 24h window: was >500/7d, now >150/24h
+        WHEN em.hours_to_event >= 0
+             AND em.hours_to_event < 168
+             AND em.owned_cnt = 0
+             AND em.listings_cnt > 150 THEN 'WATCH'
+        ELSE
+          (SELECT p.tier FROM public.sg_priority_policy p
+           WHERE p.enabled = true
+             AND em.hours_to_event >= coalesce(p.min_hours_to_event, -999999)
+             AND em.hours_to_event <  coalesce(p.max_hours_to_event, 999999)
+             AND (p.requires_owned = false OR em.owned_cnt > 0)
+           ORDER BY p.sort_order LIMIT 1)
+      END AS tier
+    FROM event_metrics em
+  )
+  INSERT INTO public.sg_event_priority_state AS s
+    (sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+     tevo_event_id, owned_count_last_7d, active_listings_last_7d, tier, hours_to_event, computed_at)
+  SELECT sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+         tevo_event_id, owned_cnt, listings_cnt, coalesce(tier, 'SKIP'), hours_to_event, v_now
+  FROM classified WHERE sg_event_id IS NOT NULL
+  ON CONFLICT (sg_event_id) DO UPDATE SET
+    sg_event_name           = EXCLUDED.sg_event_name,
+    sg_venue_name           = EXCLUDED.sg_venue_name,
+    sg_datetime_utc         = EXCLUDED.sg_datetime_utc,
+    aq_short_event_id       = EXCLUDED.aq_short_event_id,
+    tevo_event_id           = EXCLUDED.tevo_event_id,
+    owned_count_last_7d     = EXCLUDED.owned_count_last_7d,
+    active_listings_last_7d = EXCLUDED.active_listings_last_7d,
+    tier                    = EXCLUDED.tier,
+    hours_to_event          = EXCLUDED.hours_to_event,
+    computed_at             = EXCLUDED.computed_at,
+    sales_polls_today       = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.sales_polls_today END,
+    listings_polls_today    = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.listings_polls_today END,
+    budget_day              = current_date;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END
+$function$;
+
+
+-- ============================================================
+-- C. cron schedule for auto_match_sg_canonical_v3 (hourly)
+-- ============================================================
+-- Pattern: standard cron_should_fire wrapper per PROJECT_BIBLE §7.
+-- Cadence: hourly at :07. Matcher is read-heavy + does small batch INSERTs;
+-- one fire per hour is sufficient and stays well under statement_timeout.
+SELECT cron.schedule(
+  'auto_match_sg_canonical_v3_hourly',
+  '7 * * * *',
+  $cron$
+  DO $body$
+  BEGIN
+    IF NOT public.cron_should_fire('auto_match_sg_canonical_v3_hourly') THEN
+      RETURN;
+    END IF;
+    PERFORM public.auto_match_sg_canonical_v3();
+  END $body$;
+  $cron$
+);
+
+
+-- ============================================================
+-- D. cron_policy row for the new cron
+-- ============================================================
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+   work_check_sql, daily_max_fires, enabled, notes, updated_at)
+VALUES
+  ('auto_match_sg_canonical_v3_hourly',
+   ARRAY[]::int[],
+   60, 60,
+   $$ SELECT EXISTS (
+        SELECT 1 FROM public.sg_events_canonical
+        WHERE tevo_event_id IS NULL
+          AND sg_event_date >= current_date - 30
+        LIMIT 1
+      ) $$,
+   24,
+   true,
+   'Hourly local-matcher sweep. Companion to sg_to_tevo_search_bridge_30min (which fires TEvo /v9/events searches for events TEvo doesn''t carry locally). Skip when no candidates remain.',
+   now())
+ON CONFLICT (jobname) DO NOTHING;
+
+
+-- ============================================================
+-- Post-apply verification (operator may run these once)
+-- ============================================================
+-- 1) Venue aliases populated:
+--    SELECT tevo_venue_id, tevo_venue_name, sg_aliases FROM public.cross_source_venue_map
+--    WHERE tevo_venue_id IN (414, 1343, 5194, 34957);
+--    -- expect: 4 rows, each with non-empty sg_aliases.
+--
+-- 2) Cron registered:
+--    SELECT jobname, schedule, active FROM cron.job
+--    WHERE jobname = 'auto_match_sg_canonical_v3_hourly';
+--
+-- 3) Classify expansion test (run BEFORE and AFTER classify to compare):
+--    SELECT count(*) AS before_classify FROM public.sg_event_priority_state;
+--    SELECT public.sg_classify_events();
+--    SELECT count(*) AS after_classify FROM public.sg_event_priority_state;
+--    -- Expect after > before by hundreds (1,052 newly-eligible US events).
+--
+-- 4) Drain backlog with newly-aliased venues:
+--    SELECT * FROM public.auto_match_sg_canonical_v3();
+--    -- expect newly_matched to include events at the 4 newly-aliased venues
+--    -- (Dodger / Moda / Nationals / Gateway).

--- a/supabase/migrations/20260520290000_blindspot_tier_classify_step1.sql
+++ b/supabase/migrations/20260520290000_blindspot_tier_classify_step1.sql
@@ -1,0 +1,201 @@
+-- Migration 20260520290000 · lane:A1 · writes:sg_priority_policy,sg_classify_events · pre:20260520260000
+--
+-- STEP 1 of 5 — Blindspot tracking tier classification (no polling yet)
+--
+-- Goal (operator design 2026-05-18): track US SG events we don't own across
+-- 24h–365d horizons, so a separate detection layer can flag events where
+-- listings count moves ≥5% AND median price moves ≥10% over 48h. These
+-- become "BLIND SPOTS — SG SELLING, WE'RE NOT" on the D0 home page.
+--
+-- This migration only does the tier-topology work. No polling change in
+-- this step — that comes in Step 2 once we've verified events tag correctly.
+--
+-- Changes:
+--   1. INSERT row into sg_priority_policy for tier 'TRACK_BLINDSPOT' with
+--      enabled=false. The row exists for documentation + future polling
+--      function reference, but the existing classify ELSE policy lookup
+--      filters by p.enabled=true so it won't fall-through-assign this tier
+--      to non-US events. US events get TRACK_BLINDSPOT via the explicit
+--      CASE branch added below.
+--   2. UPDATE existing SKIP sort_order 8 → 9 to leave room for
+--      TRACK_BLINDSPOT (kept as sort_order=8, documentation only since
+--      enabled=false).
+--   3. CREATE OR REPLACE sg_classify_events with two new CASE branches
+--      added BEFORE the existing ELSE policy lookup:
+--         a. Early parking-SKIP: if name OR venue ILIKE '%parking%',
+--            tier='SKIP'. Catches the 393 parking pseudo-events that
+--            currently land in SKIP-by-policy-fallback and would otherwise
+--            risk polling if we later expand OBSERVE.
+--         b. US-state TRACK_BLINDSPOT: if hours_to_event between 24 and
+--            8760 (1 year), owned_cnt=0, non-parking, and sg_venue_state
+--            in the US state list, tier='TRACK_BLINDSPOT'.
+--      All other CASE branches + ELSE byte-identical to mig 20260520260000.
+--
+-- VERIFICATION QUERIES (operator runs after apply, before Step 2):
+--   -- Total TRACK_BLINDSPOT count (target: ~1,500–2,000, the non-parking
+--   -- 24h–8760h US non-owned events)
+--   SELECT tier, count(*) FROM public.sg_event_priority_state
+--   GROUP BY tier ORDER BY 1;
+--
+--   -- Spot-check: every TRACK_BLINDSPOT event must have US venue + not parking
+--   SELECT count(*) FILTER (WHERE sg_venue_name NOT ILIKE '%parking%'
+--                            AND sg_event_name NOT ILIKE '%parking%') AS clean,
+--          count(*)                                                    AS total
+--   FROM public.sg_event_priority_state ps
+--   JOIN public.sg_events_canonical c USING (sg_event_id)
+--   WHERE ps.tier = 'TRACK_BLINDSPOT';
+--   -- Expect clean == total.
+--
+--   -- Confirm parking events are SKIP'd, regardless of date
+--   SELECT count(*) AS parking_skipped
+--   FROM public.sg_event_priority_state ps
+--   JOIN public.sg_events_canonical c USING (sg_event_id)
+--   WHERE (c.sg_event_name ILIKE '%parking%' OR c.sg_venue_name ILIKE '%parking%')
+--     AND ps.tier != 'SKIP';
+--   -- Expect 0.
+
+-- ============================================================
+-- 1. Insert TRACK_BLINDSPOT policy row (enabled=false, documentation)
+-- ============================================================
+INSERT INTO public.sg_priority_policy
+  (tier, label, interval_seconds, min_hours_to_event, max_hours_to_event,
+   requires_owned, daily_polls_per_event, enabled, sort_order, notes)
+VALUES
+  ('TRACK_BLINDSPOT',
+   'US events 24h-1yr, not owned — blindspot movers tracking',
+   43200,            -- 12h
+   24,
+   8760,             -- 1 year
+   false,
+   2,                -- 2 polls/event/day (off-peak)
+   false,            -- DISABLED in policy table on purpose: only classify CASE assigns this tier
+   8,
+   'Off-peak polling tier for US unmapped events. Cadence + state-gate live in sg_classify_events explicit CASE + the (future Step 2) sg_blindspot_poll_tick. Policy row is documentation only.')
+ON CONFLICT (tier) DO UPDATE SET
+  label                 = EXCLUDED.label,
+  interval_seconds      = EXCLUDED.interval_seconds,
+  min_hours_to_event    = EXCLUDED.min_hours_to_event,
+  max_hours_to_event    = EXCLUDED.max_hours_to_event,
+  requires_owned        = EXCLUDED.requires_owned,
+  daily_polls_per_event = EXCLUDED.daily_polls_per_event,
+  enabled               = EXCLUDED.enabled,
+  sort_order            = EXCLUDED.sort_order,
+  notes                 = EXCLUDED.notes,
+  updated_at            = now();
+
+-- 2. Push SKIP from sort_order 8 to 9 (defensive — TRACK_BLINDSPOT shouldn't
+--    collide via ELSE lookup since enabled=false, but keep the topology clean)
+UPDATE public.sg_priority_policy
+   SET sort_order = 9, updated_at = now()
+ WHERE tier = 'SKIP' AND sort_order = 8;
+
+
+-- ============================================================
+-- 3. CREATE OR REPLACE sg_classify_events with parking-SKIP and
+--    explicit US-gated TRACK_BLINDSPOT branches
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.sg_classify_events()
+ RETURNS integer LANGUAGE plpgsql SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_updated int := 0;
+  v_us_states text[] := ARRAY[
+    'AL','AK','AZ','AR','CA','CO','CT','DE','DC','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME',
+    'MD','MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI',
+    'SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY',
+    'California','New York','Texas','Florida','Pennsylvania','Ohio','Illinois','Arizona','Washington',
+    'Georgia','Massachusetts','North Carolina','Tennessee'
+  ];
+BEGIN
+  WITH listings_by_tevo AS (
+    SELECT event_id AS tevo_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '24 hours' AND event_id IS NOT NULL
+    GROUP BY event_id
+  ),
+  listings_by_aq AS (
+    SELECT aq_short_event_id,
+           count(*) FILTER (WHERE is_owned = true) AS owned_cnt,
+           count(*) AS listings_cnt
+    FROM public.listings_snapshots
+    WHERE captured_at > v_now - interval '24 hours' AND aq_short_event_id IS NOT NULL
+    GROUP BY aq_short_event_id
+  ),
+  event_metrics AS (
+    SELECT c.sg_event_id, c.sg_event_name, c.sg_venue_name, c.sg_venue_state,
+           c.sg_datetime_utc,
+           a.aq_short_event_id,
+           coalesce(c.tevo_event_id,
+                    (SELECT x.tevo_event_id FROM public.seatgeek_event_xref x
+                     WHERE x.sg_event_id = c.sg_event_id LIMIT 1)) AS tevo_event_id,
+           EXTRACT(epoch FROM (c.sg_datetime_utc - v_now)) / 3600 AS hours_to_event,
+           coalesce(lt.owned_cnt,    la.owned_cnt,    0) AS owned_cnt,
+           coalesce(lt.listings_cnt, la.listings_cnt, 0) AS listings_cnt
+    FROM public.sg_events_canonical c
+    LEFT JOIN LATERAL (
+      SELECT aq_short_event_id
+      FROM public.aq_event_map
+      WHERE sg_event_id = c.sg_event_id
+      ORDER BY (aq_short_event_id LIKE 'SYS-%') ASC, aq_short_event_id
+      LIMIT 1
+    ) a ON true
+    LEFT JOIN listings_by_tevo lt ON lt.tevo_event_id = c.tevo_event_id
+    LEFT JOIN listings_by_aq   la ON la.aq_short_event_id = a.aq_short_event_id
+    WHERE c.sg_datetime_utc IS NOT NULL
+      AND c.sg_datetime_utc BETWEEN v_now - interval '6 hours' AND v_now + interval '365 days'
+  ),
+  classified AS (
+    SELECT em.*,
+      CASE
+        -- NEW: parking events always SKIP (no polling, no blindspot tracking)
+        WHEN em.sg_event_name ILIKE '%parking%'
+             OR em.sg_venue_name ILIKE '%parking%' THEN 'SKIP'
+        WHEN em.sg_event_name ~* '(cancelled|if necessary)' THEN 'SKIP'
+        WHEN em.sg_event_name ~* '(\(date tbd\)|^TBD at )'
+             AND em.tevo_event_id IS NULL THEN 'SKIP'
+        WHEN em.hours_to_event >= 0 AND em.hours_to_event < 168
+             AND em.owned_cnt = 0 AND em.listings_cnt > 150 THEN 'WATCH'
+        -- NEW: US-state blindspot tracking (24h–8760h, not owned, not parking)
+        WHEN em.hours_to_event >= 24
+             AND em.hours_to_event < 8760
+             AND em.owned_cnt = 0
+             AND em.sg_venue_state = ANY(v_us_states) THEN 'TRACK_BLINDSPOT'
+        ELSE
+          (SELECT p.tier FROM public.sg_priority_policy p
+           WHERE p.enabled = true
+             AND em.hours_to_event >= coalesce(p.min_hours_to_event, -999999)
+             AND em.hours_to_event <  coalesce(p.max_hours_to_event, 999999)
+             AND (p.requires_owned = false OR em.owned_cnt > 0)
+           ORDER BY p.sort_order LIMIT 1)
+      END AS tier
+    FROM event_metrics em
+  )
+  INSERT INTO public.sg_event_priority_state AS s
+    (sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+     tevo_event_id, owned_count_last_7d, active_listings_last_7d, tier, hours_to_event, computed_at)
+  SELECT sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+         tevo_event_id, owned_cnt, listings_cnt, coalesce(tier, 'SKIP'), hours_to_event, v_now
+  FROM classified WHERE sg_event_id IS NOT NULL
+  ON CONFLICT (sg_event_id) DO UPDATE SET
+    sg_event_name           = EXCLUDED.sg_event_name,
+    sg_venue_name           = EXCLUDED.sg_venue_name,
+    sg_datetime_utc         = EXCLUDED.sg_datetime_utc,
+    aq_short_event_id       = EXCLUDED.aq_short_event_id,
+    tevo_event_id           = EXCLUDED.tevo_event_id,
+    owned_count_last_7d     = EXCLUDED.owned_count_last_7d,
+    active_listings_last_7d = EXCLUDED.active_listings_last_7d,
+    tier                    = EXCLUDED.tier,
+    hours_to_event          = EXCLUDED.hours_to_event,
+    computed_at             = EXCLUDED.computed_at,
+    sales_polls_today       = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.sales_polls_today END,
+    listings_polls_today    = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.listings_polls_today END,
+    budget_day              = current_date;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END
+$function$;

--- a/supabase/migrations/20260520310000_blindspot_polling_step2.sql
+++ b/supabase/migrations/20260520310000_blindspot_polling_step2.sql
@@ -1,0 +1,169 @@
+-- Migration 20260520310000 · lane:A1 · writes:sg_blindspot_poll_tick,cron · pre:20260520290000
+--
+-- STEP 2 of 5 — Blindspot polling (listings only, 12h-spread, off-peak + mid-day)
+--
+-- Goal: poll the 3,154 TRACK_BLINDSPOT events at 2 polls/day with 12h spread,
+-- anchored to UTC 04-10 (off-peak ET overnight) + UTC 16-22 (mid-day ET).
+-- Listings only — sales has different semantics (point events) and isn't
+-- relevant for the price/inventory delta detection in Step 3.
+--
+-- DESIGN
+--   - New function: sg_blindspot_poll_tick(p_max int default 40)
+--     - Reads priority_state for tier='TRACK_BLINDSPOT' AND
+--       (last_polled_listings_at IS NULL OR < now() - 12 hours)
+--     - Fires SG /listings GET via net.http_get for up to p_max events
+--     - Inserts sg_broker_pending row + bumps last_polled_listings_at
+--     - Mirrors sg_priority_poll_tick's pattern but is scoped to TRACK_BLINDSPOT
+--   - New cron 'sg_blindspot_poll_5min':
+--     - Schedule: '*/5 4-10,16-22 * * *' (every 5 min during UTC 04-10 + 16-22)
+--     - 168 fires/day × 40 events = 6,720/day capacity
+--     - Actual: 3,154 events × 2 polls/day = 6,308 polls
+--   - cron_policy row with daily_max_fires + work_check_sql skip
+--
+-- BURST CAP RATIONALE
+--   p_max=40 per fire. pg_net is async — the 40 GET requests queue and SG's
+--   10/8s token bucket drains them over ~32 seconds. Within 5-min cycle. Other
+--   SG-polling crons (sg_priority_*_5min) fire on alternating minute offsets,
+--   so concurrent bucket pressure stays under quota. Per PROJECT_BIBLE §7
+--   pg_net macro: "burst × firings/hr ≥ inflow_rate" — 40 × 12/hr = 480/hr =
+--   0.13 req/s avg, well under 1.25 quota.
+--
+-- ALTERNATIVE NOT TAKEN
+--   We could've extended sg_priority_poll_tick to include TRACK_BLINDSPOT.
+--   Reasons against:
+--     - TRACK_BLINDSPOT has enabled=false (intentional, per Step 1 — keeps
+--       ELSE policy lookup from accidentally tagging non-US events).
+--       sg_priority_poll_tick filters on enabled=true.
+--     - Separate cron lets us gate by hour (04-10, 16-22) without affecting
+--       HOT/WARM/etc. polling.
+--     - Cleaner failure isolation if SG /listings starts 429ing on
+--       blindspot specifically.
+--
+-- VERIFICATION QUERIES (operator runs after apply)
+--   1) Function exists and is callable:
+--      SELECT public.sg_blindspot_poll_tick(0);  -- p_max=0 = dry-run check
+--
+--   2) Manual smoke fire (p_max=4, hits 4 events):
+--      SELECT public.sg_blindspot_poll_tick(4);
+--      SELECT count(*) FROM public.sg_broker_pending
+--      WHERE scope='listings' AND fired_at > now() - interval '5 minutes';
+--      -- expect: 4 new pending rows
+--
+--   3) Verify the poll request resolved + rows landed:
+--      SELECT p.fired_at, p.resolved_at, p.rows_persisted
+--      FROM public.sg_broker_pending p
+--      WHERE p.scope='listings' AND p.fired_at > now() - interval '10 minutes'
+--      ORDER BY p.fired_at DESC LIMIT 10;
+--
+--   4) After cron fires for the first 04:00-10:00 window, check coverage:
+--      SELECT count(*) FILTER (WHERE last_polled_listings_at IS NOT NULL) AS polled,
+--             count(*)                                                     AS total
+--      FROM public.sg_event_priority_state WHERE tier = 'TRACK_BLINDSPOT';
+--      -- expect: polled ≈ total within 6 hours of cron starting
+
+-- ============================================================
+-- 1. sg_blindspot_poll_tick function
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.sg_blindspot_poll_tick(p_max int DEFAULT 40)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  r RECORD;
+  v_req bigint;
+  v_now timestamptz := clock_timestamp();
+  v_token text := public.get_app_secret('SEATGEEK_API_TOKEN');
+  v_polled int := 0;
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'sg_blindspot_poll_tick: caller % not authorized', current_user;
+  END IF;
+
+  IF v_token IS NULL OR v_token = '' THEN
+    RAISE NOTICE 'sg_blindspot_poll_tick: SEATGEEK_API_TOKEN missing';
+    RETURN 0;
+  END IF;
+
+  -- p_max=0 = dry-run / health check
+  IF p_max <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  FOR r IN
+    SELECT s.sg_event_id
+    FROM public.sg_event_priority_state s
+    WHERE s.tier = 'TRACK_BLINDSPOT'
+      AND (s.last_polled_listings_at IS NULL
+           OR v_now - s.last_polled_listings_at >= interval '12 hours')
+    ORDER BY s.last_polled_listings_at NULLS FIRST, s.sg_event_id
+    LIMIT p_max
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/listings?token=' || v_token
+             || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+
+    INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+    VALUES (r.sg_event_id, 'listings', v_req, v_now);
+
+    UPDATE public.sg_event_priority_state
+       SET last_polled_listings_at = v_now,
+           listings_polls_today    = listings_polls_today + 1
+     WHERE sg_event_id = r.sg_event_id;
+
+    v_polled := v_polled + 1;
+  END LOOP;
+
+  RETURN v_polled;
+END
+$func$;
+
+REVOKE EXECUTE ON FUNCTION public.sg_blindspot_poll_tick(int) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.sg_blindspot_poll_tick(int) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.sg_blindspot_poll_tick(int) FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_blindspot_poll_tick(int) TO service_role;
+
+
+-- ============================================================
+-- 2. cron schedule (off-peak + mid-day windows)
+-- ============================================================
+SELECT cron.schedule(
+  'sg_blindspot_poll_5min',
+  '*/5 4-10,16-22 * * *',
+  $cron$
+  DO $body$
+  BEGIN
+    IF NOT public.cron_should_fire('sg_blindspot_poll_5min') THEN
+      RETURN;
+    END IF;
+    PERFORM public.sg_blindspot_poll_tick(40);
+  END $body$;
+  $cron$
+);
+
+
+-- ============================================================
+-- 3. cron_policy row
+-- ============================================================
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+   work_check_sql, daily_max_fires, enabled, notes, updated_at)
+VALUES
+  ('sg_blindspot_poll_5min',
+   ARRAY[]::int[],
+   5, 5,
+   $$ SELECT EXISTS (
+        SELECT 1 FROM public.sg_event_priority_state
+        WHERE tier = 'TRACK_BLINDSPOT'
+          AND (last_polled_listings_at IS NULL
+               OR last_polled_listings_at < now() - interval '12 hours')
+        LIMIT 1
+      ) $$,
+   180,
+   true,
+   'Off-peak (UTC 04-10) + mid-day (UTC 16-22) blindspot polling. 168 fires/day max via schedule, daily_max_fires=180 ceiling. Skip when no eligible events remain.',
+   now())
+ON CONFLICT (jobname) DO NOTHING;

--- a/supabase/migrations/20260520330000_sg_sales_poll_rewire.sql
+++ b/supabase/migrations/20260520330000_sg_sales_poll_rewire.sql
@@ -1,0 +1,275 @@
+-- Migration 20260520330000 · lane:A1 · writes:sg_sales_poll_tick,sg_priority_poll_tick,cron · pre:20260520310000
+--
+-- SG sales polling rewire (operator design 2026-05-18)
+--
+-- New global cadence for ALL events' sales polling (REPLACES existing
+-- HOT/WARM/COOL/COLD/WATCH/OBSERVE sales-side cadence):
+--
+--   hours_to_event in [168, 1440]   (7-60 days)        every 6h    4 polls/day
+--   hours_to_event in [24, 168)     (1-7 days)         every 4h    6 polls/day
+--   hours_to_event in [0, 24)       (last day)         every 2h   12 polls/day
+--   post-event window [2h, 24h]     (after start)      one-time   1 poll
+--   outside any window                                              skipped
+--
+-- TRADE-OFF (operator accepted): owned events near gameday lose tick-rate
+-- signal. Existing HOT polled sales every 4 min (360/day); new cadence is
+-- 12/day in last 24h. ~97% reduction in tick rate for owned events on game
+-- day, in exchange for broader-coverage tracking across the unmatched pool.
+--
+-- Two functions touched:
+--   1. NEW: sg_sales_poll_tick(p_max int default 50)
+--      — Reads sg_event_priority_state, applies the new cadence rules,
+--        fires SG /sales GETs, inserts pending rows.
+--      — Eligibility CTE buckets events by required cadence; LOOP picks
+--        the most-overdue first.
+--   2. CREATE OR REPLACE sg_priority_poll_tick: removes the sales loop
+--      entirely. Listings loop unchanged. Return shape preserved (sales
+--      rows in the report just report 0 events_polled).
+--
+-- Plus cron + cron_policy row for the new sales tick at every 5 min, 24/7
+-- (the per-event interval rule handles cadence, not the cron schedule).
+--
+-- THROUGHPUT MATH
+--   Assume distribution of priority_state events (≈4,000 non-SKIP):
+--     - 0-24h (12 polls/day):     ~50 events  →   600 polls/day
+--     - 1-7d  (6 polls/day):     ~250 events  → 1,500 polls/day
+--     - 7-60d (4 polls/day):   ~3,500 events  → 14,000 polls/day
+--     - Post-event (1 once):     ~30 events   →    30 polls/day
+--   Total ≈ 16,130 polls/day = 0.187 req/s. SG quota 1.25 req/s. ~15%.
+--   Cron at */5 24/7 = 288 fires/day. With p_max=60 = 17,280 capacity.
+--
+-- VERIFICATION (after apply, before cron's first natural fire)
+--   1) Function callable + dry-run safe:
+--      SELECT public.sg_sales_poll_tick(0);   -- expect 0
+--
+--   2) Eligibility check (no SG hit, just count):
+--      WITH e AS (...)  -- inline the eligibility CTE
+--      SELECT bucket, count(*) FROM e GROUP BY bucket;
+--      -- expect rows in d1, d2_6, d7_60, post_event buckets
+--
+--   3) Smoke fire (8 events):
+--      SELECT public.sg_sales_poll_tick(8);
+--      SELECT count(*) FROM sg_broker_pending
+--      WHERE scope='sales' AND fired_at > now() - interval '2 min';
+--      -- expect 8 new rows
+--
+--   4) Confirm sg_priority_poll_tick no longer fires sales:
+--      SELECT * FROM public.sg_priority_poll_tick(6);
+--      -- expect all 'sales' rows to be 0; listings rows unchanged
+--
+--   5) Drain pending + verify sales rows landed:
+--      SELECT public.sg_broker_sales_process(50);
+--      SELECT scope, count(*) FROM sg_broker_pending
+--      WHERE fired_at > now() - interval '5 min' GROUP BY scope;
+
+-- ============================================================
+-- 1. sg_sales_poll_tick — the new global sales polling driver
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.sg_sales_poll_tick(p_max int DEFAULT 50)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  r RECORD;
+  v_req bigint;
+  v_now timestamptz := clock_timestamp();
+  v_token text := public.get_app_secret('SEATGEEK_API_TOKEN');
+  v_polled int := 0;
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'sg_sales_poll_tick: caller % not authorized', current_user;
+  END IF;
+
+  IF v_token IS NULL OR v_token = '' THEN
+    RAISE NOTICE 'sg_sales_poll_tick: SEATGEEK_API_TOKEN missing';
+    RETURN 0;
+  END IF;
+
+  IF p_max <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  FOR r IN
+    WITH eligible AS (
+      SELECT s.sg_event_id, s.sg_datetime_utc, s.last_polled_sales_at,
+        CASE
+          -- Post-event one-shot: in [event_at + 2h, event_at + 24h] AND
+          -- last_polled_sales_at < event_at (we haven't polled post-event yet)
+          WHEN s.sg_datetime_utc < v_now - interval '2 hours'
+               AND s.sg_datetime_utc > v_now - interval '24 hours'
+               AND (s.last_polled_sales_at IS NULL
+                    OR s.last_polled_sales_at < s.sg_datetime_utc) THEN 'post_event'
+          -- Last 24h: every 2h
+          WHEN s.sg_datetime_utc BETWEEN v_now
+                                    AND v_now + interval '24 hours' THEN 'd1'
+          -- 1-7 days out: every 4h
+          WHEN s.sg_datetime_utc > v_now + interval '24 hours'
+               AND s.sg_datetime_utc <= v_now + interval '168 hours' THEN 'd2_6'
+          -- 7-60 days out: every 6h
+          WHEN s.sg_datetime_utc > v_now + interval '168 hours'
+               AND s.sg_datetime_utc <= v_now + interval '1440 hours' THEN 'd7_60'
+          ELSE NULL
+        END AS bucket,
+        CASE
+          WHEN s.sg_datetime_utc < v_now - interval '2 hours'
+               AND s.sg_datetime_utc > v_now - interval '24 hours'
+               AND (s.last_polled_sales_at IS NULL
+                    OR s.last_polled_sales_at < s.sg_datetime_utc) THEN interval '0'
+          WHEN s.sg_datetime_utc BETWEEN v_now
+                                    AND v_now + interval '24 hours' THEN interval '2 hours'
+          WHEN s.sg_datetime_utc > v_now + interval '24 hours'
+               AND s.sg_datetime_utc <= v_now + interval '168 hours' THEN interval '4 hours'
+          WHEN s.sg_datetime_utc > v_now + interval '168 hours'
+               AND s.sg_datetime_utc <= v_now + interval '1440 hours' THEN interval '6 hours'
+          ELSE NULL
+        END AS required_interval
+      FROM public.sg_event_priority_state s
+      WHERE s.sg_datetime_utc > v_now - interval '24 hours'
+        AND s.sg_datetime_utc <= v_now + interval '1440 hours'
+    )
+    SELECT sg_event_id, bucket
+    FROM eligible
+    WHERE bucket IS NOT NULL
+      AND (last_polled_sales_at IS NULL
+           OR v_now - last_polled_sales_at >= required_interval)
+    -- post_event first (one-shot, time-sensitive), then most-overdue, then by id
+    ORDER BY
+      CASE bucket WHEN 'post_event' THEN 0 WHEN 'd1' THEN 1 WHEN 'd2_6' THEN 2 ELSE 3 END,
+      last_polled_sales_at NULLS FIRST,
+      sg_event_id
+    LIMIT p_max
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/sales?token=' || v_token
+             || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+
+    INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+    VALUES (r.sg_event_id, 'sales', v_req, v_now);
+
+    UPDATE public.sg_event_priority_state
+       SET last_polled_sales_at = v_now,
+           sales_polls_today    = sales_polls_today + 1
+     WHERE sg_event_id = r.sg_event_id;
+
+    v_polled := v_polled + 1;
+  END LOOP;
+
+  RETURN v_polled;
+END
+$func$;
+
+REVOKE EXECUTE ON FUNCTION public.sg_sales_poll_tick(int) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.sg_sales_poll_tick(int) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.sg_sales_poll_tick(int) FROM authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_sales_poll_tick(int) TO service_role;
+
+
+-- ============================================================
+-- 2. CREATE OR REPLACE sg_priority_poll_tick — drop sales loop
+-- ============================================================
+-- Signature + return shape preserved (existing crons keep working). The
+-- sales loop is removed entirely; listings loop is byte-identical to the
+-- prior body. Reports still emit 'sales' rows but with events_polled=0.
+CREATE OR REPLACE FUNCTION public.sg_priority_poll_tick(p_max_polls integer DEFAULT 6)
+RETURNS TABLE(rpt_tier text, rpt_scope text, rpt_events_polled integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  r RECORD;
+  v_req bigint;
+  v_now timestamptz := clock_timestamp();
+  v_token text := public.get_app_secret('SEATGEEK_API_TOKEN');
+  v_polled_listings jsonb := '{}'::jsonb;
+  v_tier_name text;
+BEGIN
+  IF v_token IS NULL OR v_token = '' THEN
+    RAISE NOTICE 'sg_priority_poll_tick: SEATGEEK_API_TOKEN missing';
+    RETURN;
+  END IF;
+
+  -- Listings polling unchanged from prior body. Full p_max_polls budget now
+  -- goes to listings since sales is handled by sg_sales_poll_tick.
+  FOR r IN
+    SELECT s.sg_event_id, s.tier, s.listings_polls_today, p.interval_seconds, p.daily_polls_per_event
+    FROM public.sg_event_priority_state s
+    JOIN public.sg_priority_policy p ON p.tier = s.tier AND p.enabled = true
+    WHERE p.tier <> 'SKIP'
+      AND s.sg_datetime_utc > v_now - interval '2 hours'
+      AND (s.last_polled_listings_at IS NULL
+           OR v_now - s.last_polled_listings_at >= make_interval(secs => p.interval_seconds))
+      AND (p.daily_polls_per_event IS NULL OR s.listings_polls_today < p.daily_polls_per_event)
+    ORDER BY p.sort_order, s.sg_datetime_utc
+    LIMIT p_max_polls
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/listings?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+    INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+      VALUES (r.sg_event_id, 'listings', v_req, v_now);
+    UPDATE public.sg_event_priority_state
+      SET last_polled_listings_at = v_now, listings_polls_today = listings_polls_today + 1
+      WHERE sg_event_id = r.sg_event_id;
+    v_polled_listings := v_polled_listings || jsonb_build_object(r.tier, coalesce((v_polled_listings->>r.tier)::int, 0) + 1);
+  END LOOP;
+
+  -- Report rows for backward compat: emit (tier, sales, 0) + (tier, listings, N) per enabled tier
+  FOR v_tier_name IN SELECT pp.tier FROM public.sg_priority_policy pp WHERE pp.enabled = true AND pp.tier <> 'SKIP'
+  LOOP
+    rpt_tier := v_tier_name;
+    rpt_scope := 'sales';
+    rpt_events_polled := 0;  -- sales handled by sg_sales_poll_tick now
+    RETURN NEXT;
+    rpt_scope := 'listings';
+    rpt_events_polled := coalesce((v_polled_listings->>v_tier_name)::int, 0);
+    RETURN NEXT;
+  END LOOP;
+END $function$;
+
+
+-- ============================================================
+-- 3. cron schedule for the new sales tick
+-- ============================================================
+SELECT cron.schedule(
+  'sg_sales_poll_5min',
+  '*/5 * * * *',
+  $cron$
+  DO $body$
+  BEGIN
+    IF NOT public.cron_should_fire('sg_sales_poll_5min') THEN
+      RETURN;
+    END IF;
+    PERFORM public.sg_sales_poll_tick(60);
+  END $body$;
+  $cron$
+);
+
+
+-- ============================================================
+-- 4. cron_policy row
+-- ============================================================
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+   work_check_sql, daily_max_fires, enabled, notes, updated_at)
+VALUES
+  ('sg_sales_poll_5min',
+   ARRAY[]::int[],
+   5, 5,
+   $$ SELECT EXISTS (
+        SELECT 1 FROM public.sg_event_priority_state s
+        WHERE s.sg_datetime_utc > now() - interval '24 hours'
+          AND s.sg_datetime_utc <= now() + interval '1440 hours'
+          AND (s.last_polled_sales_at IS NULL OR s.last_polled_sales_at < s.sg_datetime_utc)
+        LIMIT 1
+      ) $$,
+   300,
+   true,
+   'Global sales polling (replaces tier-based sales in sg_priority_poll_tick). Cadence: 7-60d every 6h, 1-7d every 4h, 0-24h every 2h, +1 final pull 2h post-event. 288 fires/day × 60 burst = 17,280 capacity vs ≈16K expected daily polls.',
+   now())
+ON CONFLICT (jobname) DO NOTHING;

--- a/supabase/migrations/20260520360000_blindspot_detection_step3.sql
+++ b/supabase/migrations/20260520360000_blindspot_detection_step3.sql
@@ -1,0 +1,174 @@
+-- Migration 20260520360000 · lane:A1 · writes:v_sg_blindspot_movers,get_blind_spots_sg_selling · pre:20260520330000
+--
+-- STEP 3 of 5 — Blindspot detection view + RPC ("BLIND SPOTS — SG SELLING, WE'RE NOT")
+--
+-- Operator design (2026-05-18):
+--   Trigger: BOTH listings move ≥5% AND price move ≥10% over a 48h rolling window.
+--   Window: compare the latest poll snapshot (T-0, last 12h) vs the closest
+--           poll snapshot at T-48h (window 42-54h ago).
+--   Direction signal: selling_pressure = listings shrinking AND price rising
+--     (textbook SG-selling-into-strength pattern).
+--
+-- BASELINE WARNING
+--   Returns 0 rows until ≥48h of TRACK_BLINDSPOT polling history exists.
+--   Step 2 polling started 2026-05-18; first useful results ~2026-05-20.
+--
+-- DESIGN
+--   1. View v_sg_blindspot_movers — threshold-free. Returns ALL TRACK_BLINDSPOT
+--      events that have BOTH anchor snapshots (T-0 and T-48h) available, with
+--      computed deltas. Threshold filtering happens in the RPC.
+--   2. RPC get_blind_spots_sg_selling(p_min_listings_delta, p_min_price_delta)
+--      — SECDEF + @s4kent.com gate. Filters the view, joins to canonical for
+--      display fields, returns JSON array sorted by selling_pressure DESC then
+--      abs(price_pct_delta) DESC.
+--
+-- ANCHOR SELECTION
+--   T-0:   max(captured_at) within last 12h. Catches the most recent
+--          blindspot poll (cron fires at UTC 04-10 + 16-22, every 5 min).
+--   T-48h: max(captured_at) within 42-54h ago. ±6h tolerance accommodates
+--          the 12h-per-event eligibility gate (events polled at slightly
+--          different timestamps each day).
+--
+-- DEDUP NOTE
+--   We don't need DISTINCT ON (sg_event_id, sglid) per snapshot — a single
+--   blindspot poll writes all sglid rows at one clock_timestamp(). Picking
+--   `captured_at = anchor` returns exactly one row per sglid per snapshot.
+--
+-- INDEX SUPPORT
+--   idx_sg_listings_sg_event_id_time (sg_event_id, captured_at DESC) — used
+--   by both anchor CTEs.
+
+-- ============================================================
+-- 1. View
+-- ============================================================
+CREATE OR REPLACE VIEW public.v_sg_blindspot_movers
+WITH (security_invoker = on) AS
+WITH t0_anchor AS (
+  SELECT s.sg_event_id, max(l.captured_at) AS captured_at
+  FROM public.sg_event_priority_state s
+  JOIN public.seatgeek_listings_snapshots l ON l.sg_event_id = s.sg_event_id
+  WHERE s.tier = 'TRACK_BLINDSPOT'
+    AND l.captured_at > now() - interval '12 hours'
+  GROUP BY s.sg_event_id
+),
+t48_anchor AS (
+  SELECT s.sg_event_id, max(l.captured_at) AS captured_at
+  FROM public.sg_event_priority_state s
+  JOIN public.seatgeek_listings_snapshots l ON l.sg_event_id = s.sg_event_id
+  WHERE s.tier = 'TRACK_BLINDSPOT'
+    AND l.captured_at BETWEEN now() - interval '54 hours' AND now() - interval '42 hours'
+  GROUP BY s.sg_event_id
+),
+now_agg AS (
+  SELECT l.sg_event_id,
+         count(DISTINCT l.sglid)                                                AS listings_now,
+         coalesce(sum(l.quantity), 0)                                            AS tickets_now,
+         percentile_cont(0.5) WITHIN GROUP (ORDER BY l.broadcast_price)::numeric AS median_now
+  FROM public.seatgeek_listings_snapshots l
+  JOIN t0_anchor a ON a.sg_event_id = l.sg_event_id AND a.captured_at = l.captured_at
+  WHERE l.broadcast_price IS NOT NULL
+  GROUP BY l.sg_event_id
+),
+prior_agg AS (
+  SELECT l.sg_event_id,
+         count(DISTINCT l.sglid)                                                AS listings_prior,
+         coalesce(sum(l.quantity), 0)                                            AS tickets_prior,
+         percentile_cont(0.5) WITHIN GROUP (ORDER BY l.broadcast_price)::numeric AS median_prior
+  FROM public.seatgeek_listings_snapshots l
+  JOIN t48_anchor a ON a.sg_event_id = l.sg_event_id AND a.captured_at = l.captured_at
+  WHERE l.broadcast_price IS NOT NULL
+  GROUP BY l.sg_event_id
+)
+SELECT
+  n.sg_event_id,
+  n.listings_now,         p.listings_prior,
+  n.tickets_now,          p.tickets_prior,
+  n.median_now,           p.median_prior,
+  CASE WHEN p.listings_prior > 0
+       THEN round(100.0 * (n.listings_now - p.listings_prior) / p.listings_prior::numeric, 2)
+       END AS listings_pct_delta,
+  CASE WHEN p.median_prior > 0
+       THEN round(100.0 * (n.median_now - p.median_prior) / p.median_prior, 2)
+       END AS price_pct_delta,
+  (n.listings_now < p.listings_prior AND n.median_now > p.median_prior) AS selling_pressure
+FROM now_agg n
+JOIN prior_agg p USING (sg_event_id)
+WHERE p.listings_prior > 0 AND p.median_prior > 0;
+
+REVOKE ALL ON public.v_sg_blindspot_movers FROM PUBLIC;
+GRANT SELECT ON public.v_sg_blindspot_movers TO anon, authenticated, service_role;
+
+
+-- ============================================================
+-- 2. RPC
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_blind_spots_sg_selling(
+  p_min_listings_delta numeric DEFAULT 5,
+  p_min_price_delta    numeric DEFAULT 10
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  RETURN coalesce((
+    SELECT jsonb_agg(jsonb_build_object(
+             'sg_event_id',         m.sg_event_id,
+             'tevo_event_id',       c.tevo_event_id,
+             'sg_event_name',       c.sg_event_name,
+             'sg_venue_name',       c.sg_venue_name,
+             'sg_venue_city',       c.sg_venue_city,
+             'sg_venue_state',      c.sg_venue_state,
+             'sg_datetime_utc',     to_char(c.sg_datetime_utc AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'listings_now',        m.listings_now,
+             'listings_prior',      m.listings_prior,
+             'tickets_now',         m.tickets_now,
+             'tickets_prior',       m.tickets_prior,
+             'listings_pct_delta',  m.listings_pct_delta,
+             'median_now',          round(m.median_now, 2),
+             'median_prior',        round(m.median_prior, 2),
+             'price_pct_delta',     m.price_pct_delta,
+             'selling_pressure',    m.selling_pressure
+           ) ORDER BY m.selling_pressure DESC, abs(m.price_pct_delta) DESC, abs(m.listings_pct_delta) DESC)
+    FROM public.v_sg_blindspot_movers m
+    JOIN public.sg_events_canonical c ON c.sg_event_id = m.sg_event_id
+    WHERE abs(m.listings_pct_delta) >= p_min_listings_delta
+      AND abs(m.price_pct_delta)    >= p_min_price_delta
+      AND c.sg_datetime_utc > now()
+  ), '[]'::jsonb);
+END
+$func$;
+
+REVOKE ALL    ON FUNCTION public.get_blind_spots_sg_selling(numeric, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_blind_spots_sg_selling(numeric, numeric) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_blind_spots_sg_selling(numeric, numeric) IS
+  'BLIND SPOTS — SG SELLING, WE''RE NOT. Returns TRACK_BLINDSPOT events where listings count moved >= p_min_listings_delta% AND median price moved >= p_min_price_delta% over a 48h window (T-0 vs T-48h ±6h). Defaults: 5% listings + 10% price (operator AND-trigger 2026-05-18). Sorts selling_pressure DESC (listings shrinking + price rising) first, then by impact. Email-gated.';
+
+-- ============================================================
+-- Post-apply verification
+-- ============================================================
+-- 1) View resolves (returns 0 rows today, only ~4 events polled so far,
+--    no 48h history yet):
+--    SELECT count(*) FROM public.v_sg_blindspot_movers;
+--    -- expect: 0 today; will start surfacing rows ~2026-05-20 21:14 UTC
+--    -- (48h after first blindspot poll on 2026-05-18 21:14)
+--
+-- 2) RPC callable (returns '[]' without auth — fails email gate):
+--    SELECT public.get_blind_spots_sg_selling();  -- expects exception
+--
+-- 3) RPC callable as faked authed user:
+--    SELECT set_config('request.jwt.claims', '{"email":"test@s4kent.com"}', true);
+--    SELECT public.get_blind_spots_sg_selling();
+--    -- expect: '[]' today (no 48h history)
+--
+-- 4) After 48h+ of blindspot polling, lower thresholds to see all events
+--    with both anchors:
+--    SELECT public.get_blind_spots_sg_selling(0, 0);

--- a/supabase/migrations/20260520370000_blindspot_detection_step3_composite_score.sql
+++ b/supabase/migrations/20260520370000_blindspot_detection_step3_composite_score.sql
@@ -1,0 +1,259 @@
+-- Migration 20260520370000 · lane:A1 · writes:v_sg_blindspot_movers,get_blind_spots_sg_selling · pre:20260520360000
+--
+-- STEP 3.5 — Blindspot detection with composite 4-signal score
+-- (replaces the AND-trigger from mig 20260520360000)
+--
+-- Operator design (2026-05-18): 4-signal composite score:
+--   1. listings shrinking      (listings_pct_delta <= -5% over 48h)
+--   2. price rising            (price_pct_delta    >= +10% over 48h)
+--   3. sales accelerating      (sales_velocity_pct >= +30% over last 24h vs prior 24h)
+--   4. sales clearing-above-ask(sale_vs_listing_pct >= 0%)
+--   Surface events with score >= 3 of 4.
+--
+-- ADDED COLUMNS vs mig 20260520360000:
+--   sales_24h_count           DISTINCT sg_sale_id sold in last 24h (per bible §3 dedup)
+--   sales_prior_24h_count     DISTINCT sg_sale_id sold 24-48h ago
+--   sales_velocity_pct        % delta between the two windows
+--   median_sale_24h           median broadcast_price of last 24h sales
+--   sale_vs_listing_pct       (median_sale_24h - median_listing_now) / median_listing_now × 100
+--   clearing_ratio            sales_24h_count / listings_now
+--   signal_listings_drop      bool   (signal 1)
+--   signal_price_rise         bool   (signal 2)
+--   signal_sales_accel        bool   (signal 3)
+--   signal_sales_above_ask    bool   (signal 4)
+--   selling_score             int 0-4 (sum of signal_* booleans)
+--
+-- SALES DEDUP per PROJECT_BIBLE §3 landmine: UNIQUE (sg_event_id, sg_sale_id,
+-- pulled_at) means each logical sale re-inserts every poll. Must use
+-- DISTINCT ON (sg_sale_id) ORDER BY pulled_at DESC before aggregating.
+-- 11-23× overcount otherwise.
+--
+-- THRESHOLDS — RPC accepts overrides; defaults match the operator design above.
+
+-- ============================================================
+-- 1. View (uses correlated-subquery anchors for per-event index lookups)
+-- ============================================================
+-- The earlier draft used CTE anchors with a captured_at range scan that
+-- pulled 640K rows from the firehose. The current shape forces 3,154
+-- per-event lookups via idx_sg_listings_sg_event_id_time. ~2.9s on empty
+-- baseline (0 rows in the view today); expect similar latency at 1,500-row
+-- output. Materializing is a future v2 optimization.
+DROP VIEW IF EXISTS public.v_sg_blindspot_movers;
+
+CREATE VIEW public.v_sg_blindspot_movers
+WITH (security_invoker = on) AS
+WITH blindspot_events AS (
+  SELECT sg_event_id FROM public.sg_event_priority_state WHERE tier = 'TRACK_BLINDSPOT'
+),
+anchors AS (
+  SELECT
+    e.sg_event_id,
+    (SELECT max(l.captured_at) FROM public.seatgeek_listings_snapshots l
+     WHERE l.sg_event_id = e.sg_event_id
+       AND l.captured_at > now() - interval '12 hours') AS t0_at,
+    (SELECT max(l.captured_at) FROM public.seatgeek_listings_snapshots l
+     WHERE l.sg_event_id = e.sg_event_id
+       AND l.captured_at BETWEEN now() - interval '54 hours' AND now() - interval '42 hours') AS t48_at
+  FROM blindspot_events e
+),
+now_agg AS (
+  SELECT l.sg_event_id,
+         count(DISTINCT l.sglid)                                                AS listings_now,
+         coalesce(sum(l.quantity), 0)                                            AS tickets_now,
+         percentile_cont(0.5) WITHIN GROUP (ORDER BY l.broadcast_price)::numeric AS median_now
+  FROM public.seatgeek_listings_snapshots l
+  JOIN anchors a ON a.sg_event_id = l.sg_event_id AND a.t0_at = l.captured_at
+  WHERE a.t0_at IS NOT NULL AND l.broadcast_price IS NOT NULL
+  GROUP BY l.sg_event_id
+),
+prior_agg AS (
+  SELECT l.sg_event_id,
+         count(DISTINCT l.sglid)                                                AS listings_prior,
+         coalesce(sum(l.quantity), 0)                                            AS tickets_prior,
+         percentile_cont(0.5) WITHIN GROUP (ORDER BY l.broadcast_price)::numeric AS median_prior
+  FROM public.seatgeek_listings_snapshots l
+  JOIN anchors a ON a.sg_event_id = l.sg_event_id AND a.t48_at = l.captured_at
+  WHERE a.t48_at IS NOT NULL AND l.broadcast_price IS NOT NULL
+  GROUP BY l.sg_event_id
+),
+-- Sales last 24h + prior 24h (both deduped by sg_sale_id per bible §3 landmine)
+sales_dedup AS (
+  SELECT DISTINCT ON (sg_sale_id)
+    sg_event_id, sg_sale_id, sale_at_utc, broadcast_price, quantity
+  FROM public.seatgeek_sales_snapshots
+  WHERE coalesce(sale_at_utc, pulled_at) > now() - interval '48 hours'
+    AND sg_event_id IN (SELECT sg_event_id FROM blindspot_events)
+  ORDER BY sg_sale_id, pulled_at DESC
+),
+sales_24h AS (
+  SELECT sg_event_id,
+         count(*)                                                               AS sales_24h_count,
+         sum(quantity)                                                          AS sales_24h_tickets,
+         percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price)::numeric  AS median_sale_24h
+  FROM sales_dedup
+  WHERE coalesce(sale_at_utc, now()) > now() - interval '24 hours'
+  GROUP BY sg_event_id
+),
+sales_prior_24h AS (
+  SELECT sg_event_id,
+         count(*) AS sales_prior_24h_count
+  FROM sales_dedup
+  WHERE coalesce(sale_at_utc, now()) <= now() - interval '24 hours'
+    AND coalesce(sale_at_utc, now()) >  now() - interval '48 hours'
+  GROUP BY sg_event_id
+)
+SELECT
+  n.sg_event_id,
+  -- Listings
+  n.listings_now,         p.listings_prior,
+  n.tickets_now,          p.tickets_prior,
+  n.median_now,           p.median_prior,
+  CASE WHEN p.listings_prior > 0
+       THEN round(100.0 * (n.listings_now - p.listings_prior) / p.listings_prior::numeric, 2)
+       END AS listings_pct_delta,
+  CASE WHEN p.median_prior > 0
+       THEN round(100.0 * (n.median_now - p.median_prior) / p.median_prior, 2)
+       END AS price_pct_delta,
+  -- Sales
+  coalesce(s24.sales_24h_count, 0)        AS sales_24h_count,
+  coalesce(sp.sales_prior_24h_count, 0)   AS sales_prior_24h_count,
+  CASE WHEN coalesce(sp.sales_prior_24h_count, 0) > 0
+       THEN round(100.0 * (coalesce(s24.sales_24h_count, 0) - sp.sales_prior_24h_count)
+                  / sp.sales_prior_24h_count::numeric, 2)
+       END AS sales_velocity_pct,
+  round(s24.median_sale_24h, 2)           AS median_sale_24h,
+  CASE WHEN n.median_now > 0 AND s24.median_sale_24h IS NOT NULL
+       THEN round(100.0 * (s24.median_sale_24h - n.median_now) / n.median_now, 2)
+       END AS sale_vs_listing_pct,
+  CASE WHEN n.listings_now > 0
+       THEN round(coalesce(s24.sales_24h_count, 0)::numeric / n.listings_now, 4)
+       END AS clearing_ratio,
+  -- 4-signal flags (defaults match operator design 2026-05-18)
+  (p.listings_prior > 0
+   AND 100.0 * (n.listings_now - p.listings_prior) / p.listings_prior::numeric <= -5
+  )                                                                            AS signal_listings_drop,
+  (p.median_prior > 0
+   AND 100.0 * (n.median_now - p.median_prior) / p.median_prior >= 10
+  )                                                                            AS signal_price_rise,
+  (coalesce(sp.sales_prior_24h_count, 0) > 0
+   AND 100.0 * (coalesce(s24.sales_24h_count, 0) - sp.sales_prior_24h_count)
+       / sp.sales_prior_24h_count::numeric >= 30
+  )                                                                            AS signal_sales_accel,
+  (n.median_now > 0 AND s24.median_sale_24h IS NOT NULL
+   AND s24.median_sale_24h >= n.median_now
+  )                                                                            AS signal_sales_above_ask,
+  -- Composite 0-4 score
+  (
+    (p.listings_prior > 0
+     AND 100.0 * (n.listings_now - p.listings_prior) / p.listings_prior::numeric <= -5)::int +
+    (p.median_prior > 0
+     AND 100.0 * (n.median_now - p.median_prior) / p.median_prior >= 10)::int +
+    (coalesce(sp.sales_prior_24h_count, 0) > 0
+     AND 100.0 * (coalesce(s24.sales_24h_count, 0) - sp.sales_prior_24h_count)
+         / sp.sales_prior_24h_count::numeric >= 30)::int +
+    (n.median_now > 0 AND s24.median_sale_24h IS NOT NULL
+     AND s24.median_sale_24h >= n.median_now)::int
+  ) AS selling_score,
+  -- Original directional flag retained for back-compat / panel UI
+  (n.listings_now < p.listings_prior AND n.median_now > p.median_prior) AS selling_pressure
+FROM now_agg n
+JOIN prior_agg p USING (sg_event_id)
+LEFT JOIN sales_24h       s24 USING (sg_event_id)
+LEFT JOIN sales_prior_24h sp  USING (sg_event_id)
+WHERE p.listings_prior > 0 AND p.median_prior > 0;
+
+REVOKE ALL ON public.v_sg_blindspot_movers FROM PUBLIC;
+GRANT SELECT ON public.v_sg_blindspot_movers TO anon, authenticated, service_role;
+
+
+-- ============================================================
+-- 2. RPC (score-based filter, threshold-tunable)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_blind_spots_sg_selling(
+  p_min_score int DEFAULT 3
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  RETURN coalesce((
+    SELECT jsonb_agg(jsonb_build_object(
+             'sg_event_id',          m.sg_event_id,
+             'tevo_event_id',        c.tevo_event_id,
+             'sg_event_name',        c.sg_event_name,
+             'sg_venue_name',        c.sg_venue_name,
+             'sg_venue_city',        c.sg_venue_city,
+             'sg_venue_state',       c.sg_venue_state,
+             'sg_datetime_utc',      to_char(c.sg_datetime_utc AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             -- Listings half
+             'listings_now',         m.listings_now,
+             'listings_prior',       m.listings_prior,
+             'listings_pct_delta',   m.listings_pct_delta,
+             'median_now',           round(m.median_now, 2),
+             'median_prior',         round(m.median_prior, 2),
+             'price_pct_delta',      m.price_pct_delta,
+             -- Sales half
+             'sales_24h_count',      m.sales_24h_count,
+             'sales_prior_24h_count',m.sales_prior_24h_count,
+             'sales_velocity_pct',   m.sales_velocity_pct,
+             'median_sale_24h',      m.median_sale_24h,
+             'sale_vs_listing_pct',  m.sale_vs_listing_pct,
+             'clearing_ratio',       m.clearing_ratio,
+             -- Signal flags + score
+             'signal_listings_drop',    m.signal_listings_drop,
+             'signal_price_rise',       m.signal_price_rise,
+             'signal_sales_accel',      m.signal_sales_accel,
+             'signal_sales_above_ask',  m.signal_sales_above_ask,
+             'selling_score',           m.selling_score,
+             'selling_pressure',        m.selling_pressure
+           ) ORDER BY m.selling_score DESC,
+                     coalesce(m.sales_velocity_pct, 0) DESC,
+                     abs(coalesce(m.price_pct_delta, 0)) DESC)
+    FROM public.v_sg_blindspot_movers m
+    JOIN public.sg_events_canonical c ON c.sg_event_id = m.sg_event_id
+    WHERE m.selling_score >= p_min_score
+      AND c.sg_datetime_utc > now()
+  ), '[]'::jsonb);
+END
+$func$;
+
+REVOKE ALL    ON FUNCTION public.get_blind_spots_sg_selling(int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_blind_spots_sg_selling(int) TO anon, authenticated;
+
+-- Drop the prior 2-numeric-arg overload from mig 20260520360000 (per
+-- PROJECT_BIBLE §7 function-signature landmine: CREATE OR REPLACE with a
+-- different signature creates an additional overload, not a replacement).
+DROP FUNCTION IF EXISTS public.get_blind_spots_sg_selling(numeric, numeric);
+
+COMMENT ON FUNCTION public.get_blind_spots_sg_selling(int) IS
+  'BLIND SPOTS — SG SELLING, WE''RE NOT. Composite 4-signal score:
+     1. listings shrinking      >= 5% over 48h
+     2. price rising            >= 10% over 48h
+     3. sales accelerating      >= 30% velocity (last 24h vs prior 24h)
+     4. sales clearing at/above current ask
+   Default surface threshold: score >= 3. Sorted by score DESC, sales_velocity_pct DESC, |price_pct_delta| DESC. Email-gated.';
+
+-- ============================================================
+-- Post-apply verification
+-- ============================================================
+-- 1) View resolves with new columns (returns 0 rows today — no 48h history)
+--    \\d+ public.v_sg_blindspot_movers
+--    SELECT count(*) FROM public.v_sg_blindspot_movers;
+--
+-- 2) RPC overload cleanup confirmed (only 1 row):
+--    SELECT pg_get_function_identity_arguments(p.oid)
+--    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+--    WHERE n.nspname='public' AND p.proname='get_blind_spots_sg_selling';
+--
+-- 3) RPC w/ faked @s4kent.com JWT, default score >= 3:
+--    SELECT set_config('request.jwt.claims', '{"email":"test@s4kent.com"}', true);
+--    SELECT public.get_blind_spots_sg_selling();    -- expect '[]'
+--    SELECT public.get_blind_spots_sg_selling(0);   -- expect '[]' (no 48h data)


### PR DESCRIPTION
## Status: 8 of 12 commits already APPLIED TO PROD

This PR consolidates 6 open PRs (#262, #263, #264, #265, #266, #267) + 4 un-PR'd branches from this session into a single merge target. Eight of the SQL migrations were applied via `apply_migration` during the session; the FE pieces (PR #263, the blindspot panel renderer) deploy with this merge.

## Twelve commits (oldest → newest)

| # | Commit | Source | Live in prod? |
|---|---|---|---|
| 1 | `872df29` feat(sg): TRACK_BLINDSPOT tier — step 1 of 5 | blindspot-tier-classify | ✓ |
| 2 | `01a4de8` feat(sg): blindspot polling pipeline — step 2 of 5 | same | ✓ |
| 3 | `0205b97` feat(sg/sales): rewire sales polling — new global cadence | sales-poll-rewire | ✓ |
| 4 | `a935a79` feat(sg/blindspot): detection view + RPC — step 3 of 5 | blindspot-detection-step3 | ✓ |
| 5 | `3a61a25` feat(sg/blindspot): composite 4-signal score — step 3.5 | same | ✓ |
| 6 | `f3b557c` feat(d0/blindspot): wire BLIND SPOTS panel — step 4 of 5 | blindspot-panel-fe-step4 | FE only |
| 7 | `d87436c` chore(matcher): hourly cron + 4 venue aliases + classify 365d | **PR #266** | ✓ |
| 8 | `6635942` fix(d0/chart): per-bucket DISTINCT ON sglid for listings series | **PR #262** | ✓ |
| 9 | `9b31894` feat(d0/chart): event-alert markers OFF by default + toggle | **PR #263** | FE only |
| 10 | `f5bb4d0` docs(d1): codify storefront we_own/owned_tix carveout | **PR #264** | docs only |
| 11 | `38462aa` feat(d1/event): quick-pricing rollup | **PR #265** | FE only |
| 12 | `a584e3c` fix(d1/store): add 20s fetch timeout to api() | **PR #267** | FE only |

## What it does

### Blindspot tracker (5 steps, sg lane)

Steps 1-4 of the operator-designed "BLIND SPOTS — SG SELLING, WE'RE NOT" tracker:

- **Step 1**: New `TRACK_BLINDSPOT` tier classifies ~3,150 US SG events (24h-1yr horizon, not owned, non-parking) into `sg_event_priority_state`. Parking SKIP gate also added.
- **Step 2**: New `sg_blindspot_poll_tick(p_max=40)` + cron `*/5 4-10,16-22 * * *` (off-peak + mid-day, 12h-spread). 2 polls/event/day = ~6,300/day total.
- **Step 3 + 3.5**: New `v_sg_blindspot_movers` view + `get_blind_spots_sg_selling(p_min_score=3)` RPC. Composite 0-4 score across: listings shrinking ≥5%, price rising ≥10%, sales velocity ≥30%, sales clearing at/above ask.
- **Step 4 (FE)**: D0 home + movers `BLIND SPOTS` panel calls the RPC, renders a 12-column table sorted by score DESC. Replaces the prior heuristic-based renderer.

### Sales polling rewire

Replaces tier-based sales polling with single global cadence:
- 7-60d: every 6h (4/day)
- 1-7d: every 4h (6/day)
- 0-24h: every 2h (12/day)
- post-event (+2h): one-shot final pull (self-sentinel)

Cron `sg_sales_poll_5min` at `*/5 * * * *`. `sg_priority_poll_tick` modified to skip sales loop (listings only now).

### Matcher consolidation

- 4 venue aliases populated (Dodger 414 ← "Uniqlo Field at Dodger Stadium", Moda 1343 ← "Moda Center", Nationals 5194, Gateway 34957)
- New hourly cron `auto_match_sg_canonical_v3_hourly` to keep matching fresh
- `sg_classify_events` date window expanded 60d → 365d (brought 1,052 unmatched US events into priority_state)
- Dedup hotfix on classify (LATERAL with non-SYS aq id preference) — was failing 12 of 72 fires/6h pre-fix

### D0 chart fixes

- Per-bucket DISTINCT ON sglid for listings series (was global → made early-window buckets appear near-empty)
- Event-alert markers OFF by default with toggle in chart controls

### D1 lane

- LANE_DISCIPLINE.md carveout: storefront `/api/store/*` allowed to expose `we_own`/`owned_tix` (was flagged in B1-NEXT-39)
- Quick-pricing rollup on event page (from-price by quantity + by section)
- Storefront 20s fetch timeout (kills infinite spinner)

## Files

- 7 new migrations in `supabase/migrations/`
- 5 D0 files (`static/terminal/{event.html, event.js, home.js, movers.js, style.css}`)
- 3 D1 files (`static/store/{event.html, store.js, style.css}`)
- 2 governance files (`KANBAN.md`, `LANE_DISCIPLINE.md`)

## Baseline timing

Blindspot detection panel returns `'[]'` until ~2026-05-20 21:14 UTC (48h after Step 2 polling started). Then auto-populates as data accumulates. Empty-state message handles the wait.

## Supersedes

PR #262, #263, #264, #265, #266, #267 — closing those with this PR as supersedor.

## Test plan

- [ ] Verify 12-commit history is clean on `claude/blindspot-panel-fe-step4`
- [ ] CI workflows pass (`pytest`, `check`, `scan`, labelers, lint)
- [ ] Visual check on D0 home: BLIND SPOTS panel renders empty state correctly
- [ ] Visual check on `event.html`: alerts toggle present + defaults OFF
- [ ] Visual check on `event.html`: chart listings line matches per-bucket data (not pre-fix collapsed view)
- [ ] D1 storefront: quick-pricing rollup renders + 20s timeout kicks in on stuck requests
- [ ] After merge, watch first natural cron fire (next `*/5` and next `:07`) — confirm pipeline keeps running


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_