### PR TITLE
feat(d1/store): away-team logos on store cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -4599,7 +4599,30 @@ def store_events(
         # Performer media: logo + brand color from Supabase performer_metadata.
         # Falls back to None on either side if the performer isn't seeded.
         perf_id = performer.get("id")
-        assets = perf_assets.get(int(perf_id)) if perf_id else None
+        try:
+            primary_pid = int(perf_id) if perf_id else None
+        except (TypeError, ValueError):
+            primary_pid = None
+        assets = perf_assets.get(primary_pid) if primary_pid else None
+        # Away-team assets — first non-primary performance in the array.
+        # 2026-05-19: "populate all store events with team assets where
+        # available". Sports matchups: TEvo emits both teams as separate
+        # performances. Playoff placeholders may carry only home.
+        away_pid: int | None = None
+        away_name: str | None = None
+        for p in performances:
+            pf = (p or {}).get("performer") or {}
+            pid_raw = pf.get("id")
+            try:
+                pid_int = int(pid_raw) if pid_raw else None
+            except (TypeError, ValueError):
+                pid_int = None
+            if pid_int is None or pid_int == primary_pid:
+                continue
+            away_pid = pid_int
+            away_name = pf.get("name")
+            break
+        away_assets = perf_assets.get(away_pid) if away_pid else None
 
         out.append({
             "id": ev.get("id"),
@@ -4614,6 +4637,12 @@ def store_events(
             "primary_performer_logo": (assets or {}).get("logo_default_url"),
             "primary_performer_color": (assets or {}).get("color_primary"),
             "primary_performer_league": (assets or {}).get("espn_league"),
+            # Away-team assets — populated when matchup data + metadata
+            # both available. FE renders both logos for sports cards.
+            "away_performer_id":    away_pid,
+            "away_performer_name":  away_name,
+            "away_performer_logo":  (away_assets or {}).get("logo_default_url"),
+            "away_performer_color": (away_assets or {}).get("color_primary"),
             # available_count is deprecated for authoritative pricing but
             # is fine as a "tickets available" indicator on cards (the
             # detail page uses /v9/events/:id/stats for exact numbers).
@@ -5458,7 +5487,7 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     try:
         ev_q = db.table("events").select(
             "id,name,occurs_at_local,venue_id,venue_name,venue_location,"
-            "primary_performer_id,primary_performer_name"
+            "primary_performer_id,primary_performer_name,performer_ids"
         ).gte("occurs_at_local", today_iso).lte("occurs_at_local", horizon_iso + "T23:59:59")
         # PostgREST `or_()` with a comma-separated list of `<col>.ilike.<pat>`
         # supports OR filters across multiple patterns. Use _or_ilike_clause so
@@ -5520,10 +5549,23 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
         vw = []
     velocity_by_id = {int(v["tevo_event_id"]): v for v in vw if v.get("tevo_event_id") is not None}
 
-    # Bulk performer assets for card branding consistency.
-    perf_ids = [events_by_id[i].get("primary_performer_id") for i in metrics_by_id if i not in inactive]
-    perf_ids = [int(p) for p in perf_ids if p]
-    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
+    # Bulk performer assets — fetch BOTH home (primary_performer_id) AND
+    # away (first secondary in performer_ids array) so cards can render
+    # home-vs-away branding. performer_ids is a text[] column on `events`;
+    # cast to int and dedupe. 2026-05-19: extends prior home-only fetch.
+    perf_ids_set: set[int] = set()
+    for i in metrics_by_id:
+        if i in inactive:
+            continue
+        ev = events_by_id[i]
+        pp = ev.get("primary_performer_id")
+        if pp:
+            try: perf_ids_set.add(int(pp))
+            except (TypeError, ValueError): pass
+        for raw_pid in (ev.get("performer_ids") or []):
+            try: perf_ids_set.add(int(raw_pid))
+            except (TypeError, ValueError): pass
+    perf_assets = _bulk_performer_assets(db, list(perf_ids_set)) if perf_ids_set else {}
 
     # Freshness gate for velocity signals. v_event_velocity_windows computes
     # d1h/d24h via subqueries that fall back to the most recent sample <= now-Xh,
@@ -5689,7 +5731,29 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             sg_median_delta_pct = round(
                 100.0 * (sg_now["median"] - sg_prior["median"]) / sg_prior["median"], 1)
 
-        a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
+        # Home-team assets (primary performer)
+        primary_pid_raw = ev.get("primary_performer_id")
+        primary_pid: int | None = None
+        try:
+            primary_pid = int(primary_pid_raw) if primary_pid_raw else None
+        except (TypeError, ValueError):
+            primary_pid = None
+        a = perf_assets.get(primary_pid) if primary_pid else None
+        # Away-team assets — first performer_id in array that's NOT primary.
+        # Sports matchups: events.performer_ids = [home_id, away_id, ...].
+        # Playoff/single-team entries may have only the primary; in that
+        # case away_* fields stay null (graceful no-op on FE).
+        away_pid: int | None = None
+        for raw_pid in (ev.get("performer_ids") or []):
+            try:
+                pid_int = int(raw_pid)
+            except (TypeError, ValueError):
+                continue
+            if primary_pid is not None and pid_int == primary_pid:
+                continue
+            away_pid = pid_int
+            break
+        b = perf_assets.get(away_pid) if away_pid else None
         owned_tickets = m.get("owned_tickets_count") or 0
         if owned_tickets <= 50:
             # Sections (except holidays) require owned > 50 for inventory depth;
@@ -5704,6 +5768,13 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             "primary_performer_name": ev.get("primary_performer_name"),
             "primary_performer_logo": (a or {}).get("logo_default_url"),
             "primary_performer_color": (a or {}).get("color_primary"),
+            # Away-team assets — 2026-05-19: "populate all store events
+            # with team assets where available". Null when no away
+            # performer in array (e.g. playoff placeholder events).
+            "away_performer_id":    away_pid,
+            "away_performer_name":  (b or {}).get("name"),
+            "away_performer_logo":  (b or {}).get("logo_default_url"),
+            "away_performer_color": (b or {}).get("color_primary"),
             "from_price": from_price,
             "tix_d24h": d24h_val,
             "getin_pct_24h": pct_val,
@@ -5965,7 +6036,7 @@ def store_home(
         ev_rows = (db.table("events")
                      .select("id,name,occurs_at_local,venue_id,venue_name,"
                              "venue_location,primary_performer_id,"
-                             "primary_performer_name")
+                             "primary_performer_name,performer_ids")
                      .in_("id", ev_ids)
                      .gte("occurs_at_local", today_iso)
                      .limit(1000)
@@ -6021,10 +6092,18 @@ def store_home(
     # same — just two parallel calls instead of one slow one.
 
     # Bulk performer assets for card branding (logo + brand color).
-    perf_ids = list({int(e.get("primary_performer_id"))
-                     for e in events_by_id.values()
-                     if e.get("primary_performer_id")})
-    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
+    # 2026-05-19: extends to home + away performers so cards can render
+    # matchup branding (Cavs-at-Knicks both logos, etc.).
+    perf_ids_set: set[int] = set()
+    for e in events_by_id.values():
+        pp = e.get("primary_performer_id")
+        if pp:
+            try: perf_ids_set.add(int(pp))
+            except (TypeError, ValueError): pass
+        for raw_pid in (e.get("performer_ids") or []):
+            try: perf_ids_set.add(int(raw_pid))
+            except (TypeError, ValueError): pass
+    perf_assets = _bulk_performer_assets(db, list(perf_ids_set)) if perf_ids_set else {}
 
     # Build cards. Schema mirrors /api/store/events for renderer reuse, plus
     # `from_price` + `owned_tickets_count` + `signal` actually populated
@@ -6033,7 +6112,24 @@ def store_home(
     for eid, ev in events_by_id.items():
         lem = lem_by_id.get(eid, {})
         perf_id = ev.get("primary_performer_id")
-        assets = perf_assets.get(int(perf_id)) if perf_id else None
+        try:
+            primary_pid = int(perf_id) if perf_id else None
+        except (TypeError, ValueError):
+            primary_pid = None
+        assets = perf_assets.get(primary_pid) if primary_pid else None
+        # Away-team assets — first performer in array that's NOT the home
+        # team. Null when array has only the primary (playoff placeholders).
+        away_pid: int | None = None
+        for raw_pid in (ev.get("performer_ids") or []):
+            try:
+                pid_int = int(raw_pid)
+            except (TypeError, ValueError):
+                continue
+            if primary_pid is not None and pid_int == primary_pid:
+                continue
+            away_pid = pid_int
+            break
+        away_assets = perf_assets.get(away_pid) if away_pid else None
 
         try:
             rm = float(lem.get("retail_min")) if lem.get("retail_min") is not None else None
@@ -6056,6 +6152,12 @@ def store_home(
             "primary_performer_logo": (assets or {}).get("logo_default_url"),
             "primary_performer_color": (assets or {}).get("color_primary"),
             "primary_performer_league": (assets or {}).get("espn_league"),
+            # Away-team assets — 2026-05-19: populate where available.
+            # Null fields when no away performer or no metadata.
+            "away_performer_id":    away_pid,
+            "away_performer_name":  (away_assets or {}).get("name"),
+            "away_performer_logo":  (away_assets or {}).get("logo_default_url"),
+            "away_performer_color": (away_assets or {}).get("color_primary"),
             # Available_count is filled from TEvo's per-event count on the
             # detail page; the matview's tickets_count is the storefront-
             # wide listing count which is the better cards-level signal.

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -353,16 +353,33 @@
           a.style.setProperty("--card-accent", ev.primary_performer_color);
         }
 
-        // Header row: logo (if branded) + meta lines.
+        // Header row: logo(s) + meta lines.
+        // 2026-05-19: Sports matchups render BOTH team logos when away is
+        // populated (e.g. "Cavs @ Knicks" → away logo + home logo). Falls
+        // back to home-only when away is null (concerts, theater, playoff
+        // placeholders without secondary performer).
         const head = document.createElement("div");
         head.className = "card-head";
-        if (ev.primary_performer_logo) {
-          const img = document.createElement("img");
-          img.className = "card-logo";
-          img.src = ev.primary_performer_logo;
-          img.alt = "";
-          img.loading = "lazy";
-          head.append(img);
+        if (ev.away_performer_logo || ev.primary_performer_logo) {
+          const logos = document.createElement("div");
+          logos.className = "card-logos";
+          if (ev.away_performer_logo) {
+            const awayImg = document.createElement("img");
+            awayImg.className = "card-logo card-logo-away";
+            awayImg.src = ev.away_performer_logo;
+            awayImg.alt = ev.away_performer_name || "";
+            awayImg.loading = "lazy";
+            logos.append(awayImg);
+          }
+          if (ev.primary_performer_logo) {
+            const homeImg = document.createElement("img");
+            homeImg.className = "card-logo card-logo-home";
+            homeImg.src = ev.primary_performer_logo;
+            homeImg.alt = ev.primary_performer_name || "";
+            homeImg.loading = "lazy";
+            logos.append(homeImg);
+          }
+          head.append(logos);
         }
         const headText = document.createElement("div");
         const when = document.createElement("div");
@@ -504,6 +521,12 @@
             primary_performer_name: e.primary_performer_name || null,
             primary_performer_logo: e.primary_performer_logo || null,
             primary_performer_color: e.primary_performer_color || null,
+            // Away-team assets (2026-05-19) — pass through when /search
+            // payload carries them; otherwise null and card falls back to
+            // home-only render.
+            away_performer_name: e.away_performer_name || null,
+            away_performer_logo: e.away_performer_logo || null,
+            away_performer_color: e.away_performer_color || null,
             from_price: e.from_price != null ? Number(e.from_price) : null,
             owned_tickets_count: e.owned_tix != null ? Number(e.owned_tix) :
                                  (e.owned_tickets_count != null ? Number(e.owned_tickets_count) : null),

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -263,6 +263,21 @@ a { color: inherit; }
   padding: 4px;
   flex-shrink: 0;
 }
+/* Sports-matchup logo cluster (2026-05-19). When both away + home assets
+   are available the card renders as "[away] [home]". Overlap by a few px
+   so the pair reads as a single matchup glyph rather than two unrelated
+   chips. Falls back to single logo when one side is null. */
+.card-logos {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.card-logos .card-logo + .card-logo {
+  margin-left: -8px;
+}
+.card-logo-away {
+  opacity: 0.92;
+}
 .card .when {
   font-size: 12px;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- Surface away-team logos on consumer storefront cards (Cavs @ Knicks → away logo + home logo, 4px overlap).
- Backend wires `away_performer_{id,name,logo,color}` through 3 endpoints: `/api/store/events`, `/api/store/home`, `/api/store/movers`.
- Frontend renders both logos as a `.card-logos` cluster; falls back to home-only for concerts/theater + playoff placeholders without a secondary performer.

## Detail

### Backend (app.py)
- `/api/store/events`: extract first non-primary entry from `performances[]`, attach 4 away fields.
- `/api/store/home`: include `performer_ids` in the events SELECT, expand bulk `_bulk_performer_assets` to fetch all array members, attach same 4 fields.
- `_compute_movers`: identical pattern for movers rails.

### Frontend
- `store.js`: replace single `<img class="card-logo">` with `<div class="card-logos">` containing away + home `<img>` children. Pass through away_* fields in the `/search` shape adapter.
- `style.css`: `.card-logos` flex cluster, `-8px` margin between siblings so the pair reads as one glyph, slight away opacity dim.

### Graceful degradation
- Playoff placeholder events whose `performer_ids` carries only the home team (e.g. Cavs-Knicks G1 in current data) render with home logo alone — no broken images.
- Concert/theater events render unchanged.

## Test plan
- [x] `tests/test_store_home.py` — 35/35 pass (existing `primary_*` assertions unaffected)
- [x] All 47 store-related tests pass (`pytest -k store`)
- [x] `app.py` syntax OK
- [ ] Manual: visit `/store` on `vibepass-storefront-test`, confirm sports cards render two logos (e.g. Knicks home games), concerts render one
- [ ] Spot-check Cavs-Knicks playoff card (away null → home-only, no broken img)

🤖 Generated with [Claude Code](https://claude.com/claude-code)