### PR TITLE
feat(home): add Bridge as 4th surface — 2x2 grid + purple accent

### DIFF
--- a/static/home/home.js
+++ b/static/home/home.js
@@ -1,12 +1,17 @@
-// VibePass unified homescreen. Auth-aware: signed-in @s4kent.com sees all 3
-// cards; everyone else sees the Store card unlocked and the two operator
+// VibePass unified homescreen. Auth-aware: signed-in @s4kent.com sees all 4
+// cards; everyone else sees Store + Bridge unlocked and the two operator
 // cards gated. localhost dev is treated as authed (parity with terminal).
+// Bridge is always accessible — it runs on a separate Render origin and
+// manages its own Supabase auth internally (same project, different domain,
+// so localStorage sessions are not shared).
 
 (function () {
   'use strict';
 
   const cardTerminal    = document.getElementById('cardTerminal');
   const cardUndelivered = document.getElementById('cardUndelivered');
+  const cardBridge      = document.getElementById('cardBridge');
+  const bridgeNote      = document.getElementById('bridgeNote');
   const authCtrl        = document.getElementById('auth-ctrl');
   const footStatus      = document.getElementById('footStatus');
 
@@ -39,10 +44,17 @@
     if (footStatus) footStatus.textContent = text;
   }
 
+  // Bridge is always accessible — never lock it. Show a soft note when no
+  // hub session exists so the user knows Bridge has its own sign-in.
+  function setBridgeNote(signedIn) {
+    if (bridgeNote) bridgeNote.hidden = signedIn;
+  }
+
   if (!window.TerminalAuth) {
     // supabase-js or auth.js failed to load — treat as not signed in.
     lockCard(cardTerminal);
     lockCard(cardUndelivered);
+    setBridgeNote(false);
     setFootStatus('auth offline');
     renderAuth(null);
     return;
@@ -54,10 +66,12 @@
 
     if (allowed || isLocalhost()) {
       renderAuth(email || (isLocalhost() ? 'dev (localhost)' : null));
+      setBridgeNote(true);
       setFootStatus('all surfaces unlocked');
     } else {
       lockCard(cardTerminal);
       lockCard(cardUndelivered);
+      setBridgeNote(!!email);
       renderAuth(email);
       setFootStatus(email ? 'not on @s4kent.com — operator surfaces gated' : 'sign in to unlock operator surfaces');
     }
@@ -65,6 +79,7 @@
     console.error('auth ready failed', err);
     lockCard(cardTerminal);
     lockCard(cardUndelivered);
+    setBridgeNote(false);
     setFootStatus('auth init failed');
   });
 

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -14,7 +14,7 @@
 
   <header class="topbar">
     <span class="brand">VIBEPASS</span>
-    <span class="brand-sub">3-surface frontend · always-on entry</span>
+    <span class="brand-sub">4-surface frontend · always-on entry</span>
     <span id="auth-ctrl"></span>
   </header>
 
@@ -40,6 +40,14 @@
       <h2>Store</h2>
       <p>Customer-facing sales front. Browse events, view inventory, share deep-links. Public — no sign-in required.</p>
       <div class="card-cta">Open Store →</div>
+    </a>
+
+    <a class="card bridge" id="cardBridge" href="https://vibepass-storefront-test.onrender.com/bridge/" target="_blank" rel="noopener">
+      <div class="card-tag">D4 · BRIDGE</div>
+      <h2>Bridge</h2>
+      <p>Independent venue ticketing platform for organizers. Create events, manage tickets, run door check-in, invite your team. Organizer sign-in via Google.</p>
+      <div class="card-cta">Open Bridge →</div>
+      <div class="card-note" id="bridgeNote" hidden>Sign in to Bridge with your organizer account.</div>
     </a>
   </main>
 

--- a/static/home/style.css
+++ b/static/home/style.css
@@ -41,7 +41,7 @@ html, body {
 
 main.grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 16px;
   padding: 48px 32px;
   max-width: 1400px;
@@ -66,6 +66,7 @@ main.grid {
 .card.terminal    { border-top-color: var(--accent); }
 .card.undelivered { border-top-color: var(--warn); }
 .card.store       { border-top-color: var(--info); }
+.card.bridge      { border-top-color: #c084fc; }
 .card.locked {
   opacity: 0.55;
   pointer-events: none;
@@ -83,6 +84,7 @@ main.grid {
 .card.terminal    .card-tag { color: var(--accent); }
 .card.undelivered .card-tag { color: var(--warn); }
 .card.store       .card-tag { color: var(--info); }
+.card.bridge      .card-tag { color: #c084fc; }
 
 .card h2 {
   margin: 0 0 8px;
@@ -100,6 +102,12 @@ main.grid {
   font-family: var(--mono); font-size: 11px;
   text-transform: uppercase; letter-spacing: 0.5px;
   color: var(--accent);
+}
+.card.bridge .card-cta { color: #c084fc; }
+.card-note {
+  margin-top: 8px;
+  font-family: var(--mono); font-size: 11px;
+  color: var(--muted);
 }
 .card.locked .card-cta { display: none; }
 .card-gate {


### PR DESCRIPTION
## Summary

- Adds **Bridge** card to the hub (`/`) as the 4th surface
  - URL: `https://vibepass-storefront-test.onrender.com/bridge/` (opens in new tab)
  - Tag: `D4 · BRIDGE` · accent: `#c084fc` (violet)
  - Always unlocked — Bridge handles its own Supabase Google OAuth internally
  - Soft note shown when no hub session: *"Sign in to Bridge with your organizer account."*
- Grid changed from 3-column → **2×2** (`repeat(2, 1fr)`)
- Header subtitle updated: `3-surface` → `4-surface`

## Auth behaviour

Bridge runs on a different domain (`onrender.com` vs `railway.app`) so localStorage sessions are not shared. The hub `TerminalAuth` cannot auto-sign-in to Bridge. Bridge is therefore always accessible (no lock), and `setBridgeNote()` in `home.js` shows/hides a hint based on hub session state.

## Test plan

- [ ] Hub at `/` shows 4 cards in a 2×2 grid
- [ ] Bridge card is violet-accented, always clickable, opens `/bridge/` in new tab
- [ ] Signed-out: Bridge card shows note "Sign in to Bridge with your organizer account"
- [ ] Signed-in (@s4kent.com): Bridge note hidden, all 4 cards accessible
- [ ] Terminal + Undelivered still gate correctly for non-@s4kent.com sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)