### PR TITLE
feat(d4): complete Stripe backend — refunds + buyer ticket email (dormant)

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -84,6 +84,30 @@ Deno.serve(async (req: Request): Promise<Response> => {
         }
         break;
       }
+      case "charge.refunded": {
+        // Full refund of a paid order -> void its tickets + free inventory.
+        // Map the charge back to our session via the stored payment_intent.
+        const charge = event.data.object as Stripe.Charge;
+        const pi = typeof charge.payment_intent === "string"
+          ? charge.payment_intent
+          : charge.payment_intent?.id;
+        if (pi) {
+          const { data: sess } = await sb.from("exos_checkout_sessions")
+            .select("session_id").eq("payment_intent", pi).maybeSingle();
+          if (sess?.session_id) {
+            const { error } = await sb.rpc("exos_refund_checkout", {
+              p_session_id: sess.session_id,
+              p_reason: "stripe refund",
+            });
+            if (error) {
+              // 500 -> Stripe retries; exos_refund_checkout is idempotent.
+              console.error(`stripe-webhook: refund handling failed for ${sess.session_id}`, error);
+              return new Response("refund handling error", { status: 500 });
+            }
+          }
+        }
+        break;
+      }
       default:
         break; // ignore unhandled event types
     }

--- a/supabase/migrations/20260523170000_exos_stripe_checkout.sql
+++ b/supabase/migrations/20260523170000_exos_stripe_checkout.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS public.exos_checkout_sessions (
   amount_cents  int  NOT NULL CHECK (amount_cents >= 0),
   currency      text NOT NULL DEFAULT 'usd',
   status        text NOT NULL DEFAULT 'pending'
-                  CHECK (status IN ('pending','fulfilled','failed','expired')),
+                  CHECK (status IN ('pending','fulfilled','failed','expired','refunded')),
   ticket_ids    uuid[],
   payment_intent text,
   failure_reason text,
@@ -76,6 +76,8 @@ DECLARE
   v_updated  int;
   v_ids      uuid[] := '{}';
   v_id       uuid;
+  v_evname   text;
+  v_safe     text;
   i          int;
 BEGIN
   -- Lock the session row so concurrent webhook retries serialize.
@@ -140,6 +142,33 @@ BEGIN
      SET status='fulfilled', ticket_ids=v_ids, fulfilled_at=now()
    WHERE session_id = p_session_id;
 
+  -- Notify the buyer their paid tickets are ready. Recipient is server-derived
+  -- from the session (no client-supplied address); body is tag-escaped. Uses
+  -- the same 'ticket-issued' template the comp/issue path queues. Best-effort —
+  -- the drainer sends it; a mail hiccup must not unwind a paid fulfillment.
+  IF coalesce(s.buyer_email, '') <> '' THEN
+    SELECT name INTO v_evname FROM public.exos_events WHERE id = s.event_id;
+    v_safe := replace(replace(coalesce(v_evname, 'your event'), '<', '&lt;'), '>', '&gt;');
+    BEGIN
+      INSERT INTO public.exos_mail (template, to_email, subject, html, created_by, status)
+      VALUES (
+        'ticket-issued', lower(s.buyer_email),
+        left('Your ticket' || CASE WHEN s.quantity > 1 THEN 's' ELSE '' END ||
+             ' for ' || v_safe || ' ' || CASE WHEN s.quantity > 1 THEN 'are' ELSE 'is' END || ' ready', 200),
+        '<p>Payment received — your ' || s.quantity::text || ' ticket' ||
+          CASE WHEN s.quantity > 1 THEN 's' ELSE '' END ||
+          ' for <strong>' || v_safe ||
+          '</strong> ' || CASE WHEN s.quantity > 1 THEN 'are' ELSE 'is' END ||
+          ' in your wallet. Open the app to show your QR at the door.</p>',
+        s.buyer_uid, 'pending'
+      );
+    EXCEPTION WHEN others THEN
+      -- e.g. the 'ticket-issued' template predates this on a partial schema;
+      -- never fail a paid mint over a confirmation email.
+      NULL;
+    END;
+  END IF;
+
   RETURN v_ids;
 END $$;
 REVOKE ALL ON FUNCTION public.exos_fulfill_checkout(text) FROM PUBLIC, anon, authenticated;
@@ -175,3 +204,60 @@ BEGIN
 END $$;
 REVOKE ALL ON FUNCTION public.exos_record_org_stripe(uuid, text, boolean, boolean) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION public.exos_record_org_stripe(uuid, text, boolean, boolean) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 4. Refund a fulfilled checkout. Called by the webhook (service_role) on
+--    charge.refunded. Voids the session's still-ACTIVE tickets and frees their
+--    inventory back (decrements tier.sold + event.tickets_sold by the number
+--    actually voided). Idempotent: a second call after the session is already
+--    'refunded' is a no-op. Already-USED (scanned-in) tickets are left as-is —
+--    a holder who entered isn't auto-voided by a refund event; that's a manual
+--    decision. Partial refunds (a subset of a multi-ticket order) are out of
+--    scope for v1 — a full charge refund voids the whole order.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.exos_refund_checkout(
+  p_session_id text,
+  p_reason     text DEFAULT 'refunded'
+) RETURNS int
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  s     public.exos_checkout_sessions%ROWTYPE;
+  v_n   int := 0;
+  r     record;
+BEGIN
+  SELECT * INTO s FROM public.exos_checkout_sessions WHERE session_id = p_session_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'exos_refund_checkout: unknown session %', p_session_id;
+  END IF;
+  IF s.status = 'refunded' THEN
+    RETURN 0;  -- already refunded (webhook retry / double event)
+  END IF;
+
+  -- Void the session's active tickets; free inventory per voided ticket.
+  FOR r IN
+    UPDATE public.exos_tickets
+       SET status = 'voided', voided_at = now(),
+           voided_reason = left(coalesce(p_reason, 'refunded'), 500)
+     WHERE order_ref = p_session_id AND status = 'active'
+    RETURNING tier_id
+  LOOP
+    v_n := v_n + 1;
+    IF r.tier_id IS NOT NULL THEN
+      UPDATE public.exos_ticket_tiers SET sold = greatest(0, sold - 1) WHERE id = r.tier_id;
+    END IF;
+  END LOOP;
+
+  IF v_n > 0 THEN
+    UPDATE public.exos_events SET tickets_sold = greatest(0, tickets_sold - v_n) WHERE id = s.event_id;
+  END IF;
+
+  UPDATE public.exos_checkout_sessions
+     SET status = 'refunded', failure_reason = left(coalesce(p_reason, 'refunded'), 500)
+   WHERE session_id = p_session_id;
+
+  RETURN v_n;
+END $$;
+REVOKE ALL ON FUNCTION public.exos_refund_checkout(text, text) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.exos_refund_checkout(text, text) TO service_role;


### PR DESCRIPTION
Completes the **Stripe backend** (D4-OPS-7). It was already scaffolded — idempotent `exos_fulfill_checkout`, signature-verified `stripe-webhook`, `exos-checkout` (auth + caps + per-account limit + Connect destination charge + app fee), `exos-connect-onboard`, and the `lib/checkout` seams. This closes the two real production gaps, keeping everything **dormant / keys-gated** per the free-first decision.

## What's added
1. **Buyer ticket email on fulfillment.** `exos_fulfill_checkout` now queues a `ticket-issued` mail to the buyer after minting — recipient server-derived from the session, body tag-escaped, wrapped in an exception block so a mail hiccup can never unwind a paid mint. (Closes the handoff doc's TODO.)
2. **Refunds.** New `exos_refund_checkout(session_id, reason)` (service_role) voids the order's still-**active** tickets and **frees inventory** (decrements `tier.sold` + `event.tickets_sold` by the count voided); idempotent; leaves already-scanned tickets untouched. Wired into `stripe-webhook` on `charge.refunded` (maps `charge.payment_intent` → session). Added `'refunded'` to the session status CHECK. Partial refunds are out of scope for v1 (full charge refund voids the order).

## Still dormant (unchanged by this PR)
No keys, **not applied, not deployed** — free-first excludes payments.

## Activation checklist (operator + A1, when going paid)
- Operator: finalize Connect account type + charge model + `EXOS_PLATFORM_FEE_BPS`; set `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`.
- A1: **branch-validate** then apply mig `20260523170000`; deploy `exos-checkout` / `exos-connect-onboard` / `stripe-webhook` (`--no-verify-jwt`); add **`charge.refunded`** (+`checkout.session.completed`, `account.updated`) to the webhook endpoint's event list.
- FE: wire the Buy button (`startCheckout`) + org "Set up payments" (`startStripeOnboarding`) — seams exist in `lib/checkout.ts`.
- B1: review the paid-mint + refund surface.

## Test plan
- [ ] Branch-validate the migration (full exos schema) — `exos_fulfill_checkout` mints + queues mail once; retry is idempotent; `exos_refund_checkout` voids active tickets, frees inventory, idempotent on re-call.
- [ ] No Deno locally → edge fns reviewed, validated at deploy.

⚠️ Not branch-validated here (dormant scaffold; validated at apply-time per the handoff doc).

https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk)_