### PR TITLE
feat(d1/store): holiday day-of vs weekend-of rail labels

### DIFF
--- a/app.py
+++ b/app.py
@@ -4599,7 +4599,30 @@ def store_events(
         # Performer media: logo + brand color from Supabase performer_metadata.
         # Falls back to None on either side if the performer isn't seeded.
         perf_id = performer.get("id")
-        assets = perf_assets.get(int(perf_id)) if perf_id else None
+        try:
+            primary_pid = int(perf_id) if perf_id else None
+        except (TypeError, ValueError):
+            primary_pid = None
+        assets = perf_assets.get(primary_pid) if primary_pid else None
+        # Away-team assets — first non-primary performance in the array.
+        # 2026-05-19: "populate all store events with team assets where
+        # available". Sports matchups: TEvo emits both teams as separate
+        # performances. Playoff placeholders may carry only home.
+        away_pid: int | None = None
+        away_name: str | None = None
+        for p in performances:
+            pf = (p or {}).get("performer") or {}
+            pid_raw = pf.get("id")
+            try:
+                pid_int = int(pid_raw) if pid_raw else None
+            except (TypeError, ValueError):
+                pid_int = None
+            if pid_int is None or pid_int == primary_pid:
+                continue
+            away_pid = pid_int
+            away_name = pf.get("name")
+            break
+        away_assets = perf_assets.get(away_pid) if away_pid else None
 
         out.append({
             "id": ev.get("id"),
@@ -4614,6 +4637,12 @@ def store_events(
             "primary_performer_logo": (assets or {}).get("logo_default_url"),
             "primary_performer_color": (assets or {}).get("color_primary"),
             "primary_performer_league": (assets or {}).get("espn_league"),
+            # Away-team assets — populated when matchup data + metadata
+            # both available. FE renders both logos for sports cards.
+            "away_performer_id":    away_pid,
+            "away_performer_name":  away_name,
+            "away_performer_logo":  (away_assets or {}).get("logo_default_url"),
+            "away_performer_color": (away_assets or {}).get("color_primary"),
             # available_count is deprecated for authoritative pricing but
             # is fine as a "tickets available" indicator on cards (the
             # detail page uses /v9/events/:id/stats for exact numbers).
@@ -5458,7 +5487,7 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     try:
         ev_q = db.table("events").select(
             "id,name,occurs_at_local,venue_id,venue_name,venue_location,"
-            "primary_performer_id,primary_performer_name"
+            "primary_performer_id,primary_performer_name,performer_ids"
         ).gte("occurs_at_local", today_iso).lte("occurs_at_local", horizon_iso + "T23:59:59")
         # PostgREST `or_()` with a comma-separated list of `<col>.ilike.<pat>`
         # supports OR filters across multiple patterns. Use _or_ilike_clause so
@@ -5520,10 +5549,23 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
         vw = []
     velocity_by_id = {int(v["tevo_event_id"]): v for v in vw if v.get("tevo_event_id") is not None}
 
-    # Bulk performer assets for card branding consistency.
-    perf_ids = [events_by_id[i].get("primary_performer_id") for i in metrics_by_id if i not in inactive]
-    perf_ids = [int(p) for p in perf_ids if p]
-    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
+    # Bulk performer assets — fetch BOTH home (primary_performer_id) AND
+    # away (first secondary in performer_ids array) so cards can render
+    # home-vs-away branding. performer_ids is a text[] column on `events`;
+    # cast to int and dedupe. 2026-05-19: extends prior home-only fetch.
+    perf_ids_set: set[int] = set()
+    for i in metrics_by_id:
+        if i in inactive:
+            continue
+        ev = events_by_id[i]
+        pp = ev.get("primary_performer_id")
+        if pp:
+            try: perf_ids_set.add(int(pp))
+            except (TypeError, ValueError): pass
+        for raw_pid in (ev.get("performer_ids") or []):
+            try: perf_ids_set.add(int(raw_pid))
+            except (TypeError, ValueError): pass
+    perf_assets = _bulk_performer_assets(db, list(perf_ids_set)) if perf_ids_set else {}
 
     # Freshness gate for velocity signals. v_event_velocity_windows computes
     # d1h/d24h via subqueries that fall back to the most recent sample <= now-Xh,
@@ -5689,7 +5731,29 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             sg_median_delta_pct = round(
                 100.0 * (sg_now["median"] - sg_prior["median"]) / sg_prior["median"], 1)
 
-        a = perf_assets.get(int(ev.get("primary_performer_id"))) if ev.get("primary_performer_id") else None
+        # Home-team assets (primary performer)
+        primary_pid_raw = ev.get("primary_performer_id")
+        primary_pid: int | None = None
+        try:
+            primary_pid = int(primary_pid_raw) if primary_pid_raw else None
+        except (TypeError, ValueError):
+            primary_pid = None
+        a = perf_assets.get(primary_pid) if primary_pid else None
+        # Away-team assets — first performer_id in array that's NOT primary.
+        # Sports matchups: events.performer_ids = [home_id, away_id, ...].
+        # Playoff/single-team entries may have only the primary; in that
+        # case away_* fields stay null (graceful no-op on FE).
+        away_pid: int | None = None
+        for raw_pid in (ev.get("performer_ids") or []):
+            try:
+                pid_int = int(raw_pid)
+            except (TypeError, ValueError):
+                continue
+            if primary_pid is not None and pid_int == primary_pid:
+                continue
+            away_pid = pid_int
+            break
+        b = perf_assets.get(away_pid) if away_pid else None
         owned_tickets = m.get("owned_tickets_count") or 0
         if owned_tickets <= 50:
             # Sections (except holidays) require owned > 50 for inventory depth;
@@ -5704,6 +5768,13 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             "primary_performer_name": ev.get("primary_performer_name"),
             "primary_performer_logo": (a or {}).get("logo_default_url"),
             "primary_performer_color": (a or {}).get("color_primary"),
+            # Away-team assets — 2026-05-19: "populate all store events
+            # with team assets where available". Null when no away
+            # performer in array (e.g. playoff placeholder events).
+            "away_performer_id":    away_pid,
+            "away_performer_name":  (b or {}).get("name"),
+            "away_performer_logo":  (b or {}).get("logo_default_url"),
+            "away_performer_color": (b or {}).get("color_primary"),
             "from_price": from_price,
             "tix_d24h": d24h_val,
             "getin_pct_24h": pct_val,
@@ -5965,7 +6036,7 @@ def store_home(
         ev_rows = (db.table("events")
                      .select("id,name,occurs_at_local,venue_id,venue_name,"
                              "venue_location,primary_performer_id,"
-                             "primary_performer_name")
+                             "primary_performer_name,performer_ids")
                      .in_("id", ev_ids)
                      .gte("occurs_at_local", today_iso)
                      .limit(1000)
@@ -6021,10 +6092,18 @@ def store_home(
     # same — just two parallel calls instead of one slow one.
 
     # Bulk performer assets for card branding (logo + brand color).
-    perf_ids = list({int(e.get("primary_performer_id"))
-                     for e in events_by_id.values()
-                     if e.get("primary_performer_id")})
-    perf_assets = _bulk_performer_assets(db, perf_ids) if perf_ids else {}
+    # 2026-05-19: extends to home + away performers so cards can render
+    # matchup branding (Cavs-at-Knicks both logos, etc.).
+    perf_ids_set: set[int] = set()
+    for e in events_by_id.values():
+        pp = e.get("primary_performer_id")
+        if pp:
+            try: perf_ids_set.add(int(pp))
+            except (TypeError, ValueError): pass
+        for raw_pid in (e.get("performer_ids") or []):
+            try: perf_ids_set.add(int(raw_pid))
+            except (TypeError, ValueError): pass
+    perf_assets = _bulk_performer_assets(db, list(perf_ids_set)) if perf_ids_set else {}
 
     # Build cards. Schema mirrors /api/store/events for renderer reuse, plus
     # `from_price` + `owned_tickets_count` + `signal` actually populated
@@ -6033,7 +6112,24 @@ def store_home(
     for eid, ev in events_by_id.items():
         lem = lem_by_id.get(eid, {})
         perf_id = ev.get("primary_performer_id")
-        assets = perf_assets.get(int(perf_id)) if perf_id else None
+        try:
+            primary_pid = int(perf_id) if perf_id else None
+        except (TypeError, ValueError):
+            primary_pid = None
+        assets = perf_assets.get(primary_pid) if primary_pid else None
+        # Away-team assets — first performer in array that's NOT the home
+        # team. Null when array has only the primary (playoff placeholders).
+        away_pid: int | None = None
+        for raw_pid in (ev.get("performer_ids") or []):
+            try:
+                pid_int = int(raw_pid)
+            except (TypeError, ValueError):
+                continue
+            if primary_pid is not None and pid_int == primary_pid:
+                continue
+            away_pid = pid_int
+            break
+        away_assets = perf_assets.get(away_pid) if away_pid else None
 
         try:
             rm = float(lem.get("retail_min")) if lem.get("retail_min") is not None else None
@@ -6056,6 +6152,12 @@ def store_home(
             "primary_performer_logo": (assets or {}).get("logo_default_url"),
             "primary_performer_color": (assets or {}).get("color_primary"),
             "primary_performer_league": (assets or {}).get("espn_league"),
+            # Away-team assets — 2026-05-19: populate where available.
+            # Null fields when no away performer or no metadata.
+            "away_performer_id":    away_pid,
+            "away_performer_name":  (away_assets or {}).get("name"),
+            "away_performer_logo":  (away_assets or {}).get("logo_default_url"),
+            "away_performer_color": (away_assets or {}).get("color_primary"),
             # Available_count is filled from TEvo's per-event count on the
             # detail page; the matview's tickets_count is the storefront-
             # wide listing count which is the better cards-level signal.

--- a/app.py
+++ b/app.py
@@ -5350,17 +5350,18 @@ def _section_climbing(candidates: list[dict], cap: int = 10) -> list[dict]:
 
 
 def _section_specials(candidates: list[dict],
-                      holiday_by_eid: dict[int, str],
+                      holiday_by_eid: dict[int, dict],
                       rivalry_by_eid: dict[int, str],
                       cap: int = 10) -> list[dict]:
     """Curated rail — events that qualify on a non-market basis. Two
     sources fold in here:
-      1. v_event_holidays: server-side holiday window match (Memorial
-         Day, Christmas, etc.)
+      1. v_event_holidays + holiday-window expansion: day-of OR ±2 day
+         (Memorial Day vs Memorial Day Weekend, etc.)
       2. v_rivalry_events: known rivalry games (Yankees-Red Sox, etc.)
     Both gated to owned > 100 — same depth bar the operator set for
     the "specials" rail. Each card is tagged with `_special` describing
-    what earned its slot (e.g. "Memorial Day" or "Yankees vs Red Sox").
+    what earned its slot (e.g. "Memorial Day", "Memorial Day Weekend",
+    or "Yankees vs Red Sox").
     """
     out = []
     for c in candidates:
@@ -5377,7 +5378,13 @@ def _section_specials(candidates: list[dict],
         rivalry = rivalry_by_eid.get(eid_int)
         if holiday or rivalry:
             # Prefer rivalry tag when both apply — more specific narrative.
-            c["_special"] = rivalry or holiday
+            if rivalry:
+                c["_special"] = rivalry
+            else:
+                hname = (holiday or {}).get("name") or ""
+                # Weekend-of holidays get "Memorial Day Weekend" framing;
+                # day-of keeps the bare holiday name.
+                c["_special"] = f"{hname} Weekend" if (holiday or {}).get("weekend") else hname
             c["_special_kind"] = "rivalry" if rivalry else "holiday"
             out.append(c)
     out.sort(key=lambda c: c.get("occurs_at_local") or "9999")
@@ -5394,7 +5401,9 @@ def _section_featured(candidates: list,
 
       1. Playoff games           — `_classify_playoff()` regex hit
       2. Holiday calendar games  — date within holiday window (±2 days
-                                   from observed_date; weekend coverage)
+                                   from observed_date; weekend coverage).
+                                   Tag = "Memorial Day" for day-of,
+                                   "Memorial Day Weekend" for ±1/±2.
       3. Rivalry games           — `v_rivalry_events` membership
       4. Marquee competitions    — US Open Tennis / F1 / Inter Miami away
       5. Other category          — `owned_median_retail > $50` catch-all
@@ -5429,7 +5438,10 @@ def _section_featured(candidates: list,
             c["_featured_tag"] = rivalry
             c["_featured_kind"] = "rivalry"
         elif holiday:
-            c["_featured_tag"] = holiday
+            # Holiday tag — day-of keeps bare name ("Memorial Day"); ±1/±2
+            # gets the weekend framing ("Memorial Day Weekend").
+            hname = (holiday or {}).get("name") or ""
+            c["_featured_tag"] = f"{hname} Weekend" if (holiday or {}).get("weekend") else hname
             c["_featured_kind"] = "holiday"
         elif marquee:
             c["_featured_tag"] = marquee
@@ -5792,7 +5804,12 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     # tags. Both wrapped in try/except so a view-side failure degrades
     # to no-specials rather than killing the whole movers response.
     candidate_ids = [int(c["id"]) for c in candidates if c.get("id") is not None]
-    holiday_by_eid: dict[int, str] = {}
+    # holiday_by_eid value shape (2026-05-19): {"name": str, "weekend": bool}
+    # weekend=False → event is ON the holiday's observed_date (label "Memorial Day")
+    # weekend=True  → event is ±1/±2 days from observed_date (label "Memorial Day Weekend")
+    # Operator directive: distinguish day-of from weekend-of so the actual
+    # holiday day stands apart in the rail badges.
+    holiday_by_eid: dict[int, dict] = {}
     rivalry_by_eid: dict[int, str] = {}
     if candidate_ids:
         try:
@@ -5802,14 +5819,16 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
                        .execute().data) or []
             # First match wins per event — v_event_holidays can emit
             # multiple rows when a date hits multiple holidays. The view
-            # already orders by match_specificity DESC server-side.
+            # already orders by match_specificity DESC server-side. This
+            # view is exact-date only (see line 5856 landmine note), so
+            # all matches from here are day-of → weekend=False.
             for r in hrows:
                 eid = r.get("tevo_event_id")
                 if eid is None:
                     continue
                 key = int(eid)
                 if key not in holiday_by_eid and r.get("holiday_name"):
-                    holiday_by_eid[key] = r["holiday_name"]
+                    holiday_by_eid[key] = {"name": r["holiday_name"], "weekend": False}
         except Exception as e:
             print(f"store_movers v_event_holidays query failed: {e}")
         try:
@@ -5886,7 +5905,9 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
                     obs_d = _date_cls.fromisoformat(obs)
                 except (TypeError, ValueError):
                     continue
-                # Window: -2 day through +1 day inclusive
+                # Window: -2 day through +1 day inclusive.
+                # observed_date itself is included (dd=0) — used to flag
+                # day-of matches that v_event_holidays may have missed.
                 for dd in range(-2, 2):
                     ds = (obs_d + timedelta(days=dd)).isoformat()
                     date_to_options.setdefault(ds, []).append(h)
@@ -5935,7 +5956,15 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
                     -_HOLIDAY_PRIORITY.get(hh.get("holiday_name", ""), 0),
                     0 if hh.get("country") == "US" else 1,
                 ))
-                holiday_by_eid[eid_int] = applicable[0].get("holiday_name", "")
+                chosen = applicable[0]
+                hname = chosen.get("holiday_name", "")
+                # Day-of vs weekend-of: if candidate occurs exactly on the
+                # holiday's observed_date, label as the bare holiday name.
+                # Otherwise label as "{Holiday} Weekend" via the section
+                # helper. Operator directive 2026-05-19: distinguish the
+                # actual day from adjacent days in rail badges.
+                is_day_of = (chosen.get("observed_date") == cd)
+                holiday_by_eid[eid_int] = {"name": hname, "weekend": not is_day_of}
     except Exception as e:
         print(f"store_movers holiday-window expansion failed: {e}")
 

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -353,16 +353,33 @@
           a.style.setProperty("--card-accent", ev.primary_performer_color);
         }
 
-        // Header row: logo (if branded) + meta lines.
+        // Header row: logo(s) + meta lines.
+        // 2026-05-19: Sports matchups render BOTH team logos when away is
+        // populated (e.g. "Cavs @ Knicks" → away logo + home logo). Falls
+        // back to home-only when away is null (concerts, theater, playoff
+        // placeholders without secondary performer).
         const head = document.createElement("div");
         head.className = "card-head";
-        if (ev.primary_performer_logo) {
-          const img = document.createElement("img");
-          img.className = "card-logo";
-          img.src = ev.primary_performer_logo;
-          img.alt = "";
-          img.loading = "lazy";
-          head.append(img);
+        if (ev.away_performer_logo || ev.primary_performer_logo) {
+          const logos = document.createElement("div");
+          logos.className = "card-logos";
+          if (ev.away_performer_logo) {
+            const awayImg = document.createElement("img");
+            awayImg.className = "card-logo card-logo-away";
+            awayImg.src = ev.away_performer_logo;
+            awayImg.alt = ev.away_performer_name || "";
+            awayImg.loading = "lazy";
+            logos.append(awayImg);
+          }
+          if (ev.primary_performer_logo) {
+            const homeImg = document.createElement("img");
+            homeImg.className = "card-logo card-logo-home";
+            homeImg.src = ev.primary_performer_logo;
+            homeImg.alt = ev.primary_performer_name || "";
+            homeImg.loading = "lazy";
+            logos.append(homeImg);
+          }
+          head.append(logos);
         }
         const headText = document.createElement("div");
         const when = document.createElement("div");
@@ -504,6 +521,12 @@
             primary_performer_name: e.primary_performer_name || null,
             primary_performer_logo: e.primary_performer_logo || null,
             primary_performer_color: e.primary_performer_color || null,
+            // Away-team assets (2026-05-19) — pass through when /search
+            // payload carries them; otherwise null and card falls back to
+            // home-only render.
+            away_performer_name: e.away_performer_name || null,
+            away_performer_logo: e.away_performer_logo || null,
+            away_performer_color: e.away_performer_color || null,
             from_price: e.from_price != null ? Number(e.from_price) : null,
             owned_tickets_count: e.owned_tix != null ? Number(e.owned_tix) :
                                  (e.owned_tickets_count != null ? Number(e.owned_tickets_count) : null),

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -263,6 +263,21 @@ a { color: inherit; }
   padding: 4px;
   flex-shrink: 0;
 }
+/* Sports-matchup logo cluster (2026-05-19). When both away + home assets
+   are available the card renders as "[away] [home]". Overlap by a few px
+   so the pair reads as a single matchup glyph rather than two unrelated
+   chips. Falls back to single logo when one side is null. */
+.card-logos {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.card-logos .card-logo + .card-logo {
+  margin-left: -8px;
+}
+.card-logo-away {
+  opacity: 0.92;
+}
 .card .when {
   font-size: 12px;
   color: var(--muted);

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -960,3 +960,93 @@ def test_store_html_routes_respond_to_head(monkeypatch):
         assert r.status_code == 200, (
             f"HEAD {path} expected 200, got {r.status_code}"
         )
+
+
+# ---------- _section_featured / _section_specials holiday label tests ----------
+#
+# Operator directive 2026-05-19: distinguish the actual holiday day from
+# adjacent days in rail badges. Day-of keeps the bare name ("Memorial Day"),
+# weekend-of gets the framing ("Memorial Day Weekend"). holiday_by_eid value
+# shape: {"name": str, "weekend": bool}.
+
+def _featured_candidate(eid: int, owned: int = 150,
+                        occurs: str = "2026-05-25T19:00:00-04:00",
+                        med: float = 60.0) -> dict:
+    """Minimal candidate dict that satisfies the Featured 'other category'
+    branch fallthrough so we can test the holiday-tag path in isolation
+    (owned > 100, no playoff/rivalry/marquee regex hits in name)."""
+    return {
+        "id": eid,
+        "name": f"Test Event {eid}",   # no playoff/marquee keywords
+        "occurs_at_local": occurs,
+        "owned_tickets_count": owned,
+        "owned_median_retail": med,
+        "owned_share": 0.10,
+    }
+
+
+def test_section_featured_holiday_day_of_label():
+    """Holiday day-of: bare name, no 'Weekend' suffix."""
+    cand = _featured_candidate(1)
+    out = app_module._section_featured(
+        [cand],
+        holiday_by_eid={1: {"name": "Memorial Day", "weekend": False}},
+        rivalry_by_eid={},
+    )
+    assert len(out) == 1
+    assert out[0]["_featured_tag"] == "Memorial Day"
+    assert out[0]["_featured_kind"] == "holiday"
+
+
+def test_section_featured_holiday_weekend_of_label():
+    """Holiday weekend-of (±1/±2 from observed_date): 'Weekend' suffix."""
+    cand = _featured_candidate(2)
+    out = app_module._section_featured(
+        [cand],
+        holiday_by_eid={2: {"name": "Memorial Day", "weekend": True}},
+        rivalry_by_eid={},
+    )
+    assert len(out) == 1
+    assert out[0]["_featured_tag"] == "Memorial Day Weekend"
+    assert out[0]["_featured_kind"] == "holiday"
+
+
+def test_section_specials_holiday_day_of_label():
+    """Specials rail mirrors Featured for the label semantics."""
+    cand = _featured_candidate(3)
+    out = app_module._section_specials(
+        [cand],
+        holiday_by_eid={3: {"name": "Father's Day", "weekend": False}},
+        rivalry_by_eid={},
+    )
+    assert len(out) == 1
+    assert out[0]["_special"] == "Father's Day"
+    assert out[0]["_special_kind"] == "holiday"
+
+
+def test_section_specials_holiday_weekend_of_label():
+    """Specials rail — weekend-of gets the 'Weekend' framing."""
+    cand = _featured_candidate(4)
+    out = app_module._section_specials(
+        [cand],
+        holiday_by_eid={4: {"name": "Father's Day", "weekend": True}},
+        rivalry_by_eid={},
+    )
+    assert len(out) == 1
+    assert out[0]["_special"] == "Father's Day Weekend"
+    assert out[0]["_special_kind"] == "holiday"
+
+
+def test_section_specials_rivalry_wins_over_holiday():
+    """When BOTH a rivalry tag and a holiday tag apply, the rivalry text
+    is the more specific narrative — guard the prefer-rivalry behavior so
+    the new holiday-label refactor doesn't regress it."""
+    cand = _featured_candidate(5)
+    out = app_module._section_specials(
+        [cand],
+        holiday_by_eid={5: {"name": "Memorial Day", "weekend": True}},
+        rivalry_by_eid={5: "Yankees vs Red Sox"},
+    )
+    assert len(out) == 1
+    assert out[0]["_special"] == "Yankees vs Red Sox"
+    assert out[0]["_special_kind"] == "rivalry"


### PR DESCRIPTION
## Summary
- Distinguish exact-date holiday matches from ±1/±2 day window matches in Featured + Specials rail badges.
- Day-of → "Memorial Day". Weekend-of → "Memorial Day Weekend".
- Fixes operator complaint that the whole Memorial Day / Father's Day weekend was tagged identically to the holiday itself.

## Detail

### Data model change
`holiday_by_eid` value: `str` → `{"name": str, "weekend": bool}`

- `v_event_holidays` path (exact-date server-side join): `weekend=False`
- Window-expansion path (±2 from `observed_date`): compares `candidate.occurs_at_local[:10]` against the chosen holiday's `observed_date`. If equal → `weekend=False`; otherwise → `weekend=True`.

### Label rendering
`_section_featured` + `_section_specials` format the final string:
- `weekend=False` → `"Memorial Day"`
- `weekend=True`  → `"Memorial Day Weekend"`

### Behavior preserved
- Priority sort (Father's Day > Juneteenth on June 19/20/21 conflict): unchanged
- Rivalry-wins-over-holiday in Specials: unchanged
- CA-holiday-requires-Canadian-team applicability rule: unchanged
- Day-of always wins (window expansion skips `eid_int in holiday_by_eid`): unchanged

### Examples (Memorial Day = Monday May 25, 2026)
| Game date | Old label | New label |
|---|---|---|
| Sat May 23 | "Memorial Day" | "Memorial Day Weekend" |
| Sun May 24 | "Memorial Day" | "Memorial Day Weekend" |
| Mon May 25 | "Memorial Day" | "Memorial Day" ✓ |
| Tue May 26 | "Memorial Day" | "Memorial Day Weekend" |

## Test plan
- [x] +5 new unit tests on `_section_featured` / `_section_specials` cover day-of, weekend-of, and rivalry-wins-over-holiday
- [x] `52 passed` on full store test suite (`pytest -k store`)
- [x] `app.py` syntax OK
- [ ] Manual smoke: visit `/store` Memorial Day weekend, confirm Saturday/Sunday/Tuesday games show "Memorial Day Weekend" while Monday games show "Memorial Day"

🤖 Generated with [Claude Code](https://claude.com/claude-code)