### PR TITLE
fix(d1/store): TDZ on suggestEl — declare before wireSuggestDropdown call

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -303,6 +303,18 @@
     const status = $("#status");
     const grid = $("#grid");
     const empty = $("#empty");
+    // Suggest dropdown DOM + state — declared early so functions that
+    // reference them (hideSuggest/wireSuggestDropdown/scheduleSuggest)
+    // don't hit TDZ when called before the previous declaration location
+    // ~line 639. Operator report 2026-05-18: typing + Submit threw
+    // "Cannot access 'suggestEl' before initialization" because
+    // wireSuggestDropdown() is called at line 524 (was), which referenced
+    // suggestEl before its declaration ran. mountCatalog halted mid-flight
+    // there → const suggestEl line never executed → submit handler (already
+    // registered) fires later and re-hits TDZ on hideSuggest.
+    const suggestEl = $("#searchSuggest");
+    let suggestTimer = null;
+    let suggestSeq = 0;
 
     let allEvents = [];
     // loadComplete gates filter() so the user can't trigger a misleading
@@ -636,9 +648,8 @@
     // + 2-char minimum keeps upstream load reasonable (TEvo doesn't cache
     // suggestions — see notes in evo_client.search_suggestions). Server
     // also caches per-q for 60s.
-    const suggestEl = $("#searchSuggest");
-    let suggestTimer = null;
-    let suggestSeq = 0;  // monotonic so stale responses don't overwrite
+    // (suggestEl / suggestTimer / suggestSeq moved to top of mountCatalog
+    //  to fix TDZ — see comment block there.)
 
     function scheduleSuggest(qRaw) {
       const q = (qRaw || "").trim();


### PR DESCRIPTION
## Symptom

Operator 2026-05-18 (after #267 + #268 + #269 deploy):

```
Uncaught ReferenceError: Cannot access 'suggestEl' before initialization
    at hideSuggest (store.js?v=53236ea:689:7)
    at HTMLFormElement.<anonymous> (store.js?v=53236ea:430:7)
```

Typing "yankees" + Search did nothing. `preventDefault()` fired but the rest of the submit handler died on `hideSuggest`'s TDZ access.

## Root cause (pre-existing in main, not introduced by recent merges)

In `mountCatalog()`:

| Line | Code |
|---|---|
| 427 | `form.addEventListener("submit", ...)` registers handler |
| 430 | (inside handler) `hideSuggest();` |
| 524 | `wireSuggestDropdown();` — calls a function whose body references `suggestEl` |
| 639 | `const suggestEl = $("#searchSuggest");` — the actual declaration |
| 689 | `function hideSuggest() { if (!suggestEl) return; ... }` |
| 705 | `function wireSuggestDropdown() { if (!suggestEl) return; ... }` |

Flow:
1. Script loads → IIFE runs → `mountCatalog()` runs top-to-bottom.
2. At line 427, submit handler registered (closure over `hideSuggest`).
3. At line 524, `wireSuggestDropdown()` called — its body accesses `suggestEl` → **TDZ throw**.
4. `mountCatalog` halts. Line 639 never runs. `suggestEl` stays in TDZ forever.
5. User clicks Search → submit handler (still bound) fires → calls `hideSuggest()` → TDZ again.

Why my PR #269 fix didn't help: dropping the `if (!loadComplete) return;` gate at `searchAndRender` was correct but the handler dies on `hideSuggest` before reaching `searchAndRender`.

## Fix

Move 3 declarations to the top of `mountCatalog()`:
- `const suggestEl = $("#searchSuggest");`
- `let suggestTimer = null;`
- `let suggestSeq = 0;`

…right after the `form`/`input`/`status`/`grid`/`empty` declarations. Functions that close over them (`hideSuggest`, `wireSuggestDropdown`, `scheduleSuggest`, etc.) can now run without TDZ regardless of when they're invoked.

## Diff

1 file changed, 14 insertions(+), 3 deletions(-). Pure reorder; no behavior change.

## Expected post-deploy behavior

- Submit fires `/api/store/search?q=yankees&limit=60` (was silently dying on TDZ)
- The 20s timeout from #267 finally reachable (was masked by this throw)
- The `userHasSearched` gate from #269 finally reachable (same)
- Search-suggestions dropdown initializes properly (was broken since `wireSuggestDropdown`'s body bailed)

## Test plan

- [x] `node --check static/store/store.js` clean
- [ ] CI: pytest + check + scan + labelers
- [ ] After merge + autoDeploy, hard-refresh `/store`, type "yankees" + click Search:
  - [ ] Network tab shows `/api/store/search?q=yankees&limit=60` request fires
  - [ ] No console errors
  - [ ] Grid populates with Yankees events


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_