### PR TITLE
feat(d0/landing): static-site root serves unified selector (always-on entry)

### DIFF
--- a/render-d0-terminal.yaml
+++ b/render-d0-terminal.yaml
@@ -66,12 +66,15 @@ services:
         source: /login.html
         destination: /terminal/login.html
 
-      # Root index — bare `/` lands on the terminal home (D0's primary
-      # surface on this CDN). Use a redirect not a rewrite so the URL bar
-      # shows /terminal/ and relative-path nav resolves correctly.
-      - type: redirect
+      # Root index — bare `/` serves the unified landing selector (cards for
+      # Terminal / Undelivered / Store). Rewrite (not redirect) so the URL
+      # bar stays clean at `/` and a user typing the host alone lands on the
+      # always-on selector. Selector cards link to `/terminal`, `/undelivered`,
+      # `/store` — each a subtree of this same static site (publishPath=static).
+      # Landing HTML at static/home/index.html; auth-aware gating in home.js.
+      - type: rewrite
         source: /
-        destination: /terminal/
+        destination: /home/index.html
 
     # No env vars needed for static frontend. If D0 wires up
     # client-side config (Supabase anon key for read-only data fetch),

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -14,7 +14,7 @@
 
   <header class="topbar">
     <span class="brand">VIBEPASS</span>
-    <span class="brand-sub">3-surface frontend · transitional unified entry</span>
+    <span class="brand-sub">3-surface frontend · always-on entry</span>
     <span id="auth-ctrl"></span>
   </header>
 
@@ -44,7 +44,7 @@
   </main>
 
   <footer class="foot">
-    <span class="muted small">Unified entry while we evaluate. Per-surface domains may split back out post-validation.</span>
+    <span class="muted small">Always-on unified entry. Pick a surface — Render static CDN, no cold-start.</span>
     <span class="muted small" id="footStatus"></span>
   </footer>
 

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -9,6 +9,11 @@
   // at root (publishPath strips static/terminal/). Each link is resolved
   // relative to the current page URL by the browser.
   const PAGES = [
+    // ← HUB is an absolute /, taking the operator back to the unified
+    // landing selector (Terminal / Undelivered / Store) on the static
+    // site's root. HOME below remains the terminal's mark-to-market
+    // dashboard (broker desk view).
+    { id: 'hub',       label: '← HUB',     href: '/' },
     { id: 'home',      label: 'HOME',      href: './' },
     { id: 'event',     label: 'EVENT',     href: 'event.html' },
     { id: 'venue',     label: 'VENUE',     href: 'venue.html' },


### PR DESCRIPTION
## Summary

Bare `/` on `vibepass-terminal-test.onrender.com` now serves the unified selector at [`static/home/index.html`](static/home/index.html) (cards for Terminal / Undelivered / Store) instead of redirecting to `/terminal/`. Static-site CDN is inherently always-on / no-cold-start — perfect for the entry point users hit first.

## What changed (3 small edits)

### 1. [render-d0-terminal.yaml](render-d0-terminal.yaml) — root route flip

```diff
- - type: redirect
-   source: /
-   destination: /terminal/
+ - type: rewrite
+   source: /
+   destination: /home/index.html
```

URL bar stays clean at `/` (rewrite, not redirect). Existing redirect rules for `/event.html`, `/performer.html`, `/movers.html`, `/orders.html`, `/login.html` → `/terminal/*` are unchanged — old bookmarks still resolve.

### 2. [static/home/index.html](static/home/index.html) — copy polish

- Subtitle: `"3-surface frontend · transitional unified entry"` → `"3-surface frontend · always-on entry"`
- Footer: replaced "Unified entry while we evaluate. Per-surface domains may split back out post-validation." with "Always-on unified entry. Pick a surface — Render static CDN, no cold-start."

### 3. [static/terminal/nav.js](static/terminal/nav.js) — new `← HUB` nav entry

```diff
  const PAGES = [
+   { id: 'hub',       label: '← HUB',     href: '/' },
    { id: 'home',      label: 'HOME',      href: './' },
    { id: 'event',     label: 'EVENT',     href: 'event.html' },
    ...
```

Sends the operator back to the selector from any terminal page. Existing HOME entry (relative `./` → terminal's mark-to-market dashboard) preserved — no terminal navigation regression.

## What didn't change

- FastAPI shell unchanged. All `/api/store/*` / `/api/broker/*` / `/api/d2/*` endpoints continue to serve from `vibepass-storefront-test` as today.
- No service rename, no DNS change.
- No new files (landing HTML / CSS / JS / auth wiring already shipped).
- Render service IDs, branch protections, env vars all untouched.

## Verification (post-deploy)

- [ ] `https://vibepass-terminal-test.onrender.com/` → selector cards render, URL bar stays at `/`
- [ ] Click "Open Terminal" → navigates to `/terminal/`, broker UI loads
- [ ] Click "Open Store" → navigates to `/store/`, consumer storefront loads (host-aware API_BASE in store.js routes API calls cross-origin to vibepass-storefront-test)
- [ ] Click "Open Undelivered" → navigates to `/undelivered/`
- [ ] Sign-in flow: unsigned visitor sees Terminal + Undelivered cards greyed with "Sign in with @s4kent.com" gate; Store stays unlocked. After signing in, all 3 unlock.
- [ ] On any terminal page, click `← HUB` → returns to `/` and the selector reappears.
- [ ] Old bookmarks still work: `/event.html?event=3091413` → 301 → `/terminal/event.html?event=3091413` (existing redirect rules preserved).
- [ ] `curl -I https://vibepass-terminal-test.onrender.com/` returns 200 with no spin-up latency (always-on static CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)