### PR TITLE
feat(d1/store): Featured rail — playoffs + owned>200 + absorbs NYC specials

### DIFF
--- a/app.py
+++ b/app.py
@@ -5288,6 +5288,68 @@ def _section_specials(candidates: list[dict],
     return out[:cap]
 
 
+def _section_featured(candidates: list, holiday_by_eid: dict, rivalry_by_eid: dict, cap: int = 12) -> list:
+    """Featured rail — operator directive 2026-05-19. Combines THREE qualifying
+    signals into a single curated row that sits at the top of the home page:
+
+      1. Playoff games — any event whose name regex-matches via
+         `_classify_playoff()` (NBA Finals, Conference Finals, Stanley Cup,
+         World Series, "(Game N)", "Round N", etc.)
+      2. High-owned — `owned_tickets_count > 200` (depth bar set by operator)
+      3. Specials — owned > 100 AND (holiday OR rivalry) — absorbs the
+         prior `_section_specials` rail; FE drops it as a separate row
+
+    Each card gets a `_featured_tag` and `_featured_kind` describing what
+    earned the slot. Tag selection is strongest-signal-first:
+      playoff > rivalry > holiday > high_owned
+
+    Operates over the same candidate pool as the other sections (city-filtered
+    upstream — NYC for v1). A future expansion could pull globally for
+    playoff coverage outside NYC.
+    """
+    out = []
+    seen = set()
+    for c in candidates:
+        eid = c.get("id")
+        if eid is None:
+            continue
+        try:
+            eid_int = int(eid)
+        except (TypeError, ValueError):
+            continue
+        if eid_int in seen:
+            continue
+        owned = c.get("owned_tickets_count") or 0
+        playoff = _classify_playoff(c.get("name") or "")
+        holiday = holiday_by_eid.get(eid_int)
+        rivalry = rivalry_by_eid.get(eid_int)
+        is_playoff = bool(playoff)
+        is_high_owned = owned > 200
+        is_special = (owned > 100) and (holiday or rivalry)
+        if not (is_playoff or is_high_owned or is_special):
+            continue
+        # Tag selection — strongest narrative first
+        if is_playoff:
+            c["_featured_tag"] = (playoff.get("label") or "Playoff")
+            c["_featured_kind"] = "playoff"
+        elif rivalry:
+            c["_featured_tag"] = rivalry
+            c["_featured_kind"] = "rivalry"
+        elif holiday:
+            c["_featured_tag"] = holiday
+            c["_featured_kind"] = "holiday"
+        elif is_high_owned:
+            c["_featured_tag"] = f"{owned} owned tickets"
+            c["_featured_kind"] = "high_owned"
+        else:
+            c["_featured_tag"] = ""
+            c["_featured_kind"] = ""
+        out.append(c)
+        seen.add(eid_int)
+    out.sort(key=lambda c: c.get("occurs_at_local") or "9999")
+    return out[:cap]
+
+
 def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     """Pure compute path for the movers endpoint. Extracted from the route
     handler so both the cold-cache code path AND the background-refresh
@@ -5618,11 +5680,18 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     price_drops = _section_price_drops(candidates)
     climbing = _section_climbing(candidates)
     specials = _section_specials(candidates, holiday_by_eid, rivalry_by_eid)
+    # Featured (operator directive 2026-05-19): playoff games + owned>200 +
+    # NYC specials. Sits at the top of the home page; absorbs the standalone
+    # specials rail. Built off the same candidate pool so signals stay
+    # consistent across rails. `specials` is still returned for backward
+    # compat (legacy FE renders an empty section gracefully).
+    featured = _section_featured(candidates, holiday_by_eid, rivalry_by_eid)
 
     return {
         "city": city,
         "days": day_cap,
-        "count": len(moving_fast) + len(price_drops) + len(climbing) + len(specials),
+        "count": len(moving_fast) + len(price_drops) + len(climbing) + len(specials) + len(featured),
+        "featured": featured,
         "moving_fast": moving_fast,
         "price_drops": price_drops,
         "climbing": climbing,

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -834,6 +834,12 @@
   // `accent` line is the per-card secondary note describing why this event
   // qualified for the section (e.g. "↓ 35% below market" for price_drops).
   const SECTIONS = [
+    // Featured (operator directive 2026-05-19): top-of-home rail combining
+    // playoff games + owned>200 + NYC specials (which previously had its
+    // own row below). Sits first to capture attention. Tag = strongest
+    // signal: playoff > rivalry > holiday > high_owned.
+    { key: "featured", title: "Featured",
+      accent: (ev) => ev._featured_tag || "" },
     { key: "moving_fast", title: "Moving fast in NYC",
       accent: (ev) => {
         const tx = Number(ev.tix_d24h);
@@ -852,8 +858,9 @@
         const c = Number(ev._climb_pct);
         return Number.isFinite(c) ? `↑ ${c.toFixed(0)}% in 24h` : "";
       } },
-    { key: "specials", title: "Upcoming Specials in NYC",
-      accent: (ev) => ev._special || "" },
+    // Note: legacy "Upcoming Specials in NYC" rail removed — its content
+    // is now folded into the Featured section above. Backend still returns
+    // `specials` for backward compat with stale clients.
   ];
 
   function _moverCard(ev, accent) {

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -1127,6 +1127,19 @@ a.perf-chip:hover {
   flex-direction: column;
   gap: 22px;
 }
+
+/* Featured rail (operator directive 2026-05-19): top-of-home curated row
+   combining playoff + owned>200 + NYC specials. Slightly larger title +
+   accent color so it visually leads the page. */
+.movers-section.movers-featured .movers-section-title {
+  font-size: 16px;
+  color: var(--accent, #ff5c2a);
+  letter-spacing: 0.5px;
+}
+.movers-section.movers-featured .mover-accent {
+  background: var(--accent, #ff5c2a);
+  color: #111;
+}
 .movers-section-title {
   font-size: 14px;
   font-weight: 700;

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -939,8 +939,10 @@ def test_movers_response_no_longer_includes_tix_d1h(monkeypatch):
     r = client.get("/api/store/movers?city=NYC&days=30&limit=10")
     assert r.status_code == 200
     body = r.json()
-    # Inspect cards across all four themed sections — none should leak tix_d1h.
-    for key in ("moving_fast", "price_drops", "climbing", "specials"):
+    # Inspect cards across all themed sections — none should leak tix_d1h.
+    # Featured (PR 2026-05-19) added as a 5th key combining playoff + owned>200
+    # + NYC specials; shares the same candidate pool so same anti-leak check.
+    for key in ("featured", "moving_fast", "price_drops", "climbing", "specials"):
         for ev in body.get(key, []):
             assert "tix_d1h" not in ev, (
                 f"tix_d1h must not appear in mover response; got keys: {list(ev.keys())}"


### PR DESCRIPTION
## Summary

Operator directive 2026-05-19: *"add a subsection above [the home grid] that shows Playoff games, and any event where our owned tickets > 200 — call it featured. and merge Upcoming Specials in NYC into that view."*

New **Featured** rail sits at the top of the storefront home page, combining 3 qualifying signals into one curated row.

## Featured criteria (OR)

| Signal | Trigger | Source |
|---|---|---|
| Playoff | `_classify_playoff(name)` matches | app.py:1073 — NBA Finals, World Series, "(Game N)", "Round N", etc. |
| High-owned | `owned_tickets_count > 200` | `latest_event_metrics` |
| Specials | `owned > 100 AND (holiday OR rivalry)` | `v_event_holidays` + `v_rivalry_events` — absorbs the prior standalone rail |

Tag selection (strongest signal first): **playoff > rivalry > holiday > high_owned**

## Changes

| File | Change |
|---|---|
| `app.py` | `_section_featured()` helper + `featured` key added to `/api/store/movers` response |
| `static/store/store.js` | `SECTIONS` array gets `featured` as FIRST entry; legacy `specials` rail dropped |
| `static/store/style.css` | `.movers-section.movers-featured` styling — 16px accent-colored title + accent badge |
| `tests/test_store_home.py` | Anti-leak assertion extended to walk the new `featured` key |

`specials` still returned from backend for backward compat with stale clients — new FE just doesn't render it. The criteria for "what gets featured" is a strict superset of what `specials` filtered, so no content is lost.

## Scope

Operates on the NYC-scoped candidate pool (current `/api/store/movers?city=NYC` contract). A future expansion to national for playoff coverage outside NYC is noted in the function docstring as a follow-up.

## Test plan

- [x] Python syntax verified, tests updated
- [ ] CI green (forbidden-paths, pr-title-lint, pytest, secret-scan)
- [ ] Browser smoke on live deploy: Featured renders first in `#moversSections`, accent-colored title, cards show appropriate tag chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)