### PR TITLE
fix(security): REVOKE anon EXECUTE on 16 ungated SECDEF fns + close blindspot table leak

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -43,11 +43,16 @@
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
 | B1-NEXT-11 | Op | Leaked `CRON_SECRET` in git history (commit `5297739`). Value rotated but repo is public → internet-readable. | Operator decides: `git filter-repo` + force-push window, OR accept (rotated, contained blast radius). G-1. |
+| B1-NEXT-51 | A1 (B1-authored) | `tevo_blindspot_discovery_enqueue()` — anon-EXECUTE SECDEF, no gate, calls `_cron_invoke_edge_fn` → drives **paid TEvo /v9/events discovery** on demand (anon + public key via `/rest/v1/rpc/`). Cost-amplification. | **Fix authored** mig `20260520230000` (REVOKE EXECUTE FROM anon/auth/PUBLIC). Awaiting operator apply. |
+| B1-NEXT-52 | A1 (B1-authored) | `collect_listings_featured_refresh(integer)` — anon-EXECUTE SECDEF, no gate, drives the collect-listings edge fn (paid listings pulls). Same class as -51. | **Fix authored** mig `20260520230000`. Awaiting operator apply. |
 
 ### SEC-MED (defense-in-depth)
 
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
+| B1-NEXT-53 | A1 (B1-authored) | `tevo_blindspot_discovery_attempts` — RLS never enabled + anon held SELECT/INSERT/UPDATE/DELETE/TRUNCATE. Internal cron telemetry (no PII) but anon could wipe/poison over PostgREST. | **Fix authored** mig `20260520230000` (REVOKE ALL FROM anon/auth + ENABLE RLS + coworker_readonly SELECT policy). Awaiting apply. |
+| B1-NEXT-54 | A1 (B1-authored) | 14 anon-EXECUTE SECDEF write fns (matchers/backfills/ingest/`cron_should_fire`) — no gate, anon-drivable DB churn. Overlaps B1-NEXT-29/30/31 §6 backlog. | **REVOKE authored** in mig `20260520230000` (the load-bearing fix; §6 body-guard retrofit remains separate). Awaiting apply. |
+| B1-NEXT-55 | A1 (B1) | **Systemic**: 140 public tables carry the Supabase default anon/authenticated grant (RLS-gated, so latent not live). Defense-in-depth: blanket `REVOKE ... FROM anon, authenticated` on internal tables + rely on views/RPCs for the intended anon surface. | Batch-REVOKE migration (separate; high row count, low marginal risk since RLS holds). Propose to A1. |
 | B1-NEXT-3 | B1 | Edge function auth-posture inventory (16 fns). Per-function record of `x-cron-secret` vs open vs JWT-gated. | Author `docs/edge_function_auth_inventory.md` |
 | B1-NEXT-5 | B1 | Vault orphans check — `release_health_check()` row for `get_app_secret` allowlist entries unused by any prod fn/cron/edge-fn. | 1 SQL migration adding a new row to `release_health_check()` |
 | B1-NEXT-18 | Op | Verify Actions secrets populated for `sync-check.yml` (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`). | Operator confirms next session via Settings → Secrets |

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -43,8 +43,8 @@
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
 | B1-NEXT-11 | Op | Leaked `CRON_SECRET` in git history (commit `5297739`). Value rotated but repo is public → internet-readable. | Operator decides: `git filter-repo` + force-push window, OR accept (rotated, contained blast radius). G-1. |
-| B1-NEXT-51 | A1 (B1-authored) | `tevo_blindspot_discovery_enqueue()` — anon-EXECUTE SECDEF, no gate, calls `_cron_invoke_edge_fn` → drives **paid TEvo /v9/events discovery** on demand (anon + public key via `/rest/v1/rpc/`). Cost-amplification. | **Fix authored** mig `20260520230000` (REVOKE EXECUTE FROM anon/auth/PUBLIC). Awaiting operator apply. |
-| B1-NEXT-52 | A1 (B1-authored) | `collect_listings_featured_refresh(integer)` — anon-EXECUTE SECDEF, no gate, drives the collect-listings edge fn (paid listings pulls). Same class as -51. | **Fix authored** mig `20260520230000`. Awaiting operator apply. |
+| B1-NEXT-56 | A1 (B1-authored) | `tevo_blindspot_discovery_enqueue()` — anon-EXECUTE SECDEF, no gate, calls `_cron_invoke_edge_fn` → drives **paid TEvo /v9/events discovery** on demand (anon + public key via `/rest/v1/rpc/`). Cost-amplification. | **Fix authored** mig `20260520230000` (REVOKE EXECUTE FROM anon/auth/PUBLIC). Awaiting operator apply. |
+| B1-NEXT-57 | A1 (B1-authored) | `collect_listings_featured_refresh(integer)` — anon-EXECUTE SECDEF, no gate, drives the collect-listings edge fn (paid listings pulls). Same class as -56. | **Fix authored** mig `20260520230000`. Awaiting operator apply. |
 
 ### SEC-MED (defense-in-depth)
 

--- a/supabase/migrations/20260520230000_security_revoke_anon_secdef_exec.sql
+++ b/supabase/migrations/20260520230000_security_revoke_anon_secdef_exec.sql
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- Migration 20260520230000 · level:security · lane:Security
+-- writes: EXECUTE grants on 16 SECDEF fns + table grant/RLS on
+--         tevo_blindspot_discovery_attempts
+-- reads:  pg_proc, pg_class (audit only)
+-- pre:    none (idempotent REVOKE/GRANT/ENABLE RLS)
+--
+-- B1 audit 2026-05-20 (operator "audit and fix", triggered by the Exos RLS
+-- review which surfaced the Supabase default-grant gotcha). Swept the whole
+-- public schema for the same class: Supabase auto-GRANTs every new public
+-- table to anon+authenticated and every new function EXECUTE to PUBLIC. Any
+-- object that never explicitly REVOKEd inherits an internet-facing surface.
+--
+-- FINDINGS CLOSED HERE
+-- -------------------------------------------------------------------------
+-- SEC-HIGH (2) — anon-EXECUTE SECDEF fns that drive PAID external work on
+--   demand (anon + public anon key -> /rest/v1/rpc/... -> cost amplification):
+--     * tevo_blindspot_discovery_enqueue()      -> tevo-blindspot-discovery edge fn (TEvo /v9/events)
+--     * collect_listings_featured_refresh(int)   -> collect-listings edge fn
+-- SEC-MED (14) — anon-EXECUTE SECDEF write fns (matchers/backfills/ingest/
+--   cron gate); all cron/service_role-driven, no legit anon caller. Closes
+--   the anon-drivable-write surface (overlaps the B1-NEXT-29/30/31 §6 backlog,
+--   but REVOKE is the load-bearing fix; the body-guard retrofit remains a
+--   separate defense-in-depth follow-up).
+-- SEC-MED (1 table) — tevo_blindspot_discovery_attempts: RLS was never enabled
+--   and anon held SELECT/INSERT/UPDATE/DELETE/TRUNCATE. Internal cron telemetry
+--   (no PII), but anon could wipe/poison it over PostgREST.
+--
+-- SAFE: every fn is invoked by crons / edge fns running as service_role (which
+-- retains EXECUTE), and intra-DB callers run as their own SECDEF owner; no
+-- anon/authenticated app path calls any of these. The table's writer
+-- (tevo_blindspot_discovery_enqueue, SECDEF) runs as owner and bypasses RLS;
+-- the edge-fn writeback uses the service-role key and bypasses RLS.
+--
+-- ## Regression risk
+-- cron.failed_jobs_90min — none expected (service_role retains EXECUTE; cron
+--   DO-blocks unchanged). functions still resolve by oid.
+-- PostgREST anon/authenticated callers — intentionally lose access to these
+--   16 RPCs + the table. Re-probe after apply: anon EXECUTE = denied.
+--
+-- ## Already applied to prod
+-- NOT YET. Operator authorizes prod apply (2026-05-13 lockdown). A1-lane fns
+-- ride along (REVOKE is identical + safe) — A1 has apply-time veto.
+-- ============================================================================
+
+-- --- SEC-HIGH: anon-executable SECDEF fns that drive paid external work ------
+REVOKE EXECUTE ON FUNCTION public.tevo_blindspot_discovery_enqueue()              FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.tevo_blindspot_discovery_enqueue()              TO service_role;
+REVOKE EXECUTE ON FUNCTION public.collect_listings_featured_refresh(integer)      FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.collect_listings_featured_refresh(integer)      TO service_role;
+
+-- --- SEC-MED: anon-executable SECDEF write fns (cron/service_role driven) -----
+REVOKE EXECUTE ON FUNCTION public.aq_event_map_ingest(jsonb)                                                          FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.aq_event_map_ingest(jsonb)                                                          TO service_role;
+REVOKE EXECUTE ON FUNCTION public.auto_match_sg_canonical_v3()                                                        FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.auto_match_sg_canonical_v3()                                                        TO service_role;
+REVOKE EXECUTE ON FUNCTION public.backfill_seatgeek_sales_tevo_event_id(integer)                                      FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.backfill_seatgeek_sales_tevo_event_id(integer)                                      TO service_role;
+REVOKE EXECUTE ON FUNCTION public.create_system_aq_event(text, text, text, timestamp with time zone, bigint)          FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.create_system_aq_event(text, text, text, timestamp with time zone, bigint)          TO service_role;
+REVOKE EXECUTE ON FUNCTION public.cron_should_fire(text)                                                              FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.cron_should_fire(text)                                                              TO service_role;
+REVOKE EXECUTE ON FUNCTION public.listings_deltas_backfill_chunked(integer)                                          FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.listings_deltas_backfill_chunked(integer)                                          TO service_role;
+REVOKE EXECUTE ON FUNCTION public.match_unmatched_listings_chunked(integer, boolean)                                  FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.match_unmatched_listings_chunked(integer, boolean)                                  TO service_role;
+REVOKE EXECUTE ON FUNCTION public.match_unmatched_orders_sweep(integer, boolean)                                      FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.match_unmatched_orders_sweep(integer, boolean)                                      TO service_role;
+REVOKE EXECUTE ON FUNCTION public.refresh_cross_source_venue_map()                                                    FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.refresh_cross_source_venue_map()                                                    TO service_role;
+REVOKE EXECUTE ON FUNCTION public.refresh_sg_broker_listings_event_metrics(integer)                                   FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.refresh_sg_broker_listings_event_metrics(integer)                                   TO service_role;
+REVOKE EXECUTE ON FUNCTION public.sg_attempt_event_xref_v3(bigint, text, date, timestamp with time zone, text, text, text, text) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_attempt_event_xref_v3(bigint, text, date, timestamp with time zone, text, text, text, text) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.sg_canonical_link_from_tevo_chunked(integer)                                        FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_canonical_link_from_tevo_chunked(integer)                                        TO service_role;
+REVOKE EXECUTE ON FUNCTION public.sg_canonical_refresh_v2_pull(integer)                                               FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_canonical_refresh_v2_pull(integer)                                               TO service_role;
+REVOKE EXECUTE ON FUNCTION public.sg_classify_events()                                                                FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.sg_classify_events()                                                                TO service_role;
+
+-- --- SEC-MED: table grant leak + RLS on tevo_blindspot_discovery_attempts -----
+REVOKE ALL ON public.tevo_blindspot_discovery_attempts FROM anon, authenticated;
+ALTER TABLE public.tevo_blindspot_discovery_attempts ENABLE ROW LEVEL SECURITY;
+-- service_role + the SECDEF writer (owner) bypass RLS. Preserve ops read for the
+-- read-only human role; no anon/authenticated policy = deny-by-default for them.
+DROP POLICY IF EXISTS tevo_blindspot_attempts_ro ON public.tevo_blindspot_discovery_attempts;
+CREATE POLICY tevo_blindspot_attempts_ro ON public.tevo_blindspot_discovery_attempts
+  FOR SELECT TO coworker_readonly USING (true);


### PR DESCRIPTION
## Summary

B1 schema-wide audit (operator "audit and fix"), triggered by the Exos RLS review that surfaced the **Supabase default-grant gotcha**: Supabase auto-GRANTs every new `public` table to `anon`+`authenticated` and every new function `EXECUTE` to `PUBLIC`. Anything that never explicitly REVOKEs inherits an internet-facing surface reachable via PostgREST with the public anon key.

Swept all 147 public tables + all anon-EXECUTE SECDEF functions. Found a real class, not a one-off.

## Findings closed

**SEC-HIGH (2)** — anon-EXECUTE SECDEF fns with no gate that drive **paid external work** on demand (anon + public key → `/rest/v1/rpc/…` → cost amplification):
| fn | drives |
|---|---|
| `tevo_blindspot_discovery_enqueue()` | TEvo `/v9/events` discovery edge fn |
| `collect_listings_featured_refresh(integer)` | collect-listings edge fn |

**SEC-MED (14)** — anon-EXECUTE SECDEF write fns (matchers/backfills/ingest/`cron_should_fire`); all cron/`service_role`-driven, no legit anon caller. Overlaps the B1-NEXT-29/30/31 §6 backlog — REVOKE is the load-bearing fix; the body-guard retrofit stays a separate follow-up.

**SEC-MED (1 table)** — `tevo_blindspot_discovery_attempts`: RLS never enabled + anon held `SELECT/INSERT/UPDATE/DELETE/TRUNCATE`. Internal cron telemetry (no PII) but anon could wipe/poison over PostgREST. → `REVOKE ALL` + `ENABLE RLS` + `coworker_readonly` SELECT policy.

## Why it's safe

- Every fn is invoked by crons / edge fns running as `service_role` (retains EXECUTE), and intra-DB callers run as their own SECDEF owner. No `anon`/`authenticated` app path calls any of these 16 (they're matchers/backfills/discovery, not read RPCs).
- The table writer (`tevo_blindspot_discovery_enqueue`, SECDEF) runs as owner and bypasses RLS; the edge-fn writeback uses the service-role key and bypasses RLS.
- 16 signatures verified against live `pg_get_function_identity_arguments`.

## Cross-lane note

14 of the 16 fns are A1-lane. REVOKE is identical + trivial + safe, and prod-apply is operator-gated (A1 has apply-time veto). The 2 SEC-HIGH are B1's to fix urgently; the MEDs ride the same one-line pattern.

## Systemic (not in this PR)

140 public tables carry the latent default anon grant (RLS-gated → not live-exploitable). Filed **B1-NEXT-55** for a considered batch-REVOKE migration — high row count, low marginal risk since RLS holds.

## Proposed PROJECT_BIBLE §3 landmine (for A1 to drop in)

> **New `public` table/function → anon inherits it.** Supabase default-grants every new public table to `anon`+`authenticated` (full CRUD) and every function `EXECUTE` to `PUBLIC`. RLS gates *rows* but not the *grant*, and functions have no RLS. Every internal table/SECDEF fn migration MUST `REVOKE ALL/EXECUTE … FROM anon, authenticated, PUBLIC` and re-GRANT only `service_role` (+ `authenticated` if app-called). Caught live: Exos phase-1 (anon read base tables around the public views) + the 2026-05-20 schema audit (16 ungated SECDEF fns + 1 RLS-off table).

## Test plan

- [ ] (optional, B1 offers) validate on a throwaway branch: apply migration → confirm clean + `has_function_privilege('anon', …, 'EXECUTE')` = false on all 16 + table anon grant gone
- [ ] Operator applies `20260520230000` to prod
- [ ] Post-apply: re-run the audit sweep → 0 anon-EXECUTE ungated external-drivers; `tevo_blindspot_discovery_attempts` anon grant = none, RLS on
- [ ] `cron.failed_jobs_90min` stays clean (crons run as service_role, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)