### PR TITLE
fix(d1/store): search results grid — owned-inventory only

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -513,13 +513,19 @@
             tournament: e.tournament || null,
             holiday: e.holiday || null,
           }));
-          // Client-side speculative filter — mirrors PR #175's server-side
-          // logic. Drops CANCELLED + (If Necessary). Kept here in addition
-          // to the server filter so the fix works even if the older server
-          // build hasn't redeployed yet.
+          // Client-side filter — two gates:
+          // 1. Speculative-name guard (mirrors PR #175 server-side logic).
+          //    Drops CANCELLED + (If Necessary).
+          // 2. Owned-inventory only (operator 2026-05-18). Storefront pitches
+          //    "Direct inventory, transparent pricing" — Submit-driven grid
+          //    must not surface events we can't sell. _search_sql_only +
+          //    _search_live return `we_own:false` events for the as-you-type
+          //    suggest dropdown's "browse" section, but the main grid only
+          //    shows what's bookable.
           const cleaned = normalized.filter((e) => {
             const up = (e.name || "").toUpperCase();
-            return !up.includes("CANCELLED") && !up.includes("(IF NECESSARY)");
+            if (up.includes("CANCELLED") || up.includes("(IF NECESSARY)")) return false;
+            return (Number(e.owned_tickets_count) || 0) > 0;
           });
           render(cleaned, "search");
           userHasSearched = true;


### PR DESCRIPTION
## Symptom

Operator 2026-05-18 (after #270 deploy unblocked search):
> "search is also showing all events including events we dont have inventory on"

## Root cause

Both server search paths (`_search_sql_only` and `_search_live` in `app.py`) tag events with `we_own:bool` but **don't filter**. That's intentional — the as-you-type suggest dropdown renders three sections including a "browse" section for `we_own=false` events. The server response shape supports both surfaces.

But the **Submit-driven results grid** is a different surface. Storefront tagline is "Direct inventory, transparent pricing" — surfacing events we can't sell is wrong.

## Fix

In `searchAndRender`'s `cleaned` pipeline at `store.js:520`, add an `owned_tickets_count > 0` gate alongside the existing CANCELLED / (If Necessary) filter. Suggest dropdown path (`scheduleSuggest` → `renderSuggest`) unchanged — still shows owned + browse sections.

```diff
- const cleaned = normalized.filter((e) => {
-   const up = (e.name || "").toUpperCase();
-   return !up.includes("CANCELLED") && !up.includes("(IF NECESSARY)");
- });
+ const cleaned = normalized.filter((e) => {
+   const up = (e.name || "").toUpperCase();
+   if (up.includes("CANCELLED") || up.includes("(IF NECESSARY)")) return false;
+   return (Number(e.owned_tickets_count) || 0) > 0;
+ });
```

## Why client-side, not server-side

The server's mixed-ownership response is **load-bearing** for the suggest dropdown. Changing it would break that surface. Two surfaces, two filters; client decides which view it is.

A future PR could add `?owned_only=true` to `/api/store/search` and have `searchAndRender` pass it, moving the filter server-side. Not in scope for this hotfix.

## Test plan

- [x] `node --check static/store/store.js` clean
- [ ] CI: pytest + check + scan + labelers
- [ ] After merge + deploy + hard-refresh `/store`:
  - [ ] Type "yankees" + click Search → grid shows only Yankees events with `owned_tix > 0`
  - [ ] Suggest dropdown (as-you-type) still shows owned + browse sections (unchanged)
  - [ ] Empty-search Submit → grid resets to home (unchanged)

D1 lane, FE-only, no backend or DB change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_