### PR TITLE
fix(d1/store): Weekend suffix limited to actual Sat/Sun (drop Tue/Wed/Thu)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1158,6 +1158,38 @@ _HOLIDAY_PRIORITY: dict[str, int] = {
 }
 
 
+def _classify_holiday_proximity(candidate_date_iso: str,
+                                observed_date_iso: str) -> str | None:
+    """Decide whether a candidate event date earns a holiday tag, and what
+    flavor. Returns one of:
+      - "day_of"     → candidate == observed_date           (tag "Memorial Day")
+      - "weekend_of" → candidate is Sat/Sun in ±2 window    (tag "Memorial Day Weekend")
+      - None         → candidate is a non-holiday weekday   (no tag)
+
+    Operator directive 2026-05-19 v6: "suffix only when weekend = true,
+    not for a tuesday event". A Tuesday after Memorial Day Monday is NOT
+    Memorial Day Weekend — the holiday window-expansion (±2 from observed_date)
+    only earns a weekend tag for actual weekend days. Other weekdays in
+    the window fall back to the non-holiday Featured branches (premium,
+    market-anchor) or land in other rails (moving_fast, etc.).
+
+    Pure function — accepts ISO date strings, returns a string or None.
+    Caller is expected to have already verified the candidate's date is
+    within ±2 days of observed_date (i.e. the holiday is in range).
+    """
+    from datetime import date as _date_cls
+    try:
+        cand_d = _date_cls.fromisoformat(candidate_date_iso)
+    except (TypeError, ValueError):
+        return None
+    if candidate_date_iso == observed_date_iso:
+        return "day_of"
+    # weekday(): 0=Mon..6=Sun; 5=Sat, 6=Sun
+    if cand_d.weekday() in (5, 6):
+        return "weekend_of"
+    return None
+
+
 def _bulk_event_context(db, event_ids: list[int]) -> dict[int, dict]:
     """Bulk-fetch all six context dimensions a storefront card / detail page
     might surface, in one helper.
@@ -5958,13 +5990,16 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
                 ))
                 chosen = applicable[0]
                 hname = chosen.get("holiday_name", "")
-                # Day-of vs weekend-of: if candidate occurs exactly on the
-                # holiday's observed_date, label as the bare holiday name.
-                # Otherwise label as "{Holiday} Weekend" via the section
-                # helper. Operator directive 2026-05-19: distinguish the
-                # actual day from adjacent days in rail badges.
-                is_day_of = (chosen.get("observed_date") == cd)
-                holiday_by_eid[eid_int] = {"name": hname, "weekend": not is_day_of}
+                # Day-of vs weekend-of vs skip: see _classify_holiday_proximity
+                # docstring. Operator 2026-05-19 v6: Tuesday after Memorial Day
+                # Monday is NOT "Memorial Day Weekend" — only Sat/Sun in the
+                # ±2 window earn the weekend tag.
+                proximity = _classify_holiday_proximity(cd, chosen.get("observed_date") or "")
+                if proximity == "day_of":
+                    holiday_by_eid[eid_int] = {"name": hname, "weekend": False}
+                elif proximity == "weekend_of":
+                    holiday_by_eid[eid_int] = {"name": hname, "weekend": True}
+                # else: non-weekend weekday in window → no tag
     except Exception as e:
         print(f"store_movers holiday-window expansion failed: {e}")
 

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -1050,3 +1050,65 @@ def test_section_specials_rivalry_wins_over_holiday():
     assert len(out) == 1
     assert out[0]["_special"] == "Yankees vs Red Sox"
     assert out[0]["_special_kind"] == "rivalry"
+
+
+# ---------- _classify_holiday_proximity tests ----------
+#
+# Operator 2026-05-19 v6: "suffix only when weekend = true, not for a
+# tuesday event". Helper returns "day_of" | "weekend_of" | None for the
+# ±2-day window expansion around a holiday's observed_date.
+# Reference holiday: Memorial Day Mon May 25, 2026 (weekday()=0).
+
+
+def test_classify_holiday_proximity_day_of():
+    """Candidate on the exact observed_date → 'day_of'."""
+    assert app_module._classify_holiday_proximity(
+        "2026-05-25", "2026-05-25"
+    ) == "day_of"
+
+
+def test_classify_holiday_proximity_saturday_before():
+    """Saturday before Memorial Day Mon → 'weekend_of'."""
+    assert app_module._classify_holiday_proximity(
+        "2026-05-23", "2026-05-25"  # Sat May 23 (weekday 5) → weekend
+    ) == "weekend_of"
+
+
+def test_classify_holiday_proximity_sunday_before():
+    """Sunday before Memorial Day Mon → 'weekend_of'."""
+    assert app_module._classify_holiday_proximity(
+        "2026-05-24", "2026-05-25"  # Sun May 24 (weekday 6) → weekend
+    ) == "weekend_of"
+
+
+def test_classify_holiday_proximity_tuesday_after_returns_none():
+    """The operator's exact case: Tue May 26 after Memorial Day Mon
+    May 25 is NOT 'Memorial Day Weekend'. Helper returns None so the
+    upstream loop skips tagging this event with the holiday."""
+    assert app_module._classify_holiday_proximity(
+        "2026-05-26", "2026-05-25"  # Tue May 26 (weekday 1) → no tag
+    ) is None
+
+
+def test_classify_holiday_proximity_friday_before_returns_none():
+    """Friday two days before Memorial Day Mon → no tag. Friday isn't
+    Sat or Sun; the long-weekend lead-in is not Featured-as-holiday
+    territory (the event still flows to other Featured branches if it
+    qualifies on owned_median or market-anchor)."""
+    assert app_module._classify_holiday_proximity(
+        "2026-05-22", "2026-05-25"  # Fri May 22 (weekday 4) → no tag
+    ) is None
+
+
+def test_classify_holiday_proximity_fathers_day_saturday():
+    """Father's Day = Sun Jun 21, 2026. Saturday Jun 20 → 'weekend_of'."""
+    assert app_module._classify_holiday_proximity(
+        "2026-06-20", "2026-06-21"  # Sat Jun 20 (weekday 5) → weekend
+    ) == "weekend_of"
+
+
+def test_classify_holiday_proximity_invalid_input_returns_none():
+    """Malformed ISO date → None (defensive — caller may pass empty
+    observed_date string when chosen row lacks the field)."""
+    assert app_module._classify_holiday_proximity("", "2026-05-25") is None
+    assert app_module._classify_holiday_proximity("not-a-date", "2026-05-25") is None


### PR DESCRIPTION
## Summary
Operator clarification on PR #286: only Sat/Sun within the ±2 window deserve the "Weekend" suffix. Tuesday after Memorial Day Monday is NOT "Memorial Day Weekend" — drop it from the holiday window entirely.

## Detail

| Date | Day | Before PR | This PR |
|---|---|---|---|
| Fri May 22 | Fri | "Memorial Day Weekend" | (no holiday tag) |
| Sat May 23 | Sat | "Memorial Day Weekend" | "Memorial Day Weekend" |
| Sun May 24 | Sun | "Memorial Day Weekend" | "Memorial Day Weekend" |
| Mon May 25 | Mon | "Memorial Day" | "Memorial Day" |
| Tue May 26 | Tue | "Memorial Day Weekend" | (no holiday tag) |

Non-Sat/Sun-non-day-of events still appear in Featured if they qualify on `owned_median > $50`, market-anchor fallback, or land in other rails (moving_fast, etc.) — they just don't carry the holiday badge.

## Implementation
Extracted `_classify_holiday_proximity(candidate_iso, observed_iso)` returning `"day_of" | "weekend_of" | None`. The window-expansion loop in `_compute_movers` only writes to `holiday_by_eid` when the helper returns a non-None classification.

```python
proximity = _classify_holiday_proximity(cd, chosen.get("observed_date") or "")
if proximity == "day_of":
    holiday_by_eid[eid_int] = {"name": hname, "weekend": False}
elif proximity == "weekend_of":
    holiday_by_eid[eid_int] = {"name": hname, "weekend": True}
# else: non-weekend weekday in window → no tag
```

## Test plan
- [x] +7 new unit tests on `_classify_holiday_proximity` cover day-of, Sat/Sun adjacency, Tuesday-after, Friday-before, Father's Day Saturday, invalid input
- [x] `59 passed` on store test suite (52 prior + 7 new)
- [x] `app.py` syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)