### PR TITLE
perf(d1/store): long-cache /static/store assets via Cache-Control (D1-OPS-2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -489,6 +489,20 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "Strict-Transport-Security",
             "max-age=63072000; includeSubDomains",
         )
+        # Long-cache storefront static assets (D1-OPS-2). The HTML shells
+        # reference them with a ?v=<sha> cache-bust, so a versioned request
+        # is safe to pin for a year (immutable) — the next deploy serves a
+        # new URL. Rare unversioned/direct hits get a short TTL so a deploy
+        # isn't masked forever for them. HTML shells set their own
+        # no-cache header (via _render_storefront_page) and aren't matched
+        # here. setdefault() so a route that set its own Cache-Control wins.
+        if (request.url.path.startswith("/static/store/")
+                and response.status_code == 200):
+            if request.query_params.get("v"):
+                response.headers.setdefault(
+                    "Cache-Control", "public, max-age=31536000, immutable")
+            else:
+                response.headers.setdefault("Cache-Control", "public, max-age=600")
         return response
 
 

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -656,6 +656,29 @@ def test_all_storefront_html_routes_revalidate(store_home_client):
         )
 
 
+def test_static_store_asset_versioned_is_immutable(store_home_client):
+    """D1-OPS-2: a versioned (?v=<sha>) /static/store asset request gets a
+    1-year immutable Cache-Control so browsers stop revalidating every load.
+    The ?v= query is what makes immutable safe — a new deploy serves a new
+    URL."""
+    r = store_home_client.get("/static/store/style.css?v=abc1234")
+    assert r.status_code == 200, r.text
+    cc = r.headers.get("cache-control", "").lower()
+    assert "max-age=31536000" in cc and "immutable" in cc, (
+        f"versioned static asset should be immutable-cached; got: {cc!r}"
+    )
+
+
+def test_static_store_asset_unversioned_short_ttl(store_home_client):
+    """An unversioned /static/store hit (rare — crawler/manual) gets a short
+    TTL, NOT immutable, so a deploy isn't masked forever for those callers."""
+    r = store_home_client.get("/static/store/style.css")
+    assert r.status_code == 200
+    cc = r.headers.get("cache-control", "").lower()
+    assert "immutable" not in cc, f"unversioned asset must not be immutable; got: {cc!r}"
+    assert "max-age=600" in cc, f"expected short TTL; got: {cc!r}"
+
+
 # ---------- /api/store/movers stale-while-revalidate cache ----------
 #
 # The movers route refactor in PR #144 wraps the ~1s compute path in a


### PR DESCRIPTION
## Summary
Closes **D1-OPS-2**. Static storefront assets (`store.js`, `style.css`, `favicon.svg`, `og-default.svg`) returned no app `Cache-Control` — only Cloudflare's `cf-cache-status: DYNAMIC` — so browsers revalidated every asset on every load, despite the `?v=<sha>` cache-bust the HTML shells already append.

Adds a rule in the existing `_SecurityHeadersMiddleware`, scoped to `/static/store/*`:
- **versioned** request (`?v=<sha>` present) → `public, max-age=31536000, immutable` (safe to pin a year — a deploy serves a new `?v=` URL)
- **unversioned/direct** hit (rare: crawler/manual) → `public, max-age=600` (short TTL so a deploy isn't masked forever for those callers)

`setdefault()` so any route that sets its own `Cache-Control` still wins; HTML shells keep their `no-cache` header (set in `_render_storefront_page`, unaffected — different path).

## Test plan
- [x] `pytest tests/test_store_home.py -q` — 49 passing (+2)
- [x] `test_static_store_asset_versioned_is_immutable`: `?v=` → `max-age=31536000, immutable`
- [x] `test_static_store_asset_unversioned_short_ttl`: no `?v=` → `max-age=600`, no `immutable`
- [ ] Post-deploy: `curl -I /static/store/store.js?v=<sha>` shows immutable; `curl -I /store` still shows `no-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)