### PR TITLE
feat(d4): doors→show/end auto-fill (CreateEvent) + live FE test plan

### DIFF
--- a/d4_bridge/src/views/CreateEvent.tsx
+++ b/d4_bridge/src/views/CreateEvent.tsx
@@ -31,6 +31,25 @@ const SUBGENRE_MAX_LEN = 40;
 const SLUG_MAX = 80;
 const LOCATION_MAX = 200;
 
+// Doors→show and show→end default gaps used to auto-fill the show/end times
+// when the organizer sets doors first (both happen after doors open). These
+// are only applied to EMPTY fields, so a value the organizer typed is never
+// overwritten.
+const DOORS_TO_SHOW_MIN = 30;
+const SHOW_TO_END_MIN = 120;
+
+// Shift a `datetime-local` wall-clock string ('YYYY-MM-DDTHH:mm') by N minutes,
+// keeping it in the same local/wall-clock representation (the timezone
+// conversion to UTC happens later at submit via zonedWallClockToUtc). Returns
+// '' if the input can't be parsed.
+function shiftLocalDatetime(value: string, minutes: number): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  d.setMinutes(d.getMinutes() + minutes);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 // Optional Automatiq integration. The endpoint is not implemented yet, so we
 // gate the call behind an env flag — otherwise every event creation 404s and
 // writes a misleading `syncStatus: 'failed'` to the doc.
@@ -1065,7 +1084,30 @@ export default function CreateEvent() {
                       try { el.showPicker(); } catch { /* user-gesture errors are non-fatal */ }
                     }
                   }}
-                  onChange={(e) => setFormData({ ...formData, timing: { ...formData.timing, doorsOpen: e.target.value } })}
+                  onChange={(e) => {
+                    const doorsOpen = e.target.value;
+                    setFormData((prev) => {
+                      const next = { ...prev, timing: { ...prev.timing, doorsOpen } };
+                      // Auto-fill show + end (both happen after doors open), but
+                      // only when those fields are still empty — never clobber a
+                      // time the organizer already entered.
+                      if (doorsOpen) {
+                        if (!prev.timing.startTime && !prev.date) {
+                          const show = shiftLocalDatetime(doorsOpen, DOORS_TO_SHOW_MIN);
+                          if (show) {
+                            next.date = show;
+                            next.timing.startTime = show;
+                          }
+                        }
+                        const show = next.timing.startTime || next.date;
+                        if (!prev.timing.endTime && show) {
+                          const end = shiftLocalDatetime(show, SHOW_TO_END_MIN);
+                          if (end) next.timing.endTime = end;
+                        }
+                      }
+                      return next;
+                    });
+                  }}
                 />
               </div>
             </div>

--- a/docs/d4_live_fe_test_plan.md
+++ b/docs/d4_live_fe_test_plan.md
@@ -1,0 +1,51 @@
+# D4 / Bridge — live FE test plan (ticket lifecycle)
+
+**Purpose:** an executable, click-by-click test of the Bridge ticket lifecycle on the **live** site. Written because the Claude-on-the-web *sandbox* browser can't run it here (see "Environment prerequisite"); this plan is ready to run wherever the browser has network + an authenticated session.
+
+## Why this can't run from the D4 cloud sandbox
+The sandboxed Chromium (chrome-devtools MCP) is behind this environment's egress allowlist, which covers package registries + the git proxy + `localhost` only. Every app host returns **`Host not in allowlist`**:
+
+| Host | Purpose | Sandbox result |
+|---|---|---|
+| `*.up.railway.app` | Bridge shell (primary) | ❌ blocked |
+| `*.onrender.com` | Bridge shell (Render) | ❌ blocked |
+| `hzrizjeaxlqcxfrtczpq.supabase.co` | data + auth | ❌ blocked |
+
+D0/D1 ran their live Chrome-DevTools QA (PRs #330, #332) because **their** environments were provisioned with egress to these hosts. The server-side MCP tools reach Supabase (they run outside the sandbox); the browser does not.
+
+### Environment prerequisite (to run this in a sandbox)
+Provision the Claude-on-the-web environment with a network policy that allowlists `*.up.railway.app`, `*.onrender.com`, and `hzrizjeaxlqcxfrtczpq.supabase.co`
+(https://code.claude.com/docs/en/claude-code-on-the-web). **Even then**, signed-in steps need a session — the live app uses Supabase **Google OAuth**, which a headless browser can't complete. So:
+- **Public/browse steps (1, 6 view)** → runnable in an egress-enabled sandbox.
+- **Signed-in / data-editing steps (organizer + wallet + scan)** → run in **your own authenticated browser via Claude for Chrome**, where the OAuth session already exists.
+
+## Live URLs
+- Bridge (Railway primary): `https://glorious-appreciation-production-a6ce.up.railway.app/bridge/`
+- Bridge (Render): `https://vibepass-storefront-test.onrender.com/bridge/`
+- Organizer dashboard: `…/bridge/dashboard` · Create event: `…/bridge/create-event` · Scanner: `…/bridge/checkin/:eventId`
+
+## Test script — organizer + attendee lifecycle
+Run as an **organizer** account that owns (or can create) an org. Two browser profiles (or two accounts) make the transfer step realistic: **A = organizer**, **B = attendee**.
+
+| # | Actor | Action | Expected result |
+|---|---|---|---|
+| 1 | A | Sign in (Google) at `/bridge/`; open `/bridge/dashboard` | Dashboard loads; orgs listed; no console errors |
+| 2 | A | Create event (`/bridge/create-event`): title, date (tomorrow), venue, 1 tier, `total_tickets` + per-account limit | Saves; redirects to dashboard; event appears as **draft** |
+| 3 | A | Open the event in EditEvent → **Mark as published** | Banner flips to **published**; public `/event/:id` now loads it |
+| 4 | A | On the event page, use the admin **TEST mint** (or **issue ticket to email** = B's email) | Ticket minted; counter increments; mail queued |
+| 5 | A | `/my-tickets` → open the ticket → **wallet pass** | Rotating QR renders + refreshes (~30s bucket); ticket shows `active` |
+| 6 | A | From the ticket, **Transfer** → enter B's email; try to scan it now | Transfer pending; ticket **locked**; door scan → "in-transfer" refusal |
+| 7 | B | Open the claim link / `/claim/:id`; **Claim** | Ownership moves to B; B's `/my-tickets` shows it; A's no longer does |
+| 8 | A | (organizer) `/bridge/checkin/:eventId` → scan A's **old** screenshot QR | ❌ rejected (secret rotated on claim — screenshot is dead) |
+| 9 | A | Scan **B's** current wallet QR | ✅ admitted; ticket → `used`; appears in the lane's checked-in list |
+| 10 | A | Scan the same ticket again | ❌ "used" (double-scan blocked) |
+| 11 | A | Mint a 2nd ticket → **void/refund** it → scan it | ❌ "voided" |
+| 12 | — | Marketing: accept the cookie banner; confirm org pixels load (Network: `fbevents.js`/`gtag`/TikTok) only **after** accept; socials render on `/o/:slug` | Consent gate honored; pixels fire post-consent; social links present |
+
+### What to capture at each step
+- Console: zero uncaught errors (the recently-fixed spinner + consent-link bugs are regression guards).
+- Network: data calls hit `…supabase.co/rest/v1/…` with 2xx; no `Host not in allowlist`.
+- The barcode payload format `T-{ticketId}:{ownerId}:{bucket}:{hmac}` and its ~30s rotation.
+
+## Backend cross-check (already done, in this sandbox)
+Every transition above is verified at the SQL/RPC layer on a branch — 41/41 scenarios + the full single-ticket lifecycle (mint→wallet→transfer→claim/rotate→scan→double-scan→void) all green. So a live failure here points at an **FE wiring/UX** issue, not backend logic.


### PR DESCRIPTION
Clean rebase of PR #337 (closed — had timestamp-colliding migrations + 27 stale commits already in main via #323).

## Changes (2 files, net new vs main)

### 1. `d4_bridge/src/views/CreateEvent.tsx` — doors-open auto-fill
When organizer sets **doors-open**, default show→doors+30m and end→show+2h. Only fills **empty** fields — typed values never overwritten. Pure wall-clock math; tz→UTC conversion at submit is unchanged.

- Doors `19:00`, show/end empty → show `19:30`, end `21:30`
- Doors set after show already entered → show preserved, only empty end filled
- Everything pre-filled, doors changed → nothing clobbered

`tsc` + `vite build` green. Needs Bridge rebuild → deploy to reach `/bridge`.

### 2. `docs/d4_live_fe_test_plan.md` — live FE test plan
12-step lifecycle test for the live site, hosts to allowlist for egress, OAuth/sign-in routing note. Backend 41/41 ✅; FE steps need an egress-enabled authenticated browser.

## Test plan
- [ ] Live: set doors-open → show/end auto-fill; editing show/end then changing doors doesn't clobber
- [ ] Execute lifecycle steps 1–12 in egress-enabled / authenticated browser

Closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)