### PR TITLE
fix(d4): mobile door scanner camera (Permissions-Policy + FE) + wallet QR timer

### DIFF
--- a/d4_bridge/src/views/OrganizerCheckIn.tsx
+++ b/d4_bridge/src/views/OrganizerCheckIn.tsx
@@ -11,7 +11,7 @@ import {
 import { Ticket, Event } from '../types';
 import { Search, CheckCircle2, XCircle, ArrowLeft, Loader2, User, Camera, ScanLine, Download, Wifi, WifiOff, RefreshCw } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import { Html5QrcodeScanner } from 'html5-qrcode';
+import { Html5Qrcode } from 'html5-qrcode';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import { verifyBarcode, extractTicketIdFromAny } from '../lib/barcode';
@@ -100,7 +100,7 @@ export default function OrganizerCheckIn() {
   const [syncing, setSyncing] = useState(false);
   const [pendingUpdates, setPendingUpdates] = useState<string[]>([]);
   const [recentScans, setRecentScans] = useState<{ id: string, name: string, time: Date, status: string }[]>([]);
-  const scannerRef = useRef<Html5QrcodeScanner | null>(null);
+  const scannerRef = useRef<Html5Qrcode | null>(null);
   const wasOfflineRef = useRef(isOffline);
 
   useEffect(() => {
@@ -159,9 +159,7 @@ export default function OrganizerCheckIn() {
     return () => {
       window.removeEventListener('online', handleSyncStatus);
       window.removeEventListener('offline', handleSyncStatus);
-      if (scannerRef.current) {
-        scannerRef.current.clear().catch(console.error);
-      }
+      void stopScanner();
     };
   }, [eventId]);
 
@@ -194,37 +192,69 @@ export default function OrganizerCheckIn() {
     }
   };
 
+  // Tear down the live camera scanner safely. stop() rejects if the camera
+  // isn't actively running, so guard on state and swallow that case.
+  const stopScanner = async () => {
+    const s = scannerRef.current;
+    scannerRef.current = null;
+    if (!s) return;
+    try {
+      if (s.isScanning) await s.stop();
+    } catch {
+      /* not scanning / already stopped */
+    }
+    try {
+      s.clear();
+    } catch {
+      /* element already torn down */
+    }
+  };
+
   const startScanner = () => {
     setScanning(true);
     setStatus('idle');
-    
-    // Use a small delay to ensure the container is rendered
-    setTimeout(() => {
-      const scanner = new Html5QrcodeScanner(
-        "reader",
-        {
-          fps: 10,
-          qrbox: { width: 250, height: 250 },
-          // Show the device's flashlight toggle when the camera supports
-          // it — invaluable at dim-lit doors. Same with the zoom slider
-          // for far-away wallet QR codes.
-          showTorchButtonIfSupported: true,
-          showZoomSliderIfSupported: true,
-        },
-        /* verbose= */ false
-      );
-      
-      scanner.render((decodedText) => {
-        setSearchId(decodedText);
-        handleCheckIn(undefined, decodedText);
-        scanner.clear().catch(console.error);
+
+    // Defer one tick so the #reader container is in the DOM, then open the
+    // back camera DIRECTLY (facingMode: environment). The previous
+    // Html5QrcodeScanner widget required a second "Request Camera / Start"
+    // tap that often never activated the camera on phones, and its fixed
+    // 250px qrbox threw on narrow viewports (video < box) — both fixed here.
+    setTimeout(async () => {
+      try {
+        const html5Qr = new Html5Qrcode('reader');
+        scannerRef.current = html5Qr;
+        await html5Qr.start(
+          { facingMode: 'environment' },
+          {
+            fps: 10,
+            // Responsive box: 70% of the smaller video dimension, so it
+            // never exceeds the camera frame on small phones.
+            qrbox: (vw: number, vh: number) => {
+              const m = Math.floor(Math.min(vw, vh) * 0.7);
+              return { width: m, height: m };
+            },
+          },
+          (decodedText: string) => {
+            setSearchId(decodedText);
+            handleCheckIn(undefined, decodedText);
+            void stopScanner();
+            setScanning(false);
+          },
+          () => {
+            /* per-frame decode miss — ignore */
+          },
+        );
+      } catch (err) {
+        console.error('Camera start failed:', err);
+        toast({
+          kind: 'error',
+          message:
+            'Could not open the camera. Allow camera access for this site in your browser settings, or type the ticket ID below to check in.',
+        });
+        scannerRef.current = null;
         setScanning(false);
-      }, (error) => {
-        // Silently fail on non-detection
-      });
-      
-      scannerRef.current = scanner;
-    }, 100);
+      }
+    }, 50);
   };
 
   /**
@@ -837,8 +867,8 @@ export default function OrganizerCheckIn() {
               <div id="reader" className="w-full rounded-2xl border-2 border-indigo-100 overflow-hidden"></div>
               <button
                 onClick={() => {
+                  void stopScanner();
                   setScanning(false);
-                  if (scannerRef.current) scannerRef.current.clear();
                 }}
                 aria-label="Stop the QR code scanner"
                 className="mt-4 w-full py-4 text-[10px] font-bold uppercase tracking-widest text-slate-400 hover:text-slate-900 transition-colors"

--- a/d4_bridge/src/views/TicketDetail.tsx
+++ b/d4_bridge/src/views/TicketDetail.tsx
@@ -80,57 +80,63 @@ export default function TicketDetail() {
     fetchData();
   }, [id, user]);
 
+  // Depend on the current ticket's PRIMITIVE fields, not the whole array, so a
+  // refetch that replaces `tickets` with equal-id objects doesn't re-run this
+  // and reset the countdown. The QR is always valid (derived from wall-clock),
+  // but the visible timer was misleadingly resetting.
+  const td_id = tickets[currentIndex]?.id;
+  const td_secret = tickets[currentIndex]?.barcodeSecret;
+  const td_uid = user?.uid;
   useEffect(() => {
-    const currentTicket = tickets[currentIndex];
-    if (!currentTicket || !user) return;
-
+    if (!td_id || !td_uid) return;
     let cancelled = false;
+    let lastBucket = -1;
 
     // Sign the barcode for the current 30-second bucket. The HMAC binds
-    // ticketId + ownerId + bucket against the per-ticket secret stored
-    // on the ticket doc — see lib/barcode.ts. Without a per-ticket
-    // secret (legacy tickets created before this rollout), we fall back
-    // to the unsigned 3-segment shape and the organizer-side verifier
-    // tolerates it as `legacy: true`.
+    // ticketId + ownerId + bucket against the per-ticket secret (lib/barcode.ts).
+    // Legacy tickets without a secret fall back to the unsigned 3-segment shape.
     const refresh = async () => {
-      const secret = currentTicket.barcodeSecret;
       const bucket = currentBucket();
-      if (secret) {
+      lastBucket = bucket;
+      if (td_secret) {
         try {
-          const signed = await signBarcode(currentTicket.id, user.uid, secret, bucket);
-          if (!cancelled) {
-            setBarcode(signed);
-            setTimeLeft(30);
-          }
+          const signed = await signBarcode(td_id, td_uid, td_secret, bucket);
+          if (!cancelled) setBarcode(signed);
           return;
         } catch (err) {
-          // SubtleCrypto only fails in pathological browser configs.
           console.warn('Falling back to legacy unsigned barcode:', err);
         }
       }
-      // Legacy / fallback path.
-      if (!cancelled) {
-        setBarcode(`T-${currentTicket.id}:${user.uid}:${bucket}`);
-        setTimeLeft(30);
-      }
+      if (!cancelled) setBarcode(`T-${td_id}:${td_uid}:${bucket}`);
     };
 
-    refresh();
-    const interval = setInterval(() => {
-      setTimeLeft((prev) => {
-        if (prev <= 1) {
-          refresh();
-          return 30;
-        }
-        return prev - 1;
-      });
-    }, 1000);
+    const tick = () => {
+      if (cancelled) return;
+      // Wall-clock countdown — accurate across re-renders + background-tab
+      // timer throttling (a naive decrement drifts when the tab is hidden).
+      const secs = 30 - (Math.floor(Date.now() / 1000) % 30);
+      setTimeLeft(secs === 0 ? 30 : secs);
+      if (currentBucket() !== lastBucket) void refresh();
+    };
+
+    void refresh();
+    const interval = setInterval(tick, 1000);
+    // Re-issue immediately on tab-return so a throttled background timer never
+    // leaves a stale (expired-bucket) QR on screen at the door.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void refresh();
+        tick();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
 
     return () => {
       cancelled = true;
       clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
     };
-  }, [tickets, currentIndex, user]);
+  }, [td_id, td_secret, td_uid]);
 
   const nextTicket = () => {
     if (currentIndex < tickets.length - 1) {

--- a/d4_bridge/src/views/WalletPass.tsx
+++ b/d4_bridge/src/views/WalletPass.tsx
@@ -73,44 +73,58 @@ export default function WalletPass() {
   // the signed payload at every bucket boundary using the per-ticket
   // secret. Falls back to the legacy unsigned format for tickets that
   // don't carry a secret (organizer scanner tolerates them as legacy).
+  // Depend on the primitive ticket fields, NOT the whole `ticket` object: the
+  // 15s poll above replaces `ticket` with a fresh (equal-id) object every tick,
+  // which previously re-ran this effect and reset the countdown to 30 — the
+  // "switching tabs / waiting resets the timer" behavior. The QR was always
+  // valid (it's derived from wall-clock), but the visible timer was misleading.
+  const ticketId2 = ticket?.id;
+  const barcodeSecret = ticket?.barcodeSecret;
+  const uid = user?.uid;
   useEffect(() => {
-    if (!ticket || !user) return;
+    if (!ticketId2 || !uid) return;
     let cancelled = false;
+    let lastBucket = -1;
     const refresh = async () => {
-      const secret = ticket.barcodeSecret;
       const bucket = currentBucket();
-      if (secret) {
+      lastBucket = bucket;
+      if (barcodeSecret) {
         try {
-          const signed = await signBarcode(ticket.id, user.uid, secret, bucket);
-          if (!cancelled) {
-            setBarcode(signed);
-            setTimeLeft(30);
-          }
+          const signed = await signBarcode(ticketId2, uid, barcodeSecret, bucket);
+          if (!cancelled) setBarcode(signed);
           return;
         } catch (err) {
           console.warn('Falling back to legacy unsigned barcode:', err);
         }
       }
-      if (!cancelled) {
-        setBarcode(`T-${ticket.id}:${user.uid}:${bucket}`);
-        setTimeLeft(30);
-      }
+      if (!cancelled) setBarcode(`T-${ticketId2}:${uid}:${bucket}`);
+    };
+    const tick = () => {
+      if (cancelled) return;
+      // Wall-clock countdown — accurate across re-renders and background-tab
+      // timer throttling (a naive decrement drifts when the tab is hidden).
+      const secs = 30 - (Math.floor(Date.now() / 1000) % 30);
+      setTimeLeft(secs === 0 ? 30 : secs);
+      // Re-sign when the 30s bucket actually rolls over.
+      if (currentBucket() !== lastBucket) void refresh();
     };
     void refresh();
-    const interval = setInterval(() => {
-      setTimeLeft((prev) => {
-        if (prev <= 1) {
-          void refresh();
-          return 30;
-        }
-        return prev - 1;
-      });
-    }, 1000);
+    const interval = setInterval(tick, 1000);
+    // Re-issue immediately on return to the tab: a throttled background timer
+    // can otherwise leave a stale (expired-bucket) QR on screen at the door.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        void refresh();
+        tick();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
     return () => {
       cancelled = true;
       clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
     };
-  }, [ticket, user]);
+  }, [ticketId2, barcodeSecret, uid]);
 
   // Best-effort screen wake lock. Keeps the screen awake while the
   // holder is showing this page at the door. Falls through silently


### PR DESCRIPTION
Re-land of the orphaned scanner/timer FE fix, **plus the actual root-cause fix** for "camera never prompts" found during live phone testing.

## 0. ⚠️ Cross-lane: `app.py` Permissions-Policy (D1/shell lane — needs D1/A1 review)
**This is the real reason the scanner camera "doesn't ask for permission."** The unified shell's `_SecurityHeadersMiddleware` set `Permissions-Policy: …camera=()` on **every** response — which makes the browser block `getUserMedia` on `/bridge/` and never even show a permission prompt. Scoped `camera=(self)` to `/bridge/*` only; storefront + terminal stay `camera=()`. One conditional, no other header/route touched. (`d4_bridge/server.ts` already used `camera=(self)`, but on Railway the `app.py` shell serves `/bridge/`, so its header wins.)

## 1. Camera scanner opens the back camera on mobile (`OrganizerCheckIn`)
The `Html5QrcodeScanner` widget needed a second "request/start" tap that often never activated the camera, **and** its fixed `250×250` qrbox throws when the phone video is narrower than that. Switched to `Html5Qrcode.start({ facingMode: 'environment' })` (opens the back camera directly) with a **responsive qrbox** + a clear permission-denied/manual-entry fallback. (~40 KB smaller QR bundle.)

## 2. Wallet QR timer (`WalletPass` + `TicketDetail`)
Countdown reset on tab-switch / every 15s poll (effect depended on the whole `ticket` object the poll replaces). Now keyed on primitive `id/secret/uid`, wall-clock-accurate, re-signs only on bucket rollover, and refreshes on `visibilitychange` so a returned-to tab never shows a stale/expired QR.

## Test plan
- [x] `tsc` + `vite build` green; `app.py` parses
- [ ] Phone (after deploy): tap "Open Camera Scanner" → **permission prompt appears** → back camera opens + scans; denied → error + manual entry
- [ ] Wallet QR: countdown smooth, no reset on tab-switch; background→return shows fresh QR
- [ ] Regression: storefront/terminal still send `camera=()`

FE needs a Bridge rebuild→deploy; the `app.py` header ships with the Railway shell deploy.

https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk