### PR TITLE
chore(d1/store): Featured cap 12→20 + title "Featured in NYC"

### DIFF
--- a/app.py
+++ b/app.py
@@ -5358,7 +5358,7 @@ def _section_specials(candidates: list[dict],
 def _section_featured(candidates: list,
                       holiday_by_eid: dict,
                       rivalry_by_eid: dict,
-                      cap: int = 12) -> list:
+                      cap: int = 20) -> list:
     """Featured rail — operator directive 2026-05-19 v3. Multi-signal
     curation. All branches require `owned_tickets_count > 100`. Tag
     selection: playoff > rivalry > holiday > marquee > premium.

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -840,7 +840,7 @@
     // applied server-side: each event appears in AT MOST ONE rail.
     // Tag = playoff label only; premium-only events show no per-card chip
     // (internal owned counts dropped — not consumer-facing).
-    { key: "featured", title: "Featured",
+    { key: "featured", title: "Featured in NYC",
       accent: (ev) => ev._featured_tag || "" },
     // Moving fast — server flags via velocity signals. Per-card accents
     // dropped (those exposed internal sold-today counts); section title


### PR DESCRIPTION
## Summary

Two small polish items after the multi-signal Featured refactor (#282/#283).

### 1. Cap 12 → 20

Live audit shows **38 NYC events** qualify for Featured under the multi-signal criteria. Cap of 12 truncates 68% of the eligible pool. 20 keeps the rail scannable while exposing more of the Yankees regular-season + holiday-tagged inventory.

Other rails (`moving_fast`, `price_drops`, `climbing`, `specials`) stay capped at 10 — they have different signal density.

### 2. Section title "Featured" → "Featured in NYC"

Consistency with other rails:
- "Moving fast in NYC"
- "Price drops in NYC"
- "Climbing fast in NYC"
- "Upcoming Specials in NYC"
- "Featured" ← only rail without NYC framing

Now: "Featured in NYC" — sets scope expectations clearly for NYC launch.

## Files

| Path | Change |
|---|---|
| `app.py` | `_section_featured` default `cap=20` (was 12) |
| `static/store/store.js` | `SECTIONS[0].title = "Featured in NYC"` |

## Test plan

- [x] Diff stat: 2 files, +2/-2 lines
- [x] No tests assert on title string or cap value
- [ ] Browser smoke post-deploy: Featured shows up to 20 events, title reads "FEATURED IN NYC"

🤖 Generated with [Claude Code](https://claude.com/claude-code)