### PR TITLE
feat(d1/store): default search to SQL — keep TEvo live as env-flip fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -255,6 +255,17 @@ STOREFRONT_SQL_ONLY = os.environ.get("STOREFRONT_SQL_ONLY", "false").lower() == 
 if STOREFRONT_SQL_ONLY:
     print("STOREFRONT_SQL_ONLY=true — storefront serves from listings_snapshots; no live TEvo calls on store routes.")
 
+# STOREFRONT_SEARCH_SQL_ONLY — independent flag for /api/store/search routing
+# (operator 2026-05-18). Splits search off from the general STOREFRONT_SQL_ONLY
+# so search can default to SQL (snappy + zero TEvo quota) while event-detail
+# stays on TEvo live (fresh ticket-group pricing). To revert search to TEvo:
+# set STOREFRONT_SEARCH_SQL_ONLY=false. STOREFRONT_SQL_ONLY=true still wins
+# (forces SQL for both) for backward compat with prior deployments. Live
+# search code path (_search_live) is preserved as a flippable fallback.
+STOREFRONT_SEARCH_SQL_ONLY = os.environ.get("STOREFRONT_SEARCH_SQL_ONLY", "true").lower() == "true"
+if STOREFRONT_SEARCH_SQL_ONLY and not STOREFRONT_SQL_ONLY:
+    print("STOREFRONT_SEARCH_SQL_ONLY=true — /api/store/search uses _search_sql_only; event-detail still live TEvo.")
+
 # STOREFRONT_PREFER_INTERNAL_ZONES — flip on once the hand-curated granular
 # zones (NYK at MSG taxonomy, etc.) cover most/all sections. Today most of
 # them have coverage gaps that leave shoppers with un-filterable listings,
@@ -692,6 +703,7 @@ def healthz():
         "python": _sys.version.split()[0],
         "is_production": _is_production(),
         "storefront_sql_only": STOREFRONT_SQL_ONLY,
+        "storefront_search_sql_only": STOREFRONT_SEARCH_SQL_ONLY,
         "supabase_url_set": bool(SUPABASE_URL),
         "supabase_service_role_key_set": bool(SUPABASE_SERVICE_ROLE_KEY),
         "supabase_anon_key_set": bool(SUPABASE_ANON_KEY),
@@ -731,6 +743,7 @@ def public_config():
         # Storefront SQL-only demo mode flag. UI hides geolocation + shows
         # a 'demo · sql snapshot' pill so users know what they're seeing.
         "storefront_sql_only": STOREFRONT_SQL_ONLY,
+        "storefront_search_sql_only": STOREFRONT_SEARCH_SQL_ONLY,
     }
 
 # ---------- Protected routes ----------
@@ -5053,14 +5066,22 @@ def store_search(
     # Normalize so "  Knicks  ", "knicks", "KNICKS" all hit the same slot.
     # Mode (sql vs live) still differentiates so flipping STOREFRONT_SQL_ONLY
     # doesn't serve stale-mode cache entries.
-    cache_key = f"{_normalize_search_key(q_norm)}|{lim}|{'sql' if STOREFRONT_SQL_ONLY else 'live'}"
+    # Cache key segregates by which path actually ran. Matches the routing
+    # decision below so a STOREFRONT_SEARCH_SQL_ONLY flip doesn't serve stale
+    # cross-mode entries.
+    _search_path = "sql" if (STOREFRONT_SQL_ONLY or STOREFRONT_SEARCH_SQL_ONLY) else "live"
+    cache_key = f"{_normalize_search_key(q_norm)}|{lim}|{_search_path}"
     cached = _search_cache_get(cache_key)
     if cached is not None:
         return {**cached, "q": q_norm, "source": "cache", "latency_ms": 0}
 
     t0 = time.time()
     db = require_sb()
-    if STOREFRONT_SQL_ONLY:
+    # Routing: STOREFRONT_SEARCH_SQL_ONLY (default true) takes search to the
+    # SQL path. STOREFRONT_SQL_ONLY=true wins regardless (legacy unified flag).
+    # _search_live preserved as a flippable fallback — set
+    # STOREFRONT_SEARCH_SQL_ONLY=false in env to revert search to TEvo.
+    if STOREFRONT_SQL_ONLY or STOREFRONT_SEARCH_SQL_ONLY:
         payload = _search_sql_only(db, q_norm, lim)
     else:
         payload = _search_live(db, q_norm, lim)


### PR DESCRIPTION
## Summary

Per operator design (2026-05-18) + plan analysis at `/root/.claude/plans/what-if-for-search-snappy-dusk.md`: route `/api/store/search` to SQL by default for snappy + zero-quota typing; keep `_search_live` as a flippable fallback ("reserve" TEvo path). Event-detail page unchanged — stays on TEvo for fresh ticket-group data.

## Change

One new env var: **`STOREFRONT_SEARCH_SQL_ONLY`** (default `true`).

| Env state | Search path | Event detail path |
|---|---|---|
| Default (`STOREFRONT_SEARCH_SQL_ONLY` unset/true, `STOREFRONT_SQL_ONLY=false`) | **SQL** | live TEvo |
| Reserve flip (`STOREFRONT_SEARCH_SQL_ONLY=false`) | live TEvo (old behavior) | live TEvo |
| Legacy unified (`STOREFRONT_SQL_ONLY=true`) | SQL | SQL |

The legacy `STOREFRONT_SQL_ONLY` flag still wins when set — preserves prior deployment behavior. `_search_live` code path retained intact; not deleted.

## Effects (from plan)

| Effect | Direction |
|---|---|
| Cold search latency | ~1000ms → ~50ms |
| Suggest-dropdown TEvo quota burn | → 0 |
| TEvo outage resilience | search survives, was falling back |
| Event coverage | limited to events in our `events` table (~4,300 future) |
| Newly-listed TEvo events in search | lag until next collector run (HOT: 10min, COLD: 12h) |
| Suggest dropdown "browse" section | narrows from "all TEvo events" to "non-owned events we track" |
| Event detail latency / freshness | unchanged |
| Catalog filter (`/api/store/events`) | unchanged (still requires TEvo) |

## Diff

| File | Lines |
|---|---|
| `app.py:265-267` | Read new env var + boot logging |
| `app.py:706, 746` | Add `storefront_search_sql_only` to `/api/public/config` + `/api/store/home` payloads (FE debug) |
| `app.py:5070-5074` | Cache key honors active path |
| `app.py:5080-5085` | Search routing checks new var |

23 insertions, 2 deletions. Backend-only. No DB schema change. No FE change.

## Future work (operator note, separate PR)

Now that storefront search reads our `events` table, owned-event polling cadence in the collector should tighten so newly-listed inventory surfaces in storefront search faster. Not part of this PR.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` parses clean
- [ ] CI: pytest + check + scan + labelers
- [ ] Post-deploy verify:
  - [ ] `curl https://vibepass-storefront-test.onrender.com/api/store/search?q=yankees&limit=8` returns `source: "sql"`
  - [ ] Response latency < 200ms (vs ~1s prior)
  - [ ] `/store` Submit "yankees" → grid populates (with #271's owned-only filter)
  - [ ] As-you-type suggest dropdown still renders (events + performers + venues sections)
  - [ ] Open an event page from a result → still loads via TEvo `/v9/events/{id}` (Network tab)
- [ ] Reversibility: set `STOREFRONT_SEARCH_SQL_ONLY=false` in Render env → redeploy → search source returns `"live"` again

D1 lane, backend-only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_