### PR TITLE
fix(shell): allow camera on /bridge so the door scanner can prompt (re-land)

### DIFF
--- a/app.py
+++ b/app.py
@@ -481,7 +481,17 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
         response.headers.setdefault("X-Frame-Options", "DENY")
-        response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+        # Permissions-Policy: deny powerful features by default. The Bridge
+        # surface (/bridge/*) hosts the organizer door scanner, which needs
+        # getUserMedia — without camera=(self) here the browser blocks the
+        # camera and never even prompts for permission. Scope the allowance to
+        # /bridge only; storefront/terminal stay camera=().
+        if request.url.path.startswith("/bridge"):
+            response.headers.setdefault(
+                "Permissions-Policy", "geolocation=(), microphone=(), camera=(self)")
+        else:
+            response.headers.setdefault(
+                "Permissions-Policy", "geolocation=(), microphone=(), camera=()")
         # HSTS: tell browsers to upgrade to HTTPS for this host for 2y +
         # include subdomains. Render terminates TLS at the proxy so the
         # response is always HTTPS-served regardless of how we send it.


### PR DESCRIPTION
## The fix that actually unblocks the door-scanner camera

During live phone testing the scanner showed "Could not open the camera." The FE scanner rewrite (PR #339) is deployed, but `getUserMedia` still throws because the unified shell sends **`Permissions-Policy: …camera=()` on every response** — `camera=()` disables the camera even for same-origin, so the browser blocks it **and never shows a permission prompt**. `Html5Qrcode.start()` then rejects → the fallback toast.

This scopes `camera=(self)` to **`/bridge/*`** only (the organizer door scanner); storefront + terminal stay `camera=()`.

### Why a separate PR
The identical change was pushed to PR #339's branch **after #339 had already merged** (which merged FE-only), so it was orphaned and never reached `main`. Re-landing clean off current `main`.

## ⚠️ Cross-lane
`app.py` is the D1/shell lane — flagging for D1/A1 review. One conditional in `_SecurityHeadersMiddleware`; only the camera feature for `/bridge` is loosened, no other surface/route/header affected. `app.py` parses.

## Test plan
- [ ] After Railway shell deploy: `curl -I https://…/bridge/` → `Permissions-Policy: …camera=(self)`; `curl -I https://…/store` → still `camera=()`
- [ ] Phone: tap "Open Camera Scanner" → **OS camera-permission prompt appears** → grant → back camera opens + scans
- [ ] Storefront/terminal camera stays disabled (regression)

https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk)_