### PR TITLE
docs(kanban): D0 product backlog — 6 pending items for future cycles

### DIFF
--- a/KANBAN.md
+++ b/KANBAN.md
@@ -190,6 +190,19 @@ Plan: [docs/d0_frontend_consolidation_plan.md](docs/d0_frontend_consolidation_pl
 - **D0** — `docs/d0_roadmap.md` (rolling Now/Next/Later/Backlog). First version covers D1+D2 outstanding items routed through D0.
 - **D0 sign-off requirement on D1/D2 PRs PAUSED 7 days** (active 2026-05-22). Per operator directive `bot_chat` 170. Claim protocol + token discipline + CI gate still active.
 
+### NEXT (D0) — product backlog (filed 2026-05-19, event-page + chart + landing session sweep)
+
+Pending / incomplete D0 work captured for future cycles. Verified live state before filing — `cost_*`-reader blocker + parking-bridge pollution already cleared by A1, so those are NOT listed.
+
+| ID | Lane | Task | Smallest action to close |
+|---|---|---|---|
+| D0-PROD-1 | D0 | **Landing selector — verify deploy propagated.** PR #278 (static-site root → unified Terminal/Undelivered/Store selector) MERGED to main (`0ab8a53`). As of 2026-05-21 21:49 UTC the live root still returns `301 → /terminal/` (Render static deploy + Cloudflare cache lag). | Re-check `curl -I https://vibepass-terminal-test.onrender.com/` returns `200 text/html`; if still `301` after deploy completes, check Render deploy log + CF `cf-cache-status` purge. |
+| D0-PROD-2 | D0 | **Chart parity on performer + venue pages.** The 2-chart redesign + `get_event_chart_extended` (5 SG series + ESPN annotations, PR #237) live only on `event.html`. Performer + venue detail pages have no price/inventory chart. | New `get_performer_chart` / `get_venue_chart` aggregate RPCs (roll up member events) + reuse the event-page chart renderer. Medium effort. |
+| D0-PROD-3 | D0 | **Chart legend toggle state is session-only.** Hiding a series resets on reload / range-flip. | Persist hidden-series set to `localStorage` keyed by chart id; rehydrate on render. Low effort. |
+| D0-PROD-4 | D2/B1 (affects D0) | **Vivid bridge gap.** `vivid_orders.tevo_event_id` is 0/1169 populated (verified 2026-05-19) → the "Our Orders" tab TP+Vivid section shows zero Vivid rows on every event. D0 RPC bridges via `aq_short_event_id → aq_event_map → seatgeek_event_xref` but no Vivid rows carry it through. Filed `bot_chat` #292. | D2/B1: populate `vivid_orders.tevo_event_id` in the Vivid ingest/match cron (TickPick already at 14% via matcher v3 — same path). |
+| D0-PROD-5 | A1 (bible) | **`espn_team_id` cross-league collision not codified.** `id="28"` = MLB Braves AND an NHL team. Bit the chart RPC during PR #237 smoke (returned 1400 NHL injuries on a Braves game); A1 fixed inline by scoping `espn_league`, but the landmine isn't in PROJECT_BIBLE §3. | A1: add "always filter ESPN team joins by `espn_league`" to PROJECT_BIBLE §3 column-landmines. |
+| D0-PROD-6 | A1 (cleanup) | **Deprecated `cost_*` columns on `seatgeek_event_metrics` now droppable.** D0 removed the last FE reader (SG LISTINGS — COST DISTRIBUTION panel, PR #210) and `compute_alerts_tick` no longer reads `cost_median` (verified 2026-05-19). Columns are dead weight. | A1: confirm no other readers, then `ALTER TABLE … DROP COLUMN cost_min/p25/median/mean/p75/p90/max/sum`. |
+
 ### NEXT (D0 — checkpoint) — Phase 4 service-merge decision · review 2026-08-15
 
 Recommend at decision time: collapse `vibepass-terminal-test` + `d2-orders-dashboard` into one operator-facing service; keep `vibepass-storefront-test` separate. Decision gates: ops MAU >50, deploy frequency stable. Cost-saver ~$14/mo at 3-service starter baseline.


### PR DESCRIPTION
## Summary

Files the pending / incomplete D0 work from this session's event-page + chart + landing sweep into the KANBAN OPEN-WORK ledger, so nothing gets lost across cycles.

New `### NEXT (D0) — product backlog` table with 6 rows:

| ID | Lane | What |
|---|---|---|
| D0-PROD-1 | D0 | Landing selector (PR #278) merged `0ab8a53` — verify Render deploy + CF cache propagated (root still `301` at file time) |
| D0-PROD-2 | D0 | Chart parity on performer + venue pages (the 2-chart redesign + extended RPC are event-only) |
| D0-PROD-3 | D0 | Chart legend toggle state is session-only — persist to localStorage |
| D0-PROD-4 | D2/B1 | Vivid bridge gap: `vivid_orders.tevo_event_id` 0/1169 → Our Orders TP+Vivid section empty (bot_chat #292) |
| D0-PROD-5 | A1 | Codify `espn_team_id` cross-league collision (id=28 = MLB Braves + NHL) in PROJECT_BIBLE §3 |
| D0-PROD-6 | A1 | Drop deprecated `cost_*` columns — last FE reader removed (PR #210) + `compute_alerts_tick` no longer reads `cost_median` |

## Verification before filing

Queried prod to avoid filing stale items:
- Parking-bridge pollution: **0 rows remaining** (A1 already cleaned up) → NOT filed
- `compute_alerts_tick` reading `cost_median`: **0** (already migrated) → unblocks D0-PROD-6
- `vivid_orders.tevo_event_id`: **0/1169** → D0-PROD-4 still real

Docs-only change. No code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)