### PR TITLE
fix(d4): 2 orphaned bug fixes — spinner + consent banner link

### DIFF
--- a/d4_bridge/src/components/ConsentBanner.tsx
+++ b/d4_bridge/src/components/ConsentBanner.tsx
@@ -6,6 +6,7 @@
 // "Decline" is sticky so the banner doesn't nag.
 
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { getConsent, setConsent } from '../lib/consent';
 
 export default function ConsentBanner() {
@@ -32,7 +33,7 @@ export default function ConsentBanner() {
         <p className="text-xs text-white/60 leading-relaxed flex-grow">
           We use analytics and marketing cookies to measure event reach. They
           load only if you accept. See our{' '}
-          <a href="/privacy" className="underline hover:text-white">privacy policy</a>.
+          <Link to="/privacy" className="underline hover:text-white">privacy policy</Link>.
         </p>
         <div className="flex gap-2 flex-shrink-0">
           <button

--- a/d4_bridge/src/views/EventDetails.tsx
+++ b/d4_bridge/src/views/EventDetails.tsx
@@ -46,7 +46,7 @@ export default function EventDetails() {
 
   useEffect(() => {
     async function fetchEvent() {
-      if (!id) return;
+      if (!id) { setLoading(false); return; }
       // Published events via the public view; fall back to the staff read so an
       // organizer can preview their own draft (RLS gates that to org staff).
       let data = await getPublicEvent(id);
@@ -110,7 +110,12 @@ export default function EventDetails() {
       }
       setLoading(false);
     }
-    fetchEvent();
+    // A thrown fetch (network/Supabase error) must still clear the spinner so
+    // the "Event not found" state renders instead of an infinite loader.
+    fetchEvent().catch((err) => {
+      console.warn('Event load failed:', err);
+      setLoading(false);
+    });
   }, [id, user]);
 
   // (Live per-tier sold/capacity subscription removed — phase-1 reads


### PR DESCRIPTION
## Summary

Two commits from `claude/d4-comprehensive-testing-wPECJ` were pushed ~1h40min after PR #323 was squash-merged and were never PRd. Cherry-picked clean onto main.

- **fix(d4): consent banner privacy link must respect the /bridge basename** — CSP/navigation bug where the privacy policy link in the consent banner resolved to the wrong path when the Bridge app was mounted under `/bridge`
- **fix(d4): EventDetails clears spinner on a failed event fetch** — loading spinner remained visible indefinitely on a failed fetch, blocking the UI

## Test plan
- [ ] Load Bridge app at `/bridge` — verify consent banner privacy link navigates correctly
- [ ] Simulate a failed event fetch (bad event ID or network error) — verify spinner clears and error state renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)