### PR TITLE
feat(d2): production-readiness hardening — /readyz probe + dead-code drop

### DIFF
--- a/d2_dashboard/main.py
+++ b/d2_dashboard/main.py
@@ -953,14 +953,6 @@ def _fetch_evo(per_page: int, page: int = 1) -> dict:
     return _fetch_one_source("evo", per_page, page)
 
 
-def _fetch_sg(per_page: int, page: int = 1) -> dict:
-    # SG source on the orders feed is the broker firehose post-2026-05-16
-    # rewire — see _SQL_BACKED_SOURCES comment. Helper is currently
-    # unreferenced; kept for symmetry with the other per-source fetchers in
-    # case the bundled orders feed is ever decomposed.
-    return _fetch_one_source("seatgeek_sales", per_page, page)
-
-
 def _fetch_tickpick(per_page: int, page: int = 1) -> dict:
     return _fetch_one_source("tickpick", per_page, page)
 
@@ -985,10 +977,45 @@ def _fetch_one_source(source: str, per_page: int, page: int = 1) -> dict:
 
 @app.get("/healthz")
 def healthz():
-    """Public health check. Stripped to a minimal shape — operator can still
-    confirm the service is up, but no fingerprintable detail is exposed.
-    Use /healthz?detail=1 with a valid Bearer token for the full diagnostic."""
+    """Public LIVENESS check. Stripped to a minimal shape — operator can still
+    confirm the process is up, but no fingerprintable detail is exposed.
+    Use /healthz/detail with a valid Bearer token for the full diagnostic,
+    or /readyz for a Supabase-connectivity readiness probe.
+
+    Render's health-check path points HERE (liveness) on purpose — a transient
+    Supabase blip must NOT mark the process unhealthy and trigger a restart."""
     return {"ok": True, "service": "d2_dashboard"}
+
+
+@app.get("/readyz")
+def readyz():
+    """Public READINESS probe — verifies the dashboard can actually reach
+    Supabase and read its serving view (`unified_orders`), not just that the
+    process is up. Catches the failure mode /healthz can't see: a present-but-
+    wrong/unreachable SUPABASE_URL passes liveness but 503s on the first data
+    hit. Operators + uptime monitors curl this post-deploy.
+
+    Leaks only a reachability enum (no error detail to the client; the full
+    exception goes to stderr). One cheap LIMIT-1 read per hit. Do NOT wire
+    Render's health-check path to this — keep that on /healthz (see above)."""
+    sb = _sb()
+    if sb is None:
+        return JSONResponse(
+            {"ok": False, "service": "d2_dashboard", "supabase": "not_configured"},
+            status_code=503,
+        )
+    try:
+        # Probe the exact surface the dashboard serves. UNION-ALL view + LIMIT 1
+        # short-circuits after the first branch's first row — cheap.
+        sb.table("unified_orders").select("source").limit(1).execute()
+        return {"ok": True, "service": "d2_dashboard", "supabase": "reachable"}
+    except Exception as e:
+        import sys as _sys
+        print(f"[d2_dashboard] /readyz supabase probe failed: {e!r}", file=_sys.stderr, flush=True)
+        return JSONResponse(
+            {"ok": False, "service": "d2_dashboard", "supabase": "unreachable"},
+            status_code=503,
+        )
 
 
 @app.get("/healthz/detail")

--- a/tests/test_d2_dashboard.py
+++ b/tests/test_d2_dashboard.py
@@ -94,6 +94,51 @@ def test_healthz_public_minimal(client):
     assert body == {"ok": True, "service": "d2_dashboard"}
 
 
+class _ReadyzQuery:
+    """Minimal chainable stub for sb.table(...).select(...).limit(...).execute()."""
+    def __init__(self, raises=False):
+        self._raises = raises
+    def select(self, *a, **k): return self
+    def limit(self, *a, **k): return self
+    def execute(self):
+        if self._raises:
+            raise RuntimeError("connection refused to db.internal:5432")
+        return type("R", (), {"data": [{"source": "evo"}]})()
+
+
+def test_readyz_reachable_when_supabase_responds(monkeypatch, client):
+    """/readyz does a real LIMIT-1 read against unified_orders. When Supabase
+    answers, it returns 200 + supabase=reachable — the readiness signal that
+    /healthz (liveness only) can't give."""
+    sb = type("Sb", (), {"table": lambda self, *a, **k: _ReadyzQuery()})()
+    monkeypatch.setattr(d2_main, "_sb", lambda: sb)
+    r = client.get("/readyz")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "service": "d2_dashboard", "supabase": "reachable"}
+
+
+def test_readyz_503_when_supabase_not_configured(monkeypatch, client):
+    """No Supabase client (unset/missing env) → 503 + supabase=not_configured.
+    This is the failure mode /healthz can't see (process is up, DB isn't)."""
+    monkeypatch.setattr(d2_main, "_sb", lambda: None)
+    r = client.get("/readyz")
+    assert r.status_code == 503
+    assert r.json()["supabase"] == "not_configured"
+
+
+def test_readyz_503_when_supabase_unreachable_without_leaking_detail(monkeypatch, client):
+    """Client present but the probe read raises (wrong URL / DB down) → 503 +
+    supabase=unreachable. The exception detail must NOT leak into the client
+    body (it goes to stderr); only the reachability enum is exposed."""
+    sb = type("Sb", (), {"table": lambda self, *a, **k: _ReadyzQuery(raises=True)})()
+    monkeypatch.setattr(d2_main, "_sb", lambda: sb)
+    r = client.get("/readyz")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["supabase"] == "unreachable"
+    assert "connection refused" not in str(body)  # no internal detail leaks
+
+
 def test_cors_storefront_origin_allowed(client):
     """D0's /undelivered scaffold on vibepass-storefront-test.onrender.com
     must be able to fetch /api/d2/* cross-origin per the unified architecture


### PR DESCRIPTION
## Summary

First hardening pass from the D2 production-readiness audit (2026-05-22). Two changes; both in the D2 lane (`d2_dashboard/*` + `tests/`).

### 1. `/readyz` readiness probe (closes the audit's one real gap)

`/healthz` is **liveness-only** (process up, no DB) and Render's health-check path stays pointed there — a transient Supabase blip must not mark the process unhealthy and trigger a restart loop. But that left a real failure mode: a **present-but-wrong/unreachable `SUPABASE_URL` passes `/healthz` yet 503s on the first data hit**. The audit flagged this as the top deploy gap.

`/readyz` closes it with one cheap `LIMIT 1` read against the serving view (`unified_orders`):

| Condition | Response |
|---|---|
| DB answers | `200 {ok:true, supabase:"reachable"}` |
| No client (env unset) | `503 {supabase:"not_configured"}` |
| Probe read raises (wrong URL / DB down) | `503 {supabase:"unreachable"}` |

Leaks only the reachability enum — the full exception goes to stderr, never the client body (tested). Operators + uptime monitors curl this post-deploy.

### 2. Drop dead `_fetch_sg()`

Unreferenced since the 2026-05-16 SQL-only rewire (grep-verified zero callers repo-wide). Live per-source path is `_fetch_one_source('seatgeek_sales', …)`.

## Tests

`tests/test_d2_dashboard.py`: **60 → 63** (all green in 2.27s). +3 for `/readyz`:
- reachable → 200
- not_configured → 503
- unreachable → 503 **+ asserts the exception detail does not leak into the body**

## Audit context (full assessment in the session summary)

Two parallel Explore-agent audits + a data-layer check concluded D2 is **already production-ready** (code 10/10 error-handling+auth+XSS+secrets; tests/deploy 8.5/10). The only code gaps were this health probe + the dead function. Remaining items are tracked as KANBAN `D2-OPS-1/2/3` (PR #311) — the one *live* bug (D2-OPS-1, Metrics tab reads dormant SG source) is an A1-apply of an existing in-repo migration, not code.

## Test plan

- [x] `py -m pytest tests/test_d2_dashboard.py -q` → 63 passed
- [ ] (post-deploy) `curl https://<service>/readyz` → 200 reachable
- [ ] (post-deploy) confirm Render health-check path still on `/healthz` (not `/readyz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)