### PR TITLE
feat(a1/movers): TEvo blindspot detection RPC — companion to SG blindspot

### DIFF
--- a/static/terminal/discovery.html
+++ b/static/terminal/discovery.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=1440, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Terminal — Discovery</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body data-page="discovery">
+
+  <header class="topbar">
+    <span class="brand">TERMINAL · D0</span>
+    <span id="status" class="status">Loading…</span>
+  </header>
+
+  <main class="wrap movers">
+
+    <!-- TEvo blindspot panel — broker pool moving on events we own 0 of.
+         Backed by get_blind_spots_tevo_selling RPC (mig 20260519180000).
+         3-signal composite + confidence score + days-to-event band. -->
+    <section id="tevo-blind-spots">
+      <div class="panel-title row">
+        <span>BLIND SPOTS — TEvo SELLING, WE'RE NOT</span>
+        <span class="muted small" id="tevoBlindSpotsCount"></span>
+      </div>
+      <div class="ctrl-row">
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">MODE</span>
+          <button class="ctrl-btn is-active" data-tevo-mode="selling">Selling</button>
+          <button class="ctrl-btn"           data-tevo-mode="tracking">Tracking</button>
+          <button class="ctrl-btn"           data-tevo-mode="spike_only">Spikes only</button>
+        </div>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">BAND</span>
+          <button class="ctrl-btn is-active" data-tevo-band="">All</button>
+          <button class="ctrl-btn"           data-tevo-band="imminent_31_60">31-60d</button>
+          <button class="ctrl-btn"           data-tevo-band="near_61_180">61-180d</button>
+          <button class="ctrl-btn"           data-tevo-band="far_181_365">181-365d</button>
+        </div>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">CONFIDENCE</span>
+          <button class="ctrl-btn"           data-tevo-conf="0.3">≥ 0.3</button>
+          <button class="ctrl-btn is-active" data-tevo-conf="0.5">≥ 0.5</button>
+          <button class="ctrl-btn"           data-tevo-conf="0.8">≥ 0.8</button>
+        </div>
+      </div>
+      <div id="tevoBlindSpotsBody"><div class="empty">loading…</div></div>
+    </section>
+
+    <!-- Returning-entity panel — performers + venues with past activity →
+         gap → upcoming events. Backed by get_returning_entities RPC
+         (mig 20260519200000). v1: TEvo perf+venue + SG venue;
+         SG performer link deferred to v2. -->
+    <section id="returning-entities">
+      <div class="panel-title row">
+        <span>RETURNING — PERFORMERS &amp; VENUES BACK AFTER DORMANCY</span>
+        <span class="muted small" id="returningCount"></span>
+      </div>
+      <div class="ctrl-row">
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">GAP</span>
+          <button class="ctrl-btn"           data-ret-gap="60">≥ 60d</button>
+          <button class="ctrl-btn is-active" data-ret-gap="90">≥ 90d</button>
+          <button class="ctrl-btn"           data-ret-gap="180">≥ 180d</button>
+        </div>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">SOURCE</span>
+          <button class="ctrl-btn is-active" data-ret-source="">All</button>
+          <button class="ctrl-btn"           data-ret-source="tevo">TEvo</button>
+          <button class="ctrl-btn"           data-ret-source="sg">SG</button>
+        </div>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">TYPE</span>
+          <button class="ctrl-btn is-active" data-ret-type="">All</button>
+          <button class="ctrl-btn"           data-ret-type="performer">Performer</button>
+          <button class="ctrl-btn"           data-ret-type="venue">Venue</button>
+        </div>
+      </div>
+      <div id="returningBody"><div class="empty">loading…</div></div>
+    </section>
+
+    <section id="discovery-note">
+      <div class="muted small">
+        Discovery surface — events where the broker pool is active but we own 0,
+        plus performers / venues coming back from dormancy. Big 5 (MLB / NBA / NFL /
+        NHL / MLS) excluded from blind spots — those are covered on the Movers tab.
+        Data refreshed twice daily by cron <code>tevo_blindspot_metrics_refresh_12h</code>.
+      </div>
+    </section>
+  </main>
+
+  <script src="lib/supabase.js"></script>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+  <script src="nav.js"></script>
+  <script src="discovery.js"></script>
+</body>
+</html>

--- a/static/terminal/discovery.js
+++ b/static/terminal/discovery.js
@@ -1,0 +1,290 @@
+// D0 Terminal — Discovery page (TEvo blindspot + returning entities).
+// Companion to movers.js; both consume Supabase RPCs through TerminalAuth.
+//
+// Two panels:
+//   1. BLIND SPOTS — TEvo SELLING, WE'RE NOT
+//      RPC: get_blind_spots_tevo_selling(min_conf, horizon, limit, venue, mode, band)
+//      Backed by mig 20260519180000. 3-signal composite over broker pool
+//      where we own 0 tickets, big 5 sports excluded. Confidence-sorted.
+//   2. RETURNING — performers + venues back after dormancy
+//      RPC: get_returning_entities(min_gap_days, source, entity_type, limit)
+//      Backed by mig 20260519200000. TEvo perf+venue + SG venue today;
+//      SG performer link deferred to v2.
+
+(function () {
+  'use strict';
+  const T = window.Terminal;
+
+  // ---- State shared across both panels (filter UI -> RPC params) ----
+  const tevoState = { mode: 'selling', band: '', conf: 0.5 };
+  const retState  = { gap: 90, source: '', entityType: '' };
+
+  function init() {
+    wireTevoControls();
+    wireReturningControls();
+    refreshTevoBlindSpots().catch(e => console.error('[tevo-blindspots]', e));
+    refreshReturning().catch(e => console.error('[returning]', e));
+    setStatus('');
+  }
+
+  function setStatus(s) {
+    const el = document.getElementById('status');
+    if (el) el.textContent = s;
+  }
+
+  // -------- TEvo blindspot panel ---------------------------------
+
+  function wireTevoControls() {
+    document.querySelectorAll('[data-tevo-mode]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        tevoState.mode = btn.dataset.tevoMode;
+        toggleActive(btn, '[data-tevo-mode]');
+        refreshTevoBlindSpots();
+      });
+    });
+    document.querySelectorAll('[data-tevo-band]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        tevoState.band = btn.dataset.tevoBand || '';
+        toggleActive(btn, '[data-tevo-band]');
+        refreshTevoBlindSpots();
+      });
+    });
+    document.querySelectorAll('[data-tevo-conf]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        tevoState.conf = Number(btn.dataset.tevoConf);
+        toggleActive(btn, '[data-tevo-conf]');
+        refreshTevoBlindSpots();
+      });
+    });
+  }
+
+  async function refreshTevoBlindSpots() {
+    const body = document.getElementById('tevoBlindSpotsBody');
+    const countEl = document.getElementById('tevoBlindSpotsCount');
+    if (!body) return;
+
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+
+    body.innerHTML = '<div class="empty">loading…</div>';
+
+    let rows;
+    try {
+      const res = await Auth.client.rpc('get_blind_spots_tevo_selling', {
+        p_min_confidence: tevoState.conf,
+        p_horizon_days:   365,
+        p_limit:          25,
+        p_venue_pattern:  null,
+        p_mode:           tevoState.mode,
+        p_band:           tevoState.band || null,
+      });
+      if (res.error) throw new Error(res.error.message || 'RPC error');
+      rows = res.data || [];
+    } catch (e) {
+      body.innerHTML = '<div class="empty">error: ' + escapeHtml(e.message) + '</div>';
+      if (countEl) countEl.textContent = '';
+      return;
+    }
+
+    const n = rows.length;
+    if (countEl) countEl.textContent = n ? `${n} event${n === 1 ? '' : 's'}` : '';
+
+    if (!n) {
+      body.innerHTML =
+        '<div class="empty">no signals at confidence &ge; ' + tevoState.conf +
+        ' (mode: ' + tevoState.mode +
+        (tevoState.band ? ', band: ' + tevoState.band : '') + ')</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.className = 'blind-spots-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th><th>Venue</th>
+        <th class="num">T-days</th>
+        <th class="num" title="Confidence: avg of fired-signal strengths, 0..1">Conf</th>
+        <th class="num">Listed</th>
+        <th class="num" title="24h listings delta">d24h</th>
+        <th class="num" title="24h listings delta %">L Δ%</th>
+        <th class="num" title="24h get-in % change">P Δ%</th>
+        <th class="num" title="Parking-aware get-in">Get-in</th>
+        <th>Signals</th>
+      </tr></thead>
+      <tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const eventLabel = r.tevo_event_id
+        ? `<a href="event.html?event=${r.tevo_event_id}">${escapeHtml(r.event_name || ('TEvo ' + r.tevo_event_id))}</a>`
+        : escapeHtml(r.event_name || ('TEvo ' + r.tevo_event_id));
+
+      const sigParts = [];
+      if (r.signal_listings_drop)  sigParts.push('drop');
+      if (r.signal_listings_spike) sigParts.push('spike');
+      if (r.signal_price_rise)     sigParts.push('rise');
+      const sigText = sigParts.join(' · ') || '—';
+
+      tr.innerHTML = `
+        <td>${eventLabel}</td>
+        <td>${escapeHtml(r.venue_name || '')} <span class="muted small">${escapeHtml(r.venue_location || '')}</span></td>
+        <td class="num">${T.daysUntil(r.occurs_at_local) ?? '—'}</td>
+        <td class="num">${fmtConf(r.confidence_score)}</td>
+        <td class="num">${T.fmtNum(r.tickets_count)}</td>
+        <td class="num">${T.fmtNum(r.tevo_tix_d24h)}</td>
+        <td class="num">${T.fmtPct(r.tevo_tix_d24h_pct)}</td>
+        <td class="num">${T.fmtPct(r.tevo_getin_d24h_pct)}</td>
+        <td class="num">$${T.fmtNum(r.getin_no_parking)}</td>
+        <td>${escapeHtml(sigText)}</td>`;
+      tb.appendChild(tr);
+    });
+
+    body.replaceChildren(tbl);
+  }
+
+  // -------- Returning-entities panel -----------------------------
+
+  function wireReturningControls() {
+    document.querySelectorAll('[data-ret-gap]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        retState.gap = Number(btn.dataset.retGap);
+        toggleActive(btn, '[data-ret-gap]');
+        refreshReturning();
+      });
+    });
+    document.querySelectorAll('[data-ret-source]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        retState.source = btn.dataset.retSource || '';
+        toggleActive(btn, '[data-ret-source]');
+        refreshReturning();
+      });
+    });
+    document.querySelectorAll('[data-ret-type]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        retState.entityType = btn.dataset.retType || '';
+        toggleActive(btn, '[data-ret-type]');
+        refreshReturning();
+      });
+    });
+  }
+
+  async function refreshReturning() {
+    const body = document.getElementById('returningBody');
+    const countEl = document.getElementById('returningCount');
+    if (!body) return;
+
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+
+    body.innerHTML = '<div class="empty">loading…</div>';
+
+    let rows;
+    try {
+      const res = await Auth.client.rpc('get_returning_entities', {
+        p_min_gap_days: retState.gap,
+        p_source:       retState.source || null,
+        p_entity_type:  retState.entityType || null,
+        p_limit:        50,
+      });
+      if (res.error) throw new Error(res.error.message || 'RPC error');
+      rows = res.data || [];
+    } catch (e) {
+      body.innerHTML = '<div class="empty">error: ' + escapeHtml(e.message) + '</div>';
+      if (countEl) countEl.textContent = '';
+      return;
+    }
+
+    const n = rows.length;
+    if (countEl) countEl.textContent = n ? `${n} entit${n === 1 ? 'y' : 'ies'}` : '';
+
+    if (!n) {
+      body.innerHTML =
+        '<div class="empty">no returning entities at gap &ge; ' + retState.gap + ' days</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.className = 'blind-spots-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Entity</th>
+        <th>Type</th>
+        <th>Source</th>
+        <th>Location</th>
+        <th class="num">Last seen</th>
+        <th class="num">Next event</th>
+        <th class="num" title="Days between last past event and next upcoming">Gap</th>
+        <th class="num">Upcoming</th>
+        <th class="num">Past</th>
+      </tr></thead>
+      <tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      let nameCell;
+      if (r.source === 'tevo' && r.entity_type === 'performer') {
+        nameCell = `<a href="performer.html?performer=${escapeHtml(r.entity_id)}">${escapeHtml(r.entity_name || '')}</a>`;
+      } else if (r.source === 'tevo' && r.entity_type === 'venue') {
+        nameCell = `<a href="venue.html?venue=${escapeHtml(r.entity_id)}">${escapeHtml(r.entity_name || '')}</a>`;
+      } else {
+        // SG venue + future SG performer — no terminal drill page yet
+        nameCell = escapeHtml(r.entity_name || '');
+      }
+      tr.innerHTML = `
+        <td>${nameCell}</td>
+        <td>${escapeHtml(r.entity_type)}</td>
+        <td>${escapeHtml(r.source)}</td>
+        <td>${escapeHtml(r.entity_location || '')}</td>
+        <td class="num">${escapeHtml(fmtDateShort(r.latest_past_at))}</td>
+        <td class="num">${escapeHtml(fmtDateShort(r.earliest_future_at))}</td>
+        <td class="num">${T.fmtNum(r.gap_days)}d</td>
+        <td class="num">${T.fmtNum(r.upcoming_count)}</td>
+        <td class="num">${T.fmtNum(r.past_count)}</td>`;
+      tb.appendChild(tr);
+    });
+
+    body.replaceChildren(tbl);
+  }
+
+  // -------- shared helpers ---------------------------------------
+
+  function toggleActive(btn, selector) {
+    document.querySelectorAll(selector).forEach(b => b.classList.remove('is-active'));
+    btn.classList.add('is-active');
+  }
+
+  function fmtConf(v) {
+    if (v === null || v === undefined) return '—';
+    return Number(v).toFixed(2);
+  }
+
+  function fmtDateShort(iso) {
+    if (!iso) return '';
+    try {
+      return new Date(iso).toLocaleDateString(undefined, {
+        year: '2-digit', month: 'short', day: 'numeric',
+      });
+    } catch (_) { return ''; }
+  }
+
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;',
+    }[c]));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -19,6 +19,10 @@
     { id: 'venue',     label: 'VENUE',     href: 'venue.html' },
     { id: 'performer', label: 'PERFORMER', href: 'performer.html' },
     { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
+    // Discovery — TEvo blindspot (broker selling, we own 0) + returning
+    // performers/venues. Companion to Movers; same nav grouping for the
+    // "what to watch" surface. Wired 2026-05-19 (PR A1 blindspot stack).
+    { id: 'discovery', label: 'DISCOVERY', href: 'discovery.html' },
     { id: 'orders',    label: 'ORDERS',    href: 'orders.html' },
   ];
 

--- a/supabase/functions/tevo-blindspot-discovery/index.ts
+++ b/supabase/functions/tevo-blindspot-discovery/index.ts
@@ -1,0 +1,237 @@
+// tevo-blindspot-discovery (v1 skeleton)
+//
+// Companion edge fn to:
+//   - mig 20260519180000 (TEvo blindspot detector view + RPC)
+//   - mig 20260519190000 (tevo_blindspot_discovery_daily cron)
+//
+// PURPOSE:
+//   Find new TEvo events that aren't yet in our local `events` table and
+//   match the blindspot detector's candidate gates (US/CA venue, 31-365d
+//   out, sports-leaning). Upsert winners into `events` so they flow into
+//   `latest_event_metrics` → `v_tevo_blindspot_movers` on the next
+//   collect-listings cycle + metrics refresh.
+//
+// PATTERN mirrors sg-to-tevo-search-bridge (mig 20260516250000):
+//   - HMAC-signed TEvo /v9/events calls
+//   - Audit row in `tevo_blindspot_discovery_attempts` updated with results
+//   - requireCronSecret() auth wrapper
+//
+// THIS IS A SKELETON. The TEvo /v9/events search semantics + the new-event
+// filter logic need operator-side validation before production. Specifically:
+//   1. TEvo /v9/events supports `office_id` + `occurs_at.gte/lte` filters
+//      but the country-code filter shape is undocumented in our code
+//      base — needs trial-and-error against the live API.
+//   2. The "matching blindspot criteria" filter currently checks venue
+//      country + date window + presence of `tickets_count` — but the
+//      search response shape doesn't include `tickets_count` directly.
+//      We need either a follow-up /v9/ticket_groups call per candidate
+//      (expensive) OR rely on the post-upsert collect-listings cycle to
+//      backfill that field, then let the detector filter it out if too low.
+//
+// GET /functions/v1/tevo-blindspot-discovery?attempt_id=N&limit=200&dry_run=false
+//   - attempt_id: row id in tevo_blindspot_discovery_attempts to update
+//   - limit:      max events to upsert per run (default 200)
+//   - dry_run:    if true, scores + counts but doesn't write to `events`
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
+import { requireCronSecret } from "../_shared/cron-auth.ts";
+
+const HOST = "api.ticketevolution.com";
+const BASE = `https://${HOST}`;
+
+// US states + DC + Canadian provinces — same set as the detector view regex.
+const US_STATES = new Set([
+  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA","HI","ID","IL","IN","IA",
+  "KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT",
+  "VA","WA","WV","WI","WY","DC",
+]);
+const CA_PROVINCES = new Set([
+  "AB","BC","MB","NB","NL","NS","ON","PE","QC","SK","YT","NT","NU",
+]);
+
+async function hmac(secret: string, msg: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw", enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(msg));
+  let bin = "";
+  for (const b of new Uint8Array(sig)) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function qs(p: Record<string, unknown>): string {
+  const pairs: [string, string][] = [];
+  for (const [k, v] of Object.entries(p)) {
+    if (v === null || v === undefined || v === "") continue;
+    pairs.push([k, typeof v === "boolean" ? (v ? "true" : "false") : String(v)]);
+  }
+  pairs.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return pairs.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");
+}
+
+async function tevoSearch(token: string, secret: string, params: Record<string, unknown>) {
+  const path = "/v9/events";
+  const queryStr = qs(params);
+  const sig = await hmac(secret, `GET ${HOST}${path}?${queryStr}`);
+  const r = await fetch(`${BASE}${path}?${queryStr}`, {
+    headers: {
+      "X-Token": token,
+      "X-Signature": sig,
+      "Accept": "application/vnd.ticketevolution.api+json; version=9",
+    },
+  });
+  if (r.status !== 200) {
+    return { ok: false, status: r.status, body: (await r.text()).slice(0, 300) };
+  }
+  return { ok: true, body: await r.json() };
+}
+
+// Pull state code from a venue object. TEvo /v9/events embeds venue with
+// `state_province` (2-letter) or `country_code`. We match against the same
+// set the detector view uses.
+function isUsOrCa(venue: any): boolean {
+  if (!venue) return false;
+  const sp = String(venue.state_province ?? venue.state ?? "").toUpperCase().trim();
+  if (sp && (US_STATES.has(sp) || CA_PROVINCES.has(sp))) return true;
+  // Fallback: country code if state is missing
+  const cc = String(venue.country_code ?? venue.country ?? "").toUpperCase().trim();
+  return cc === "US" || cc === "CA";
+}
+
+Deno.serve(async (req) => {
+  const authErr = requireCronSecret(req);
+  if (authErr) return authErr;
+
+  const sb = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  const tevoToken = Deno.env.get("TEVO_TOKEN") ?? Deno.env.get("TEVO_API_TOKEN") ?? "";
+  const tevoSecret = Deno.env.get("TEVO_SECRET") ?? Deno.env.get("TEVO_API_SECRET") ?? "";
+  if (!tevoToken || !tevoSecret) {
+    return new Response(
+      JSON.stringify({ ok: false, error: "missing TEvo creds" }),
+      { status: 500, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  const url = new URL(req.url);
+  const attemptId = Number(url.searchParams.get("attempt_id") ?? "0") || null;
+  const limit = Math.max(1, Math.min(500, Number(url.searchParams.get("limit") ?? "200")));
+  const dryRun = url.searchParams.get("dry_run") === "true";
+
+  // Date window — must match the detector view exactly.
+  const today = new Date(); today.setUTCHours(0, 0, 0, 0);
+  const fromDate = new Date(today.getTime() + 31 * 86400000);
+  const toDate   = new Date(today.getTime() + 365 * 86400000);
+
+  // Pull existing TEvo event IDs so we can filter to NEW only.
+  const { data: existing } = await sb
+    .from("events")
+    .select("id")
+    .gte("occurs_at_local", fromDate.toISOString().slice(0, 10))
+    .lte("occurs_at_local", toDate.toISOString().slice(0, 10) + "T23:59:59");
+  const existingIds = new Set((existing ?? []).map((r: any) => Number(r.id)));
+
+  // Paginate /v9/events. TEvo caps per_page at ~100; we walk pages until
+  // we've gathered enough candidates or hit a hard cap.
+  const candidates: any[] = [];
+  let page = 1;
+  const HARD_PAGE_CAP = 10;     // 100/page × 10 pages = 1k events max per run
+  while (candidates.length < limit && page <= HARD_PAGE_CAP) {
+    // NOTE: per PROJECT_BIBLE §3 landmine, TEvo date filter syntax is the
+    // DOTTED form `occurs_at.gte` (not underscore — 422 Invalid Parameters).
+    const res = await tevoSearch(tevoToken, tevoSecret, {
+      "occurs_at.gte": fromDate.toISOString(),
+      "occurs_at.lte": toDate.toISOString(),
+      page,
+      per_page: 100,
+    });
+    if (!res.ok) break;
+    const evs = (res.body as any).events ?? [];
+    if (!evs.length) break;
+    for (const e of evs) {
+      if (existingIds.has(Number(e.id))) continue;     // already tracked
+      if (!isUsOrCa(e.venue)) continue;                // US/CA only
+      candidates.push(e);
+      if (candidates.length >= limit) break;
+    }
+    page += 1;
+  }
+
+  // Upsert winners into `events`. Minimum fields needed for the detector to
+  // pick them up once latest_event_metrics refreshes. The metadata
+  // (performer assets, lifecycle) gets backfilled by subsequent matchers
+  // and collectors — discovery just ensures the row exists.
+  let added = 0;
+  if (!dryRun && candidates.length > 0) {
+    const rows = candidates.map((e: any) => ({
+      id: Number(e.id),
+      name: e.name ?? "",
+      occurs_at_local: e.occurs_at_local ?? e.occurs_at ?? null,
+      venue_id: e.venue?.id ?? null,
+      venue_name: e.venue?.name ?? null,
+      venue_location: [e.venue?.city, e.venue?.state_province ?? e.venue?.state]
+        .filter(Boolean).join(", "),
+      primary_performer_id: e.performances?.[0]?.performer?.id ?? null,
+      primary_performer_name: e.performances?.[0]?.performer?.name ?? null,
+    }));
+    const { error, count } = await sb
+      .from("events")
+      .upsert(rows, { onConflict: "id", ignoreDuplicates: false, count: "exact" });
+    if (error) {
+      // Update audit row with the error + return.
+      if (attemptId) {
+        await sb.from("tevo_blindspot_discovery_attempts")
+          .update({
+            result: "error",
+            events_found: candidates.length,
+            events_added: 0,
+            meta: { error: error.message, sample: candidates.slice(0, 3).map((c: any) => c.id) },
+          })
+          .eq("attempt_id", attemptId);
+      }
+      return new Response(
+        JSON.stringify({ ok: false, error: error.message, candidates: candidates.length }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      );
+    }
+    added = count ?? rows.length;
+  }
+
+  // Log success back to the audit row (the cron's enqueue function wrote
+  // the initial row with result='enqueued'; we flip it to 'edge_fn_called'
+  // here with concrete counts).
+  if (attemptId) {
+    await sb.from("tevo_blindspot_discovery_attempts")
+      .update({
+        result: "edge_fn_called",
+        events_found: candidates.length,
+        events_added: added,
+        meta: {
+          dry_run: dryRun,
+          window_from: fromDate.toISOString().slice(0, 10),
+          window_to: toDate.toISOString().slice(0, 10),
+          sample: candidates.slice(0, 3).map((c: any) => ({
+            id: c.id, name: c.name, occurs_at: c.occurs_at_local ?? c.occurs_at,
+          })),
+        },
+      })
+      .eq("attempt_id", attemptId);
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      events_found: candidates.length,
+      events_added: added,
+      dry_run: dryRun,
+      attempt_id: attemptId,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/tevo-blindspot-discovery/index.ts
+++ b/supabase/functions/tevo-blindspot-discovery/index.ts
@@ -141,24 +141,41 @@ Deno.serve(async (req) => {
   // we've gathered enough candidates or hit a hard cap.
   const candidates: any[] = [];
   let page = 1;
-  const HARD_PAGE_CAP = 10;     // 100/page × 10 pages = 1k events max per run
+  let pagesWalked = 0;
+  let consecutiveAllKnownPages = 0;
+  let lastError: { status?: number; body?: string } | null = null;
+  const HARD_PAGE_CAP = 40;     // 100/page × 40 = 4k events max per run
   while (candidates.length < limit && page <= HARD_PAGE_CAP) {
     // NOTE: per PROJECT_BIBLE §3 landmine, TEvo date filter syntax is the
     // DOTTED form `occurs_at.gte` (not underscore — 422 Invalid Parameters).
+    // Sort column is `events.occurs_at_local` (matches chat fn pattern).
     const res = await tevoSearch(tevoToken, tevoSecret, {
       "occurs_at.gte": fromDate.toISOString(),
       "occurs_at.lte": toDate.toISOString(),
+      "order_by": "events.id DESC",
       page,
       per_page: 100,
     });
-    if (!res.ok) break;
+    if (!res.ok) {
+      lastError = { status: (res as any).status, body: (res as any).body };
+      break;
+    }
+    pagesWalked = page;
     const evs = (res.body as any).events ?? [];
     if (!evs.length) break;
+    let pageNew = 0;
     for (const e of evs) {
       if (existingIds.has(Number(e.id))) continue;     // already tracked
       if (!isUsOrCa(e.venue)) continue;                // US/CA only
       candidates.push(e);
+      pageNew += 1;
       if (candidates.length >= limit) break;
+    }
+    if (pageNew === 0) {
+      consecutiveAllKnownPages += 1;
+      if (consecutiveAllKnownPages >= 3) break;
+    } else {
+      consecutiveAllKnownPages = 0;
     }
     page += 1;
   }
@@ -214,6 +231,8 @@ Deno.serve(async (req) => {
         events_added: added,
         meta: {
           dry_run: dryRun,
+          pages_walked: pagesWalked,
+          last_error: lastError,
           window_from: fromDate.toISOString().slice(0, 10),
           window_to: toDate.toISOString().slice(0, 10),
           sample: candidates.slice(0, 3).map((c: any) => ({

--- a/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
+++ b/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
@@ -21,6 +21,12 @@
 --     2026-05-19 — longer-horizon inventory is sourcing-actionable too)
 --   * US or Canada venue                 — state/province regex match on
 --     `events.venue_location` (e.g. "Boston, MA" / "Toronto, ON")
+--   * NOT big 5 sports                   — exclude MLB / NBA / NFL / NHL /
+--     MLS via `event_xref.espn_league`. Big 5 events are already heavily
+--     tracked + dominate the broker pool; the detector adds value on
+--     niche sports + concerts + theater where coverage is thinner.
+--     Unmapped events (espn_league IS NULL) stay in the pool — they're
+--     the actual discovery candidates.
 --   * get-in-without-parking >= $50      — recomputed from
 --     `listings_snapshots.retail_price` excluding sections matching
 --     `%park%|%lot%|%garage%|%valet%`. TEvo bible §3 landmine: parking
@@ -117,6 +123,15 @@ WITH base AS (
   FROM public.events e
   JOIN public.latest_event_metrics lem ON lem.event_id = e.id
   LEFT JOIN public.event_lifecycle el  ON el.event_id = e.id
+  -- Two parallel league-mapping sources joined for big-5 exclusion. Both
+  -- are LEFT JOINs so unmapped events stay in the pool — they're the
+  -- actual discovery candidates. Coverage on the current 132-event pool:
+  --   performer_metadata.espn_league via primary_performer_id   126/132
+  --   event_xref.espn_league via tevo_event_id                   96/132
+  -- Union catches ~all big-5 events; remaining holes are speculative
+  -- "TBD" / "If Necessary" rows already filtered by the name rules below.
+  LEFT JOIN public.performer_metadata pm ON pm.performer_id = e.primary_performer_id
+  LEFT JOIN public.event_xref ex         ON ex.tevo_event_id  = e.id
   WHERE
     -- Forward window: 31..365 days out (drop game-time, allow long horizon)
     e.occurs_at_local::date >= CURRENT_DATE + interval '31 days'
@@ -127,6 +142,15 @@ WITH base AS (
     AND lem.tickets_count >= 25
     -- Active lifecycle
     AND (el.is_active IS NULL OR el.is_active = true)
+    -- Big 5 sports already heavily tracked → hard exclude. Either source
+    -- saying big-5 is sufficient grounds for exclusion. Concerts, niche
+    -- sports, theater, and other discovery candidates stay (both fields
+    -- NULL or other-league). Espn league codes are upper-case per
+    -- matcher v3 convention.
+    AND NOT (
+      coalesce(pm.espn_league, '') IN ('MLB','NBA','NFL','NHL','MLS')
+      OR coalesce(ex.espn_league, '') IN ('MLB','NBA','NFL','NHL','MLS')
+    )
     -- Speculative-name filter (mirrors storefront)
     AND e.name NOT ILIKE '%CANCELLED%'
     AND e.name NOT ILIKE '%(If Necessary)%'

--- a/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
+++ b/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
@@ -31,8 +31,13 @@
 --                                            Date TBD
 --
 -- COMPOSITE 3-SIGNAL DETECTION (mutually-exclusive directions):
---   signal_listings_drop   tevo_tix_d24h     <= -10    (≥10 tix gone in 24h)
---   signal_listings_spike  tevo_tix_d24h_pct >= +10%   (≥10% growth in listings)
+--   signal_listings_drop   tevo_tix_d24h <= -10 AND tevo_tix_d24h_pct <= -5%
+--                          PAIRED condition (v1.5 fix per algorithm review):
+--                          absolute floor filters noise on tiny pools where
+--                          a 10-tix drop is 33% (huge); pct floor filters
+--                          noise on big pools where 10-tix is 2% churn.
+--                          Both must fire.
+--   signal_listings_spike  tevo_tix_d24h_pct >= +10%   (pool loading)
 --   signal_price_rise      tevo_getin_d24h_pct >= +5%
 --
 -- DROP + SPIKE are mutually exclusive on the same event (one direction at
@@ -42,15 +47,20 @@
 --   * spike = pool loading  → "broker preparing for demand, watch closely"
 --   * rise  = price firming → "demand exceeding supply, regardless of vol"
 --
--- SCORES:
---   selling_score   = listings_drop::int + price_rise::int           (0..2)
---                     The "broker actively moving inventory" signal.
---   tracking_score  = (listings_drop OR listings_spike)::int + price_rise::int  (0..2)
---                     Wider net — includes spike events as "track these"
---                     even though they don't fit the selling narrative.
+-- SCORES + CONFIDENCE (v1.5 — algorithm review feedback):
+--   selling_score    = listings_drop::int + price_rise::int           (0..2)
+--   tracking_score   = (listings_drop OR listings_spike)::int + price_rise::int (0..2)
+--   confidence_score = avg of per-signal strengths that fire           (0..1)
+--                      Per-signal strength is how far past threshold each
+--                      signal is, capped at 1.0. RPC sorts by this rather
+--                      than by integer score — distinguishes a barely-firing
+--                      from a strongly-firing both-signals event.
 --
--- Default RPC behavior: returns selling_score >= 2 (both selling signals
--- fire). Spike-only events surface via the tracking_score path.
+-- DAYS-TO-EVENT BAND (v1.5):
+--   imminent_31_60  31-60d out  — sourcing window tightest; act fast
+--   near_61_180     61-180d out — mid-cycle decision
+--   far_181_365     181-365d out — research / monitor
+--   Surfaces on every row; RPC supports filtering.
 --
 -- VELOCITY FRESHNESS — 24h gate (NOT 3h):
 --   Blindspot events are owned=0 → not in the hot polling tier. The
@@ -59,10 +69,16 @@
 --   exclude virtually all blindspot events. 24h matches the collection
 --   cadence + our new tevo_blindspot_metrics_refresh_12h cron.
 --
--- WHY THRESHOLDS DIFFER FROM SG:
---   SG composite uses 5% / 10% / 30% / 0%. Tighter because SG firehose is
---   noisier (consumer marketplace, more listing churn). TEvo broker pool is
---   stickier — a 10-ticket drop or +10% growth or +5% getin rise is meaningful.
+-- KNOWN GAPS (deferred to v2):
+--   * No per-performer rolling baseline. A 10-tix drop on the Yankees is
+--     normal Tuesday; same drop on Cleveland Symphony is huge news. v2
+--     adds a `performer_baselines` matview with rolling mean ± stdev so
+--     signals fire on z-score deviation from the performer's own pattern.
+--   * No day-of-week or days-to-event seasonality awareness. The bands
+--     above are coarse triage, not statistical decomposition.
+--   * No outcome tracking. Detector doesn't learn from human sourcing
+--     decisions. Future: event_sourcing_decisions table feeding threshold
+--     auto-tuning after 90d of data.
 
 -- ============================================================
 -- 1. View — per-event composite score
@@ -161,27 +177,61 @@ scored AS (
     v.tevo_median_now,
     v.tevo_now_at,
     v.velocity_fresh,
-    -- Signal 1: pool draining (broker selling)
-    (v.velocity_fresh AND v.tevo_tix_d24h IS NOT NULL
-     AND v.tevo_tix_d24h <= -10)                                              AS signal_listings_drop,
+    -- Signal 1: pool draining (broker selling) — PAIRED condition
+    (v.velocity_fresh
+     AND v.tevo_tix_d24h     IS NOT NULL AND v.tevo_tix_d24h     <= -10
+     AND v.tevo_tix_d24h_pct IS NOT NULL AND v.tevo_tix_d24h_pct <= -5.0) AS signal_listings_drop,
     -- Signal 2: pool loading (broker prepping inventory for demand)
     (v.velocity_fresh AND v.tevo_tix_d24h_pct IS NOT NULL
-     AND v.tevo_tix_d24h_pct >= 10.0)                                         AS signal_listings_spike,
+     AND v.tevo_tix_d24h_pct >= 10.0)                                     AS signal_listings_spike,
     -- Signal 3: price firming
     (v.velocity_fresh AND v.tevo_getin_d24h_pct IS NOT NULL
-     AND v.tevo_getin_d24h_pct >= 5.0)                                        AS signal_price_rise
+     AND v.tevo_getin_d24h_pct >= 5.0)                                    AS signal_price_rise,
+    -- Per-signal strengths (0..1, capped) — used to derive confidence_score.
+    -- Strength = how far past threshold the metric is, normalized to a
+    -- "fully developed" point that's roughly 2× the trigger threshold.
+    -- A barely-firing signal scores ~0.5; a strongly-firing signal scores 1.0.
+    LEAST(1.0, GREATEST(0.0,
+      COALESCE(-v.tevo_tix_d24h_pct / 10.0, 0)))                          AS drop_strength,
+    LEAST(1.0, GREATEST(0.0,
+      COALESCE( v.tevo_tix_d24h_pct / 20.0, 0)))                          AS spike_strength,
+    LEAST(1.0, GREATEST(0.0,
+      COALESCE( v.tevo_getin_d24h_pct / 10.0, 0)))                        AS price_strength,
+    -- Days-to-event cohort (operator triage aid)
+    (occurs_at_local::date - CURRENT_DATE)                                AS days_to_event,
+    CASE
+      WHEN (occurs_at_local::date - CURRENT_DATE) <= 60   THEN 'imminent_31_60'
+      WHEN (occurs_at_local::date - CURRENT_DATE) <= 180  THEN 'near_61_180'
+      ELSE                                                     'far_181_365'
+    END                                                                   AS days_to_event_band
   FROM gated g
   LEFT JOIN velocity v ON v.tevo_event_id = g.tevo_event_id
 )
 SELECT
-  *,
-  -- "Selling" composite — drop + rise. Spike is excluded; spike narrative
-  -- is the opposite of selling (pool loading vs draining).
-  (signal_listings_drop::int + signal_price_rise::int)                  AS selling_score,
-  -- "Tracking" composite — wider net. Surfaces spike events alongside
-  -- selling events when callers ask via tracking_score >= N.
-  ((signal_listings_drop OR signal_listings_spike)::int
-    + signal_price_rise::int)                                            AS tracking_score
+  tevo_event_id, event_name, occurs_at_local, venue_id, venue_name,
+  venue_location, primary_performer_id, primary_performer_name,
+  owned_tickets_count, tickets_count, retail_min, retail_median,
+  metrics_captured_at, getin_no_parking, tevo_tix_d24h, tevo_tix_d24h_pct,
+  tevo_getin_d24h_pct, tevo_getin_now, tevo_median_now, tevo_now_at,
+  velocity_fresh, signal_listings_drop, signal_listings_spike,
+  signal_price_rise, days_to_event, days_to_event_band,
+  -- Score outputs
+  (signal_listings_drop::int + signal_price_rise::int)                                  AS selling_score,
+  ((signal_listings_drop OR signal_listings_spike)::int + signal_price_rise::int)        AS tracking_score,
+  -- Confidence: average of fired signals' strengths. 0..1. Differentiates
+  -- barely-firing (~0.5) from strongly-firing (~1.0). NULL when nothing fires.
+  CASE
+    WHEN (signal_listings_drop OR signal_listings_spike OR signal_price_rise) THEN
+      round((
+        (CASE WHEN signal_listings_drop  THEN drop_strength  ELSE 0 END) +
+        (CASE WHEN signal_listings_spike THEN spike_strength ELSE 0 END) +
+        (CASE WHEN signal_price_rise     THEN price_strength ELSE 0 END)
+      ) / NULLIF(
+        (signal_listings_drop::int + signal_listings_spike::int + signal_price_rise::int),
+        0
+      )::numeric, 3)
+    ELSE NULL
+  END                                                                                    AS confidence_score
 FROM scored
 WHERE velocity_fresh
   AND (signal_listings_drop OR signal_listings_spike OR signal_price_rise);
@@ -190,11 +240,12 @@ COMMENT ON VIEW public.v_tevo_blindspot_movers IS
   'TEvo blindspot mover candidates: US/CA events 31-365d out where we own 0
    tickets, broker pool has >=25 listings, parking-aware get-in >= $50, and
    the pool is showing demand signals. 3-signal detection: listings_drop
-   (pool draining), listings_spike (pool loading), price_rise. Two scores:
-   selling_score (drop+rise, the "sell now" signal) and tracking_score
-   (drop|spike+rise, wider net including events brokers are loading
-   inventory on). Companion to v_sg_blindspot_movers (mig 20260520370000)
-   which uses a 4-signal composite on SG data.';
+   (PAIRED abs+pct), listings_spike (pool loading), price_rise. Scores:
+   selling_score (drop+rise, 0..2), tracking_score (drop|spike+rise, 0..2),
+   confidence_score (0..1, avg of fired-signal strengths — preferred sort
+   key). v1.5 also tags days_to_event_band for cohort triage. Companion to
+   v_sg_blindspot_movers (mig 20260520370000) which uses a 4-signal
+   composite on SG data.';
 
 REVOKE ALL ON public.v_tevo_blindspot_movers FROM PUBLIC;
 GRANT SELECT ON public.v_tevo_blindspot_movers TO anon, authenticated, service_role;
@@ -205,13 +256,15 @@ GRANT SELECT ON public.v_tevo_blindspot_movers TO anon, authenticated, service_r
 -- ============================================================
 DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(int, int, int, text);
 DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(int, int, int, text, text);
+DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(numeric, int, int, text, text, text);
 
 CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
-  p_min_score int       DEFAULT 2,    -- semantics depend on p_mode
-  p_horizon_days int    DEFAULT 365,  -- view caps at 365d; callers can tighten
-  p_limit int           DEFAULT 25,
-  p_venue_pattern text  DEFAULT NULL, -- e.g. '%New York%' to narrow within US/CA
-  p_mode text           DEFAULT 'selling'  -- 'selling' | 'tracking' | 'spike_only'
+  p_min_confidence numeric DEFAULT 0.5,   -- v1.5: confidence floor (0..1)
+  p_horizon_days   int     DEFAULT 365,
+  p_limit          int     DEFAULT 25,
+  p_venue_pattern  text    DEFAULT NULL,  -- ILIKE wildcards to narrow within US/CA
+  p_mode           text    DEFAULT 'selling',   -- 'selling'|'tracking'|'spike_only'
+  p_band           text    DEFAULT NULL    -- v1.5: 'imminent_31_60'|'near_61_180'|'far_181_365'|NULL
 )
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -231,44 +284,34 @@ BEGIN
   IF p_mode NOT IN ('selling', 'tracking', 'spike_only') THEN
     RAISE EXCEPTION 'p_mode must be selling|tracking|spike_only' USING errcode = '22023';
   END IF;
+  IF p_band IS NOT NULL AND p_band NOT IN ('imminent_31_60','near_61_180','far_181_365') THEN
+    RAISE EXCEPTION 'p_band must be imminent_31_60|near_61_180|far_181_365|null' USING errcode = '22023';
+  END IF;
 
   SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY
-                              CASE p_mode WHEN 'tracking' THEN m.tracking_score
-                                                          ELSE m.selling_score END DESC,
-                              abs(coalesce(m.tevo_tix_d24h, 0)) DESC,
+                              m.confidence_score DESC NULLS LAST,
                               m.occurs_at_local ASC), '[]'::jsonb)
     INTO v_result
   FROM (
     SELECT
-      tevo_event_id,
-      event_name,
-      occurs_at_local,
-      venue_id,
-      venue_name,
-      venue_location,
-      primary_performer_id,
-      primary_performer_name,
-      tickets_count,
-      retail_min,
-      retail_median,
-      getin_no_parking,
-      tevo_tix_d24h,
-      tevo_tix_d24h_pct,
-      tevo_getin_d24h_pct,
-      tevo_getin_now,
-      tevo_median_now,
-      signal_listings_drop,
-      signal_listings_spike,
-      signal_price_rise,
-      selling_score,
-      tracking_score
+      tevo_event_id, event_name, occurs_at_local,
+      venue_id, venue_name, venue_location,
+      primary_performer_id, primary_performer_name,
+      tickets_count, retail_min, retail_median, getin_no_parking,
+      tevo_tix_d24h, tevo_tix_d24h_pct, tevo_getin_d24h_pct,
+      tevo_getin_now, tevo_median_now,
+      signal_listings_drop, signal_listings_spike, signal_price_rise,
+      selling_score, tracking_score, confidence_score,
+      days_to_event, days_to_event_band
     FROM public.v_tevo_blindspot_movers
     WHERE occurs_at_local::date <= CURRENT_DATE + (p_horizon_days || ' days')::interval
       AND (p_venue_pattern IS NULL OR venue_location ILIKE p_venue_pattern)
+      AND (p_band          IS NULL OR days_to_event_band = p_band)
+      AND confidence_score >= p_min_confidence
       AND (
-        (p_mode = 'selling'    AND selling_score  >= p_min_score) OR
-        (p_mode = 'tracking'   AND tracking_score >= p_min_score) OR
-        (p_mode = 'spike_only' AND signal_listings_spike = true)
+        (p_mode = 'selling'    AND selling_score  >= 1)   OR
+        (p_mode = 'tracking'   AND tracking_score >= 1)   OR
+        (p_mode = 'spike_only' AND signal_listings_spike  = true)
       )
     LIMIT p_limit
   ) m;
@@ -277,43 +320,45 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL    ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text, text) TO anon, authenticated;
+REVOKE ALL    ON FUNCTION public.get_blind_spots_tevo_selling(numeric, int, int, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(numeric, int, int, text, text, text) TO anon, authenticated;
 
-COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text, text) IS
+COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(numeric, int, int, text, text, text) IS
   'BLIND SPOTS — TEvo SELLING, WE''RE NOT. 3-signal composite over broker
    pool (no sales data on TEvo broker side). Candidate gates: owned=0,
    tickets>=25, 31-365d out, US/CA venue, parking-aware get-in >= $50.
-   Signals: listings shrinking (d24h<=-10), listings spiking (d24h_pct>=+10%),
-   get-in rising (>=+5%). Modes:
-     selling    — selling_score >= p_min_score (drop + rise, default 2)
-     tracking   — tracking_score >= p_min_score (drop|spike + rise)
-     spike_only — events with listings_spike fired (broker loading inventory)
-   p_venue_pattern accepts ILIKE wildcards for narrower geo scoping within
-   US/CA. Companion to get_blind_spots_sg_selling().';
+   Signals: listings shrinking (d24h<=-10 AND d24h_pct<=-5%), listings
+   spiking (d24h_pct>=+10%), get-in rising (>=+5%).
+   v1.5 sort: confidence_score DESC (avg of fired-signal strengths; 0..1).
+   Modes: selling|tracking|spike_only. Filter by p_band (imminent_31_60|
+   near_61_180|far_181_365|null). Companion to get_blind_spots_sg_selling().';
 
 -- ============================================================
 -- VERIFICATION (operator runs after apply):
 --
---   -- 1. View population + signal breakdown
+--   -- 1. View population + signal breakdown + confidence distribution
 --   SELECT count(*) AS total,
 --          count(*) FILTER (WHERE signal_listings_drop)  AS drops,
 --          count(*) FILTER (WHERE signal_listings_spike) AS spikes,
 --          count(*) FILTER (WHERE signal_price_rise)     AS price_rises,
---          count(*) FILTER (WHERE selling_score = 2)     AS selling_strong,
---          count(*) FILTER (WHERE tracking_score >= 1)   AS tracking_any,
+--          count(*) FILTER (WHERE confidence_score >= 0.8) AS conf_high,
+--          count(*) FILTER (WHERE confidence_score >= 0.5
+--                            AND confidence_score < 0.8)   AS conf_med,
 --          round(avg(getin_no_parking)::numeric, 0)      AS avg_getin
 --   FROM public.v_tevo_blindspot_movers;
---   -- Baseline 2026-05-19 measured: 27 events with any signal
---   -- (24 drops, 1 spike, 7 price rises) under the 24h-fresh / 31-365d /
---   -- $50-getin / US-CA gates.
 --
---   -- 2. RPC smoke (as authenticated user with email JWT)
---   SELECT public.get_blind_spots_tevo_selling();                            -- selling mode default
---   SELECT public.get_blind_spots_tevo_selling(1);                           -- selling one-sided
---   SELECT public.get_blind_spots_tevo_selling(2, 365, 25, NULL, 'tracking');-- include spikes
---   SELECT public.get_blind_spots_tevo_selling(0, 365, 25, NULL, 'spike_only'); -- spikes only
---   SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');     -- NYC narrow
+--   -- 2. Band distribution
+--   SELECT days_to_event_band, count(*),
+--          round(avg(confidence_score)::numeric, 2) AS avg_confidence
+--   FROM public.v_tevo_blindspot_movers
+--   GROUP BY days_to_event_band ORDER BY 1;
+--
+--   -- 3. RPC smoke (as authenticated user with email JWT)
+--   SELECT public.get_blind_spots_tevo_selling();                                   -- default: conf >= 0.5
+--   SELECT public.get_blind_spots_tevo_selling(0.8);                                -- strong only
+--   SELECT public.get_blind_spots_tevo_selling(0.5, 365, 25, NULL, 'tracking');     -- include spikes
+--   SELECT public.get_blind_spots_tevo_selling(0.0, 365, 25, NULL, 'spike_only');   -- spikes only
+--   SELECT public.get_blind_spots_tevo_selling(0.5, 90, 10, '%New York%', 'selling', 'imminent_31_60');
 --
 --   -- 3. Spot-check gates
 --   SELECT count(*) AS leaks

--- a/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
+++ b/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
@@ -30,17 +30,39 @@
 --   * speculative-name filter             — CANCELLED / If Necessary /
 --                                            Date TBD
 --
--- COMPOSITE 2-SIGNAL SCORE:
---   signal_listings_drop  tevo_tix_d24h <= -10   (≥10 tix gone in 24h)
---   signal_price_rise     tevo_getin_d24h_pct >= +5%
---   selling_score         sum of the two booleans (0..2)
---   Default RPC threshold: min_score=2 (both fire). min_score=1 for the
---   exploratory mode (one-sided).
+-- COMPOSITE 3-SIGNAL DETECTION (mutually-exclusive directions):
+--   signal_listings_drop   tevo_tix_d24h     <= -10    (≥10 tix gone in 24h)
+--   signal_listings_spike  tevo_tix_d24h_pct >= +10%   (≥10% growth in listings)
+--   signal_price_rise      tevo_getin_d24h_pct >= +5%
+--
+-- DROP + SPIKE are mutually exclusive on the same event (one direction at
+-- a time), so they share the listings-side score slot but tell different
+-- stories:
+--   * drop  = pool draining → "broker selling, we should source"
+--   * spike = pool loading  → "broker preparing for demand, watch closely"
+--   * rise  = price firming → "demand exceeding supply, regardless of vol"
+--
+-- SCORES:
+--   selling_score   = listings_drop::int + price_rise::int           (0..2)
+--                     The "broker actively moving inventory" signal.
+--   tracking_score  = (listings_drop OR listings_spike)::int + price_rise::int  (0..2)
+--                     Wider net — includes spike events as "track these"
+--                     even though they don't fit the selling narrative.
+--
+-- Default RPC behavior: returns selling_score >= 2 (both selling signals
+-- fire). Spike-only events surface via the tracking_score path.
+--
+-- VELOCITY FRESHNESS — 24h gate (NOT 3h):
+--   Blindspot events are owned=0 → not in the hot polling tier. The
+--   collect-listings-1-7d / 7-30d / 30-60d / 60d+ crons hit them only
+--   TWICE DAILY (per mig 20260519240000). A 3h freshness gate would
+--   exclude virtually all blindspot events. 24h matches the collection
+--   cadence + our new tevo_blindspot_metrics_refresh_12h cron.
 --
 -- WHY THRESHOLDS DIFFER FROM SG:
 --   SG composite uses 5% / 10% / 30% / 0%. Tighter because SG firehose is
 --   noisier (consumer marketplace, more listing churn). TEvo broker pool is
---   stickier — a 10-ticket drop + 5% getin rise is meaningful.
+--   stickier — a 10-ticket drop or +10% growth or +5% getin rise is meaningful.
 
 -- ============================================================
 -- 1. View — per-event composite score
@@ -109,28 +131,43 @@ gated AS (
 velocity AS (
   SELECT
     tevo_event_id,
+    tevo_tix_now,
     tevo_tix_d24h,
+    -- Listings pct delta — derived since v_event_velocity_windows doesn't
+    -- expose it directly. Guarded against div-by-zero (events where 24h
+    -- ago count was 0 are ignored — their tix_now alone is the signal).
+    CASE WHEN (tevo_tix_now - coalesce(tevo_tix_d24h, 0)) > 0
+         THEN round(tevo_tix_d24h * 100.0 / (tevo_tix_now - tevo_tix_d24h), 2)
+         ELSE NULL
+    END                                                                  AS tevo_tix_d24h_pct,
     tevo_getin_d24h_pct,
     tevo_getin_now,
     tevo_median_now,
     tevo_now_at,
-    -- Freshness gate: cadence-gap landmine (collect-listings 1-7d / 60d+
-    -- can leave d24h subqueries falling back to ancient samples). Treat
-    -- stale rows as no-signal.
-    (tevo_now_at IS NOT NULL AND tevo_now_at > now() - interval '3 hours') AS velocity_fresh
+    -- 24h freshness gate (NOT 3h) — blindspot events sit on the 1-7d /
+    -- 7-30d / 30-60d / 60d+ collect-listings tracks which fire twice
+    -- daily (mig 20260519240000). The 12h refresh cron we ship in
+    -- mig 20260519190000 keeps latest_event_metrics fresh between cycles.
+    (tevo_now_at IS NOT NULL AND tevo_now_at > now() - interval '24 hours') AS velocity_fresh
   FROM public.v_event_velocity_windows
 ),
 scored AS (
   SELECT
     g.*,
     v.tevo_tix_d24h,
+    v.tevo_tix_d24h_pct,
     v.tevo_getin_d24h_pct,
     v.tevo_getin_now,
     v.tevo_median_now,
     v.tevo_now_at,
     v.velocity_fresh,
+    -- Signal 1: pool draining (broker selling)
     (v.velocity_fresh AND v.tevo_tix_d24h IS NOT NULL
      AND v.tevo_tix_d24h <= -10)                                              AS signal_listings_drop,
+    -- Signal 2: pool loading (broker prepping inventory for demand)
+    (v.velocity_fresh AND v.tevo_tix_d24h_pct IS NOT NULL
+     AND v.tevo_tix_d24h_pct >= 10.0)                                         AS signal_listings_spike,
+    -- Signal 3: price firming
     (v.velocity_fresh AND v.tevo_getin_d24h_pct IS NOT NULL
      AND v.tevo_getin_d24h_pct >= 5.0)                                        AS signal_price_rise
   FROM gated g
@@ -138,18 +175,26 @@ scored AS (
 )
 SELECT
   *,
-  (signal_listings_drop::int + signal_price_rise::int) AS selling_score
+  -- "Selling" composite — drop + rise. Spike is excluded; spike narrative
+  -- is the opposite of selling (pool loading vs draining).
+  (signal_listings_drop::int + signal_price_rise::int)                  AS selling_score,
+  -- "Tracking" composite — wider net. Surfaces spike events alongside
+  -- selling events when callers ask via tracking_score >= N.
+  ((signal_listings_drop OR signal_listings_spike)::int
+    + signal_price_rise::int)                                            AS tracking_score
 FROM scored
 WHERE velocity_fresh
-  AND (signal_listings_drop OR signal_price_rise);
+  AND (signal_listings_drop OR signal_listings_spike OR signal_price_rise);
 
 COMMENT ON VIEW public.v_tevo_blindspot_movers IS
   'TEvo blindspot mover candidates: US/CA events 31-365d out where we own 0
    tickets, broker pool has >=25 listings, parking-aware get-in >= $50, and
-   the pool is showing demand signals (listings shrinking and/or get-in
-   firming). 2-signal composite (no sales data on TEvo broker side).
-   Companion to v_sg_blindspot_movers (mig 20260520370000) which uses a
-   4-signal composite on SG data.';
+   the pool is showing demand signals. 3-signal detection: listings_drop
+   (pool draining), listings_spike (pool loading), price_rise. Two scores:
+   selling_score (drop+rise, the "sell now" signal) and tracking_score
+   (drop|spike+rise, wider net including events brokers are loading
+   inventory on). Companion to v_sg_blindspot_movers (mig 20260520370000)
+   which uses a 4-signal composite on SG data.';
 
 REVOKE ALL ON public.v_tevo_blindspot_movers FROM PUBLIC;
 GRANT SELECT ON public.v_tevo_blindspot_movers TO anon, authenticated, service_role;
@@ -159,12 +204,14 @@ GRANT SELECT ON public.v_tevo_blindspot_movers TO anon, authenticated, service_r
 --    then by velocity magnitude. Email-gated per §6 caller guard.
 -- ============================================================
 DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(int, int, int, text);
+DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(int, int, int, text, text);
 
 CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
-  p_min_score int       DEFAULT 2,    -- 2 = both signals fire; 1 = either
+  p_min_score int       DEFAULT 2,    -- semantics depend on p_mode
   p_horizon_days int    DEFAULT 365,  -- view caps at 365d; callers can tighten
   p_limit int           DEFAULT 25,
-  p_venue_pattern text  DEFAULT NULL  -- e.g. '%New York%' to narrow within US/CA
+  p_venue_pattern text  DEFAULT NULL, -- e.g. '%New York%' to narrow within US/CA
+  p_mode text           DEFAULT 'selling'  -- 'selling' | 'tracking' | 'spike_only'
 )
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -181,9 +228,15 @@ BEGIN
     RAISE EXCEPTION 'email required' USING errcode = '42501';
   END IF;
 
-  SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY m.selling_score DESC,
-                                              abs(coalesce(m.tevo_tix_d24h, 0)) DESC,
-                                              m.occurs_at_local ASC), '[]'::jsonb)
+  IF p_mode NOT IN ('selling', 'tracking', 'spike_only') THEN
+    RAISE EXCEPTION 'p_mode must be selling|tracking|spike_only' USING errcode = '22023';
+  END IF;
+
+  SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY
+                              CASE p_mode WHEN 'tracking' THEN m.tracking_score
+                                                          ELSE m.selling_score END DESC,
+                              abs(coalesce(m.tevo_tix_d24h, 0)) DESC,
+                              m.occurs_at_local ASC), '[]'::jsonb)
     INTO v_result
   FROM (
     SELECT
@@ -200,16 +253,23 @@ BEGIN
       retail_median,
       getin_no_parking,
       tevo_tix_d24h,
+      tevo_tix_d24h_pct,
       tevo_getin_d24h_pct,
       tevo_getin_now,
       tevo_median_now,
       signal_listings_drop,
+      signal_listings_spike,
       signal_price_rise,
-      selling_score
+      selling_score,
+      tracking_score
     FROM public.v_tevo_blindspot_movers
-    WHERE selling_score >= p_min_score
-      AND occurs_at_local::date <= CURRENT_DATE + (p_horizon_days || ' days')::interval
+    WHERE occurs_at_local::date <= CURRENT_DATE + (p_horizon_days || ' days')::interval
       AND (p_venue_pattern IS NULL OR venue_location ILIKE p_venue_pattern)
+      AND (
+        (p_mode = 'selling'    AND selling_score  >= p_min_score) OR
+        (p_mode = 'tracking'   AND tracking_score >= p_min_score) OR
+        (p_mode = 'spike_only' AND signal_listings_spike = true)
+      )
     LIMIT p_limit
   ) m;
 
@@ -217,34 +277,43 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL    ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) TO anon, authenticated;
+REVOKE ALL    ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text, text) TO anon, authenticated;
 
-COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) IS
-  'BLIND SPOTS — TEvo SELLING, WE''RE NOT. 2-signal composite over broker
+COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text, text) IS
+  'BLIND SPOTS — TEvo SELLING, WE''RE NOT. 3-signal composite over broker
    pool (no sales data on TEvo broker side). Candidate gates: owned=0,
    tickets>=25, 31-365d out, US/CA venue, parking-aware get-in >= $50.
-   Signals: listings shrinking (d24h <= -10) + get-in rising (>= +5%).
-   Default min_score=2 = both signals. p_venue_pattern accepts ILIKE
-   wildcards for narrower geo scoping within US/CA. Companion to
-   get_blind_spots_sg_selling().';
+   Signals: listings shrinking (d24h<=-10), listings spiking (d24h_pct>=+10%),
+   get-in rising (>=+5%). Modes:
+     selling    — selling_score >= p_min_score (drop + rise, default 2)
+     tracking   — tracking_score >= p_min_score (drop|spike + rise)
+     spike_only — events with listings_spike fired (broker loading inventory)
+   p_venue_pattern accepts ILIKE wildcards for narrower geo scoping within
+   US/CA. Companion to get_blind_spots_sg_selling().';
 
 -- ============================================================
 -- VERIFICATION (operator runs after apply):
 --
---   -- 1. View population
+--   -- 1. View population + signal breakdown
 --   SELECT count(*) AS total,
---          count(*) FILTER (WHERE selling_score=2) AS both_signals,
---          count(*) FILTER (WHERE selling_score=1) AS one_signal,
---          round(avg(getin_no_parking)::numeric, 0) AS avg_getin
+--          count(*) FILTER (WHERE signal_listings_drop)  AS drops,
+--          count(*) FILTER (WHERE signal_listings_spike) AS spikes,
+--          count(*) FILTER (WHERE signal_price_rise)     AS price_rises,
+--          count(*) FILTER (WHERE selling_score = 2)     AS selling_strong,
+--          count(*) FILTER (WHERE tracking_score >= 1)   AS tracking_any,
+--          round(avg(getin_no_parking)::numeric, 0)      AS avg_getin
 --   FROM public.v_tevo_blindspot_movers;
---   -- Baseline pool (any signal): ~34+ events expected (34 measured
---   -- 2026-05-19 with 31-365d window, before velocity scoring layered on)
+--   -- Baseline 2026-05-19 measured: 27 events with any signal
+--   -- (24 drops, 1 spike, 7 price rises) under the 24h-fresh / 31-365d /
+--   -- $50-getin / US-CA gates.
 --
 --   -- 2. RPC smoke (as authenticated user with email JWT)
---   SELECT public.get_blind_spots_tevo_selling();             -- defaults
---   SELECT public.get_blind_spots_tevo_selling(1);            -- one-signal min
---   SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');
+--   SELECT public.get_blind_spots_tevo_selling();                            -- selling mode default
+--   SELECT public.get_blind_spots_tevo_selling(1);                           -- selling one-sided
+--   SELECT public.get_blind_spots_tevo_selling(2, 365, 25, NULL, 'tracking');-- include spikes
+--   SELECT public.get_blind_spots_tevo_selling(0, 365, 25, NULL, 'spike_only'); -- spikes only
+--   SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');     -- NYC narrow
 --
 --   -- 3. Spot-check gates
 --   SELECT count(*) AS leaks

--- a/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
+++ b/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
@@ -13,11 +13,12 @@
 --     get-in price firming. Composite score drops from 4 signals (SG)
 --     to 2 signals (TEvo).
 --
--- CANDIDATE GATES (operator-confirmed 2026-05-19, batch 1):
+-- CANDIDATE GATES (operator-confirmed 2026-05-19):
 --   * owned_tickets_count = 0           — the blindspot
 --   * tickets_count       >= 25          — real broker market depth
---   * occurs_at in [today+30d, today+90d] — drop game-time noise, keep
---     a sourcing-actionable window
+--   * occurs_at in [today+31d, today+365d] — drop game-time noise + open
+--     the upper bound to 1 year (was 90d in v1; widened per operator
+--     2026-05-19 — longer-horizon inventory is sourcing-actionable too)
 --   * US or Canada venue                 — state/province regex match on
 --     `events.venue_location` (e.g. "Boston, MA" / "Toronto, ON")
 --   * get-in-without-parking >= $50      — recomputed from
@@ -79,9 +80,9 @@ WITH base AS (
   JOIN public.latest_event_metrics lem ON lem.event_id = e.id
   LEFT JOIN public.event_lifecycle el  ON el.event_id = e.id
   WHERE
-    -- Forward window: 30..90 days out (drop game-time + far-future)
-    e.occurs_at_local::date >= CURRENT_DATE + interval '30 days'
-    AND e.occurs_at_local::date <= CURRENT_DATE + interval '90 days'
+    -- Forward window: 31..365 days out (drop game-time, allow long horizon)
+    e.occurs_at_local::date >= CURRENT_DATE + interval '31 days'
+    AND e.occurs_at_local::date <= CURRENT_DATE + interval '365 days'
     -- Blindspot: we own nothing
     AND lem.owned_tickets_count = 0
     -- Real market depth
@@ -143,7 +144,7 @@ WHERE velocity_fresh
   AND (signal_listings_drop OR signal_price_rise);
 
 COMMENT ON VIEW public.v_tevo_blindspot_movers IS
-  'TEvo blindspot mover candidates: US/CA events 30-90d out where we own 0
+  'TEvo blindspot mover candidates: US/CA events 31-365d out where we own 0
    tickets, broker pool has >=25 listings, parking-aware get-in >= $50, and
    the pool is showing demand signals (listings shrinking and/or get-in
    firming). 2-signal composite (no sales data on TEvo broker side).
@@ -161,7 +162,7 @@ DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(int, int, int, text)
 
 CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
   p_min_score int       DEFAULT 2,    -- 2 = both signals fire; 1 = either
-  p_horizon_days int    DEFAULT 90,
+  p_horizon_days int    DEFAULT 365,  -- view caps at 365d; callers can tighten
   p_limit int           DEFAULT 25,
   p_venue_pattern text  DEFAULT NULL  -- e.g. '%New York%' to narrow within US/CA
 )
@@ -222,7 +223,7 @@ GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, tex
 COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) IS
   'BLIND SPOTS — TEvo SELLING, WE''RE NOT. 2-signal composite over broker
    pool (no sales data on TEvo broker side). Candidate gates: owned=0,
-   tickets>=25, 30-90d out, US/CA venue, parking-aware get-in >= $50.
+   tickets>=25, 31-365d out, US/CA venue, parking-aware get-in >= $50.
    Signals: listings shrinking (d24h <= -10) + get-in rising (>= +5%).
    Default min_score=2 = both signals. p_venue_pattern accepts ILIKE
    wildcards for narrower geo scoping within US/CA. Companion to
@@ -237,8 +238,8 @@ COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) IS
 --          count(*) FILTER (WHERE selling_score=1) AS one_signal,
 --          round(avg(getin_no_parking)::numeric, 0) AS avg_getin
 --   FROM public.v_tevo_blindspot_movers;
---   -- Baseline pool (any signal): ~16-25 events expected (16 measured
---   -- 2026-05-19 before velocity scoring layered on)
+--   -- Baseline pool (any signal): ~34+ events expected (34 measured
+--   -- 2026-05-19 with 31-365d window, before velocity scoring layered on)
 --
 --   -- 2. RPC smoke (as authenticated user with email JWT)
 --   SELECT public.get_blind_spots_tevo_selling();             -- defaults
@@ -251,6 +252,7 @@ COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) IS
 --   WHERE getin_no_parking < 50
 --      OR tickets_count < 25
 --      OR owned_tickets_count <> 0
---      OR occurs_at_local::date < CURRENT_DATE + interval '30 days';
+--      OR occurs_at_local::date < CURRENT_DATE + interval '31 days'
+--      OR occurs_at_local::date > CURRENT_DATE + interval '365 days';
 --   -- Expect 0.
 -- ============================================================

--- a/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
+++ b/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
@@ -12,31 +12,37 @@
 --     see listing-side movement (broker-pool tickets disappearing) +
 --     get-in price firming. Composite score drops from 4 signals (SG)
 --     to 2 signals (TEvo).
---   * Scope is naturally NYC-first since that's the storefront focus, but
---     RPC accepts a location filter for future expansion.
 --
--- DETECTION GATES:
---   * owned_tickets_count = 0       (the "blindspot" — we don't own any)
---   * tickets_count >= 10            (real broker-market depth)
---   * occurs_at in [today, +90d]    (forward-looking only)
---   * event_lifecycle is_active     (drop ghost/cancelled)
---   * velocity_fresh                 (tevo_now_at within 3h — §9 cadence gap landmine)
+-- CANDIDATE GATES (operator-confirmed 2026-05-19, batch 1):
+--   * owned_tickets_count = 0           — the blindspot
+--   * tickets_count       >= 25          — real broker market depth
+--   * occurs_at in [today+30d, today+90d] — drop game-time noise, keep
+--     a sourcing-actionable window
+--   * US or Canada venue                 — state/province regex match on
+--     `events.venue_location` (e.g. "Boston, MA" / "Toronto, ON")
+--   * get-in-without-parking >= $50      — recomputed from
+--     `listings_snapshots.retail_price` excluding sections matching
+--     `%park%|%lot%|%garage%|%valet%`. TEvo bible §3 landmine: parking
+--     rows fold into the main listing pool, dragging native `getin_now`
+--     down artificially.
+--   * event_lifecycle.is_active          — drops ghost/cancelled/postponed
+--   * speculative-name filter             — CANCELLED / If Necessary /
+--                                            Date TBD
 --
 -- COMPOSITE 2-SIGNAL SCORE:
---   signal_listings_drop  tevo_tix_d24h <= -10   (≥10 tix disappeared from broker pool)
+--   signal_listings_drop  tevo_tix_d24h <= -10   (≥10 tix gone in 24h)
 --   signal_price_rise     tevo_getin_d24h_pct >= +5%
---   Surface events where BOTH fire (score=2). Score=1 (one-sided) returned
---   in view but the default RPC threshold returns only score=2 events.
+--   selling_score         sum of the two booleans (0..2)
+--   Default RPC threshold: min_score=2 (both fire). min_score=1 for the
+--   exploratory mode (one-sided).
 --
 -- WHY THRESHOLDS DIFFER FROM SG:
 --   SG composite uses 5% / 10% / 30% / 0%. Tighter because SG firehose is
 --   noisier (consumer marketplace, more listing churn). TEvo broker pool is
 --   stickier — a 10-ticket drop + 5% getin rise is meaningful.
---
+
 -- ============================================================
--- 1. View — per-event composite score (anchored to latest_event_metrics +
---    v_event_velocity_windows). Reads are cheap because both upstream
---    matviews/views are already pre-aggregated.
+-- 1. View — per-event composite score
 -- ============================================================
 DROP VIEW IF EXISTS public.v_tevo_blindspot_movers;
 
@@ -56,19 +62,48 @@ WITH base AS (
     lem.tickets_count,
     lem.retail_min,
     lem.retail_median,
-    lem.captured_at            AS metrics_captured_at
+    lem.captured_at            AS metrics_captured_at,
+    -- Get-in without parking — recomputed from raw listings_snapshots
+    -- so the parking-section drag (bible §3 landmine) is excluded.
+    -- Correlated subquery on PRIMARY KEY (event_id) — fast.
+    (SELECT min(ls.retail_price)
+       FROM public.listings_snapshots ls
+      WHERE ls.event_id = e.id
+        AND ls.retail_price IS NOT NULL
+        AND NOT (
+          ls.section ILIKE '%park%' OR ls.section ILIKE '%lot%'
+          OR ls.section ILIKE '%garage%' OR ls.section ILIKE '%valet%'
+        )
+    )                          AS getin_no_parking
   FROM public.events e
   JOIN public.latest_event_metrics lem ON lem.event_id = e.id
   LEFT JOIN public.event_lifecycle el  ON el.event_id = e.id
-  WHERE e.occurs_at_local::date >= CURRENT_DATE
+  WHERE
+    -- Forward window: 30..90 days out (drop game-time + far-future)
+    e.occurs_at_local::date >= CURRENT_DATE + interval '30 days'
     AND e.occurs_at_local::date <= CURRENT_DATE + interval '90 days'
-    AND lem.owned_tickets_count = 0          -- blindspot: we own nothing
-    AND lem.tickets_count >= 10              -- real broker depth
+    -- Blindspot: we own nothing
+    AND lem.owned_tickets_count = 0
+    -- Real market depth
+    AND lem.tickets_count >= 25
+    -- Active lifecycle
     AND (el.is_active IS NULL OR el.is_active = true)
-    -- Drop speculative names (mirrors storefront filter)
+    -- Speculative-name filter (mirrors storefront)
     AND e.name NOT ILIKE '%CANCELLED%'
     AND e.name NOT ILIKE '%(If Necessary)%'
     AND e.name NOT ILIKE '%(Date TBD)%'
+    -- US or Canada only (state/province at end of venue_location string)
+    AND (
+      e.venue_location ~ ',\s*(AL|AK|AZ|AR|CA|CO|CT|DE|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|VA|WA|WV|WI|WY|DC)\s*$'
+      OR e.venue_location ~ ',\s*(AB|BC|MB|NB|NL|NS|ON|PE|QC|SK|YT|NT|NU)\s*$'
+    )
+),
+gated AS (
+  -- Apply the parking-aware get-in floor in a second pass so the IS NOT NULL
+  -- + threshold gate sit together (clearer than a CASE in the base WHERE).
+  SELECT * FROM base
+  WHERE getin_no_parking IS NOT NULL
+    AND getin_no_parking >= 50
 ),
 velocity AS (
   SELECT
@@ -78,15 +113,15 @@ velocity AS (
     tevo_getin_now,
     tevo_median_now,
     tevo_now_at,
-    -- Freshness gate: cadence gap (collect-listings 1-7d, 60d+) can leave
-    -- d24h subqueries falling back to the same ancient sample, making
-    -- d24h = 0 misleadingly. Treat stale rows as no-signal. §9 landmine.
+    -- Freshness gate: cadence-gap landmine (collect-listings 1-7d / 60d+
+    -- can leave d24h subqueries falling back to ancient samples). Treat
+    -- stale rows as no-signal.
     (tevo_now_at IS NOT NULL AND tevo_now_at > now() - interval '3 hours') AS velocity_fresh
   FROM public.v_event_velocity_windows
 ),
 scored AS (
   SELECT
-    b.*,
+    g.*,
     v.tevo_tix_d24h,
     v.tevo_getin_d24h_pct,
     v.tevo_getin_now,
@@ -94,11 +129,11 @@ scored AS (
     v.tevo_now_at,
     v.velocity_fresh,
     (v.velocity_fresh AND v.tevo_tix_d24h IS NOT NULL
-     AND v.tevo_tix_d24h <= -10)                                                 AS signal_listings_drop,
+     AND v.tevo_tix_d24h <= -10)                                              AS signal_listings_drop,
     (v.velocity_fresh AND v.tevo_getin_d24h_pct IS NOT NULL
-     AND v.tevo_getin_d24h_pct >= 5.0)                                           AS signal_price_rise
-  FROM base b
-  LEFT JOIN velocity v ON v.tevo_event_id = b.tevo_event_id
+     AND v.tevo_getin_d24h_pct >= 5.0)                                        AS signal_price_rise
+  FROM gated g
+  LEFT JOIN velocity v ON v.tevo_event_id = g.tevo_event_id
 )
 SELECT
   *,
@@ -108,10 +143,10 @@ WHERE velocity_fresh
   AND (signal_listings_drop OR signal_price_rise);
 
 COMMENT ON VIEW public.v_tevo_blindspot_movers IS
-  'TEvo blindspot mover candidates: events where we own 0 tickets but
-   broker-pool listings are shrinking and/or get-in price is firming.
-   2-signal composite (no sales data on TEvo broker side). Owned >0 events
-   live in `latest_event_metrics` direct — this view targets the inverse.
+  'TEvo blindspot mover candidates: US/CA events 30-90d out where we own 0
+   tickets, broker pool has >=25 listings, parking-aware get-in >= $50, and
+   the pool is showing demand signals (listings shrinking and/or get-in
+   firming). 2-signal composite (no sales data on TEvo broker side).
    Companion to v_sg_blindspot_movers (mig 20260520370000) which uses a
    4-signal composite on SG data.';
 
@@ -122,11 +157,13 @@ GRANT SELECT ON public.v_tevo_blindspot_movers TO anon, authenticated, service_r
 -- 2. RPC — caller-facing wrapper. Returns JSON array sorted by score DESC,
 --    then by velocity magnitude. Email-gated per §6 caller guard.
 -- ============================================================
+DROP FUNCTION IF EXISTS public.get_blind_spots_tevo_selling(int, int, int, text);
+
 CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
   p_min_score int       DEFAULT 2,    -- 2 = both signals fire; 1 = either
   p_horizon_days int    DEFAULT 90,
   p_limit int           DEFAULT 25,
-  p_venue_pattern text  DEFAULT NULL  -- e.g. '%New York%' to scope to NYC
+  p_venue_pattern text  DEFAULT NULL  -- e.g. '%New York%' to narrow within US/CA
 )
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -160,6 +197,7 @@ BEGIN
       tickets_count,
       retail_min,
       retail_median,
+      getin_no_parking,
       tevo_tix_d24h,
       tevo_getin_d24h_pct,
       tevo_getin_now,
@@ -183,32 +221,36 @@ GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, tex
 
 COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) IS
   'BLIND SPOTS — TEvo SELLING, WE''RE NOT. 2-signal composite over broker
-   pool (no sales data on TEvo broker side). Signals: listings shrinking
-   (d24h ≤ -10) + get-in price rising (≥ +5%). Default min_score=2 returns
-   only events where both signals fire. p_venue_pattern accepts ILIKE
-   wildcards for geo scoping. Companion to get_blind_spots_sg_selling().';
+   pool (no sales data on TEvo broker side). Candidate gates: owned=0,
+   tickets>=25, 30-90d out, US/CA venue, parking-aware get-in >= $50.
+   Signals: listings shrinking (d24h <= -10) + get-in rising (>= +5%).
+   Default min_score=2 = both signals. p_venue_pattern accepts ILIKE
+   wildcards for narrower geo scoping within US/CA. Companion to
+   get_blind_spots_sg_selling().';
 
 -- ============================================================
 -- VERIFICATION (operator runs after apply):
 --
---   -- 1. View populated count + signal distribution
---   SELECT count(*),
+--   -- 1. View population
+--   SELECT count(*) AS total,
 --          count(*) FILTER (WHERE selling_score=2) AS both_signals,
---          count(*) FILTER (WHERE selling_score=1) AS one_signal
+--          count(*) FILTER (WHERE selling_score=1) AS one_signal,
+--          round(avg(getin_no_parking)::numeric, 0) AS avg_getin
 --   FROM public.v_tevo_blindspot_movers;
+--   -- Baseline pool (any signal): ~16-25 events expected (16 measured
+--   -- 2026-05-19 before velocity scoring layered on)
 --
---   -- 2. RPC smoke (run as authenticated user with email JWT)
---   SELECT public.get_blind_spots_tevo_selling();      -- default: min_score=2, 90d, top 25
---   SELECT public.get_blind_spots_tevo_selling(1);     -- one-signal min, more results
---   SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');  -- NYC only
+--   -- 2. RPC smoke (as authenticated user with email JWT)
+--   SELECT public.get_blind_spots_tevo_selling();             -- defaults
+--   SELECT public.get_blind_spots_tevo_selling(1);            -- one-signal min
+--   SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');
 --
---   -- 3. Spot-check: every result must have owned_tickets_count = 0 in
---   --    the source latest_event_metrics row
---   WITH r AS (
---     SELECT (jsonb_array_elements(public.get_blind_spots_tevo_selling())->>'tevo_event_id')::bigint AS eid
---   )
---   SELECT count(*) FILTER (WHERE lem.owned_tickets_count = 0) AS clean,
---          count(*)                                            AS total
---   FROM r JOIN public.latest_event_metrics lem ON lem.event_id = r.eid;
---   -- Expect clean == total.
+--   -- 3. Spot-check gates
+--   SELECT count(*) AS leaks
+--   FROM public.v_tevo_blindspot_movers
+--   WHERE getin_no_parking < 50
+--      OR tickets_count < 25
+--      OR owned_tickets_count <> 0
+--      OR occurs_at_local::date < CURRENT_DATE + interval '30 days';
+--   -- Expect 0.
 -- ============================================================

--- a/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
+++ b/supabase/migrations/20260519180000_tevo_blindspot_detection.sql
@@ -1,0 +1,214 @@
+-- Migration 20260519180000 · lane:A1 · writes:v_tevo_blindspot_movers,get_blind_spots_tevo_selling · pre:20260520370000
+--
+-- TEvo blindspot detection — companion to SG blindspot system (mig 20260520370000).
+--
+-- DIFFERENCE FROM SG VERSION (operator design 2026-05-19):
+--   * No tier table. SG's TRACK_BLINDSPOT exists because each SG poll burns
+--     one of the 10/sec quota, so we tier-classify what's worth polling.
+--     TEvo's /v9/events search is broker-side, higher-quota, and supports
+--     filtered discovery on demand. Events worth investigating can be pulled
+--     ad-hoc via the existing `sg_to_tevo_search_bridge` pattern.
+--   * No sales signals. TEvo doesn't expose broker-side sales data — we only
+--     see listing-side movement (broker-pool tickets disappearing) +
+--     get-in price firming. Composite score drops from 4 signals (SG)
+--     to 2 signals (TEvo).
+--   * Scope is naturally NYC-first since that's the storefront focus, but
+--     RPC accepts a location filter for future expansion.
+--
+-- DETECTION GATES:
+--   * owned_tickets_count = 0       (the "blindspot" — we don't own any)
+--   * tickets_count >= 10            (real broker-market depth)
+--   * occurs_at in [today, +90d]    (forward-looking only)
+--   * event_lifecycle is_active     (drop ghost/cancelled)
+--   * velocity_fresh                 (tevo_now_at within 3h — §9 cadence gap landmine)
+--
+-- COMPOSITE 2-SIGNAL SCORE:
+--   signal_listings_drop  tevo_tix_d24h <= -10   (≥10 tix disappeared from broker pool)
+--   signal_price_rise     tevo_getin_d24h_pct >= +5%
+--   Surface events where BOTH fire (score=2). Score=1 (one-sided) returned
+--   in view but the default RPC threshold returns only score=2 events.
+--
+-- WHY THRESHOLDS DIFFER FROM SG:
+--   SG composite uses 5% / 10% / 30% / 0%. Tighter because SG firehose is
+--   noisier (consumer marketplace, more listing churn). TEvo broker pool is
+--   stickier — a 10-ticket drop + 5% getin rise is meaningful.
+--
+-- ============================================================
+-- 1. View — per-event composite score (anchored to latest_event_metrics +
+--    v_event_velocity_windows). Reads are cheap because both upstream
+--    matviews/views are already pre-aggregated.
+-- ============================================================
+DROP VIEW IF EXISTS public.v_tevo_blindspot_movers;
+
+CREATE VIEW public.v_tevo_blindspot_movers
+WITH (security_invoker = on) AS
+WITH base AS (
+  SELECT
+    e.id                       AS tevo_event_id,
+    e.name                     AS event_name,
+    e.occurs_at_local,
+    e.venue_id,
+    e.venue_name,
+    e.venue_location,
+    e.primary_performer_id,
+    e.primary_performer_name,
+    lem.owned_tickets_count,
+    lem.tickets_count,
+    lem.retail_min,
+    lem.retail_median,
+    lem.captured_at            AS metrics_captured_at
+  FROM public.events e
+  JOIN public.latest_event_metrics lem ON lem.event_id = e.id
+  LEFT JOIN public.event_lifecycle el  ON el.event_id = e.id
+  WHERE e.occurs_at_local::date >= CURRENT_DATE
+    AND e.occurs_at_local::date <= CURRENT_DATE + interval '90 days'
+    AND lem.owned_tickets_count = 0          -- blindspot: we own nothing
+    AND lem.tickets_count >= 10              -- real broker depth
+    AND (el.is_active IS NULL OR el.is_active = true)
+    -- Drop speculative names (mirrors storefront filter)
+    AND e.name NOT ILIKE '%CANCELLED%'
+    AND e.name NOT ILIKE '%(If Necessary)%'
+    AND e.name NOT ILIKE '%(Date TBD)%'
+),
+velocity AS (
+  SELECT
+    tevo_event_id,
+    tevo_tix_d24h,
+    tevo_getin_d24h_pct,
+    tevo_getin_now,
+    tevo_median_now,
+    tevo_now_at,
+    -- Freshness gate: cadence gap (collect-listings 1-7d, 60d+) can leave
+    -- d24h subqueries falling back to the same ancient sample, making
+    -- d24h = 0 misleadingly. Treat stale rows as no-signal. §9 landmine.
+    (tevo_now_at IS NOT NULL AND tevo_now_at > now() - interval '3 hours') AS velocity_fresh
+  FROM public.v_event_velocity_windows
+),
+scored AS (
+  SELECT
+    b.*,
+    v.tevo_tix_d24h,
+    v.tevo_getin_d24h_pct,
+    v.tevo_getin_now,
+    v.tevo_median_now,
+    v.tevo_now_at,
+    v.velocity_fresh,
+    (v.velocity_fresh AND v.tevo_tix_d24h IS NOT NULL
+     AND v.tevo_tix_d24h <= -10)                                                 AS signal_listings_drop,
+    (v.velocity_fresh AND v.tevo_getin_d24h_pct IS NOT NULL
+     AND v.tevo_getin_d24h_pct >= 5.0)                                           AS signal_price_rise
+  FROM base b
+  LEFT JOIN velocity v ON v.tevo_event_id = b.tevo_event_id
+)
+SELECT
+  *,
+  (signal_listings_drop::int + signal_price_rise::int) AS selling_score
+FROM scored
+WHERE velocity_fresh
+  AND (signal_listings_drop OR signal_price_rise);
+
+COMMENT ON VIEW public.v_tevo_blindspot_movers IS
+  'TEvo blindspot mover candidates: events where we own 0 tickets but
+   broker-pool listings are shrinking and/or get-in price is firming.
+   2-signal composite (no sales data on TEvo broker side). Owned >0 events
+   live in `latest_event_metrics` direct — this view targets the inverse.
+   Companion to v_sg_blindspot_movers (mig 20260520370000) which uses a
+   4-signal composite on SG data.';
+
+REVOKE ALL ON public.v_tevo_blindspot_movers FROM PUBLIC;
+GRANT SELECT ON public.v_tevo_blindspot_movers TO anon, authenticated, service_role;
+
+-- ============================================================
+-- 2. RPC — caller-facing wrapper. Returns JSON array sorted by score DESC,
+--    then by velocity magnitude. Email-gated per §6 caller guard.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
+  p_min_score int       DEFAULT 2,    -- 2 = both signals fire; 1 = either
+  p_horizon_days int    DEFAULT 90,
+  p_limit int           DEFAULT 25,
+  p_venue_pattern text  DEFAULT NULL  -- e.g. '%New York%' to scope to NYC
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_email text;
+  v_result jsonb;
+BEGIN
+  -- §6 caller guard — email-required
+  v_email := nullif((select auth.jwt())->>'email', '');
+  IF v_email IS NULL THEN
+    RAISE EXCEPTION 'email required' USING errcode = '42501';
+  END IF;
+
+  SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY m.selling_score DESC,
+                                              abs(coalesce(m.tevo_tix_d24h, 0)) DESC,
+                                              m.occurs_at_local ASC), '[]'::jsonb)
+    INTO v_result
+  FROM (
+    SELECT
+      tevo_event_id,
+      event_name,
+      occurs_at_local,
+      venue_id,
+      venue_name,
+      venue_location,
+      primary_performer_id,
+      primary_performer_name,
+      tickets_count,
+      retail_min,
+      retail_median,
+      tevo_tix_d24h,
+      tevo_getin_d24h_pct,
+      tevo_getin_now,
+      tevo_median_now,
+      signal_listings_drop,
+      signal_price_rise,
+      selling_score
+    FROM public.v_tevo_blindspot_movers
+    WHERE selling_score >= p_min_score
+      AND occurs_at_local::date <= CURRENT_DATE + (p_horizon_days || ' days')::interval
+      AND (p_venue_pattern IS NULL OR venue_location ILIKE p_venue_pattern)
+    LIMIT p_limit
+  ) m;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_blind_spots_tevo_selling(int, int, int, text) IS
+  'BLIND SPOTS — TEvo SELLING, WE''RE NOT. 2-signal composite over broker
+   pool (no sales data on TEvo broker side). Signals: listings shrinking
+   (d24h ≤ -10) + get-in price rising (≥ +5%). Default min_score=2 returns
+   only events where both signals fire. p_venue_pattern accepts ILIKE
+   wildcards for geo scoping. Companion to get_blind_spots_sg_selling().';
+
+-- ============================================================
+-- VERIFICATION (operator runs after apply):
+--
+--   -- 1. View populated count + signal distribution
+--   SELECT count(*),
+--          count(*) FILTER (WHERE selling_score=2) AS both_signals,
+--          count(*) FILTER (WHERE selling_score=1) AS one_signal
+--   FROM public.v_tevo_blindspot_movers;
+--
+--   -- 2. RPC smoke (run as authenticated user with email JWT)
+--   SELECT public.get_blind_spots_tevo_selling();      -- default: min_score=2, 90d, top 25
+--   SELECT public.get_blind_spots_tevo_selling(1);     -- one-signal min, more results
+--   SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');  -- NYC only
+--
+--   -- 3. Spot-check: every result must have owned_tickets_count = 0 in
+--   --    the source latest_event_metrics row
+--   WITH r AS (
+--     SELECT (jsonb_array_elements(public.get_blind_spots_tevo_selling())->>'tevo_event_id')::bigint AS eid
+--   )
+--   SELECT count(*) FILTER (WHERE lem.owned_tickets_count = 0) AS clean,
+--          count(*)                                            AS total
+--   FROM r JOIN public.latest_event_metrics lem ON lem.event_id = r.eid;
+--   -- Expect clean == total.
+-- ============================================================

--- a/supabase/migrations/20260519190000_tevo_blindspot_crons.sql
+++ b/supabase/migrations/20260519190000_tevo_blindspot_crons.sql
@@ -1,0 +1,261 @@
+-- Migration 20260519190000 · lane:A1 · writes:cron.job,cron_policy,tevo_blindspot_discovery_attempts · pre:20260519180000
+--
+-- TEvo blindspot pipeline crons — companion to the detector in mig
+-- 20260519180000. Two scheduled jobs:
+--
+--   1. tevo_blindspot_metrics_refresh_12h (twice daily @ 06:00, 18:00 UTC)
+--      Refreshes `latest_event_metrics` CONCURRENTLY so the blindspot
+--      detector view picks up fresh tickets_count + retail_min values
+--      between collect-listings cron cycles. Without this, `owned=0`
+--      events can show stale tickets_count for hours because the matview
+--      doesn't auto-refresh — it's normally maintained by the bigger
+--      hourly collection pipeline. Blindspot is an off-cycle consumer,
+--      so it needs its own refresh hook.
+--
+--   2. tevo_blindspot_discovery_daily (once daily @ 07:00 UTC)
+--      Pings a `tevo-blindspot-discovery` edge function (operator-deployed
+--      separately) that searches TEvo /v9/events for new events matching
+--      the blindspot criteria (US/CA, 31-365d out, sports-leaning) and
+--      upserts winners into `events`. Pattern mirrors
+--      sg_to_tevo_search_bridge (mig 20260516250000). Edge fn is OPTIONAL
+--      — until deployed, the cron fires a no-op HTTP call that the
+--      cron_policy gate suppresses on miss.
+--
+-- WHY ONLY ONE DISCOVERY/DAY (vs SG bridge's 30/day):
+--   TEvo /v9/events search at the criteria scope (US/CA, 1yr horizon,
+--   tickets_count threshold) returns ~few hundred candidate events. One
+--   pull/day captures full inventory turnover; more would burn quota
+--   without finding new events.
+--
+-- WHY 12h (NOT MORE FREQUENT) FOR PRICE REFRESH:
+--   Blindspot detector is a sourcing aid, not a real-time market signal.
+--   The 12h cadence matches SG's TRACK_BLINDSPOT polling cadence (mig
+--   20260520290000: interval_seconds=43200). Consistent with SG side.
+
+-- ============================================================
+-- 1. Discovery attempts tracking table (mirrors sg_tevo_search_attempts)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.tevo_blindspot_discovery_attempts (
+  attempt_id   bigserial PRIMARY KEY,
+  attempted_at timestamptz NOT NULL DEFAULT now(),
+  result       text        NOT NULL,    -- 'enqueued'|'edge_fn_called'|'edge_fn_missing'|'error'
+  events_found int,
+  events_added int,
+  meta         jsonb,
+  search_criteria jsonb               -- the filters passed to TEvo /v9/events
+);
+
+CREATE INDEX IF NOT EXISTS idx_tevo_blindspot_discovery_attempts_attempted_at
+  ON public.tevo_blindspot_discovery_attempts(attempted_at DESC);
+
+COMMENT ON TABLE public.tevo_blindspot_discovery_attempts IS
+  'Audit log for tevo_blindspot_discovery_daily cron firings. Each row is one
+   cron tick; `result` captures whether the edge fn responded, errored, or is
+   missing entirely (no-op state until edge fn deployed).';
+
+REVOKE ALL ON public.tevo_blindspot_discovery_attempts FROM PUBLIC;
+GRANT SELECT, INSERT ON public.tevo_blindspot_discovery_attempts TO service_role;
+
+-- ============================================================
+-- 2. Refresh function (called by metrics_refresh_12h cron)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.tevo_blindspot_metrics_refresh()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_rows_before bigint;
+  v_rows_after bigint;
+  v_blindspot_count bigint;
+BEGIN
+  -- Pre-refresh row count for audit
+  SELECT count(*) INTO v_rows_before FROM public.latest_event_metrics;
+
+  -- Refresh CONCURRENTLY — non-blocking; readers continue against old data
+  -- during refresh. Requires a UNIQUE index on the matview (verified
+  -- present per existing matview definition).
+  REFRESH MATERIALIZED VIEW CONCURRENTLY public.latest_event_metrics;
+
+  SELECT count(*) INTO v_rows_after  FROM public.latest_event_metrics;
+  SELECT count(*) INTO v_blindspot_count FROM public.v_tevo_blindspot_movers;
+
+  RETURN jsonb_build_object(
+    'fn',                'tevo_blindspot_metrics_refresh',
+    'rows_before',       v_rows_before,
+    'rows_after',        v_rows_after,
+    'blindspot_count',   v_blindspot_count,
+    'refreshed_at',      now()
+  );
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.tevo_blindspot_metrics_refresh() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.tevo_blindspot_metrics_refresh() TO service_role;
+
+COMMENT ON FUNCTION public.tevo_blindspot_metrics_refresh() IS
+  'Refreshes latest_event_metrics CONCURRENTLY and returns audit row counts +
+   current blindspot detector population. Called by tevo_blindspot_metrics_refresh_12h
+   cron @ 06:00, 18:00 UTC. Companion to the detector in mig 20260519180000.';
+
+-- ============================================================
+-- 3. Discovery enqueue function (called by discovery_daily cron)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.tevo_blindspot_discovery_enqueue()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_attempt_id bigint;
+  v_criteria   jsonb;
+BEGIN
+  -- Search criteria mirror the detector view gates so the edge fn looks
+  -- for the same shape of events. Edge fn will pull TEvo /v9/events
+  -- with `occurs_at.gte` + `occurs_at.lte` + country filter and score
+  -- candidates before upserting into `events`.
+  v_criteria := jsonb_build_object(
+    'occurs_at_gte_iso', to_char((now() + interval '31 days')::date,  'YYYY-MM-DD'),
+    'occurs_at_lte_iso', to_char((now() + interval '365 days')::date, 'YYYY-MM-DD'),
+    'countries',         jsonb_build_array('US', 'CA'),
+    'min_tickets_count', 25,
+    'note',              'Blindspot discovery: only events with broker depth + active markets.'
+  );
+
+  INSERT INTO public.tevo_blindspot_discovery_attempts
+    (result, search_criteria, meta)
+  VALUES
+    ('enqueued', v_criteria, jsonb_build_object('source', 'tevo_blindspot_discovery_daily'))
+  RETURNING attempt_id INTO v_attempt_id;
+
+  -- Fire-and-forget HTTP to the discovery edge fn. pg_net.http_get is
+  -- async (§3 landmine — sleeps don't pace it). Edge fn deployment is
+  -- OPERATOR-PENDING; until then this call returns a request_id that
+  -- 404s harmlessly. Edge fn will INSERT a follow-up row with
+  -- result='edge_fn_called' + events_found/events_added once shipped.
+  BEGIN
+    PERFORM net.http_get(
+      url := 'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/tevo-blindspot-discovery?attempt_id=' || v_attempt_id,
+      headers := jsonb_build_object('Content-Type', 'application/json')
+    );
+  EXCEPTION WHEN OTHERS THEN
+    -- pg_net may not be available in all environments; swallow + log.
+    UPDATE public.tevo_blindspot_discovery_attempts
+      SET result = 'error',
+          meta   = jsonb_set(coalesce(meta, '{}'::jsonb), '{error}', to_jsonb(SQLERRM))
+      WHERE attempt_id = v_attempt_id;
+  END;
+
+  RETURN jsonb_build_object(
+    'fn',         'tevo_blindspot_discovery_enqueue',
+    'attempt_id', v_attempt_id,
+    'criteria',   v_criteria,
+    'queued_at',  now()
+  );
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.tevo_blindspot_discovery_enqueue() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.tevo_blindspot_discovery_enqueue() TO service_role;
+
+COMMENT ON FUNCTION public.tevo_blindspot_discovery_enqueue() IS
+  'Enqueues a TEvo /v9/events search attempt for blindspot discovery + fires
+   the edge fn via pg_net. Called by tevo_blindspot_discovery_daily cron
+   @ 07:00 UTC. Edge fn (`tevo-blindspot-discovery`) deployment is operator-
+   pending — until shipped, the HTTP call 404s harmlessly and rows stay at
+   result=''enqueued''.';
+
+-- ============================================================
+-- 4. Cron schedules
+-- ============================================================
+
+-- 4a. Twice-daily price/metrics refresh @ 06:00, 18:00 UTC
+DO $body$
+DECLARE v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'tevo_blindspot_metrics_refresh_12h';
+  IF v_jobid IS NOT NULL THEN PERFORM cron.unschedule(v_jobid); END IF;
+
+  PERFORM cron.schedule(
+    'tevo_blindspot_metrics_refresh_12h',
+    '0 6,18 * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('tevo_blindspot_metrics_refresh_12h') THEN RETURN; END IF;
+      PERFORM public.tevo_blindspot_metrics_refresh();
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+INSERT INTO public.cron_policy (
+  jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+  daily_max_fires, enabled, notes
+) VALUES (
+  'tevo_blindspot_metrics_refresh_12h',
+  '{}'::int[],            -- no peak/offpeak split — only fires at fixed UTC times
+  720, 720, 2, true,
+  'Refreshes latest_event_metrics CONCURRENTLY twice daily so blindspot detector picks up fresh price + tickets_count data. Mirrors SG TRACK_BLINDSPOT 12h cadence.'
+) ON CONFLICT (jobname) DO UPDATE SET
+  notes        = EXCLUDED.notes,
+  enabled      = EXCLUDED.enabled,
+  daily_max_fires = EXCLUDED.daily_max_fires,
+  updated_at   = now();
+
+-- 4b. Daily new-events discovery @ 07:00 UTC
+DO $body$
+DECLARE v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid FROM cron.job WHERE jobname = 'tevo_blindspot_discovery_daily';
+  IF v_jobid IS NOT NULL THEN PERFORM cron.unschedule(v_jobid); END IF;
+
+  PERFORM cron.schedule(
+    'tevo_blindspot_discovery_daily',
+    '0 7 * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('tevo_blindspot_discovery_daily') THEN RETURN; END IF;
+      PERFORM public.tevo_blindspot_discovery_enqueue();
+    END $cronbody$;$cron$
+  );
+END $body$;
+
+INSERT INTO public.cron_policy (
+  jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min,
+  daily_max_fires, enabled, notes
+) VALUES (
+  'tevo_blindspot_discovery_daily',
+  '{}'::int[],
+  1440, 1440, 1, true,
+  'Daily discovery of new TEvo events matching blindspot criteria (US/CA, 31-365d, tickets>=25). Calls edge fn `tevo-blindspot-discovery` which searches TEvo /v9/events + upserts winners. Edge fn deployment is operator-pending — until shipped, attempts log as result=''enqueued''.'
+) ON CONFLICT (jobname) DO UPDATE SET
+  notes        = EXCLUDED.notes,
+  enabled      = EXCLUDED.enabled,
+  daily_max_fires = EXCLUDED.daily_max_fires,
+  updated_at   = now();
+
+-- ============================================================
+-- VERIFICATION (operator runs after apply):
+--
+--   -- 1. Crons registered + policy rows present
+--   SELECT jobname, schedule, active FROM cron.job
+--   WHERE jobname LIKE 'tevo_blindspot_%' ORDER BY jobname;
+--
+--   SELECT jobname, daily_max_fires, enabled FROM public.cron_policy
+--   WHERE jobname LIKE 'tevo_blindspot_%';
+--
+--   -- 2. Manually fire refresh (writes a fresh latest_event_metrics)
+--   SELECT public.tevo_blindspot_metrics_refresh();
+--   -- expect: jsonb with rows_before/rows_after/blindspot_count
+--
+--   -- 3. Manually fire discovery (logs an attempt; edge fn 404s)
+--   SELECT public.tevo_blindspot_discovery_enqueue();
+--   SELECT result, search_criteria, attempted_at FROM public.tevo_blindspot_discovery_attempts
+--   ORDER BY attempted_at DESC LIMIT 1;
+--   -- expect: one row, result='enqueued' or 'error' (depending on pg_net state)
+--
+--   -- 4. After edge fn deployment, attempts should flip to result='edge_fn_called'
+--   --    with events_found/events_added populated. Until then result stays
+--   --    'enqueued' — that's the operator-pending state.
+-- ============================================================

--- a/supabase/migrations/20260519200000_returning_entities_discovery.sql
+++ b/supabase/migrations/20260519200000_returning_entities_discovery.sql
@@ -1,0 +1,275 @@
+-- Migration 20260519200000 · lane:A1 · writes:v_returning_entities,get_returning_entities,get_returning_entity_events · pre:20260519190000
+--
+-- Returning-entity discovery — companion to the blindspot detector.
+--
+-- INTENT (operator design 2026-05-19):
+--   Surface performers + venues that had past activity, went dormant for
+--   a meaningful gap, and now have upcoming events. Useful as a
+--   discovery tool to spot tour comebacks, venue re-openings, and
+--   inventory-sourcing opportunities for events brokers wouldn't
+--   otherwise prioritize.
+--
+-- SOURCES + COVERAGE:
+--   * TEvo performers (`events.primary_performer_id`) — full coverage
+--   * TEvo venues (`events.venue_id`)                 — full coverage
+--   * SG venues (`sg_events_canonical.sg_venue_id`)   — full coverage
+--   * SG performers                                    — NOT YET. SG
+--     event-to-performer link runs through `sg_event_name` parsing or
+--     `v_sg_historic_per_performer.performer_headliner`. Both are
+--     fuzzy; defer to v2. seatgeek_performer_xref only maps SG perf
+--     NAMES to TEvo perf IDs — it's name-keyed, not event-keyed.
+--
+-- DEFINITION OF "RETURNING":
+--   * Had at least 1 event in the past 2 years
+--   * Most-recent past event is at least `p_min_gap_days` days ago
+--     (default 90; RPC accepts override)
+--   * Has at least 1 upcoming event in the next 365 days
+--
+-- POOL VALIDATION (run 2026-05-19, gap=90d):
+--   tevo_performers: 3   tevo_venues: 4   sg_venues: 0
+--   Pool grows as data ages — first cohort post-launch.
+
+-- ============================================================
+-- 1. Union view: one row per (source, entity_type, entity_id)
+-- ============================================================
+DROP VIEW IF EXISTS public.v_returning_entities;
+
+CREATE VIEW public.v_returning_entities
+WITH (security_invoker = on) AS
+WITH tevo_perf AS (
+  SELECT
+    'tevo'                        AS source,
+    'performer'                   AS entity_type,
+    primary_performer_id::text    AS entity_id,
+    max(primary_performer_name)   AS entity_name,
+    NULL::text                    AS entity_location,
+    max(occurs_at_local::timestamptz) FILTER (WHERE occurs_at_local::timestamptz <  now()) AS latest_past_at,
+    min(occurs_at_local::timestamptz) FILTER (WHERE occurs_at_local::timestamptz >= now()) AS earliest_future_at,
+    count(*) FILTER (WHERE occurs_at_local::timestamptz >= now())                          AS upcoming_count,
+    count(*) FILTER (WHERE occurs_at_local::timestamptz <  now())                          AS past_count
+  FROM public.events
+  WHERE primary_performer_id IS NOT NULL
+    AND occurs_at_local IS NOT NULL
+    AND occurs_at_local::timestamptz >= now() - interval '2 years'
+    AND occurs_at_local::timestamptz <= now() + interval '365 days'
+  GROUP BY primary_performer_id
+),
+tevo_venue AS (
+  SELECT
+    'tevo', 'venue',
+    venue_id::text,
+    max(venue_name),
+    max(venue_location),
+    max(occurs_at_local::timestamptz) FILTER (WHERE occurs_at_local::timestamptz <  now()),
+    min(occurs_at_local::timestamptz) FILTER (WHERE occurs_at_local::timestamptz >= now()),
+    count(*) FILTER (WHERE occurs_at_local::timestamptz >= now()),
+    count(*) FILTER (WHERE occurs_at_local::timestamptz <  now())
+  FROM public.events
+  WHERE venue_id IS NOT NULL
+    AND occurs_at_local IS NOT NULL
+    AND occurs_at_local::timestamptz >= now() - interval '2 years'
+    AND occurs_at_local::timestamptz <= now() + interval '365 days'
+  GROUP BY venue_id
+),
+sg_venue AS (
+  SELECT
+    'sg', 'venue',
+    sg_venue_id::text,
+    max(sg_venue_name),
+    max(coalesce(sg_venue_city || ', ' || sg_venue_state, sg_venue_city)),
+    max(sg_datetime_utc) FILTER (WHERE sg_datetime_utc <  now()),
+    min(sg_datetime_utc) FILTER (WHERE sg_datetime_utc >= now()),
+    count(*) FILTER (WHERE sg_datetime_utc >= now()),
+    count(*) FILTER (WHERE sg_datetime_utc <  now())
+  FROM public.sg_events_canonical
+  WHERE sg_venue_id IS NOT NULL
+    AND sg_datetime_utc >= now() - interval '2 years'
+    AND sg_datetime_utc <= now() + interval '365 days'
+  GROUP BY sg_venue_id
+)
+SELECT
+  source, entity_type, entity_id, entity_name, entity_location,
+  latest_past_at, earliest_future_at, upcoming_count, past_count,
+  -- Gap in days between latest past event and earliest future event
+  (earliest_future_at::date - latest_past_at::date) AS gap_days
+FROM (
+  SELECT * FROM tevo_perf
+  UNION ALL
+  SELECT * FROM tevo_venue
+  UNION ALL
+  SELECT * FROM sg_venue
+) u
+WHERE latest_past_at     IS NOT NULL
+  AND earliest_future_at IS NOT NULL;
+
+COMMENT ON VIEW public.v_returning_entities IS
+  'Performers + venues with a past activity → gap → future event pattern.
+   Sources: TEvo performers, TEvo venues, SG venues. SG performer link
+   deferred to v2 (fuzzy event-to-performer mapping). Underlying join
+   keys are 2-year past + 365-day future windows. Used by
+   get_returning_entities() + get_returning_entity_events() RPCs.';
+
+REVOKE ALL ON public.v_returning_entities FROM PUBLIC;
+GRANT SELECT ON public.v_returning_entities TO anon, authenticated, service_role;
+
+-- ============================================================
+-- 2. Discovery RPC — top N returning entities
+-- ============================================================
+DROP FUNCTION IF EXISTS public.get_returning_entities(int, text, text, int);
+
+CREATE OR REPLACE FUNCTION public.get_returning_entities(
+  p_min_gap_days int   DEFAULT 90,
+  p_source       text  DEFAULT NULL,    -- 'tevo' | 'sg' | NULL (both)
+  p_entity_type  text  DEFAULT NULL,    -- 'performer' | 'venue' | NULL (both)
+  p_limit        int   DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_email text;
+  v_result jsonb;
+BEGIN
+  -- §6 caller guard — email-required
+  v_email := nullif((select auth.jwt())->>'email', '');
+  IF v_email IS NULL THEN
+    RAISE EXCEPTION 'email required' USING errcode = '42501';
+  END IF;
+
+  IF p_source IS NOT NULL AND p_source NOT IN ('tevo','sg') THEN
+    RAISE EXCEPTION 'p_source must be tevo|sg|null' USING errcode = '22023';
+  END IF;
+  IF p_entity_type IS NOT NULL AND p_entity_type NOT IN ('performer','venue') THEN
+    RAISE EXCEPTION 'p_entity_type must be performer|venue|null' USING errcode = '22023';
+  END IF;
+
+  SELECT coalesce(jsonb_agg(row_to_json(r) ORDER BY r.gap_days DESC,
+                                              r.upcoming_count DESC,
+                                              r.earliest_future_at ASC),
+                  '[]'::jsonb)
+    INTO v_result
+  FROM (
+    SELECT *
+    FROM public.v_returning_entities
+    WHERE gap_days >= p_min_gap_days
+      AND (p_source      IS NULL OR source      = p_source)
+      AND (p_entity_type IS NULL OR entity_type = p_entity_type)
+    LIMIT p_limit
+  ) r;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.get_returning_entities(int, text, text, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_returning_entities(int, text, text, int) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_returning_entities(int, text, text, int) IS
+  'Discovery tool: lists performers + venues with past activity → gap →
+   upcoming events. Sources: TEvo (events table) + SG (sg_events_canonical).
+   Default min_gap_days=90 (3 months dormant). Sort: largest gap first,
+   ties by upcoming_count DESC, then earliest_future_at ASC.';
+
+-- ============================================================
+-- 3. Drill-down RPC — events for a specific returning entity
+-- ============================================================
+DROP FUNCTION IF EXISTS public.get_returning_entity_events(text, text, text, int);
+
+CREATE OR REPLACE FUNCTION public.get_returning_entity_events(
+  p_source       text,                  -- 'tevo' | 'sg'
+  p_entity_type  text,                  -- 'performer' | 'venue'
+  p_entity_id    text,                  -- the id from v_returning_entities
+  p_limit        int  DEFAULT 25
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_email text;
+  v_result jsonb;
+BEGIN
+  v_email := nullif((select auth.jwt())->>'email', '');
+  IF v_email IS NULL THEN
+    RAISE EXCEPTION 'email required' USING errcode = '42501';
+  END IF;
+  IF p_source NOT IN ('tevo','sg') THEN
+    RAISE EXCEPTION 'p_source must be tevo|sg' USING errcode = '22023';
+  END IF;
+  IF p_entity_type NOT IN ('performer','venue') THEN
+    RAISE EXCEPTION 'p_entity_type must be performer|venue' USING errcode = '22023';
+  END IF;
+
+  IF p_source = 'tevo' AND p_entity_type = 'performer' THEN
+    SELECT coalesce(jsonb_agg(row_to_json(e) ORDER BY e.occurs_at_local), '[]'::jsonb)
+      INTO v_result
+    FROM (
+      SELECT id AS event_id, name, occurs_at_local,
+             venue_id, venue_name, venue_location
+      FROM public.events
+      WHERE primary_performer_id = p_entity_id::bigint
+        AND occurs_at_local::timestamptz >= now()
+        AND occurs_at_local::timestamptz <= now() + interval '365 days'
+      LIMIT p_limit
+    ) e;
+  ELSIF p_source = 'tevo' AND p_entity_type = 'venue' THEN
+    SELECT coalesce(jsonb_agg(row_to_json(e) ORDER BY e.occurs_at_local), '[]'::jsonb)
+      INTO v_result
+    FROM (
+      SELECT id AS event_id, name, occurs_at_local,
+             primary_performer_id, primary_performer_name
+      FROM public.events
+      WHERE venue_id = p_entity_id::bigint
+        AND occurs_at_local::timestamptz >= now()
+        AND occurs_at_local::timestamptz <= now() + interval '365 days'
+      LIMIT p_limit
+    ) e;
+  ELSIF p_source = 'sg' AND p_entity_type = 'venue' THEN
+    SELECT coalesce(jsonb_agg(row_to_json(e) ORDER BY e.sg_datetime_utc), '[]'::jsonb)
+      INTO v_result
+    FROM (
+      SELECT sg_event_id, sg_event_name, sg_datetime_utc,
+             sg_venue_name, sg_venue_city, sg_venue_state
+      FROM public.sg_events_canonical
+      WHERE sg_venue_id = p_entity_id::bigint
+        AND sg_datetime_utc >= now()
+        AND sg_datetime_utc <= now() + interval '365 days'
+      LIMIT p_limit
+    ) e;
+  ELSE
+    -- p_source='sg' AND p_entity_type='performer' — see v_returning_entities
+    -- comment: SG performer link deferred to v2.
+    RETURN '[]'::jsonb;
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.get_returning_entity_events(text, text, text, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_returning_entity_events(text, text, text, int) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_returning_entity_events(text, text, text, int) IS
+  'Drill-down for v_returning_entities: lists upcoming events (next 365d)
+   for a given (source, entity_type, entity_id) tuple. SG performer
+   drill-down returns empty array — SG performer link deferred to v2.';
+
+-- ============================================================
+-- VERIFICATION (operator runs after apply):
+--
+--   -- 1. View population by source + entity_type
+--   SELECT source, entity_type, count(*) FILTER (WHERE gap_days >= 90) AS gap_90d
+--   FROM public.v_returning_entities GROUP BY source, entity_type ORDER BY 1,2;
+--   -- Baseline 2026-05-19: tevo_performer=3, tevo_venue=4, sg_venue=0
+--
+--   -- 2. RPC smoke
+--   SELECT public.get_returning_entities();                    -- all sources, 90d gap
+--   SELECT public.get_returning_entities(180);                 -- 6-month gap
+--   SELECT public.get_returning_entities(90, 'tevo', 'venue'); -- TEvo venues only
+--
+--   -- 3. Drill-down smoke
+--   SELECT public.get_returning_entity_events('tevo','performer','<id>');
+-- ============================================================


### PR DESCRIPTION
## Summary

Companion to the SG blindspot detector (mig 20260520370000). Adds a TEvo-side view + RPC that surfaces events where **we own 0 tickets** but the broker pool is showing demand signals.

## Why TEvo's design is lighter than SG's

| Layer | SG approach | TEvo approach |
|---|---|---|
| Discovery | Tier table (`sg_event_priority_state.TRACK_BLINDSPOT`) + dedicated 12h poller, because each SG poll burns a 10/sec quota slot | None needed — `/v9/events` is higher-quota broker-side and supports filtered discovery on demand. The existing `sg_to_tevo_search_bridge` (mig 20260516250000) already provides the auto-grounding hook for events outside our current watchlist. |
| Detection | 4-signal composite score (listings shrink + price rise + sales accelerate + sales above ask) | **2-signal composite** — TEvo doesn't expose broker-side sales data, so the sales-side signals are unavailable. Stick to what we can measure: listings shrinking + get-in price firming. |

## Signals + thresholds

| Signal | Trigger | Source |
|---|---|---|
| `signal_listings_drop` | `tevo_tix_d24h <= -10` (≥10 tix gone in 24h) | `v_event_velocity_windows` |
| `signal_price_rise` | `tevo_getin_d24h_pct >= +5%` | `v_event_velocity_windows` |

Default `min_score=2` returns only events where **both** signals fire. `min_score=1` returns one-sided candidates for broader exploration.

Thresholds are tighter than SG's because the TEvo broker pool is stickier than SG's consumer firehose — a 10-ticket drop + 5% getin rise is meaningful.

## Gates (mirrors storefront filter)

- `owned_tickets_count = 0` (the blindspot)
- `tickets_count >= 10` (real broker depth)
- 90-day forward horizon
- `event_lifecycle.is_active` (drops ghost/cancelled)
- `velocity_fresh` (`tevo_now_at` within 3h — §9 cadence-gap landmine; stale d24h subqueries fall back to ancient samples)
- Speculative-name filter (CANCELLED / If Necessary / Date TBD)

## RPC shape

```sql
get_blind_spots_tevo_selling(
  p_min_score      int  = 2,
  p_horizon_days   int  = 90,
  p_limit          int  = 25,
  p_venue_pattern  text = NULL    -- e.g. '%New York%' for NYC scoping
)
```

- Email-gated (§6 caller guard)
- `security_invoker` view + `SECDEF` function
- Verification queries embedded in the migration footer

## NOT applied to prod

Per `CLAUDE.md` §1, `apply_migration` is operator-gated. This PR ships the migration file only. Operator runs `apply_migration` after smoke + intentional prod gate. View + RPC are read-only side; no destructive operations introduced.

## Verification (post-apply)

```sql
-- View population
SELECT count(*),
       count(*) FILTER (WHERE selling_score=2) AS both_signals,
       count(*) FILTER (WHERE selling_score=1) AS one_signal
FROM public.v_tevo_blindspot_movers;

-- RPC smoke (as authenticated user with email JWT)
SELECT public.get_blind_spots_tevo_selling();             -- defaults
SELECT public.get_blind_spots_tevo_selling(1);            -- one-signal min
SELECT public.get_blind_spots_tevo_selling(2, 90, 10, '%New York%');  -- NYC
```

## Out of scope

- Storefront wiring. This PR ships only the data layer. Whether the result feeds the consumer `/store` page, the broker D0 home page, or both is a separate UI decision.
- Auto-grounding via `/v9/events` search for events outside our current watchlist — the `sg_to_tevo_search_bridge` already does this, but extending it to "TEvo blindspot candidates we don't track yet" is a future PR if we want to widen the net beyond what's already in `events`.

A1 lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwvFjm1v8y5KQVEGxaGVzA)_