### PR TITLE
feat(d1/store): SEO head parity on legal pages + canonical URLs

### DIFF
--- a/static/store/about.html
+++ b/static/store/about.html
@@ -7,6 +7,17 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>About — VibePass</title>
+  <meta name="description" content="VibePass is a direct-inventory ticket marketplace for sports and live events — tickets we hold directly, transparent pricing, no daisy chains." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VibePass" />
+  <meta property="og:title" content="About VibePass" />
+  <meta property="og:description" content="A direct-inventory ticket marketplace. Tickets we hold directly, transparent pricing." />
+  <meta property="og:url" content="https://vibepass-storefront-test.onrender.com/store/about" />
+  <meta property="og:image" content="https://vibepass-storefront-test.onrender.com/static/store/og-default.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="About VibePass" />
+  <meta name="twitter:description" content="A direct-inventory ticket marketplace. Tickets we hold directly, transparent pricing." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="about">

--- a/static/store/event.html
+++ b/static/store/event.html
@@ -26,6 +26,10 @@
   <meta name="twitter:title" content="VibePass — event tickets" />
   <meta name="twitter:description" content="Direct-inventory tickets for this event." />
 
+  <!-- Canonical points at the filter-less event URL so the ?zones=&min_price=
+       filter variants don't fragment into duplicate-content pages. store.js
+       rewrites href to location.origin + location.pathname once it mounts. -->
+  <link rel="canonical" href="" />
   <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -25,6 +25,7 @@
   <meta name="twitter:title" content="VibePass — direct-inventory tickets" />
   <meta name="twitter:description" content="Sports + live-event tickets we hold directly. Transparent pricing." />
 
+  <link rel="canonical" href="https://vibepass-storefront-test.onrender.com/store" />
   <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>

--- a/static/store/privacy.html
+++ b/static/store/privacy.html
@@ -7,6 +7,17 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Privacy — VibePass</title>
+  <meta name="description" content="VibePass privacy policy — what data the storefront collects, how it's used, and who it's shared with." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VibePass" />
+  <meta property="og:title" content="Privacy — VibePass" />
+  <meta property="og:description" content="What data the VibePass storefront collects and how it's used." />
+  <meta property="og:url" content="https://vibepass-storefront-test.onrender.com/store/privacy" />
+  <meta property="og:image" content="https://vibepass-storefront-test.onrender.com/static/store/og-default.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Privacy — VibePass" />
+  <meta name="twitter:description" content="What data the VibePass storefront collects and how it's used." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="privacy">

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -1009,6 +1009,10 @@
     setMeta('meta[property="og:url"]', location.href);
     setMeta('meta[name="twitter:title"]', titleText);
     setMeta('meta[name="twitter:description"]', descText);
+    // Canonical = filter-less event URL (drop ?zones=&min_price= etc.) so
+    // the filter variants don't fragment into duplicate-content pages.
+    const canonical = document.querySelector('link[rel="canonical"]');
+    if (canonical) canonical.setAttribute("href", location.origin + location.pathname);
   }
 
   function mountEvent() {

--- a/static/store/terms.html
+++ b/static/store/terms.html
@@ -7,6 +7,17 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terms — VibePass</title>
+  <meta name="description" content="VibePass terms of service — listings, pricing, and acceptable use of the storefront." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="VibePass" />
+  <meta property="og:title" content="Terms — VibePass" />
+  <meta property="og:description" content="Listings, pricing, and acceptable use of the VibePass storefront." />
+  <meta property="og:url" content="https://vibepass-storefront-test.onrender.com/store/terms" />
+  <meta property="og:image" content="https://vibepass-storefront-test.onrender.com/static/store/og-default.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Terms — VibePass" />
+  <meta name="twitter:description" content="Listings, pricing, and acceptable use of the VibePass storefront." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="terms">

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -615,6 +615,27 @@ def test_legal_pages_render(monkeypatch):
         )
 
 
+def test_legal_pages_have_seo_head(monkeypatch):
+    """Legal pages reached SEO parity with index.html — favicon link, a
+    meta description, and an og:title. Guards against the D1-OPS-4 gap
+    where about/privacy/terms shipped (PR #164) before the SEO scaffold
+    (PR #166) and had only a bare <title>."""
+    client = TestClient(app_module.app)
+    for path in ("/store/about", "/store/privacy", "/store/terms"):
+        body = client.get(path).text
+        assert 'rel="icon"' in body, f"{path} missing favicon link"
+        assert 'name="description"' in body, f"{path} missing meta description"
+        assert 'property="og:title"' in body, f"{path} missing og:title"
+
+
+def test_event_page_has_canonical_link(monkeypatch):
+    """event.html carries a <link rel='canonical'> element (store.js fills
+    href at mount to the filter-less URL, deduping ?zones= filter variants)."""
+    client = TestClient(app_module.app)
+    body = client.get("/store/event/3346001").text
+    assert 'rel="canonical"' in body, "event page missing canonical link element"
+
+
 def test_legal_pages_have_no_cache_revalidate_header(store_home_client):
     """Legal pages route through _render_storefront_page so they inherit
     the same Cache-Control: no-cache, must-revalidate header. Guards


### PR DESCRIPTION
## Summary
Browse-only production-readiness track. Closes **D1-OPS-4** + adds canonical URLs.

**Legal pages SEO head (D1-OPS-4)** — about/privacy/terms shipped (PR #164) before the SEO scaffold (PR #166), so they had only a bare `<title>`. Now each carries the same head block as `index.html`: favicon, `<meta name="description">`, OG tags, Twitter card — tailored per page. Indexable pages → better SERP snippets + share-card rendering.

**Canonical URLs** (dedupe filter-param variants):
- `index.html`: static `<link rel="canonical">` → `/store`
- `event.html`: placeholder `<link rel="canonical">`; `store.js` `updateEventMeta()` sets `href = location.origin + location.pathname` at mount, stripping `?zones=&min_price=` so filter variants don't fragment into duplicate-content pages.

**Deferred to a follow-up**: `robots.txt` + `sitemap.xml`. They're root-level resources on the **unified-shell service** (also hosts D0 terminal + D2 dashboard), so the indexing policy needs D0/A1 coordination — not a unilateral D1 change.

## Test plan
- [x] `pytest tests/test_store_home.py -q` — 49 passing (+2)
- [x] `node --check static/store/store.js` + HTML parse on all 5 pages
- [x] `test_legal_pages_have_seo_head`: about/privacy/terms carry favicon + description + og:title
- [x] `test_event_page_has_canonical_link`: event page has a canonical element
- [ ] Post-deploy: view-source `/store/about` shows OG tags; DevTools on `/store/event/{id}?min_price=50` → canonical resolves to the param-less URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)