### PR TITLE
feat(d1/store): home grid UX bundle — header + NYC-first + skeleton + copy

### DIFF
--- a/static/store/index.html
+++ b/static/store/index.html
@@ -70,6 +70,7 @@
            slider with its own header; empty sections are hidden. -->
       <div id="moversSections" class="movers-sections" hidden></div>
       <div id="status" class="status" aria-live="polite">Loading available events…</div>
+      <h2 id="gridHeading" class="grid-heading" hidden>All events</h2>
       <div id="grid" class="grid" hidden></div>
       <div id="empty" class="empty" hidden>
         No events match. Try a broader search, or clear the box to see all.

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -351,6 +351,7 @@
     const input = $("#q");
     const status = $("#status");
     const grid = $("#grid");
+    const gridHeading = $("#gridHeading");
     const empty = $("#empty");
     // Suggest dropdown DOM + state — declared early so functions that
     // reference them (hideSuggest/wireSuggestDropdown/scheduleSuggest)
@@ -385,6 +386,7 @@
       status.hidden = true;
       if (!events.length) {
         grid.hidden = true;
+        if (gridHeading) gridHeading.hidden = true;
         empty.hidden = false;
         empty.textContent = mode === "search"
           ? "No events match. Try a broader search, or clear the box to see all."
@@ -393,6 +395,13 @@
       }
       empty.hidden = true;
       grid.hidden = false;
+      // Section header so the grid reads as distinct from the themed NYC
+      // rails above it (which carry their own titles). "Search results"
+      // when the grid is showing a query's matches, "All events" otherwise.
+      if (gridHeading) {
+        gridHeading.textContent = mode === "search" ? "Search results" : "All events";
+        gridHeading.hidden = false;
+      }
 
       for (const ev of events) {
         const a = document.createElement("a");

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -388,7 +388,7 @@
         empty.hidden = false;
         empty.textContent = mode === "search"
           ? "No events match. Try a broader search, or clear the box to see all."
-          : "No events with available inventory right now. Check back after the next collector run.";
+          : "No events available right now. Check back soon — we add inventory daily.";
         return;
       }
       empty.hidden = true;

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -380,6 +380,42 @@
     // produced silent no-op because the gate at searchAndRender bailed).
     let userHasSearched = false;
 
+    // Shimmer placeholder cards shown while the catalog loads. Static
+    // markup (no user data); aria-hidden so screen readers ignore them —
+    // the grid's aria-busy attr carries the loading semantics.
+    function renderSkeleton(n) {
+      grid.replaceChildren();
+      if (gridHeading) gridHeading.hidden = true;
+      empty.hidden = true;
+      for (let i = 0; i < n; i++) {
+        const sk = document.createElement("div");
+        sk.className = "card skeleton-card";
+        sk.setAttribute("aria-hidden", "true");
+        for (const c of ["sk-logo", "sk-when", "sk-name", "sk-where", "sk-meta"]) {
+          const bar = document.createElement("div");
+          bar.className = `sk-bar ${c}`;
+          sk.append(bar);
+        }
+        grid.append(sk);
+      }
+      grid.hidden = false;
+    }
+
+    // Stable partition that floats NYC-area events to the front while
+    // preserving the server's within-group order. Keeps the home grid
+    // coherent with the "…in NYC" rails without dropping national
+    // inventory (non-NYC events still follow). Word-boundary \bny\b also
+    // catches "…, NY"; "new york"/borough names cover the rest.
+    function nycFirst(events) {
+      const isNyc = (e) => {
+        const loc = String(e.venue_location || "").toLowerCase();
+        return /\bny\b|new york|bronx|brooklyn|flushing|queens|manhattan|staten island/.test(loc);
+      };
+      const nyc = [], rest = [];
+      for (const e of events) (isNyc(e) ? nyc : rest).push(e);
+      return nyc.concat(rest);
+    }
+
     function render(events, mode) {
       // mode: "all" (initial load) or "search" (after a query)
       grid.innerHTML = "";
@@ -669,15 +705,28 @@
       : `/api/store/events?${qs.toString()}`;
 
     function loadCatalog() {
-      status.textContent = "Loading available events…";
-      status.style.color = "";
-      status.hidden = false;
+      // Skeleton cards ARE the loading affordance now (replaces the plain
+      // "Loading…" text pill). On a cold Render dyno first paint can take
+      // ~12s; shimmer placeholders make that wait feel responsive instead
+      // of blank. aria-busy on the grid announces the load to screen
+      // readers; the skeleton cards themselves are aria-hidden.
+      status.hidden = true;
+      grid.setAttribute("aria-busy", "true");
+      renderSkeleton(8);
       // Reset gate — Retry re-fires this and we want the same race
       // protection on the second attempt.
       loadComplete = false;
       api(catalogEndpoint)
         .then((res) => {
+          grid.removeAttribute("aria-busy");
           allEvents = res.events || [];
+          // NYC-first ordering on the home view so the grid coheres with the
+          // "…in NYC" rails above it (the home endpoint returns owned events
+          // nationwide; without this the grid leads with Baltimore/Toronto/
+          // KC games while the rails say NYC). Stable partition — preserves
+          // the endpoint's within-group order. Filtered views keep server
+          // order. H2, 2026-05-25 UX audit.
+          if (isHomeView) allEvents = nycFirst(allEvents);
           loadComplete = true;
           renderCatalogFilterBanner(performerId, venueId, allEvents);
           // Don't clobber a backend search the user submitted while home
@@ -702,6 +751,10 @@
           // loadComplete stays false — filter() correctly bails out so a
           // user typing during error state doesn't see "No events match"
           // on top of the Retry-button error UI.
+          grid.removeAttribute("aria-busy");
+          grid.replaceChildren();   // clear skeleton cards
+          grid.hidden = true;
+          if (gridHeading) gridHeading.hidden = true;
           status.replaceChildren();
           status.style.color = "var(--bad)";
           status.hidden = false;

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -266,6 +266,33 @@ a { color: inherit; }
   gap: 12px;
   align-items: flex-start;
 }
+
+/* ----- Skeleton loading cards -----
+   Shown in the grid while the catalog loads (replaces the plain
+   "Loading…" text). Shimmer keyframe sweeps a light band across each bar
+   so the wait reads as "loading" not "broken". Respects reduced-motion. */
+.skeleton-card {
+  pointer-events: none;
+  gap: 10px;
+}
+.sk-bar {
+  background: linear-gradient(90deg, var(--panel-2) 25%, var(--line) 37%, var(--panel-2) 63%);
+  background-size: 400% 100%;
+  border-radius: 6px;
+  animation: sk-shimmer 1.4s ease-in-out infinite;
+}
+.sk-logo { width: 40px; height: 40px; border-radius: 6px; }
+.sk-when { width: 45%; height: 10px; margin-top: 4px; }
+.sk-name { width: 85%; height: 16px; }
+.sk-where { width: 60%; height: 12px; }
+.sk-meta { width: 100%; height: 28px; margin-top: 10px; }
+@keyframes sk-shimmer {
+  0%   { background-position: 100% 50%; }
+  100% { background-position: 0 50%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sk-bar { animation: none; }
+}
 .card-logo {
   width: 40px;
   height: 40px;

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -207,6 +207,18 @@ a { color: inherit; }
 
 /* ----- Catalog grid ----- */
 .results { margin-top: 8px; }
+/* Section header above the grid — delineates the "All events" / "Search
+   results" grid from the themed NYC rails above it (which each carry their
+   own title). Matches the rails' uppercase-muted treatment for visual
+   rhythm. */
+.grid-heading {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 18px 0 10px;
+}
 .status, .empty {
   padding: 24px;
   text-align: center;


### PR DESCRIPTION
## Summary
Four home-page UX-audit fixes (all pure FE, no backend, browse-only safe):

**H1 — "All events" / "Search results" grid header.** The 60-card grid had no title under the themed rails. Added `#gridHeading` ("All events" in browse / "Search results" on a query; hidden on empty).

**H2 — NYC-first grid order.** The home endpoint returns owned events *nationwide*, so the grid led with Baltimore/Toronto/KC while every rail said "…in NYC" (live: 48/60 non-NYC). `nycFirst()` stable-partitions NYC-area events to the front, preserving the server's within-group order — **no inventory dropped**, non-NYC events still follow. Home view only.

**H4 — loading skeleton.** 8 shimmer placeholder cards while `/api/store/home` loads (cold dyno first paint ~12s) instead of plain "Loading…" text. `grid[aria-busy]` for SR; skeletons `aria-hidden`; respects `prefers-reduced-motion`; error path clears them → existing Retry UI.

**H5 — consumer empty-state copy.** Dropped "…check back after the next collector run" → "No events available right now. Check back soon — we add inventory daily."

## Test plan
- [x] `node --check store.js`, HTML parses
- [x] `pytest tests/test_store_home.py tests/test_store_events.py -q` — 64 passing
- [ ] Live: cold load shows shimmer skeletons → real cards; grid leads with NYC (Yankees/Mets/Knicks) then national; "ALL EVENTS" header present; search → "SEARCH RESULTS"; empty → new copy

Companion to PR #335 (movers freshness gate, re-fills the empty rails) — together they address the full home-page UX audit. H2 grid scope chosen as **NYC-first sort** (keeps national inventory, reversible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)