### PR TITLE
feat(d0/terminal): SG discovery fix + performer scope + v3 perf + analyst skill

### DIFF
--- a/docs/d0_llm_analysis_layer_spec.md
+++ b/docs/d0_llm_analysis_layer_spec.md
@@ -90,3 +90,26 @@ For the **single-operator phase (below)** this is trivial — it's your own sess
 4. **BYO-chat via MCP** — power users plug their own chat client into the same tool surface.
 
 Built once, the tool surface powers the in-app panel *and* the BYO-chat path.
+
+---
+
+## 8. Write / action layer — OFF now, explicit future goal
+
+**Today: read-only, period.** The skill, every tool, and the whole terminal are read-only
+(lockdown rule #2). No writes to terminal data; no writes/holds/orders to any upstream
+marketplace (TEvo / SG / Vivid / TickPick). The LLM *proposes*; the human acts in the POS.
+
+**Future goal (operator directive 2026-05-24):** a write / action layer — e.g. the **Pricing
+Queue** (draft a price change here → human approves → push back to the marketplace) — *is* the
+eventual goal. Deliberately off now; recorded so it isn't lost.
+
+**Gates to flip it on (all required):**
+- Explicit **operator authorization** to open a write path (lockdown rule #2).
+- **Human approves every write.** The LLM may *draft* a change; it never auto-executes —
+  per-action confirmation, never bulk-auto.
+- Full **audit log** (who / what / when / old→new) + **reversibility / undo**.
+- Per-user scope + rate limits; writes use the user's identity, never a shared elevated key.
+- **Force-multiplier preserved:** even with write on, the human stays the decision-maker —
+  the layer makes *execution* faster, never *autonomous*.
+
+Until every gate is met, read-only stands.

--- a/docs/d0_llm_analysis_layer_spec.md
+++ b/docs/d0_llm_analysis_layer_spec.md
@@ -1,0 +1,92 @@
+# D0 LLM Analysis Layer — Design Spec
+
+**Author:** D0 · 2026-05-24 · status: draft for operator approval
+**North star (operator directive 2026-05-24):** the LLM is a **force multiplier for the
+broker's judgment** — it makes the human faster and sharper, and *the human always makes
+the call*. It is **complementary, never a replacement for human insight.** It never
+auto-acts, never becomes the source of truth, and never gathers data the human couldn't.
+
+This spec exists so "add Grok / an LLM" is a *wiring* job against the existing read-RPC
+surface — and so the force-multiplier principle is enforced in code, not just aspired to.
+
+---
+
+## 1. Design tenets (force-multiplier → enforceable rules)
+
+| Tenet | What it means in build terms |
+|---|---|
+| **Human-in-the-loop** | LLM *surfaces, computes, summarizes, proposes* — the broker *decides + acts*. No autonomous pricing or actions. Any suggestion is framed as "consider," never "done." |
+| **Grounded in truth** | Every figure comes from a **tool call** (the read RPCs). The LLM **quotes exact tool values verbatim** and the UI **renders the underlying numbers inline** so the human verifies at a glance. It never paraphrases or estimates a number. |
+| **Augment, don't replace the dashboards** | Dense views (Movers, Event, ladder) stay for scanning / monitoring / exact data. The LLM owns the *long tail*: NL queries, synthesis, "explain / compare," ad-hoc views you'd otherwise hand-build. |
+| **Compress the gather, not the judgment** | The LLM's job is to collapse "find → compute → summarize" so the broker spends their time on the call, not on data wrangling. Optimize for *time-to-insight*, then get out of the way. |
+| **Transparent + honest about uncertainty** | Shows its work (which tools it called), cites sources, flags staleness / low confidence, and says "verify this / I don't know" rather than guessing. |
+| **Read-only + identity-scoped** | Tools are read-only (lockdown rule #2). The LLM runs as **the user's** token → RLS scopes it. Never the `service_role` key; never data the human can't see. |
+
+**Anti-goals (explicit):** auto-pricing; replacing the scan tables; being the number-of-record;
+acting without the human; a chat that hides the data behind prose.
+
+---
+
+## 2. What it does / doesn't
+
+- **Does:** natural-language queries over the data ("MLB events where SG median >20% over our ask"), synthesis ("summarize today's movers + why"), explain/compare, draft a pricing rationale, the long tail of one-off views.
+- **Doesn't:** set or push prices, replace the dense scanning grid, serve as the authoritative number, take any irreversible action.
+
+---
+
+## 3. Tool surface (read RPCs exposed as LLM tools)
+
+All SECURITY DEFINER, read-only, RLS-scoped. Reuse what exists — no new data plumbing:
+
+| Tool | RPC | Returns |
+|---|---|---|
+| search | `terminal_search` | events / performers / venues typeahead |
+| event detail | `get_broker_event_page_v2` | full event payload (pricing, our position, freshness) |
+| event chart | `get_event_chart_extended` | price/inventory time-series + ESPN annotations |
+| movers | `get_event_movers_with_sg` | book mark-to-market winners/losers |
+| zones/splits | `get_event_sg_zones_splits` | section-level price ladder |
+| performer / venue | `get_broker_performer_page` / `get_broker_venue_page` | aggregate rollups |
+| blind spots | `get_blind_spots_sg_selling` / `_tevo_selling` | demand signals |
+| weather | `get_event_weather_localized` | venue forecast + alerts |
+
+The model calls these; it never queries raw tables or invents values.
+
+---
+
+## 4. Data scope (RLS) — the crux
+
+Split the surface explicitly:
+- **Shareable market intelligence** (events, TEvo/SG prices + medians, ESPN, weather, movers) → readable by any authenticated role.
+- **Private book** (owned positions, our orders, owned-premium, P&L) → **only the owner's own**; never another user's chat. This boundary protects the edge — get it wrong and the LLM leaks your positions.
+
+For the **single-operator phase (below)** this is trivial — it's your own session over your own data. The split only matters when "others" are added.
+
+---
+
+## 5. Grounding & safety contract (system prompt)
+
+- "Always call a tool for any figure; quote the tool's exact value; never invent or round-without-saying-so."
+- "Render the supporting numbers alongside any prose claim."
+- "Flag stale data (use the `freshness` keys) and low-confidence inferences."
+- "Never recommend an irreversible or money action as done — frame as the human's decision."
+- Per-user token; per-IP rate limit; the 8s RPC ceiling stays in front; BYO-key optional (personal cost).
+
+---
+
+## 6. Open decisions (operator)
+
+1. **Who are "others"?** invite/allowlist vs open signup (drives the auth change off the `@s4kent` single-gate).
+2. **What can a personal chat see?** public intel only, or also their own private data?
+3. **Vendor:** Grok / Claude / GPT — pick on tool-use reliability + cost (Grok's live-X data is a *bonus* for sentiment, not a deciding factor).
+4. **Cost model:** BYO-key (personal usage) vs hosted.
+
+---
+
+## 7. Phased build (lowest-risk first)
+
+1. **This spec** — tool surface + grounding rules approved.
+2. **Operator analysis panel (single-user).** An in-terminal chat panel scoped to *your own* authenticated session + the read tools + one LLM. **No multi-tenancy, no RLS split, no new auth** — pure force-multiplier on your own data. Highest immediate value, lowest risk. *Recommended starting point.*
+3. **RLS public/private split + per-user accounts** — when opening to others.
+4. **BYO-chat via MCP** — power users plug their own chat client into the same tool surface.
+
+Built once, the tool surface powers the in-app panel *and* the BYO-chat path.

--- a/docs/d0_terminal_analyst_skill.md
+++ b/docs/d0_terminal_analyst_skill.md
@@ -1,0 +1,73 @@
+# Terminal Analyst — skill (canonical source)
+
+**Step-one LLM force-multiplier on the terminal data.** This is the version-controlled
+canonical. To activate it in Claude Code, it's installed (locally, gitignored) at
+`.claude/skills/terminal-analyst/SKILL.md` — copy this body there (with the frontmatter)
+on any machine that should have it. Works today: your Claude already has read access to the
+terminal's Supabase via the user-level MCP (it's how the whole 2026-05-24 QA/fix session
+queried the data). Step two (a remote MCP server so *others'* Claudes connect) reuses the
+same tool surface + the RLS split — see `d0_llm_analysis_layer_spec.md`.
+
+Frontmatter for the skill file:
+```
+---
+name: terminal-analyst
+description: Analyze the s4kent ticket-broker terminal data as a force multiplier for pricing/trading decisions. Use when the operator asks to price an event, compare our ask vs market/SG, find movers or blind spots, assess demand (sales velocity, weather, injuries/standings), or research a performer/venue. Read-only.
+---
+```
+
+---
+
+# Terminal Analyst
+
+You are a **force multiplier for the broker's judgment** — make the human faster and
+sharper at pricing/trading tickets. **The human always makes the call.** You surface,
+compute, and summarize; you never decide, never act, never become the source of truth.
+
+## Hard contract
+1. **Read-only, always.** Only `SELECT` / read RPCs against the Supabase project
+   (`execute_sql`). Never INSERT/UPDATE/DELETE/DDL, never touch upstream ticketing APIs.
+2. **Ground every number in a query.** Quote exact values; never estimate. Show the figures
+   you reason from so the human verifies.
+3. **Human-in-the-loop.** Frame pricing as "consider / the data suggests" — never "set it to X."
+4. **Flag uncertainty + staleness.** Use `freshness.*_latest`; say when data is old/thin.
+
+## How to read the data (proven patterns)
+MCP runs as `service_role` → can read all tables/views directly. The curated read RPCs are
+email-gated (`@s4kent.com`) — call them inside a JWT-claim wrapper:
+```sql
+BEGIN;
+SET LOCAL statement_timeout = '8s';
+SET LOCAL request.jwt.claims = '{"email":"julian@s4kent.com","role":"authenticated"}';
+SELECT public.get_broker_event_page_v2(<event_id>::int, 168);
+COMMIT;
+```
+Prefer the curated RPCs over hand-rolled SQL:
+
+| Need | RPC |
+|---|---|
+| Find event/performer/venue | `terminal_search(p_q, p_limit)` |
+| Price one event (our position vs market) | `get_broker_event_page_v2(p_event_id, p_chart_hours)` |
+| Event + enrichments (sales 7d, zones, ESPN) | `get_broker_event_page_v3(p_event_id, p_chart_hours)` |
+| Section price ladder | `get_event_sg_zones_splits(p_event_id)` |
+| Book mark-to-market | `get_event_movers_with_sg(p_window_hours)` |
+| Demand "selling, we're not" | `get_blind_spots_sg_selling(p_min_score)` |
+| Performer / venue rollups | `get_broker_performer_page` / `get_broker_venue_page` |
+| Weather (demand factor) | `get_event_weather_localized(p_event_id)` |
+
+## Landmines (heed before any raw SQL — full table: PROJECT_BIBLE.md §3)
+- `events` has no `occurs_at` — only `occurs_at_local` (offset TEXT; cast `::timestamptz`).
+- `events.id` is `bigint`; RPCs take `integer` — cast `::int`.
+- SG sales = 11-15× firehose dup: `DISTINCT ON (sg_sale_id) ORDER BY sg_sale_id, pulled_at DESC`
+  before any aggregate. Even one heavy event = ~300k rows (~14s) — prefer RPCs/matviews.
+- Don't seq-scan `listings_snapshots` (8M) / `seatgeek_sales_snapshots` (5.9M); query by indexed
+  ids; use `latest_event_metrics` / `mv_sg_blindspot_movers`; always `SET LOCAL statement_timeout`.
+- `espn_team_id` collides across leagues — scope by `espn_league`.
+
+## Example asks
+- "Are we underpriced on the Yankees game?" → event page: our owned median ($9) vs non-owned/market
+  ($56), get-in, owned share — quote figures + freshness.
+- "What moved in our book in 24h?" → movers RPC, biggest Δmarket_val with numbers.
+- "MLB events where SG is active but we own nothing." → blind-spots / cross-source.
+
+End pricing analysis by handing the decision back: *"That's the picture — your call."*

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="5" fill="#0a0a0a"/><text x="16" y="22" font-family="ui-monospace,monospace" font-size="15" font-weight="700" fill="#f5b301" text-anchor="middle">S4</text></svg>

--- a/static/terminal/discovery.html
+++ b/static/terminal/discovery.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -595,7 +595,7 @@
       cursor: { drag: { x: true, y: false } },
       scales: {
         x: { time: true, range: xRange ? (() => xRange) : undefined },
-        y: {},
+        y: { range: robustYRange },
       },
       axes: [
         X_AXIS,
@@ -638,6 +638,30 @@
     }
   }
 
+  // Robust Y-axis range. uPlot's default auto-scale spans data min→max, so a
+  // single outlier (e.g. a $500+ suite sale spiking a median bucket) blows the
+  // axis out and compresses the $4-60 trading band into an unreadable sliver.
+  // This clips the top to ~p95 ONLY when a real outlier exists (real max > 1.5×
+  // p95); otherwise it shows the full range. Lines above the cap clip off-top.
+  function robustYRange(u, initMin, initMax) {
+    var fallback = [0, (initMax == null || !isFinite(initMax)) ? 1 : initMax];
+    if (!u || !u.series || !u.data) return fallback;
+    var vals = [];
+    for (var i = 1; i < u.series.length; i++) {
+      if (u.series[i] && u.series[i].show === false) continue;
+      var d = u.data[i]; if (!d) continue;
+      for (var j = 0; j < d.length; j++) {
+        var v = d[j]; if (v != null && isFinite(v)) vals.push(v);
+      }
+    }
+    if (!vals.length) return fallback;
+    vals.sort(function (a, b) { return a - b; });
+    var p95 = vals[Math.min(vals.length - 1, Math.floor(vals.length * 0.95))];
+    var realMax = vals[vals.length - 1];
+    var top = (realMax <= p95 * 1.5) ? realMax * 1.08 : Math.max(p95 * 1.1, 1);
+    return [0, top > 0 ? top : 1];
+  }
+
   // ---------- INVENTORY CHART ----------
   // 3 line series on left Y-axis (integer ticket counts) + 1 bar series on
   // right Y-axis (SG sale count). uPlot supports per-series scales natively;
@@ -672,7 +696,7 @@
       cursor: { drag: { x: true, y: false } },
       scales: {
         x:  { time: true, range: xRange ? (() => xRange) : undefined },
-        y:  {},
+        y:  { range: robustYRange },
         yr: { range: (u, dataMin, dataMax) => [0, Math.max(dataMax || 1, 1)] },
       },
       axes: [

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -202,8 +202,17 @@
       // X-axis afterward; no v3 re-fetch on window flips.
       let res = await Auth.client
         .rpc('get_broker_event_page_v3', { p_event_id: eventId, p_chart_hours: V3_LOAD_HOURS });
-      if (res.error && (res.error.code === '42883' || /does not exist/i.test(res.error.message || ''))) {
-        // v3 not applied yet — fall back to v2
+      // Fall back to the lighter/faster v2 when v3 is either (a) not applied on
+      // this project (42883 / "does not exist") OR (b) times out (57014 /
+      // "statement timeout"/"canceling statement"). v3 (~5.8s on heavy events
+      // like Yankees) can exceed PostgREST's 8s cap under concurrent load and
+      // blank the whole header; v2 (~185ms) still fills the core page and the
+      // 9 v3-only enrichment panels just render their empty states. (QA 2026-05-24.)
+      if (res.error && (
+            res.error.code === '42883' ||
+            res.error.code === '57014' ||
+            /does not exist|statement timeout|canceling statement/i.test(res.error.message || '')
+          )) {
         res = await Auth.client
           .rpc('get_broker_event_page_v2', { p_event_id: eventId, p_chart_hours: V3_LOAD_HOURS });
       }

--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -87,14 +87,15 @@
   //   2. price rising       >= 10% over 48h
   //   3. sales accelerating >= 30% (last 24h vs prior 24h)
   //   4. sales clearing at/above current ask
-  // Surfaces events scoring >= 3/4. Pool: ~3,150 unmatched US SG events
-  // polled at 12h cadence (TRACK_BLINDSPOT tier).
+  // Surfaces events scoring >= 2/4 (two independent signals agreeing). Pool:
+  // ~2,930 unmatched US SG events polled at 12h cadence (TRACK_BLINDSPOT tier).
+  // RPC perf-fixed via matview mig 20260524120000 (was timing out >11s).
   //
   // Replaces the prior heuristic (sg_sales_window >= 5 AND cur_owned_tix == 0
   // pulled from /api/broker/movers) — that surfaced matched events with SG
   // activity but doesn't cover the unmatched-US cohort the new tracker targets.
 
-  const BLIND_SPOT_MIN_SCORE = 3;
+  const BLIND_SPOT_MIN_SCORE = 2;  // was 3; audit 2026-05-24 found score>=3 ~never reached
   const BLIND_SPOT_MAX_ROWS  = 20;
   // Threshold for the table-row "blindspot" highlight: SG sales activity
   // above this level with zero owned tickets flags the row warn-color.

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -71,9 +71,14 @@
     return Array.from(seen.values());
   }
 
-  // Blind spots — calls get_blind_spots_sg_selling RPC (mig 20260520370000).
-  // Same RPC + render shape as home.js. See home.js comment block for design.
-  const BLIND_SPOT_MIN_SCORE = 3;
+  // Blind spots — calls get_blind_spots_sg_selling RPC (mig 20260520370000;
+  // perf-fixed via matview mig 20260524120000). Same RPC + render shape as
+  // home.js. See home.js comment block for design.
+  // selling_score is a 0-4 composite (listings drop + price rise + sales accel
+  // + sales above ask). Default 2 = "two independent signals agree" — a real
+  // blind-spot, not single-signal noise. Lowered from 3 (audit 2026-05-24:
+  // score>=3 essentially never reached given the live signal distribution).
+  const BLIND_SPOT_MIN_SCORE = 2;
   const BLIND_SPOT_MAX_ROWS  = 20;
   // Threshold for the row-level "blindspot" highlight: SG sales activity
   // above this level with zero owned tickets flags the row warn-color.

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/static/version.json
+++ b/static/version.json
@@ -1,0 +1,1 @@
+{"version": "2026.05.24-d0", "note": "manual marker; replace with build-injected git sha when a build step lands"}

--- a/supabase/migrations/20260524120000_sg_blindspot_movers_matview.sql
+++ b/supabase/migrations/20260524120000_sg_blindspot_movers_matview.sql
@@ -1,0 +1,116 @@
+-- 20260524120000_sg_blindspot_movers_matview.sql
+--
+-- ## Already applied to prod — applied via MCP apply_migration 2026-05-24.
+--   Post-apply verified: get_blind_spots_sg_selling(2) = 4.989ms (was >11,000ms);
+--   mv_sg_blindspot_movers = 43 rows; cron 'sg_blindspot_mv_refresh' scheduled.
+--   A1: please push this file to main (sole-pusher) so repo↔prod stay in sync.
+--
+-- D0 (operator-directed; crosses into A1's migration domain via the bot_chat
+-- override path — "fix and test", 2026-05-24).
+--
+-- PROBLEM (audit 2026-05-24): get_blind_spots_sg_selling() reads
+--   public.v_sg_blindspot_movers, which does per-event correlated-subquery
+--   anchoring (t0/t48) + percentile_cont medians + DISTINCT-ON sales dedup over
+--   the 7.46M-row seatgeek_listings_snapshots firehose for 2,932 TRACK_BLINDSPOT
+--   events — every call, synchronously. Measured >11s. PostgREST caps
+--   authenticated calls at 8s, so the SG blind-spots panel on the Home and
+--   Movers terminal pages TIMES OUT on every load (renders
+--   "error: canceling statement due to statement timeout").
+--
+-- FIX: materialize the heavy view into mv_sg_blindspot_movers (the scan runs
+--   off-request on a cron), repoint the RPC at the matview (sub-second indexed
+--   read), and refresh on a gated 10-min cron. Mirrors the latest_event_metrics
+--   matview pattern (PROJECT_BIBLE §3: "use the matview, don't scan the firehose").
+--   The RPC body is byte-identical to the prior version except the FROM target.
+--
+-- ROLLBACK: repoint the RPC's FROM back to public.v_sg_blindspot_movers,
+--   cron.unschedule('sg_blindspot_mv_refresh'), DROP MATERIALIZED VIEW
+--   public.mv_sg_blindspot_movers, DELETE the cron_policy row.
+
+SET statement_timeout = '120s';  -- CREATE ... WITH DATA runs the heavy scan once
+
+-- 1) Materialized snapshot of the heavy view -------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_sg_blindspot_movers AS
+  SELECT * FROM public.v_sg_blindspot_movers
+WITH DATA;
+
+-- unique index → enables REFRESH ... CONCURRENTLY (non-blocking) + fast PK lookup
+CREATE UNIQUE INDEX IF NOT EXISTS mv_sg_blindspot_movers_pk
+  ON public.mv_sg_blindspot_movers (sg_event_id);
+-- supports the RPC's `WHERE selling_score >= p_min_score` filter
+CREATE INDEX IF NOT EXISTS mv_sg_blindspot_movers_score_idx
+  ON public.mv_sg_blindspot_movers (selling_score DESC);
+
+-- secure-by-default: only the SECURITY DEFINER RPC (owner) reads the matview;
+-- no direct anon/authenticated PostgREST surface (preempts B1-NEXT-55 class).
+REVOKE ALL ON public.mv_sg_blindspot_movers FROM anon, authenticated;
+
+-- 2) Repoint the RPC at the matview ----------------------------------------
+--    (identical to prior definition except FROM v_... -> FROM mv_...)
+CREATE OR REPLACE FUNCTION public.get_blind_spots_sg_selling(p_min_score integer DEFAULT 3)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  RETURN coalesce((
+    SELECT jsonb_agg(jsonb_build_object(
+             'sg_event_id', m.sg_event_id, 'tevo_event_id', c.tevo_event_id,
+             'sg_event_name', c.sg_event_name, 'sg_venue_name', c.sg_venue_name,
+             'sg_venue_city', c.sg_venue_city, 'sg_venue_state', c.sg_venue_state,
+             'sg_datetime_utc', to_char(c.sg_datetime_utc AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'listings_now', m.listings_now, 'listings_prior', m.listings_prior,
+             'listings_pct_delta', m.listings_pct_delta,
+             'median_now', round(m.median_now, 2), 'median_prior', round(m.median_prior, 2),
+             'price_pct_delta', m.price_pct_delta,
+             'sales_24h_count', m.sales_24h_count, 'sales_prior_24h_count', m.sales_prior_24h_count,
+             'sales_velocity_pct', m.sales_velocity_pct,
+             'median_sale_24h', m.median_sale_24h, 'sale_vs_listing_pct', m.sale_vs_listing_pct,
+             'clearing_ratio', m.clearing_ratio,
+             'signal_listings_drop', m.signal_listings_drop,
+             'signal_price_rise', m.signal_price_rise,
+             'signal_sales_accel', m.signal_sales_accel,
+             'signal_sales_above_ask', m.signal_sales_above_ask,
+             'selling_score', m.selling_score, 'selling_pressure', m.selling_pressure
+           ) ORDER BY m.selling_score DESC,
+                     coalesce(m.sales_velocity_pct, 0) DESC,
+                     abs(coalesce(m.price_pct_delta, 0)) DESC)
+    FROM public.mv_sg_blindspot_movers m
+    JOIN public.sg_events_canonical c ON c.sg_event_id = m.sg_event_id
+    WHERE m.selling_score >= p_min_score
+      AND c.sg_datetime_utc > now()
+  ), '[]'::jsonb);
+END
+$function$;
+
+-- 3) Gated refresh cron -----------------------------------------------------
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES
+  ('sg_blindspot_mv_refresh',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   10, 30, 120, true,
+   'Refresh mv_sg_blindspot_movers (materializes v_sg_blindspot_movers). Underlying SG blindspot poll runs UTC 4-10/16-22; 10-min peak / 30-min offpeak refresh keeps the matview fresh. Added by D0 fixing get_blind_spots_sg_selling 8s timeout (audit 2026-05-24).')
+ON CONFLICT (jobname) DO UPDATE
+  SET peak_hours_et = EXCLUDED.peak_hours_et,
+      peak_min_interval_min = EXCLUDED.peak_min_interval_min,
+      offpeak_min_interval_min = EXCLUDED.offpeak_min_interval_min,
+      daily_max_fires = EXCLUDED.daily_max_fires,
+      enabled = true,
+      notes = EXCLUDED.notes,
+      updated_at = now();
+
+SELECT cron.schedule('sg_blindspot_mv_refresh', '3-59/10 * * * *', $cron$
+  DO $body$ BEGIN
+    IF NOT public.cron_should_fire('sg_blindspot_mv_refresh') THEN RETURN; END IF;
+    SET LOCAL statement_timeout = '5min';
+    REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_sg_blindspot_movers;
+  END $body$;
+$cron$);

--- a/supabase/migrations/20260524130000_fix_performer_index_league_scope.sql
+++ b/supabase/migrations/20260524130000_fix_performer_index_league_scope.sql
@@ -1,0 +1,78 @@
+-- 20260524130000_fix_performer_index_league_scope.sql
+--
+-- ## Already applied to prod — applied via MCP apply_migration 2026-05-24.
+--
+-- D0 (operator-directed QA fix; crosses into A1's migration lane via the
+-- "begin fixing and testing" directive, 2026-05-24).
+--
+-- BUG (found live on the Performer index page): get_broker_performer_index
+--   joins espn_teams_canonical on espn_team_id ALONE. espn_team_id collides
+--   across leagues (PROJECT_BIBLE §3 landmine — id reused per league), so each
+--   of the 122 clean performer_espn_team_xref rows fans out to every same-id
+--   team across leagues. Result: 122 → 425 output rows, and the NFL/NBA/MLB
+--   columns each show a cross-league mix (e.g. NHL "Anaheim Ducks", MLB
+--   "Diamondbacks", WNBA "Atlanta Dream" all rendered under NFL). MLS happened
+--   to look right only because few ids collide into it.
+--
+-- FIX: scope the canonical join by league too (AND etc.espn_league =
+--   xt.espn_league). Verified pre-apply: corrected per-league counts =
+--   NFL 32, NBA 30, MLB 30, MLS 30 (= 122, matching the xref). Only change
+--   vs the prior definition is that one extra join predicate.
+--
+-- ROLLBACK: re-create the function with the espn_teams_canonical join keyed on
+--   espn_team_id alone.
+
+CREATE OR REPLACE FUNCTION public.get_broker_performer_index()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE v_email text; v_result jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  WITH base AS (
+    SELECT xt.tevo_performer_id, xt.espn_team_id, xt.espn_league,
+           ap.performer_name, etc.display_name, etc.abbreviation
+    FROM public.performer_espn_team_xref xt
+    LEFT JOIN public.aq_performer_map ap ON ap.tevo_performer_id = xt.tevo_performer_id
+    LEFT JOIN public.espn_teams_canonical etc
+      ON etc.espn_team_id = xt.espn_team_id AND etc.espn_league = xt.espn_league
+    WHERE xt.espn_league IN ('NFL','NBA','MLB','MLS') AND xt.tevo_performer_id IS NOT NULL
+  ),
+  counts AS (
+    SELECT b.tevo_performer_id, COUNT(*) AS events_count_next_90d
+    FROM base b
+    JOIN public.events ev ON ev.primary_performer_id = b.tevo_performer_id
+    WHERE ev.occurs_at_local ~ '^\d{4}'
+      AND ev.occurs_at_local::timestamptz >= now()
+      AND ev.occurs_at_local::timestamptz < now() + interval '90 days'
+    GROUP BY b.tevo_performer_id
+  ),
+  rows0 AS (
+    SELECT b.espn_league,
+           jsonb_build_object(
+             'tevo_performer_id', b.tevo_performer_id, 'performer_name', b.performer_name,
+             'espn_team_id', b.espn_team_id, 'abbreviation', b.abbreviation,
+             'display_name', b.display_name,
+             'events_count_next_90d', coalesce(c.events_count_next_90d, 0)
+           ) AS team_obj,
+           coalesce(b.display_name, b.performer_name, '') AS sort_key
+    FROM base b LEFT JOIN counts c ON c.tevo_performer_id = b.tevo_performer_id
+  ),
+  per_league AS (
+    SELECT espn_league, jsonb_agg(team_obj ORDER BY sort_key) AS teams, COUNT(*) AS team_count
+    FROM rows0 GROUP BY espn_league
+  )
+  SELECT jsonb_build_object(
+    'counts',  jsonb_object_agg(espn_league, team_count) ||
+               jsonb_build_object('total', (SELECT sum(team_count) FROM per_league)),
+    'leagues', jsonb_object_agg(espn_league, teams)
+  ) INTO v_result FROM per_league;
+
+  RETURN coalesce(v_result, jsonb_build_object('counts', '{}'::jsonb, 'leagues', '{}'::jsonb));
+END $function$;

--- a/supabase/migrations/20260524140000_v3_sg_broker_sales_7d_window.sql
+++ b/supabase/migrations/20260524140000_v3_sg_broker_sales_7d_window.sql
@@ -1,0 +1,239 @@
+-- 20260524140000_v3_sg_broker_sales_7d_window.sql
+--
+-- ## Already applied to prod — applied via MCP apply_migration 2026-05-24.
+--
+-- D0 (operator-directed QA perf fix; A1 migration lane via "do both" directive 2026-05-24).
+--
+-- PROBLEM: get_broker_event_page_v3's sg_broker_sales enrichment live-dedups
+--   the ENTIRE seatgeek_sales_snapshots history for the event — 315,284 firehose
+--   rows on a heavy event (Yankees) = ~14s, the entire v3 latency (the other 8
+--   enrichments are <1s combined). v3 tips over PostgREST's 8s cap under load.
+--   A precomputed all-time rollup is non-viable (full firehose dedup = 45-53s
+--   refresh + 260-559MB disk spill → would itself cause IO contention).
+--
+-- FIX: window the sales dedup to the last 7 days (by sale_at_utc). Measured
+--   1.34s for the Yankees event (60,964 rows vs 315,284) → v3 total ~2s, well
+--   under 8s, reliably. SEMANTIC CHANGE (operator-approved): sg_broker_sales is
+--   now "recent broker sales (last 7d)" rather than all-time — recent velocity
+--   is the actionable metric for an event-page summary, and the v2 base already
+--   carries the live sales_tape. A `window_days: 7` field makes it explicit to
+--   the FE. The v2-fallback (commit 5be3290) remains as the safety net.
+--   Durable all-time-fast path (if ever needed) = incremental rollup (A1 pipeline).
+--
+-- Only changes vs the prior v3 definition: (1) the dedup CTE adds
+--   `AND sale_at_utc > now() - interval '7 days'`, (2) the output object adds
+--   `7 AS window_days`. Everything else is byte-identical.
+
+CREATE OR REPLACE FUNCTION public.get_broker_event_page_v3(p_event_id integer, p_chart_hours integer DEFAULT 720)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email                text;
+  v_base                 jsonb;
+  v_now                  timestamptz := now();
+  v_sg_event_id          bigint;
+  v_espn_event_id        text;
+  v_espn_team_id         text;
+  v_espn_league          text;
+  v_tevo_performer_id    bigint;
+  v_performer            jsonb;
+  v_velocity             jsonb;
+  v_sg_broker_sales      jsonb;
+  v_sg_listings_summary  jsonb;
+  v_competing_events     jsonb;
+  v_cross_source_orders  jsonb;
+  v_recent_listings      jsonb;
+  v_zone_deltas          jsonb;
+  v_performer_espn       jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_base := public.get_broker_event_page_v2(p_event_id, p_chart_hours);
+  v_sg_event_id    := nullif(v_base->'bridge_ids'->>'sg_event_id', '')::bigint;
+  v_espn_event_id  := nullif(v_base->'bridge_ids'->>'espn_event_id', '');
+  v_espn_league    := nullif(v_base->'bridge_ids'->>'espn_league', '');
+
+  SELECT primary_performer_id INTO v_tevo_performer_id
+  FROM public.events WHERE id = p_event_id LIMIT 1;
+
+  IF v_tevo_performer_id IS NOT NULL THEN
+    SELECT to_jsonb(p) INTO v_performer FROM (
+      SELECT pm.performer_id AS tevo_performer_id, pm.name,
+        pm.logo_default_url, pm.logo_dark_url, pm.logo_4k_primary_url,
+        pm.color_primary, pm.color_alternate, pm.espn_league, pm.espn_team_id,
+        pm.what_event_type, pm.popularity_score, em.genre, em.top_category_name
+      FROM public.performer_metadata pm
+      LEFT JOIN public.entity_performer_map em ON em.tevo_performer_id = pm.performer_id
+      WHERE pm.performer_id = v_tevo_performer_id LIMIT 1
+    ) p;
+    IF v_performer IS NOT NULL THEN
+      v_espn_team_id := v_performer->>'espn_team_id';
+      IF v_espn_league IS NULL THEN v_espn_league := v_performer->>'espn_league'; END IF;
+    END IF;
+  END IF;
+  IF v_performer IS NULL THEN v_performer := jsonb_build_object('hidden', true, 'reason', 'no_performer_id'); END IF;
+
+  SELECT to_jsonb(v) INTO v_velocity FROM (
+    SELECT tevo_event_id, tevo_now_at, tevo_tix_now, tevo_tix_d1h, tevo_tix_d24h,
+      tevo_getin_now, tevo_getin_d1h, tevo_getin_d6h, tevo_getin_d24h,
+      tevo_getin_d1h_pct, tevo_getin_d24h_pct, tevo_median_now,
+      sg_now_at, sg_tix_now, sg_getin_now, sg_median_now, sg_getin_d1h, sg_getin_d24h
+    FROM public.v_event_velocity_windows WHERE tevo_event_id = p_event_id LIMIT 1
+  ) v;
+  IF v_velocity IS NULL THEN v_velocity := jsonb_build_object('hidden', true, 'reason', 'no_velocity_row'); END IF;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    WITH dedup AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, quantity, broadcast_price, section, sale_at_utc
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id AND section IS NOT NULL
+        AND sale_at_utc > now() - interval '7 days'
+      ORDER BY sg_sale_id, pulled_at DESC
+    ),
+    agg AS (
+      SELECT count(*) AS sales_count,
+             sum(quantity)::bigint AS tickets_sold,
+             sum(broadcast_price * COALESCE(quantity, 1)::numeric) AS gross_estimate,
+             min(broadcast_price) AS min_sale_price,
+             round(percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price::double precision)::numeric, 2) AS median_sale_price,
+             max(broadcast_price) AS max_sale_price,
+             count(DISTINCT section) AS distinct_sections,
+             max(sale_at_utc) AS latest_sale_at
+      FROM dedup
+    )
+    SELECT to_jsonb(s) INTO v_sg_broker_sales FROM (
+      SELECT v_sg_event_id AS sg_event_id, sgc.sg_event_name, sgc.sg_event_date,
+        7 AS window_days,
+        a.sales_count, a.tickets_sold, a.gross_estimate, a.min_sale_price,
+        a.median_sale_price, a.max_sale_price, a.distinct_sections, a.latest_sale_at
+      FROM agg a LEFT JOIN public.sg_events_canonical sgc ON sgc.sg_event_id = v_sg_event_id
+      WHERE a.sales_count > 0 LIMIT 1
+    ) s;
+  END IF;
+  IF v_sg_broker_sales IS NULL THEN
+    v_sg_broker_sales := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_sg_event_id IS NULL THEN 'no_sg_bridge' ELSE 'no_broker_sales_row' END);
+  END IF;
+
+  IF v_sg_event_id IS NOT NULL THEN
+    SELECT to_jsonb(m) INTO v_sg_listings_summary FROM (
+      SELECT captured_at,
+        listings_all_count, listings_all_tickets,
+        listings_all_min, listings_all_p25, listings_all_median, listings_all_mean,
+        listings_all_p75, listings_all_p90, listings_all_max,
+        listings_owned_count, listings_owned_tickets,
+        listings_owned_min, listings_owned_p25, listings_owned_median, listings_owned_mean,
+        listings_owned_p75, listings_owned_p90, listings_owned_max,
+        fill_rate, unique_sections, unique_rows, edelivery_share, instant_share
+      FROM public.seatgeek_event_metrics
+      WHERE sg_event_id = v_sg_event_id
+      ORDER BY captured_at DESC LIMIT 1
+    ) m;
+  END IF;
+  IF v_sg_listings_summary IS NULL THEN
+    v_sg_listings_summary := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_sg_event_id IS NULL THEN 'no_sg_bridge' ELSE 'no_sg_metrics_row' END);
+  END IF;
+
+  SELECT jsonb_build_object(
+    'count', competitors_count, 'refreshed_at', refreshed_at,
+    'events', coalesce(competitors, '[]'::jsonb)
+  ) INTO v_competing_events
+  FROM public.event_competitors_snapshot WHERE tevo_event_id = p_event_id LIMIT 1;
+  IF v_competing_events IS NULL THEN v_competing_events := jsonb_build_object('count', 0, 'events', '[]'::jsonb); END IF;
+
+  SELECT jsonb_build_object(
+    'tickpick', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'tp_order_id', tp_order_id, 'status', status, 'quantity', quantity,
+        'total', total, 'section', section, 'row', row, 'ordered_at', ordered_at
+      ) ORDER BY ordered_at DESC NULLS LAST)
+      FROM public.tickpick_orders WHERE tevo_event_id = p_event_id LIMIT 50
+    ), '[]'::jsonb),
+    'vivid', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'vivid_order_id', vivid_order_id, 'status', status, 'quantity', quantity,
+        'total', total, 'section', section, 'row', row, 'ordered_at', ordered_at
+      ) ORDER BY ordered_at DESC NULLS LAST)
+      FROM public.vivid_orders WHERE tevo_event_id = p_event_id LIMIT 50
+    ), '[]'::jsonb)
+  ) INTO v_cross_source_orders;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.captured_at DESC), '[]'::jsonb)
+  INTO v_recent_listings FROM (
+    SELECT DISTINCT ON (tevo_ticket_group_id)
+      tevo_ticket_group_id, captured_at, section, row, quantity,
+      retail_price, format, is_owned, brokerage_name
+    FROM public.listings_snapshots
+    WHERE event_id = p_event_id AND captured_at > now() - interval '24 hours'
+    ORDER BY tevo_ticket_group_id, captured_at DESC LIMIT 10
+  ) l;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (zone) zone, retail_median, tickets_count, owned_tickets_count, captured_at
+    FROM public.section_metrics
+    WHERE event_id = p_event_id AND zone IS NOT NULL
+    ORDER BY zone, captured_at DESC
+  ),
+  prior AS (
+    SELECT DISTINCT ON (zone) zone, retail_median AS prior_median, tickets_count AS prior_tix, captured_at AS prior_at
+    FROM public.section_metrics
+    WHERE event_id = p_event_id AND zone IS NOT NULL
+      AND captured_at <= now() - interval '24 hours'
+    ORDER BY zone, captured_at DESC
+  )
+  SELECT coalesce(jsonb_agg(jsonb_build_object(
+    'zone', l.zone, 'cur_median', l.retail_median, 'cur_tix', l.tickets_count,
+    'cur_owned_tix', l.owned_tickets_count,
+    'prior_median', p.prior_median, 'prior_tix', p.prior_tix,
+    'delta_median_pct',
+      CASE WHEN p.prior_median IS NULL OR p.prior_median = 0 THEN NULL
+           ELSE round(((l.retail_median - p.prior_median) / p.prior_median * 100)::numeric, 2) END,
+    'delta_tix_abs',
+      CASE WHEN p.prior_tix IS NULL THEN NULL ELSE l.tickets_count - p.prior_tix END,
+    'latest_at', l.captured_at, 'prior_at', p.prior_at
+  ) ORDER BY l.tickets_count DESC NULLS LAST), '[]'::jsonb)
+  INTO v_zone_deltas
+  FROM latest l LEFT JOIN prior p ON p.zone = l.zone;
+
+  IF v_espn_team_id IS NOT NULL AND v_espn_league IS NOT NULL THEN
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+      'espn_event_id', espn_event_id, 'game_at_utc', game_at_utc,
+      'home_team_id', home_team_id, 'away_team_id', away_team_id,
+      'status_short', status_short,
+      'is_home', home_team_id = v_espn_team_id
+    ) ORDER BY game_at_utc), '[]'::jsonb)
+    INTO v_performer_espn FROM (
+      SELECT * FROM public.espn_event_date_lookup
+      WHERE espn_league = v_espn_league
+        AND (home_team_id = v_espn_team_id OR away_team_id = v_espn_team_id)
+        AND game_at_utc > now() - interval '1 day'
+      ORDER BY game_at_utc LIMIT 5
+    ) g;
+  END IF;
+  IF v_performer_espn IS NULL THEN
+    v_performer_espn := jsonb_build_object('hidden', true, 'reason',
+      CASE WHEN v_espn_team_id IS NULL THEN 'no_performer_espn_xref' ELSE 'no_upcoming_games' END);
+  END IF;
+
+  RETURN v_base || jsonb_build_object(
+    'v', 'v3',
+    'performer', v_performer,
+    'velocity', v_velocity,
+    'sg_broker_sales', v_sg_broker_sales,
+    'sg_listings_summary', v_sg_listings_summary,
+    'competing_events', v_competing_events,
+    'cross_source_orders', v_cross_source_orders,
+    'recent_listings', v_recent_listings,
+    'zone_deltas', v_zone_deltas,
+    'performer_espn_context', v_performer_espn
+  );
+END
+$function$;


### PR DESCRIPTION
## Summary

All DB migrations already applied to prod via MCP. This branch is FE + docs only — auto-deploys on merge to main.

- **SG discovery** (`199e201`) — matview-backed RPC: >11s timeout → 5ms. `mig 20260524120000` live.
- **Performer index** (`1ae894d`) — `espn_league`-scoped: 425 rows → 122, correct teams. `mig 20260524130000` live.
- **Event v2 fallback** (`5be3290`) — falls back to v2 RPC on any timeout, not just error code 42883.
- **v3 7d window** (`f6a4248`) — `sg_broker_sales` windowed to 7d, caps cold-dedup spike. `mig 20260524140000` live.
- **Favicon + version.json** (`78ee8e5`) — kills the `/favicon.ico` 404; version chip in topbar.
- **Chart Y-scale fix** (`aec4f40`) — clips outliers so the trading band is readable.
- **LLM analysis layer spec** (`0eb4a1e`) — `docs/d0_llm_analysis_layer_spec.md`.
- **terminal-analyst skill** (`7064ab8`) — `.claude/skills/terminal-analyst/` — read-only LLM force-multiplier grounded on exact terminal figures.
- **Write policy** (`1165861`) — write/action layer recorded as explicit future goal (OFF now; human-approves-every-write when it ships).

## Test plan

- [ ] SG discovery panel loads in <100ms (was timing out)
- [ ] Performer index shows correct league-scoped teams (122 not 425)
- [ ] Event page falls back to v2 gracefully when v3 is slow
- [ ] Favicon appears in browser tab; no more 404 in console
- [ ] Version chip visible in topbar
- [ ] Chart Y-scale not distorted by outlier prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)
