### PR TITLE
fix(d1/store): submit no-op when home loading — drop gate

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -285,6 +285,12 @@
     // cold-start where the round-trip is ~12s). When load resolves below,
     // any pending user query is re-applied at that point.
     let loadComplete = false;
+    // True once the user has submitted a backend search via /api/store/
+    // search. Prevents loadCatalog's late .then() from clobbering search
+    // results with the unfiltered home grid when home was still pending
+    // at submit time (operator report 2026-05-18 — "yankees" + Search
+    // produced silent no-op because the gate at searchAndRender bailed).
+    let userHasSearched = false;
 
     function render(events, mode) {
       // mode: "all" (initial load) or "search" (after a query)
@@ -398,6 +404,7 @@
       hideSuggest();
       // Empty submit → revert to the home view (full catalog).
       if (!q) {
+        userHasSearched = false;
         render(allEvents, "all");
         return;
       }
@@ -430,7 +437,16 @@
     // (If Necessary) speculative names client-side until PR #175 lands
     // the server-side filter.
     function searchAndRender(q) {
-      if (!loadComplete) return;  // same cold-start gate as filter()
+      // No loadComplete gate here — Submit is an explicit user action and
+      // /api/store/search is independent of /api/store/home (different
+      // endpoint, different code path). If the home catalog is still
+      // pending or stalled, the user can still recover by submitting a
+      // search. The original gate (PR #141) was added to prevent the
+      // in-memory filter() from racing with the home fetch; that race
+      // never applied to backend-search Submit because Submit doesn't
+      // touch the in-memory allEvents array. Removed 2026-05-18 after
+      // operator report: typing "yankees" + clicking Search produced
+      // silent no-op when home was hanging.
       status.hidden = false;
       status.textContent = `Searching for "${q}"…`;
       grid.hidden = true;
@@ -468,6 +484,7 @@
             return !up.includes("CANCELLED") && !up.includes("(IF NECESSARY)");
           });
           render(cleaned, "search");
+          userHasSearched = true;
         })
         .catch((err) => {
           console.error("searchAndRender failed:", err);
@@ -538,6 +555,14 @@
           allEvents = res.events || [];
           loadComplete = true;
           renderCatalogFilterBanner(performerId, venueId, allEvents);
+          // Don't clobber a backend search the user submitted while home
+          // was still pending. The Submit-gate removal (2026-05-18) lets
+          // a user search even before home resolves; if they did, leave
+          // their results in place.
+          if (userHasSearched) {
+            status.hidden = true;
+            return;
+          }
           // If user typed during the load window, honor that query now.
           // Otherwise render the full grid as before.
           const pendingQuery = (input.value || "").trim();


### PR DESCRIPTION
## Symptom

Operator report 2026-05-18: typing `yankees` in `/store` + clicking **Search** → no UI feedback, no network request, no error. Search felt completely dead.

## Root cause

`searchAndRender()` at `static/store/store.js:432` had:

```js
function searchAndRender(q) {
  if (!loadComplete) return;  // same cold-start gate as filter()
  ...
}
```

That gate is a copy of the one `filter()` uses to prevent the in-memory race during cold-start (PR #141). But Submit talks to `/api/store/search` — its own endpoint, completely independent of `/api/store/home` — so the race never applied. The gate was **over-broad** and turned an explicit user action into a silent no-op whenever home was pending or stalled.

## Fix

1. **Remove the gate** at `searchAndRender` entry. Submit always fires the backend search. `/api/store/search` has its own data path (events ILIKE + LEM join) — works regardless of whether home has returned.

2. **Add `userHasSearched` flag** set to true once a backend search lands. Prevents `loadCatalog`'s late `.then()` from clobbering the user's search results with the unfiltered home grid when home finally resolves AFTER the search.

3. **Empty-query Submit** (clear-the-box pattern) resets `userHasSearched = false` so subsequent home renders work normally.

## Diff

```
 static/store/store.js | 27 ++++++++++++++++++++++++++-
 1 file changed, 26 insertions(+), 1 deletion(-)
```

D1 lane only. No backend change. Live TEvo pulls unaffected.

## Companion to #267

The infinite-spinner stall behind this (`/api/store/home` hanging) is still addressed by PR #267 (20s fetch timeout). This PR is the orthogonal "Submit shouldn't be silent even while home is pending" fix.

Both PRs can land in any order; they're independent.

## Test plan

- [x] `node --check static/store/store.js` clean
- [ ] CI: pytest
- [ ] Manual smoke after merge:
  - [ ] Hard-refresh `/store` cold (free-tier dyno paused) — type "yankees" + click Search BEFORE the catalog finishes loading — verify backend search fires (network tab shows `/api/store/search?q=yankees`) and grid populates with Yankees events
  - [ ] When home finishes loading after the search lands — verify search results stay (don't get overwritten by full catalog)
  - [ ] Clear the search box + click Search — verify grid resets to full home catalog
  - [ ] Regression check on warm state: type + Submit still works as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01YTqt7DDgLwBvhjcwqGgVsX)_