### PR TITLE
fix(d0/terminal): define BLIND_SPOT_MIN_SG_SALES (was ReferenceError on row render)

### DIFF
--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -96,6 +96,12 @@
 
   const BLIND_SPOT_MIN_SCORE = 3;
   const BLIND_SPOT_MAX_ROWS  = 20;
+  // Threshold for the table-row "blindspot" highlight: SG sales activity
+  // above this level with zero owned tickets flags the row warn-color.
+  // Mirrors the legacy heuristic (sg_sales_window >= 5 AND cur_owned_tix == 0)
+  // documented at line 93. Was referenced at line 290 but never declared —
+  // ReferenceError on render. Default kept at 5 to match prior behavior.
+  const BLIND_SPOT_MIN_SG_SALES = 5;
 
   async function renderBlindSpots() {
     const body = document.getElementById('blindSpotsBody');

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -75,6 +75,11 @@
   // Same RPC + render shape as home.js. See home.js comment block for design.
   const BLIND_SPOT_MIN_SCORE = 3;
   const BLIND_SPOT_MAX_ROWS  = 20;
+  // Threshold for the row-level "blindspot" highlight: SG sales activity
+  // above this level with zero owned tickets flags the row warn-color.
+  // Mirrors the legacy heuristic; matched declaration in home.js (PR fixing
+  // ReferenceError on render).
+  const BLIND_SPOT_MIN_SG_SALES = 5;
 
   async function renderBlindSpots() {
     const body = document.getElementById('blindSpotsBody');


### PR DESCRIPTION
## Summary

User-reported: `BLIND_SPOT_MIN_SG_SALES is not defined`.

`home.js:290` and `movers.js:247` both reference `BLIND_SPOT_MIN_SG_SALES` to compute the per-row blindspot warning class:

\`\`\`js
const sgBlind = sg > BLIND_SPOT_MIN_SG_SALES && ownedTix === 0;
\`\`\`

…but neither file declares it. The other `BLIND_SPOT_*` constants were declared (`MIN_SCORE=3`, `MAX_ROWS=20`) but this one was orphaned by a refactor.

## Threshold choice

`home.js:93` comment documents the legacy heuristic was *"sg_sales_window >= 5 AND cur_owned_tix == 0"*. Preserving prior behavior: **`BLIND_SPOT_MIN_SG_SALES = 5`**.

## Changes

| File | Change |
|---|---|
| `static/terminal/home.js` | Added const next to existing BLIND_SPOT_* declarations |
| `static/terminal/movers.js` | Same |

## Test plan

- [x] Grep confirms no other references in codebase
- [ ] Browser smoke: terminal home + movers tables render without console error, "Blindspot" warn-cell highlight appears on rows where SG sales > 5 AND owned tix == 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)