### PR TITLE
fix(d4): block transfer of used tickets + Inside Venue shows scanned-in count

### DIFF
--- a/d4_bridge/src/lib/tickets.ts
+++ b/d4_bridge/src/lib/tickets.ts
@@ -296,6 +296,18 @@ export async function listEventCheckins(eventId: string): Promise<CheckinRow[]> 
   }));
 }
 
+// Count of tickets scanned in (checked in) for an event = "inside venue".
+// One row per check-in in exos_event_checkins (the flip is one-shot), so a
+// head count is the authoritative attendance number. Org-staff RLS gated.
+export async function countEventCheckins(eventId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('exos_event_checkins')
+    .select('*', { count: 'exact', head: true })
+    .eq('event_id', eventId);
+  if (error) throw error;
+  return count ?? 0;
+}
+
 export interface ScanRejectRow {
   id: string;
   reason: string;

--- a/d4_bridge/src/views/OrganizerCheckIn.tsx
+++ b/d4_bridge/src/views/OrganizerCheckIn.tsx
@@ -6,6 +6,7 @@ import {
   listEventTicketsForRegistry,
   checkInTicket,
   recordScanReject,
+  countEventCheckins,
   type ScanTicket,
 } from '../lib/tickets';
 import { Ticket, Event } from '../types';
@@ -100,6 +101,10 @@ export default function OrganizerCheckIn() {
   const [syncing, setSyncing] = useState(false);
   const [pendingUpdates, setPendingUpdates] = useState<string[]>([]);
   const [recentScans, setRecentScans] = useState<{ id: string, name: string, time: Date, status: string }[]>([]);
+  // "Inside venue" = tickets actually scanned in (exos_event_checkins count),
+  // NOT tickets sold. Seeded on mount; refreshed by the realtime channel below
+  // as scans land (this lane + others).
+  const [insideVenue, setInsideVenue] = useState(0);
   const scannerRef = useRef<Html5Qrcode | null>(null);
   const wasOfflineRef = useRef(isOffline);
 
@@ -381,8 +386,20 @@ export default function OrganizerCheckIn() {
         saveRegistry(eventId, next);
         return next;
       });
+      // A check-in landed (this lane or another) — refresh the attendance count.
+      countEventCheckins(eventId).then(setInsideVenue).catch(() => {});
     });
     return () => ch.leave();
+  }, [eventId]);
+
+  // Seed "inside venue" on mount (the realtime channel keeps it live after).
+  useEffect(() => {
+    if (!eventId) return;
+    let cancelled = false;
+    countEventCheckins(eventId)
+      .then((n) => { if (!cancelled) setInsideVenue(n); })
+      .catch(() => {/* non-fatal */});
+    return () => { cancelled = true; };
   }, [eventId]);
 
   // On reconnect, re-pull the registry: Realtime doesn't replay check-ins other
@@ -1022,7 +1039,7 @@ export default function OrganizerCheckIn() {
       <div className="grid grid-cols-2 gap-4 mb-12">
          <div className="bg-slate-900 p-6 rounded-3xl text-center">
             <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest mb-1">Inside Venue</p>
-            <p className="text-2xl font-bold text-white">{event.ticketsSold}</p>
+            <p className="text-2xl font-bold text-white">{insideVenue}</p>
          </div>
          <div className="bg-slate-50 p-6 rounded-3xl text-center border border-slate-100">
             <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest mb-1">Total Authorized</p>

--- a/d4_bridge/src/views/TicketDetail.tsx
+++ b/d4_bridge/src/views/TicketDetail.tsx
@@ -358,13 +358,37 @@ export default function TicketDetail() {
                         <Share2 className="w-4 h-4 text-brand-primary" />
                         <span>SHARE</span>
                       </button>
-                      <Link
-                        to={`/transfer/${currentTicket.id}`}
-                        className="bg-white/5 border border-white/10 text-white/50 py-5 font-black uppercase tracking-tighter italic text-xs flex items-center justify-center space-x-3 hover:border-white hover:text-white transition-all"
-                      >
-                        <Send className="w-4 h-4 text-brand-primary" />
-                        <span>TRANSFER</span>
-                      </Link>
+                      {currentTicket.status === 'active' && !(currentTicket as any).pendingTransferId ? (
+                        <Link
+                          to={`/transfer/${currentTicket.id}`}
+                          className="bg-white/5 border border-white/10 text-white/50 py-5 font-black uppercase tracking-tighter italic text-xs flex items-center justify-center space-x-3 hover:border-white hover:text-white transition-all"
+                        >
+                          <Send className="w-4 h-4 text-brand-primary" />
+                          <span>TRANSFER</span>
+                        </Link>
+                      ) : (
+                        // Only an unused, unlocked ticket can be transferred —
+                        // a scanned-in (used), refunded (voided), or already-
+                        // pending ticket shows TRANSFER disabled with the reason.
+                        // The server enforces the same (exos_create_transfer
+                        // requires status='active'); this is the UX mirror.
+                        <button
+                          type="button"
+                          disabled
+                          aria-disabled="true"
+                          title={
+                            currentTicket.status === 'used'
+                              ? "Already scanned in — used tickets can't be transferred"
+                              : currentTicket.status === 'voided'
+                              ? "Refunded tickets can't be transferred"
+                              : 'A transfer is already pending for this ticket'
+                          }
+                          className="bg-white/[0.02] border border-white/5 text-white/20 py-5 font-black uppercase tracking-tighter italic text-xs flex items-center justify-center space-x-3 cursor-not-allowed"
+                        >
+                          <Send className="w-4 h-4 text-white/20" />
+                          <span>TRANSFER</span>
+                        </button>
+                      )}
                     </div>
                  </div>
               </div>


### PR DESCRIPTION
Two fixes from live testing.

## 1. Block transfer of scanned/used tickets (UI)
Only an **unused, unlocked** ticket should be transferable. `TicketDetail` previously always showed a live TRANSFER link, so a used (scanned-in), voided (refunded), or already-pending ticket let you start a transfer that the server then rejects. Now TRANSFER renders **disabled with the reason** for those states.

**Security note:** the server already enforces this — `exos_create_transfer` requires `status='active'` (verified on prod: `guards_active_status = true`). So this is the UX mirror, not the enforcement; a used ticket could never actually transfer.

## 2. "Inside Venue" = scanned-in count, not tickets sold
The check-in screen showed `event.ticketsSold` (tickets **bought**) under "Inside Venue." Replaced with the real attendance number:
- New `countEventCheckins(eventId)` — a head-count on `exos_event_checkins` (one row per check-in; the flip is one-shot, so it's authoritative). Org-staff RLS-gated.
- Seeded on mount and **refreshed by the existing realtime check-in channel** as scans land (this lane + other lanes), so the counter stays live during the door rush.

## Test plan
- [x] `tsc` + `vite build` green
- [ ] Live (after Bridge redeploy): a used ticket shows TRANSFER greyed/disabled with a tooltip; an active one still transfers
- [ ] "Inside Venue" starts at the current scanned count and increments by 1 per scan (≈1s realtime latency), never showing the sold total

FE-only (+ one read-only lib helper); needs a Bridge rebuild→deploy.

https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk)_