### PR TITLE
fix(d1/store): scrub TEvo error leaks on 3 public 502 paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -6381,7 +6381,8 @@ def store_events_near(
                 per_page=min(cap, 100),
             )
         except RuntimeError as e:
-            raise HTTPException(502, f"TEvo geo lookup failed: {e}")
+            print(f"[store_events_near] TEvo geo lookup failed: {e!r}")
+            raise HTTPException(502, "geo lookup failed")
         evs = tevo_resp.get("events") or []
         return {
             "count": len(evs),
@@ -6809,7 +6810,8 @@ def _fetch_owned_ticket_groups(
     try:
         live = client.get_ticket_groups(event_id, owned=True)
     except RuntimeError as e:
-        raise HTTPException(502, f"TEvo ticket_groups failed: {e}")
+        print(f"[ticket_groups] TEvo ticket_groups failed for {event_id}: {e!r}")
+        raise HTTPException(502, "ticket listings fetch failed")
     groups = live.get("ticket_groups", []) or []
     if sb is not None:
         try:
@@ -7342,7 +7344,8 @@ def store_reserve(payload: dict = Body(...), authorization: str | None = Header(
         try:
             tg_resp = client.get_ticket_groups(event_id, owned=True)
         except RuntimeError as e:
-            raise HTTPException(502, f"TEvo ticket_groups failed: {e}")
+            print(f"[store_reserve] TEvo ticket_groups failed for {event_id}: {e!r}")
+            raise HTTPException(502, "ticket listings fetch failed")
         match = next(
             (tg for tg in (tg_resp.get("ticket_groups") or []) if int(tg.get("id") or 0) == ticket_group_id),
             None,

--- a/tests/test_store_events.py
+++ b/tests/test_store_events.py
@@ -257,3 +257,28 @@ def test_503_when_client_unconfigured(client, monkeypatch):
     r = client.get("/api/store/events?limit=5")
     assert r.status_code == 503
     assert "TEvo client not configured" in r.json().get("detail", "")
+
+
+# ---------- error-message scrubbing (no upstream details leak to public) ----------
+
+def test_reserve_upstream_error_does_not_leak_tevo(client, monkeypatch):
+    """When the upstream ticket_groups fetch raises, the public 502 must NOT
+    echo 'TEvo' or the raw exception text (which can carry tokens / URLs /
+    stack fragments). The full error is logged server-side only."""
+    class _BoomFake:
+        def get_ticket_groups(self, *_, **__):
+            raise RuntimeError("TEvo API 500 https://api.tevo/x?token=SECRET")
+    monkeypatch.setattr(app_module, "client", _BoomFake())
+    r = client.post("/api/store/reserve", json={
+        "event_id": 3346000, "ticket_group_id": 12345, "quantity": 2,
+    })
+    assert r.status_code == 502, r.text
+    detail = r.json().get("detail", "")
+    assert "TEvo" not in detail
+    assert "SECRET" not in detail
+    assert "token" not in detail.lower()
+    # The same scrub pattern (log {e!r} server-side, return generic public
+    # message) is applied at all 3 storefront TEvo-error sites: this reserve
+    # path (app.py:7345), the cached ticket_groups helper (6812), and
+    # /api/store/events/near (6384). reserve is the representative public
+    # case; the other two are identical scrubs.


### PR DESCRIPTION
## Summary
The public storefront API echoed raw upstream exception text + "TEvo" branding in 502 responses at three sites. Exception messages can carry tokens, URLs, or stack fragments — they shouldn't reach the public.

| Site | Endpoint | Before | After |
|---|---|---|---|
| `app.py:6384` | `/api/store/events/near` geo lookup | `f"TEvo geo lookup failed: {e}"` | log `{e!r}` + `"geo lookup failed"` |
| `app.py:6812` | cached ticket_groups helper (event detail) | `f"TEvo ticket_groups failed: {e}"` | log `{e!r}` + `"ticket listings fetch failed"` |
| `app.py:7345` | `/api/store/reserve` inventory check | `f"TEvo ticket_groups failed: {e}"` | log `{e!r}` + `"ticket listings fetch failed"` |

Matches the already-scrubbed event-detail (`6864`) and events-list (`4626`) sites — full error logged server-side, generic message public.

**Out of scope** (flagged separately): `/api/broker/event/{id}/raw-tevo` (`app.py:2487`) leaks the same way but is **D0/broker lane** + auth-gated internal terminal — not a D1 file.

## Test plan
- [x] `pytest tests/test_store_events.py tests/test_store_home.py -q` — 59 passing (+1 new)
- [x] New `test_reserve_upstream_error_does_not_leak_tevo`: forces `client.get_ticket_groups` to raise `RuntimeError("...token=SECRET")`, asserts 502 detail has no `TEvo`/`SECRET`/`token`
- [x] `grep` confirms no remaining `HTTPException(50x, f"TEvo...")` in `/api/store/*` paths
- [ ] Post-deploy: `curl /api/store/events/99999999` already returns scrubbed `"event lookup failed"` (verified live pre-PR)

Part of the **browse-only production-readiness** track (operator-selected target). Sprint 2 purchase path stays frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)