### PR TITLE
fix(d1/store): drop frame-ancestors from <meta> CSP (console-error noise)

### DIFF
--- a/static/store/about.html
+++ b/static/store/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>About — VibePass</title>

--- a/static/store/event.html
+++ b/static/store/event.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <!-- Title + description are overridden per-event by store.js once the

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>VibePass — direct-inventory tickets for sports + live events</title>

--- a/static/store/privacy.html
+++ b/static/store/privacy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Privacy — VibePass</title>

--- a/static/store/shares.html
+++ b/static/store/shares.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <meta name="robots" content="noindex" />

--- a/static/store/terms.html
+++ b/static/store/terms.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terms — VibePass</title>

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -516,6 +516,31 @@ def test_or_ilike_clause_escapes_embedded_double_quote():
     assert out == 'name.ilike."%He said ""yes"",%"'
 
 
+def test_csp_frame_ancestors_header_only_not_meta(store_home_client):
+    """frame-ancestors is honored ONLY as an HTTP header, never in a <meta>
+    CSP — browsers ignore it there and log a console error on every page
+    load. So: the served HTML's <meta> CSP must NOT contain frame-ancestors,
+    while the HTTP response header CSP MUST (clickjacking protection
+    preserved). Guards against re-adding it to the meta tag."""
+    r = store_home_client.get("/store")
+    assert r.status_code == 200
+    body = r.text
+    # The meta CSP line must be present but without frame-ancestors.
+    assert 'http-equiv="Content-Security-Policy"' in body
+    # Isolate the meta tag content to avoid matching anything else.
+    meta_idx = body.find('http-equiv="Content-Security-Policy"')
+    meta_tag = body[meta_idx:body.find(">", meta_idx)]
+    assert "frame-ancestors" not in meta_tag, (
+        "frame-ancestors must not appear in the <meta> CSP (browsers ignore "
+        "it there + log a console error)"
+    )
+    # HTTP-header CSP still enforces it.
+    hdr_csp = r.headers.get("content-security-policy", "")
+    assert "frame-ancestors 'none'" in hdr_csp, (
+        "frame-ancestors 'none' must remain in the HTTP-header CSP"
+    )
+
+
 # ---------- Storefront cache-bust helper ----------
 
 def test_store_home_html_includes_version_query_string(store_home_client, monkeypatch):


### PR DESCRIPTION
## Summary
Live FE check (Chrome DevTools against the deployed site) surfaced a console **error on every storefront page load**:

> The Content Security Policy directive 'frame-ancestors' is ignored when delivered via a `<meta>` element.

`frame-ancestors` is only honored as an **HTTP response header** — in a `<meta>` CSP, browsers ignore it *and* log the error. It was redundant anyway: `_SecurityHeadersMiddleware` already sets `frame-ancestors 'none'` on the HTTP-header CSP, which **is** enforced.

Removed the directive from the `<meta>` CSP in all 6 storefront shells (event/index/about/privacy/terms/shares). **Clickjacking protection is unchanged** — only the duplicate invalid meta directive is gone, so the console stays clean.

## Test plan
- [x] `grep` — `frame-ancestors` no longer in any `static/store/*.html`
- [x] HTML parses on all 6 shells
- [x] `pytest tests/test_store_home.py -q` — 49 passing (+1)
- [x] New `test_csp_frame_ancestors_header_only_not_meta`: served `/store` `<meta>` CSP has no `frame-ancestors`; HTTP-header CSP still carries `frame-ancestors 'none'`

Found during the "build backend + test FE" pass. Backend side: integrated all 5 open D1 PRs locally — merges clean, app imports (112 routes), 164 store/share tests pass (the 4 vivid + 3 broadway failures are pre-existing on main, D2/D3 lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)