### PR TITLE
feat(d4): wallet QR reads "ENTERED" after a door scan

### DIFF
--- a/d4_bridge/src/views/TicketDetail.tsx
+++ b/d4_bridge/src/views/TicketDetail.tsx
@@ -229,10 +229,10 @@ export default function TicketDetail() {
                     {currentTicket.status === 'used' ? (
                        <div className="absolute inset-0 flex flex-col items-center justify-center z-30">
                           <div className="bg-red-600 text-white px-8 py-3 font-black text-2xl uppercase italic tracking-tighter -rotate-12 shadow-2xl skew-x-12">
-                             REDEEMED
+                             ENTERED
                           </div>
                           <p className="text-black font-black text-[10px] uppercase tracking-widest mt-4 bg-white px-3 py-1">
-                             {currentTicket.checkInDate ? formatInTz(currentTicket.checkInDate.toDate(), event.timezone, { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' }) : 'SCAN VERIFIED'}
+                             {currentTicket.checkInDate ? `Scanned ${formatInTz(currentTicket.checkInDate.toDate(), event.timezone, { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' })}` : 'SCANNED'}
                           </p>
                        </div>
                     ) : currentTicket.status === 'voided' ? (

--- a/d4_bridge/src/views/WalletPass.tsx
+++ b/d4_bridge/src/views/WalletPass.tsx
@@ -12,7 +12,7 @@
 //
 // Status semantics — the QR is muted and the page shows a clear stamp
 // when the ticket is:
-//   * status === 'used'      → REDEEMED (already scanned)
+//   * status === 'used'      → ENTERED (scanned in at the door)
 //   * status === 'voided'    → REFUNDED (organizer revoked / refunded)
 //   * pendingTransferId set  → IN TRANSFER (mid-flight to a recipient)
 // The same checks happen server-side at the door scanner — this UI
@@ -190,16 +190,16 @@ export default function WalletPass() {
       }
     : isUsed
     ? {
-        text: 'REDEEMED',
+        text: 'ENTERED',
         sub:
           ticket.checkInDate && event
-            ? formatInTz(ticket.checkInDate.toDate(), event.timezone, {
+            ? `Scanned ${formatInTz(ticket.checkInDate.toDate(), event.timezone, {
                 hour: '2-digit',
                 minute: '2-digit',
                 month: 'short',
                 day: 'numeric',
-              })
-            : 'SCAN VERIFIED',
+              })}`
+            : 'SCANNED',
         cls: 'bg-red-600',
       }
     : isInTransfer


### PR DESCRIPTION
## Summary
From live testing: after a ticket is scanned at the door, the holder's QR should clearly **read as entered/scanned** when the pass refreshes.

Both `TicketDetail` and `WalletPass` already mute the QR + show a stamp when `status === 'used'`, and that refreshes on the 15s poll / `visibilitychange`. The only gap was the **wording** — it said **"REDEEMED"**. Renamed to **"ENTERED"** with a **"Scanned &lt;time&gt;"** subline (fallback "SCANNED").

- `TicketDetail` (in-app ticket carousel) and `WalletPass` (lock-screen pass) both updated.
- Wording only — the mute + auto-refresh behavior is unchanged.

## Test plan
- [x] `tsc` + `vite build` green
- [ ] Live (after Bridge redeploy): scan a ticket → on the holder's open pass, within ~15s (or on tab-return) the QR greys out and the stamp reads **ENTERED** / **Scanned &lt;time&gt;**; a hard refresh shows the same

FE-only; needs a Bridge rebuild→deploy.

https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk)_