### PR TITLE
feat(home+bridge): Railway as Bridge primary — same-origin auth sharing

### DIFF
--- a/app.py
+++ b/app.py
@@ -662,14 +662,16 @@ def undelivered_landing():
 
 
 # --- D4 / Exos (Bridge) ----------------------------------------------------
-# Serve the d4_bridge Vite SPA in the unified static Render env the same way
-# D0's terminal is served (PR #168 testing-unified architecture): a landing
-# redirect to the trailing slash, an index handler, and a path-catch-all that
-# proxies static/bridge/<asset>. The app is BUILT with Vite base '/bridge/'
-# (vite.config.ts) + <BrowserRouter basename="/bridge">, so its asset refs and
-# client routes resolve under this prefix. Build artifact lives at
-# static/bridge/ (run `npm --prefix d4_bridge run build`, then copy dist →
-# static/bridge/). Returns 404 cleanly until that build is present.
+# Serve the d4_bridge Vite SPA from this Railway app — same origin as the hub,
+# Terminal, Store, and Undelivered (PR #318 — Railway is now the primary host).
+# Landing redirect, index handler, path-catch-all for assets + SPA deep links.
+# App is built with Vite base '/bridge/' (vite.config.ts) and
+# <BrowserRouter basename="/bridge">, so asset refs + client routes resolve
+# under this prefix. Build artifact: static/bridge/ (rebuild via
+# `npm --prefix d4_bridge run build` then copy dist → static/bridge/).
+# Same-origin means the Supabase session in localStorage is shared with the
+# hub — a user signed in on the home page is automatically signed into Bridge.
+# Returns 404 cleanly until the build artifact is present.
 _BRIDGE_DIR = os.path.join(STATIC_DIR, "bridge")
 
 

--- a/static/home/home.js
+++ b/static/home/home.js
@@ -1,9 +1,8 @@
 // VibePass unified homescreen. Auth-aware: signed-in @s4kent.com sees all 4
 // cards; everyone else sees Store + Bridge unlocked and the two operator
 // cards gated. localhost dev is treated as authed (parity with terminal).
-// Bridge is always accessible — it runs on a separate Render origin and
-// manages its own Supabase auth internally (same project, different domain,
-// so localStorage sessions are not shared).
+// Bridge runs at /bridge/ on the same Railway origin — same localStorage,
+// so the Supabase session from the hub carries over to Bridge automatically.
 
 (function () {
   'use strict';
@@ -44,8 +43,10 @@
     if (footStatus) footStatus.textContent = text;
   }
 
-  // Bridge is always accessible — never lock it. Show a soft note when no
-  // hub session exists so the user knows Bridge has its own sign-in.
+  // Bridge is always accessible — never lock it. Same-origin means the hub's
+  // Supabase session (localStorage) is shared with Bridge automatically.
+  // Show a soft note only when signed out so the user knows signing in here
+  // will carry over. Hide it once any session exists.
   function setBridgeNote(signedIn) {
     if (bridgeNote) bridgeNote.hidden = signedIn;
   }

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -42,12 +42,12 @@
       <div class="card-cta">Open Store →</div>
     </a>
 
-    <a class="card bridge" id="cardBridge" href="https://vibepass-storefront-test.onrender.com/bridge/" target="_blank" rel="noopener">
+    <a class="card bridge" id="cardBridge" href="/bridge/">
       <div class="card-tag">D4 · BRIDGE</div>
       <h2>Bridge</h2>
-      <p>Independent venue ticketing platform for organizers. Create events, manage tickets, run door check-in, invite your team. Organizer sign-in via Google.</p>
+      <p>Independent venue ticketing platform for organizers. Create events, manage tickets, run door check-in, invite your team.</p>
       <div class="card-cta">Open Bridge →</div>
-      <div class="card-note" id="bridgeNote" hidden>Sign in to Bridge with your organizer account.</div>
+      <div class="card-note" id="bridgeNote" hidden>Sign in above — your session carries over to Bridge automatically.</div>
     </a>
   </main>
 


### PR DESCRIPTION
## Summary

- **Bridge hub card** now routes to `/bridge/` (Railway, same-origin) instead of external Render URL
- Removes `target="_blank"` / `rel="noopener"` — same domain
- **PR #317 merged** (C1 Quality & Continuity charter — governance docs only)

## Auth sharing

Same origin = shared `localStorage`. Hub Supabase session carries over to Bridge at `/bridge/` automatically — one sign-in covers all surfaces. Bridge note updated: *"Sign in above — your session carries over to Bridge automatically."*

## Test plan

- [ ] Hub at `/` shows 4 cards, Bridge links to `/bridge/` (same tab)
- [ ] Sign in on hub → `/bridge/` → Bridge is already signed in
- [ ] Signed out → Bridge card shows the carry-over note

🤖 Generated with [Claude Code](https://claude.com/claude-code)