### PR TITLE
fix(d1/store): seat-map "null"-string renders broken image on event pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -4976,6 +4976,23 @@ def _is_tbd(name: str | None) -> bool:
     )
 
 
+def _clean_opt_url(v) -> str | None:
+    """Coerce sentinel non-URLs to real None.
+
+    `v_event_seating_chart` (and occasionally TEvo's inline config) carry the
+    literal string "null" / "None" / "" for an absent seat-map URL. Passed
+    through verbatim, the frontend treats the truthy string "null" as a URL
+    and renders a broken <img> whose src resolves to /store/event/null. Coerce
+    those sentinels to None so the no-chart placeholder path is taken.
+    """
+    if v is None:
+        return None
+    s = str(v).strip()
+    if s.lower() in ("null", "none", ""):
+        return None
+    return v
+
+
 def _search_cache_get(key: str) -> dict | None:
     hit = _search_cache.get(key)
     if not hit:
@@ -7096,11 +7113,15 @@ def _resolve_event_with_filters(event_id: int, filters: dict, include_inactive: 
                 # /v9/events/:id response.
                 "id": asset_bundle.get("configuration_id") or config.get("id"),
                 "name": asset_bundle.get("configuration_name") or config.get("name"),
+                # _clean_opt_url BEFORE the `or` so a sentinel "null" in
+                # asset_bundle doesn't shadow a real URL from the live config.
                 "seating_chart_medium": (
-                    asset_bundle.get("seating_chart_medium") or seating.get("medium")
+                    _clean_opt_url(asset_bundle.get("seating_chart_medium"))
+                    or _clean_opt_url(seating.get("medium"))
                 ),
                 "seating_chart_large": (
-                    asset_bundle.get("seating_chart_large") or seating.get("large")
+                    _clean_opt_url(asset_bundle.get("seating_chart_large"))
+                    or _clean_opt_url(seating.get("large"))
                 ),
                 # fanvenues_key — opaque ID for TEvo's seatmaps-client.js
                 # interactive seat picker. Surfaced so a future enhancement

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -2027,7 +2027,18 @@
       // 2-column event-body grid keeps its left column (without the placeholder
       // the listings reflow into the empty space, jumping content around at
       // the 760px breakpoint). Per D1 UX audit 2026-05-12 fix #3.
-      const map = event.configuration?.seating_chart_medium || event.configuration?.seating_chart_large;
+      // Defensive: v_event_seating_chart / TEvo sometimes carry the literal
+      // string "null" (or "none"/"") for an absent chart. Treat those as no
+      // map so we don't set <img src="null"> (a broken image resolving to
+      // /store/event/null). Backend also coerces these, but guard here too
+      // in case a stale-cached payload slips through.
+      const cleanMapUrl = (v) => {
+        if (!v) return null;
+        const s = String(v).trim().toLowerCase();
+        return (s === "null" || s === "none" || s === "undefined" || s === "") ? null : v;
+      };
+      const map = cleanMapUrl(event.configuration?.seating_chart_medium)
+        || cleanMapUrl(event.configuration?.seating_chart_large);
       const mapHost = seatMap.parentElement; // the <aside class="map">
       if (map) {
         seatMap.src = map;

--- a/tests/test_store_events.py
+++ b/tests/test_store_events.py
@@ -282,3 +282,27 @@ def test_reserve_upstream_error_does_not_leak_tevo(client, monkeypatch):
     # path (app.py:7345), the cached ticket_groups helper (6812), and
     # /api/store/events/near (6384). reserve is the representative public
     # case; the other two are identical scrubs.
+
+
+# ---------- seat-map "null"-string coercion (broken-image bug) ----------
+
+def test_clean_opt_url_coerces_null_sentinels():
+    """v_event_seating_chart / TEvo carry the literal string 'null' for an
+    absent seat-map URL. _clean_opt_url must coerce 'null'/'none'/'' (any
+    case, with whitespace) to real None so the frontend takes the no-chart
+    placeholder path instead of rendering <img src="null"> (a broken image
+    resolving to /store/event/null). Found live on event 3091432
+    (Tigers @ Yankees): configuration.seating_chart_medium == 'null'."""
+    f = app_module._clean_opt_url
+    # sentinels → None
+    assert f("null") is None
+    assert f("NULL") is None
+    assert f("  null  ") is None
+    assert f("none") is None
+    assert f("") is None
+    assert f("   ") is None
+    assert f(None) is None
+    # real URLs pass through untouched
+    assert f("https://s3.amazonaws.com/chart/medium.jpg") == "https://s3.amazonaws.com/chart/medium.jpg"
+    # a string that merely contains "null" is NOT a sentinel
+    assert f("https://x/nullsville.jpg") == "https://x/nullsville.jpg"


### PR DESCRIPTION
## Summary
Live FE QA (Chrome DevTools) on `/store/event/3091432` (Tigers @ Yankees) found a **broken seating-chart image** on the event page: `<img id="seatMap" src="null">`, `naturalWidth=0`, visible — plus a failed request to `/store/event/null` on every event lacking a seat-map.

**Root cause:** `/api/store/events/{id}` returns `configuration.seating_chart_medium == "null"` — the **literal string** (sourced from `v_event_seating_chart`, occasionally TEvo's inline config). The frontend's `map = …seating_chart_medium || …seating_chart_large` treats the truthy string `"null"` as a URL → sets `src="null"` → broken image instead of the existing "Seating chart unavailable" placeholder.

Verified live:
```json
"configuration": {"id":53,"name":"Baseball","seating_chart_medium":"null","seating_chart_large":"null","fanvenues_key":null}
```

## Fix (both D1-lane layers)
- **Backend** — new `_clean_opt_url()` coerces `"null"`/`"none"`/`""` (any case, trimmed) → real `None`, applied **before** the `or` so a sentinel in `asset_bundle` can't shadow a real URL from the live config.
- **Frontend** — `cleanMapUrl()` guard in `store.js` mirrors it, so a stale-cached payload carrying `"null"` still takes the placeholder path.

## Upstream note
The literal `"null"` lives in `v_event_seating_chart` (A1-owned view) — a data-quality issue. Coercing in the D1 endpoint is the correct consumer-side defense; flagging the view to A1 separately.

## Test plan
- [x] `pytest tests/test_store_events.py -q` — 13 passing (+1 `_clean_opt_url` unit)
- [x] `node --check store.js` + `ast.parse app.py`
- [ ] Post-deploy: `/store/event/3091432` → no broken image; left column shows "Seating chart unavailable for this venue." placeholder; no `/store/event/null` request in Network tab
- [ ] An event WITH a real chart still renders it (regression)

Found during the live FE testing pass. Reserve modal focus-trap (#328), home grid, Featured rail, holiday labels, and clean console all verified working in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)