### PR TITLE
feat(d1/store): movers — four themed sliders (moving fast / price drops / climbing / specials)

### DIFF
--- a/app.py
+++ b/app.py
@@ -5163,141 +5163,129 @@ def _refresh_movers(city: str, days: int, limit: int, key: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Movers label system (multi-label per event + proportional sampling).
-# Used by _compute_movers below. Labels:
-#   selling_fast   TEvo d24h <= -50 OR SG sales_24h >= 25
-#   demand_rising  (TEvo d24h<0 AND getin pct >= 5%) OR
-#                  (SG median delta >= +5% AND SG listings delta <= -5%)
-#   trending       SG sales_24h >= 10 (absolute volume, regardless of velocity)
-#   deal           retail_min < $20
-# Confidence = 2 if both TEvo+SG paths fire for the label, else 1.
-# selling_fast > demand_rising > trending > deal is the priority order for
-# bucketing in proportional rest sampling (each event bucketed under its
-# highest-priority label only).
+# Storefront sections — 3 themed sliders (price movement split into 2 rows):
+#   moving_fast   demand velocity        sg_sales_24h >= 10 OR tix_d24h <= -50
+#   price_drops   our price < SG market  retail_min < 0.7 * sg_median_now
+#   climbing      price firming          (TEvo getin +5% AND d24h<0) OR
+#                                        (SG median +5% AND SG listings -5%)
+#   specials      curated/calendar       owned > 100 AND (holiday-window
+#                                        match via v_event_holidays OR
+#                                        rivalry game via v_rivalry_events)
+# Each section is independent — a single event can appear in 0, 1, or 2
+# sections (e.g., a Yankees vs Red Sox game on July 4th qualifies as
+# both `specials` and `moving_fast`). The 4-row layout replaces the
+# previous single-strip label-mix approach so deals can't crowd out
+# other signals.
 # ---------------------------------------------------------------------------
-_LABEL_PRIORITY = ("selling_fast", "demand_rising", "trending", "deal")
 
 
-def _movers_compute_labels(d24h_val, pct_val, retail_min,
-                           sg_sales_24h, sg_median_delta_pct,
-                           sg_listings_delta_pct) -> list[dict]:
-    """Classify an event into 0+ labels based on TEvo + SG signals. Returns
-    a list of {"name": str, "conf": 1|2}. Empty list means the event doesn't
-    qualify for the movers strip.
+def _section_moving_fast(candidates: list[dict], cap: int = 10) -> list[dict]:
+    """Demand velocity: events selling fast across either market. SG path
+    is more reliable (confirmed sales); TEvo path captures supply leaving
+    the broker market even when SG xref is missing.
     """
-    labels: list[dict] = []
+    out = []
+    for c in candidates:
+        sg_sales = c.get("sg_sales_24h") or 0
+        d24h = c.get("tix_d24h")
+        if sg_sales >= 10 or (isinstance(d24h, int) and d24h <= -50):
+            out.append(c)
+    out.sort(key=lambda c: (
+        -(c.get("sg_sales_24h") or 0),
+        -abs(c.get("tix_d24h") or 0),
+        c.get("occurs_at_local") or "9999",
+    ))
+    return out[:cap]
 
-    # selling_fast: high velocity (either market)
-    tevo_sf = d24h_val is not None and d24h_val <= -50
-    sg_sf = sg_sales_24h is not None and sg_sales_24h >= 25
-    if tevo_sf or sg_sf:
-        labels.append({"name": "selling_fast", "conf": 2 if (tevo_sf and sg_sf) else 1})
 
-    # demand_rising: tickets dropping AND price firming, either market
-    tevo_dr = (d24h_val is not None and d24h_val < 0
-               and pct_val is not None and pct_val >= 5.0)
-    sg_dr = (sg_median_delta_pct is not None and sg_median_delta_pct >= 5.0
-             and sg_listings_delta_pct is not None and sg_listings_delta_pct <= -5.0)
-    if tevo_dr or sg_dr:
-        labels.append({"name": "demand_rising", "conf": 2 if (tevo_dr and sg_dr) else 1})
-
-    # trending: SG absolute volume signal (single-source)
-    if sg_sales_24h is not None and sg_sales_24h >= 10:
-        labels.append({"name": "trending", "conf": 1})
-
-    # deal: cheap get-in (single-source)
-    if retail_min is not None:
+def _section_price_drops(candidates: list[dict], cap: int = 10) -> list[dict]:
+    """Our get-in price is below SG market median by ≥30%. A real deal
+    signal vs. a flat $20 cutoff — captures relative value, not absolute
+    cheapness. Requires SG xref + recent listings; events without SG
+    coverage are silently skipped.
+    """
+    out = []
+    for c in candidates:
+        retail_min = c.get("from_price")
+        sg_median = c.get("sg_median_now")
+        if retail_min is None or sg_median is None:
+            continue
         try:
-            if float(retail_min) < 20:
-                labels.append({"name": "deal", "conf": 1})
+            rm = float(retail_min)
+            sm = float(sg_median)
+            if sm <= 0:
+                continue
+            discount = (sm - rm) / sm
+            if discount >= 0.30:
+                c["_discount_pct"] = round(discount * 100.0, 1)
+                out.append(c)
         except (TypeError, ValueError):
-            pass
+            continue
+    out.sort(key=lambda c: (-c.get("_discount_pct", 0.0),
+                            c.get("occurs_at_local") or "9999"))
+    return out[:cap]
 
-    return labels
 
-
-def _movers_compute_score(labels: list[dict], d24h_val) -> float:
-    """Per-event ranking score used by top-1% slice + within-bucket ordering
-    in proportional rest sampling. Higher = better.
+def _section_climbing(candidates: list[dict], cap: int = 10) -> list[dict]:
+    """Price firming: tickets dropping AND get-in climbing, or SG median
+    climbing AND SG listings shrinking. Dual-source for noise resistance
+    in thin pools (single-listing changes can shift median 5%+).
     """
-    if not labels:
-        return 0.0
-    max_conf = max(L["conf"] for L in labels)
-    n = len(labels)
-    mag = abs(int(d24h_val)) if isinstance(d24h_val, int) else 0
-    return max_conf * 10.0 + n * 2.0 + (mag / 50.0)
+    out = []
+    for c in candidates:
+        d24h = c.get("tix_d24h")
+        getin_pct = c.get("getin_pct_24h")
+        sg_med_d = c.get("sg_median_delta_pct")
+        sg_list_d = c.get("sg_listings_delta_pct")
+        tevo_climb = (isinstance(d24h, int) and d24h < 0
+                      and isinstance(getin_pct, (int, float)) and getin_pct >= 5.0)
+        sg_climb = (isinstance(sg_med_d, (int, float)) and sg_med_d >= 5.0
+                    and isinstance(sg_list_d, (int, float)) and sg_list_d <= -5.0)
+        if tevo_climb or sg_climb:
+            climb_pct = max(
+                getin_pct if isinstance(getin_pct, (int, float)) else -999,
+                sg_med_d if isinstance(sg_med_d, (int, float)) else -999,
+            )
+            c["_climb_pct"] = round(climb_pct, 1) if climb_pct > -999 else None
+            out.append(c)
+    out.sort(key=lambda c: (-(c.get("_climb_pct") or 0),
+                            c.get("occurs_at_local") or "9999"))
+    return out[:cap]
 
 
-def _bucket_by_primary_label(pool: list[dict]) -> dict[str, list[dict]]:
-    """Group events into buckets keyed by their highest-priority label
-    (per _LABEL_PRIORITY). Each bucket is sorted by score DESC, then by
-    soonest occurs_at_local as tiebreak.
+def _section_specials(candidates: list[dict],
+                      holiday_by_eid: dict[int, str],
+                      rivalry_by_eid: dict[int, str],
+                      cap: int = 10) -> list[dict]:
+    """Curated rail — events that qualify on a non-market basis. Two
+    sources fold in here:
+      1. v_event_holidays: server-side holiday window match (Memorial
+         Day, Christmas, etc.)
+      2. v_rivalry_events: known rivalry games (Yankees-Red Sox, etc.)
+    Both gated to owned > 100 — same depth bar the operator set for
+    the "specials" rail. Each card is tagged with `_special` describing
+    what earned its slot (e.g. "Memorial Day" or "Yankees vs Red Sox").
     """
-    buckets: dict[str, list[dict]] = {lbl: [] for lbl in _LABEL_PRIORITY}
-    for e in pool:
-        for lbl in _LABEL_PRIORITY:
-            if any(L["name"] == lbl for L in (e.get("labels") or [])):
-                buckets[lbl].append(e)
-                break
-    for lbl in buckets:
-        buckets[lbl].sort(
-            key=lambda c: (-c.get("score", 0.0), c.get("occurs_at_local") or "9999"))
-    return buckets
-
-
-# Grading curve thresholds. If any single label holds more than
-# _DOMINANCE_THRESHOLD of the pool at sample time, cap its share in the
-# output to _DOMINANT_CAP_PCT. Without this, a pool that's 95% deals
-# still yields ~90% deals via round-robin (small buckets drain first,
-# then the dominant bucket fills the remainder). The curve trades a
-# smaller card count for a guaranteed label mix.
-_DOMINANCE_THRESHOLD = 0.80
-_DOMINANT_CAP_PCT = 0.40
-
-
-def _round_robin_pop_by_label(buckets: dict[str, list[dict]], n: int) -> list[dict]:
-    """Drain up to `n` events from `buckets` by rotating through
-    _LABEL_PRIORITY. Pops the top-score event from each non-empty bucket
-    per cycle. Mutates `buckets` in place so successive calls continue
-    from where the prior call left off (used to build top-strip then
-    rest-grid from one shared pool with no overlap).
-
-    Grading curve: if any single label exceeds _DOMINANCE_THRESHOLD of
-    the current pool, cap its picks at ceil(n * _DOMINANT_CAP_PCT). When
-    the cap is hit and only the dominant bucket has items left, the
-    function returns fewer than `n` events — under-filling is preferred
-    over a monolithic output (e.g., 10 deals).
-    """
-    if n <= 0:
-        return []
-    total = sum(len(buckets[lbl]) for lbl in _LABEL_PRIORITY)
-    dominant_lbl: str | None = None
-    dominant_cap = n
-    if total > 0:
-        for lbl in _LABEL_PRIORITY:
-            if buckets[lbl] and len(buckets[lbl]) / total > _DOMINANCE_THRESHOLD:
-                dominant_lbl = lbl
-                dominant_cap = max(1, int(n * _DOMINANT_CAP_PCT + 0.5))
-                break
-
-    out: list[dict] = []
-    dominant_taken = 0
-    while len(out) < n:
-        made_progress = False
-        for lbl in _LABEL_PRIORITY:
-            if len(out) >= n:
-                break
-            if not buckets[lbl]:
-                continue
-            if lbl == dominant_lbl and dominant_taken >= dominant_cap:
-                continue
-            out.append(buckets[lbl].pop(0))
-            if lbl == dominant_lbl:
-                dominant_taken += 1
-            made_progress = True
-        if not made_progress:
-            break
-    return out
+    out = []
+    for c in candidates:
+        if (c.get("owned_tickets_count") or 0) <= 100:
+            continue
+        eid = c.get("id")
+        try:
+            eid_int = int(eid) if eid is not None else None
+        except (TypeError, ValueError):
+            eid_int = None
+        if eid_int is None:
+            continue
+        holiday = holiday_by_eid.get(eid_int)
+        rivalry = rivalry_by_eid.get(eid_int)
+        if holiday or rivalry:
+            # Prefer rivalry tag when both apply — more specific narrative.
+            c["_special"] = rivalry or holiday
+            c["_special_kind"] = "rivalry" if rivalry else "holiday"
+            out.append(c)
+    out.sort(key=lambda c: c.get("occurs_at_local") or "9999")
+    return out[:cap]
 
 
 def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
@@ -5513,12 +5501,11 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
                 median = prices[len(prices) // 2] if prices else None
                 target[tev] = {"count": len(agg["sglids"]), "median": median}
 
-    # ----- Classify each event into 0+ labels -----
-    # We compute labels for ALL owned (>=1) events. Partition into primary
-    # (owned > 50) and secondary (owned 1-50) downstream — secondary is used
-    # only to pad the rest grid when primary is thin.
-    primary: list[dict] = []
-    secondary: list[dict] = []
+    # ----- Build candidate pool with all signal data attached -----
+    # Every owned (>=1) event lands in `candidates` with its full signal
+    # payload. Each section helper below filters this pool independently;
+    # an event can qualify for 0, 1, or multiple sections.
+    candidates: list[dict] = []
     for eid, m in metrics_by_id.items():
         if eid in inactive:
             continue
@@ -5539,7 +5526,6 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
         except (TypeError, ValueError):
             pct_val = None
 
-        # SG aggregates for this event
         sg_sales_24h = sg_sales_24h_by_tevo.get(eid, 0)
         sg_sales_prior = sg_sales_prior_24h_by_tevo.get(eid, 0)
         sg_sales_delta_pct = None
@@ -5557,16 +5543,13 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             sg_median_delta_pct = round(
                 100.0 * (sg_now["median"] - sg_prior["median"]) / sg_prior["median"], 1)
 
-        labels = _movers_compute_labels(
-            d24h_val, pct_val, m.get("retail_min"),
-            sg_sales_24h, sg_median_delta_pct, sg_listings_delta_pct)
-        if not labels:
-            continue
-        score = _movers_compute_score(labels, d24h_val)
-
         a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
         owned_tickets = m.get("owned_tickets_count") or 0
-        card = {
+        if owned_tickets <= 50:
+            # Sections (except holidays) require owned > 50 for inventory depth;
+            # holidays is even tighter at > 100, applied in the section helper.
+            continue
+        candidates.append({
             "id": ev.get("id"),
             "name": ev.get("name"),
             "occurs_at_local": ev.get("occurs_at_local"),
@@ -5582,45 +5565,68 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             "sg_sales_delta_pct": sg_sales_delta_pct,
             "sg_listings_delta_pct": sg_listings_delta_pct,
             "sg_median_delta_pct": sg_median_delta_pct,
+            "sg_median_now": (sg_now or {}).get("median"),
             "owned_tickets_count": owned_tickets,
-            "labels": labels,
-            "score": score,
-        }
-        if owned_tickets > 50:
-            primary.append(card)
-        else:
-            secondary.append(card)
+        })
 
-    # ----- Round-robin by label so strip + grid show a mix, not just the
-    # dominant bucket. Pure score-sort + proportional sampling both
-    # collapsed to whichever label was largest in the pool (typically
-    # deal, since cheap inventory dominates NYC owned events). Cycling
-    # selling_fast → demand_rising → trending → deal guarantees label
-    # diversity whenever 2+ buckets are non-empty.
-    primary_buckets = _bucket_by_primary_label(primary)
-    n_primary = len(primary)
-    n_top = max(5, min(8, round(n_primary * 0.01))) if n_primary else 0
-    n_top = min(n_top, n_primary)
-    top = _round_robin_pop_by_label(primary_buckets, n_top)
-    rest = _round_robin_pop_by_label(primary_buckets, 10)
+    # ----- Specials enrichment: pull holiday-window matches + rivalry
+    # tags. Both wrapped in try/except so a view-side failure degrades
+    # to no-specials rather than killing the whole movers response.
+    candidate_ids = [int(c["id"]) for c in candidates if c.get("id") is not None]
+    holiday_by_eid: dict[int, str] = {}
+    rivalry_by_eid: dict[int, str] = {}
+    if candidate_ids:
+        try:
+            hrows = (db.table("v_event_holidays")
+                       .select("tevo_event_id,holiday_name")
+                       .in_("tevo_event_id", candidate_ids)
+                       .execute().data) or []
+            # First match wins per event — v_event_holidays can emit
+            # multiple rows when a date hits multiple holidays. The view
+            # already orders by match_specificity DESC server-side.
+            for r in hrows:
+                eid = r.get("tevo_event_id")
+                if eid is None:
+                    continue
+                key = int(eid)
+                if key not in holiday_by_eid and r.get("holiday_name"):
+                    holiday_by_eid[key] = r["holiday_name"]
+        except Exception as e:
+            print(f"store_movers v_event_holidays query failed: {e}")
+        try:
+            rrows = (db.table("v_rivalry_events")
+                       .select("tevo_event_id,rivalry_name,rivalry_intensity")
+                       .in_("tevo_event_id", candidate_ids)
+                       .execute().data) or []
+            # v_rivalry_events emits duplicate rows when both teams in a
+            # matchup are competitors (app.py:1198 bible landmine).
+            # Dedupe Python-side; first row wins.
+            for r in rrows:
+                eid = r.get("tevo_event_id")
+                if eid is None:
+                    continue
+                key = int(eid)
+                if key not in rivalry_by_eid and r.get("rivalry_name"):
+                    rivalry_by_eid[key] = r["rivalry_name"]
+        except Exception as e:
+            print(f"store_movers v_rivalry_events query failed: {e}")
 
-    # Pad rest from secondary (owned 1-50) when primary pool runs thin.
-    if len(rest) < 10 and secondary:
-        seen_ids = {c["id"] for c in primary}
-        secondary_pool = [c for c in secondary if c["id"] not in seen_ids]
-        sec_buckets = _bucket_by_primary_label(secondary_pool)
-        pad_n = 10 - len(rest)
-        padded = _round_robin_pop_by_label(sec_buckets, pad_n)
-        for c in padded:
-            c["from_pad"] = True
-        rest.extend(padded)
+    # ----- Build the 4 themed sliders. Each section is independent and
+    # gets its own copy of qualifying candidates (cards may appear in
+    # more than one section, e.g. a rivalry game that's also moving fast).
+    moving_fast = _section_moving_fast(candidates)
+    price_drops = _section_price_drops(candidates)
+    climbing = _section_climbing(candidates)
+    specials = _section_specials(candidates, holiday_by_eid, rivalry_by_eid)
 
     return {
         "city": city,
         "days": day_cap,
-        "count": len(top) + len(rest),
-        "events": top,
-        "rest": rest,
+        "count": len(moving_fast) + len(price_drops) + len(climbing) + len(specials),
+        "moving_fast": moving_fast,
+        "price_drops": price_drops,
+        "climbing": climbing,
+        "specials": specials,
     }
 
 

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -63,22 +63,11 @@
       <!-- Filter banner — shown when the catalog was opened via a
            ?performer_id= or ?venue_id= link from an event page. -->
       <div id="catalogFilterBanner" class="banner" hidden></div>
-      <!-- Movers strip — top events in NYC for the next 3 weeks by
-           24h ticket velocity. Hidden when the user is filtered (the
-           strip is a home-view discovery aid, not a filter-respecting
-           list). Populated by /api/store/movers. -->
-      <section id="moversStrip" class="movers-strip" hidden aria-label="Moving fast in NYC">
-        <h2 class="movers-title">Moving fast in NYC · next 3 weeks</h2>
-        <div id="moversRow" class="movers-row"></div>
-      </section>
-      <!-- Rest section — 10 cards in 2 rows × 5, sampled proportionally to the
-           label distribution in the pool. Padded from owned-1-50 events if the
-           strict owned>50 primary pool runs short. Populated by /api/store/movers
-           (response key: `rest`). -->
-      <section id="moversRest" class="movers-rest" hidden aria-label="More moving in NYC">
-        <h2 class="movers-rest-title">More moving in NYC</h2>
-        <div id="moversRestGrid" class="movers-rest-grid"></div>
-      </section>
+      <!-- Themed sliders container — populated dynamically from
+           /api/store/movers (response keys: moving_fast, price_drops,
+           climbing, specials). Each section becomes one horizontal
+           slider with its own header; empty sections are hidden. -->
+      <div id="moversSections" class="movers-sections" hidden></div>
       <div id="status" class="status" aria-live="polite">Loading available events…</div>
       <div id="grid" class="grid" hidden></div>
       <div id="empty" class="empty" hidden>

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -637,26 +637,17 @@
     }
     loadCatalog();
 
-    // NYC movers strip + rest grid — only shown on the bare /store view
-    // (no performer or venue filter). Label-driven now (selling_fast /
-    // demand_rising / trending / deal). days=90 to give the 3mo horizon
-    // enough pool for the proportional rest sampling. limit kept at 8 for
-    // back-compat (the server clamps top to [5,8] of 1% regardless).
+    // NYC themed sliders — only shown on the bare /store view (no performer
+    // or venue filter). Server returns 4 keyed arrays (moving_fast,
+    // price_drops, climbing, specials) and each becomes its own horizontal
+    // slider. Empty sections are hidden. days=90 to give the 3mo horizon
+    // enough pool depth for each section's filter.
     if (!performerId && !venueId) {
-      const strip = $("#moversStrip");
-      const row = $("#moversRow");
-      const rest = $("#moversRest");
-      const restGrid = $("#moversRestGrid");
-      if (strip && row) {
-        api("/api/store/movers?city=NYC&days=90&limit=8")
-          .then((res) => {
-            renderMoversStrip(strip, row, res);
-            if (rest && restGrid) renderMoversRest(rest, restGrid, res);
-          })
-          .catch(() => {
-            strip.hidden = true;
-            if (rest) rest.hidden = true;
-          });
+      const host = $("#moversSections");
+      if (host) {
+        api("/api/store/movers?city=NYC&days=90")
+          .then((res) => renderMoversSections(host, res))
+          .catch(() => { host.hidden = true; });
       }
     }
 
@@ -839,40 +830,44 @@
     return a;
   }
 
-  // Label badge config — multi-label system (server returns `labels` array of
-  // {name, conf}). conf=2 (dual TEvo+SG corroboration) renders with an accent
-  // outline via CSS, conf=1 is the base style. Order in this map controls
-  // the visual display order of badges on a card.
-  const LABEL_DISPLAY = {
-    selling_fast:  "🔥 selling fast",
-    demand_rising: "📈 demand rising",
-    trending:      "✨ trending",
-    deal:          "💸 deal",
-  };
+  // Section render config — one entry per themed slider in display order.
+  // `accent` line is the per-card secondary note describing why this event
+  // qualified for the section (e.g. "↓ 35% below market" for price_drops).
+  const SECTIONS = [
+    { key: "moving_fast", title: "Moving fast in NYC",
+      accent: (ev) => {
+        const tx = Number(ev.tix_d24h);
+        const sg = Number(ev.sg_sales_24h);
+        if (Number.isFinite(tx) && tx < 0) return `${Math.abs(tx)} sold today`;
+        if (Number.isFinite(sg) && sg > 0) return `${sg} SG sold 24h`;
+        return "";
+      } },
+    { key: "price_drops", title: "Price drops in NYC",
+      accent: (ev) => {
+        const d = Number(ev._discount_pct);
+        return Number.isFinite(d) ? `↓ ${d.toFixed(0)}% below market` : "";
+      } },
+    { key: "climbing", title: "Climbing fast in NYC",
+      accent: (ev) => {
+        const c = Number(ev._climb_pct);
+        return Number.isFinite(c) ? `↑ ${c.toFixed(0)}% in 24h` : "";
+      } },
+    { key: "specials", title: "Upcoming Specials in NYC",
+      accent: (ev) => ev._special || "" },
+  ];
 
-  function _moverCard(ev) {
+  function _moverCard(ev, accent) {
     const a = document.createElement("a");
     a.className = "mover-card";
-    if (ev.from_pad) a.classList.add("from-pad");
     a.href = `/store/event/${Number(ev.id) || 0}`;
     if (ev.primary_performer_color) {
       a.style.setProperty("--card-accent", ev.primary_performer_color);
     }
-    // Multi-label badges. Server returns labels array; iterate in our display
-    // order to keep badge sequence consistent across cards.
-    const labels = Array.isArray(ev.labels) ? ev.labels : [];
-    if (labels.length) {
-      const badges = document.createElement("div");
-      badges.className = "mover-badges";
-      Object.keys(LABEL_DISPLAY).forEach((lblName) => {
-        const lbl = labels.find((L) => L && L.name === lblName);
-        if (!lbl) return;
-        const span = document.createElement("span");
-        span.className = `mover-badge ${lblName} conf-${lbl.conf || 1}`;
-        span.textContent = LABEL_DISPLAY[lblName];
-        badges.append(span);
-      });
-      a.append(badges);
+    if (accent) {
+      const badge = document.createElement("div");
+      badge.className = "mover-accent";
+      badge.textContent = accent;
+      a.append(badge);
     }
     const title = document.createElement("div");
     title.className = "mover-title";
@@ -890,47 +885,37 @@
       fp.textContent = `from ${fmtMoney(ev.from_price)}`;
       meta.append(fp);
     }
-    if (ev.tix_d24h != null && Number(ev.tix_d24h) < 0) {
-      const note = document.createElement("span");
-      note.className = "mover-note";
-      note.textContent = `${Math.abs(Number(ev.tix_d24h))} sold today`;
-      meta.append(note);
-    } else if (ev.sg_sales_24h && Number(ev.sg_sales_24h) > 0) {
-      // Fallback note: SG-side activity when TEvo velocity isn't available
-      const note = document.createElement("span");
-      note.className = "mover-note";
-      note.textContent = `${Number(ev.sg_sales_24h)} SG sold 24h`;
-      meta.append(note);
-    }
     a.append(meta);
     return a;
   }
 
-  // Render the "Moving fast in NYC" strip — horizontal card row above
-  // the main grid. Each card carries 1+ multi-label badges (selling_fast /
-  // demand_rising / trending / deal). Top 1% of qualifying pool, clamped
-  // server-side to [5, 8] cards.
-  function renderMoversStrip(strip, row, payload) {
-    const items = (payload && payload.events) || [];
-    row.replaceChildren();
-    if (!items.length) { strip.hidden = true; return; }
-    strip.hidden = false;
-    for (const ev of items) {
-      row.append(_moverCard(ev));
+  // Render the 4 themed sliders. Each one builds a labeled <section> with
+  // a horizontal scrolling row of `_moverCard()`s. Empty sections are
+  // skipped entirely (no header rendered); when all 4 are empty, the
+  // whole container hides.
+  function renderMoversSections(host, payload) {
+    host.replaceChildren();
+    let rendered = 0;
+    for (const cfg of SECTIONS) {
+      const items = (payload && payload[cfg.key]) || [];
+      if (!items.length) continue;
+      const section = document.createElement("section");
+      section.className = `movers-section movers-${cfg.key.replace(/_/g, "-")}`;
+      section.setAttribute("aria-label", cfg.title);
+      const h = document.createElement("h2");
+      h.className = "movers-section-title";
+      h.textContent = cfg.title;
+      section.append(h);
+      const row = document.createElement("div");
+      row.className = "movers-section-row";
+      for (const ev of items) {
+        row.append(_moverCard(ev, cfg.accent(ev)));
+      }
+      section.append(row);
+      host.append(section);
+      rendered += 1;
     }
-  }
-
-  // Render the "More moving in NYC" rest grid (2 rows × 5 cards). Same card
-  // markup as the strip. Server sends `rest` array (≤10) sampled proportional
-  // to label distribution; padded from owned-1-50 events when primary thin.
-  function renderMoversRest(section, gridEl, payload) {
-    const items = (payload && payload.rest) || [];
-    gridEl.replaceChildren();
-    if (!items.length) { section.hidden = true; return; }
-    section.hidden = false;
-    for (const ev of items) {
-      gridEl.append(_moverCard(ev));
-    }
+    host.hidden = rendered === 0;
   }
 
   // Shows a "Showing events for ___" banner above the catalog when the user

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -1116,14 +1116,18 @@ a.perf-chip:hover {
   text-decoration: underline;
 }
 
-/* ----- Movers strip (homepage NYC widget) -----
-   Horizontal scroll row above the main grid. One card per top mover.
-   Hidden when the user is filtered (performer_id / venue_id) since the
-   strip is a home-view discovery aid, not a filter-respecting list. */
-.movers-strip {
+/* ----- Movers themed sliders (homepage NYC widget) -----
+   Four horizontal scrolling rows, one per theme (moving_fast, price_drops,
+   climbing, specials). Hidden when the user is filtered (performer_id /
+   venue_id) since these are home-view discovery aids, not filter-aware
+   lists. Empty sections are skipped server-side via the JS renderer. */
+.movers-sections {
   margin: 0 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
 }
-.movers-title {
+.movers-section-title {
   font-size: 14px;
   font-weight: 700;
   letter-spacing: 0.3px;
@@ -1131,16 +1135,16 @@ a.perf-chip:hover {
   color: var(--muted);
   margin: 0 0 10px;
 }
-.movers-row {
+.movers-section-row {
   display: flex;
   gap: 10px;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   padding-bottom: 6px;
 }
-.movers-row::-webkit-scrollbar { height: 8px; }
-.movers-row::-webkit-scrollbar-track { background: transparent; }
-.movers-row::-webkit-scrollbar-thumb {
+.movers-section-row::-webkit-scrollbar { height: 8px; }
+.movers-section-row::-webkit-scrollbar-track { background: transparent; }
+.movers-section-row::-webkit-scrollbar-thumb {
   background: var(--line);
   border-radius: 4px;
 }
@@ -1172,7 +1176,11 @@ a.perf-chip:hover {
   background: var(--card-accent);
   border-radius: var(--radius) var(--radius) 0 0;
 }
-.mover-badge {
+
+/* Per-section accent line — replaces the prior multi-label badge stack.
+   Each section colors its accent to telegraph the signal: red for fast-
+   selling, green for drops, amber for climbing, gold for specials. */
+.mover-accent {
   align-self: flex-start;
   font-size: 10px;
   font-weight: 700;
@@ -1180,86 +1188,30 @@ a.perf-chip:hover {
   padding: 2px 8px;
   border-radius: 999px;
   margin-bottom: 4px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.mover-badge.selling_fast {
+.movers-moving-fast .mover-accent {
   background: rgba(239, 68, 68, 0.12);
   border: 1px solid rgba(239, 68, 68, 0.45);
   color: #ffb6b6;
 }
-.mover-badge.demand_rising {
+.movers-price-drops .mover-accent {
   background: rgba(74, 222, 128, 0.12);
   border: 1px solid rgba(74, 222, 128, 0.45);
   color: #b6f0c8;
 }
-/* premium label dropped per operator 2026-05-18; selectors kept commented
-   for searchability but no rules emit. */
-
-/* New label-system additions (operator 2026-05-18 — multi-label per card) */
-.mover-badge.trending {
-  background: rgba(96, 165, 250, 0.12);
-  border: 1px solid rgba(96, 165, 250, 0.45);
-  color: #b9d5fb;
+.movers-climbing .mover-accent {
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  color: #ffe3a3;
 }
-.mover-badge.deal {
+.movers-specials .mover-accent {
   background: rgba(168, 85, 247, 0.12);
   border: 1px solid rgba(168, 85, 247, 0.45);
   color: #d8b7fb;
-}
-/* conf-2 (dual TEvo+SG corroboration) renders with a brighter/thicker outline */
-.mover-badge.conf-2 {
-  border-width: 1.5px;
-  filter: brightness(1.15);
-}
-/* Multi-badge container — flex wrap so 2+ badges stack tidily */
-.mover-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-bottom: 4px;
-}
-
-/* Rest grid below the strip — 2 rows × 5 cards. */
-.movers-rest {
-  margin-top: 16px;
-}
-.movers-rest-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin: 0 0 8px;
-}
-.movers-rest-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: repeat(2, auto);
-  gap: 12px;
-}
-@media (max-width: 1100px) {
-  .movers-rest-grid {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: auto;
-  }
-}
-@media (max-width: 700px) {
-  .movers-rest-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-/* Pad-fill cards (owned 1-50) get a subtle de-emphasis so users can tell
-   they're "limited inventory" — still bookable, just thinner. */
-.mover-card.from-pad {
-  opacity: 0.78;
-}
-.mover-card.from-pad::after {
-  content: "limited";
-  position: absolute;
-  bottom: 6px;
-  right: 8px;
-  font-size: 9px;
-  color: var(--muted);
-  letter-spacing: 0.5px;
 }
 .mover-title {
   font-size: 14px;

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -871,26 +871,23 @@ def test_movers_drops_tix_d24h_when_velocity_stale(monkeypatch):
     r = client.get("/api/store/movers?city=NYC&days=30&limit=10")
     assert r.status_code == 200, r.text
 
-    by_id = {e["id"]: e for e in r.json()["events"]}
+    # Post-PR #274/#275: response is split into 4 themed arrays
+    # (moving_fast, price_drops, climbing, specials). The fresh-velocity
+    # event with -500 d24h qualifies for `moving_fast` (d24h <= -50).
+    body = r.json()
+    moving_fast_by_id = {e["id"]: e for e in body.get("moving_fast", [])}
 
-    # Stale event (1001): velocity-suspect, so tix_d24h must be None and
-    # signal must NOT be selling_fast (no velocity-derived signal allowed).
-    # It also shouldn't make the cut as a candidate (no signal, no
-    # meaningful d24h activity since d24h was dropped).
-    assert 1001 not in by_id, (
-        "stale-velocity event must NOT surface — tix_d24h suppressed and no signal"
+    # Stale event (1001): velocity-suspect → tix_d24h dropped → no
+    # qualification for moving_fast (no d24h, no SG sales stubbed).
+    assert 1001 not in moving_fast_by_id, (
+        "stale-velocity event must NOT surface — tix_d24h suppressed"
     )
 
-    # Fresh event (1002): velocity trusted; -500 ticket drop fires selling_fast.
-    # Note: post-PR #273, signal-string was replaced with labels-array
-    # (multi-label per event). The selling_fast label still fires from the
-    # TEvo path here (SG data not stubbed in this fixture, so conf=1).
-    assert 1002 in by_id, "fresh-velocity event should make the strip"
-    labels_1002 = by_id[1002].get("labels") or []
-    assert any(L.get("name") == "selling_fast" for L in labels_1002), (
-        f"fresh event must carry selling_fast label; got labels={labels_1002}"
-    )
-    assert by_id[1002]["tix_d24h"] == -500
+    # Fresh event (1002): velocity trusted; -500 ticket drop qualifies it
+    # for the moving_fast section via the TEvo path. SG sales not stubbed
+    # here, so SG path doesn't fire — TEvo path is sufficient.
+    assert 1002 in moving_fast_by_id, "fresh-velocity event should make moving_fast"
+    assert moving_fast_by_id[1002]["tix_d24h"] == -500
 
 
 def test_movers_response_no_longer_includes_tix_d1h(monkeypatch):
@@ -900,7 +897,7 @@ def test_movers_response_no_longer_includes_tix_d1h(monkeypatch):
     from datetime import datetime, timezone, timedelta
     fresh_ts = (datetime.now(timezone.utc) - timedelta(minutes=15)).isoformat()
 
-    fake_metrics = [{"event_id": 2001, "owned_tickets_count": 50, "owned_groups_count": 5, "retail_min": 30.0}]
+    fake_metrics = [{"event_id": 2001, "owned_tickets_count": 100, "owned_groups_count": 5, "retail_min": 30.0}]
     fake_events = [{"id": 2001, "name": "Test", "occurs_at_local": "2026-06-01T19:00:00-04:00",
                     "venue_name": "MSG", "venue_location": "New York, NY",
                     "primary_performer_id": 16303, "primary_performer_name": "Yankees"}]
@@ -941,10 +938,13 @@ def test_movers_response_no_longer_includes_tix_d1h(monkeypatch):
     client = TestClient(app_module.app)
     r = client.get("/api/store/movers?city=NYC&days=30&limit=10")
     assert r.status_code == 200
-    for ev in r.json()["events"]:
-        assert "tix_d1h" not in ev, (
-            f"tix_d1h must not appear in mover response; got keys: {list(ev.keys())}"
-        )
+    body = r.json()
+    # Inspect cards across all four themed sections — none should leak tix_d1h.
+    for key in ("moving_fast", "price_drops", "climbing", "specials"):
+        for ev in body.get(key, []):
+            assert "tix_d1h" not in ev, (
+                f"tix_d1h must not appear in mover response; got keys: {list(ev.keys())}"
+            )
 
 
 def test_store_html_routes_respond_to_head(monkeypatch):


### PR DESCRIPTION
## Summary

Restructure the storefront home rail into **four independent horizontal sliders**, patterned on SeatGeek's homepage `buzzfeed-horizontal-list` sections. Replaces the single "Moving fast in NYC" strip + 10-card rest grid that landed in PR #273.

The deal-domination problem (PR #274's fix tried to address via round-robin + curve) is solved structurally here — deals can't crowd selling_fast or trending because each lives in its own row.

## Sections

| Section | Trigger | Accent line |
|---|---|---|
| **Moving fast in NYC** | `sg_sales_24h >= 10` OR `tix_d24h <= -50` | "120 sold today" / "35 SG sold 24h" |
| **Price drops in NYC** | `retail_min < 0.7 × sg_median_now` (≥30% below market) | "↓ 35% below market" |
| **Climbing fast in NYC** | (TEvo: `d24h<0` AND getin `+5%`) OR (SG: median `+5%` AND listings `-5%`) | "↑ 8% in 24h" |
| **Upcoming Specials in NYC** | `owned > 100` AND (`v_event_holidays` match OR `v_rivalry_events` match) | "Independence Day" / "Yankees vs Red Sox" |

Each section is independent — an event can appear in 0, 1, or multiple sections (e.g., July 4th Yankees vs Red Sox: `specials` + `moving_fast`).

## Backend (`app.py`)

- **Dropped**: `_movers_compute_labels`, `_movers_compute_score`, `_bucket_by_primary_label`, `_round_robin_pop_by_label` (label-bucket system from PR #273/#274).
- **New helpers**: `_section_moving_fast`, `_section_price_drops`, `_section_climbing`, `_section_specials`.
- `_compute_movers` builds one candidate pool gated to `owned > 50` (specials raises gate to `> 100`); each section then filters + sorts that pool independently.
- Specials pulls `v_event_holidays` + `v_rivalry_events` Python-side, deduped on `tevo_event_id` (rivalry view emits duplicate rows when both teams are competitors — bible §3 landmine).
- Response shape: `moving_fast`, `price_drops`, `climbing`, `specials` replacing `events` + `rest`.

## Frontend

| File | Change |
|---|---|
| `static/store/index.html` | Replace `#moversStrip` + `#moversRest` with single `#moversSections` container |
| `static/store/store.js` | Drop `LABEL_DISPLAY` / `renderMoversStrip` / `renderMoversRest`. Add `SECTIONS` config + `renderMoversSections`. Each card gets a per-section accent line. |
| `static/store/style.css` | Drop `.mover-badge.*` rules. Add `.movers-section-*` + `.mover-accent` with per-section color (red / green / amber / purple). |

## Verification

- [x] `python -m pytest tests/test_store_home.py -x -q` — **35/35 pass**
- [x] Local smoke-test of section helpers: confirmed correct filtering for moving_fast, price_drops, climbing, specials (rivalry tag takes priority over holiday tag when both apply).
- [ ] CI: pytest + check + scan
- [ ] Post-deploy hit `/api/store/movers?city=NYC&days=90` — confirm response has `moving_fast`/`price_drops`/`climbing`/`specials` arrays, no `events`/`rest`.
- [ ] Hard-reload `/store` — four sliders render, each with section-colored accent badges.

## Pool validation (run 2026-05-19)

Against current NYC owned-100 inventory in the next 90 days:
- **Specials pool**: 17 holiday-window events + 3 rivalry events ≈ 20 qualifying. Easily fills 10-card rail.
- Per-month: May 8, Jun 14, Jul 9, Aug 8 events with owned > 100. Plenty of depth.

## Notes / out of scope

- Holiday calendar comes from `v_event_holidays` (server-managed) — no Python hardcoded list to rotate annually.
- Frontend nav reshape (Categories tiles, Highlights row) deferred — keeping current `/store` header.
- Geo: hardcoded NYC (same as before). Future PR for user-location resolution.

D1 lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_