### PR TITLE
feat(evo): decrypt TEvo Fernet encrypted_barcode (read-side)

### DIFF
--- a/evo_client.py
+++ b/evo_client.py
@@ -87,6 +87,45 @@ class EvoClient:
         ).digest()
         return base64.b64encode(digest).decode("utf-8")
 
+    # ---------- barcode decryption (read-side; /v9/orders, /v9/listings) ----------
+
+    def decrypt_barcode(self, encrypted_barcode: str) -> str:
+        """Decrypt a TEvo Fernet-encrypted ``encrypted_barcode`` field.
+
+        Per the TEvo docs, the barcode is Fernet-encrypted and the key is the
+        first 32 chars of the API-credential secret, base64url-encoded. This is
+        purely a READ-side decode of data we already fetched — no upstream
+        write — so it's within the read-only-upstream rule.
+
+        ``cryptography`` is imported lazily so this module still loads (and the
+        rest of the read pipeline keeps working) on a host where the optional
+        dependency isn't installed; only calling this method requires it.
+
+        Raises ValueError on a malformed/forged token or a too-short secret,
+        RuntimeError if the dependency is missing.
+        """
+        try:
+            from cryptography.fernet import Fernet, InvalidToken
+        except ImportError as e:  # pragma: no cover - dep-present in deploy
+            raise RuntimeError(
+                "decrypt_barcode requires the 'cryptography' package "
+                "(add it to requirements.txt / the deploy image)"
+            ) from e
+        if len(self._secret) < 32:
+            raise ValueError(
+                "API secret is shorter than 32 bytes — cannot derive the Fernet key"
+            )
+        # Key = base64url(first 32 bytes of the secret). self._secret is the
+        # raw secret bytes (set in __init__).
+        key = base64.urlsafe_b64encode(self._secret[:32])
+        try:
+            token = encrypted_barcode.encode("utf-8") if isinstance(encrypted_barcode, str) else encrypted_barcode
+            # ttl=None: these tokens are issued by TEvo, not us, and don't expire
+            # on a clock we control — verify integrity, not freshness.
+            return Fernet(key).decrypt(token).decode("utf-8")
+        except InvalidToken as e:
+            raise ValueError("invalid or forged encrypted_barcode (Fernet verification failed)") from e
+
     @staticmethod
     def _normalize(params: dict | None) -> dict:
         """Drop None values, stringify bools to TEvo's 'true'/'false'."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,7 @@ defusedxml>=0.7.1,<1.0
 # (Windows dev, slim Docker images). Needed by d2_dashboard's metrics endpoint
 # for the "today" window which anchors on America/New_York. Tiny (~330 KB).
 tzdata>=2026.2,<2027.0
+# cryptography — Fernet decryption of TEvo encrypted_barcode fields
+# (/v9/orders, /v9/listings) in evo_client.decrypt_barcode. Imported lazily so
+# the broker read-pipeline still loads if the dep is absent on a given host.
+cryptography>=42.0,<46.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tzdata>=2026.2,<2027.0
 # cryptography — Fernet decryption of TEvo encrypted_barcode fields
 # (/v9/orders, /v9/listings) in evo_client.decrypt_barcode. Imported lazily so
 # the broker read-pipeline still loads if the dep is absent on a given host.
-cryptography>=42.0,<46.0
+cryptography>=46.0.5,<49.0  # >=46.0.5 clears GHSA-r6ph-v2qm-q3c2 (SECT curve subgroup attack, HIGH)

--- a/tests/test_evo_barcode.py
+++ b/tests/test_evo_barcode.py
@@ -1,0 +1,63 @@
+"""EvoClient.decrypt_barcode — TEvo Fernet barcode decryption (read-side).
+
+Validates the documented recipe: the barcode is Fernet-encrypted and the key
+is base64url(first 32 chars of the API secret). We encrypt with that exact
+recipe, then assert the client decrypts back to the plaintext.
+"""
+
+import base64
+
+import pytest
+
+from evo_client import EvoClient
+
+# >= 32 chars so the key derivation is valid (Fernet needs a 32-byte key).
+SECRET = "32_CHARS_LONG_EXAMPLE_API_SECRET"  # exactly 32
+assert len(SECRET) >= 32
+
+
+def _encrypt(plaintext: str, secret: str = SECRET) -> str:
+    """Encrypt the way TEvo documents it, so the round-trip is faithful."""
+    from cryptography.fernet import Fernet
+
+    key = base64.urlsafe_b64encode(secret.encode("utf-8")[:32])
+    return Fernet(key).encrypt(plaintext.encode("utf-8")).decode("utf-8")
+
+
+def _client(secret: str = SECRET) -> EvoClient:
+    # token is only used for signing live calls; decrypt_barcode doesn't need it.
+    return EvoClient(token="unused-token", secret=secret)
+
+
+def test_decrypt_barcode_roundtrip():
+    barcode = "723917860"
+    token = _encrypt(barcode)
+    assert _client().decrypt_barcode(token) == barcode
+
+
+def test_decrypt_barcode_longer_secret_uses_first_32_chars():
+    # A secret longer than 32 chars must key off the first 32 only.
+    long_secret = SECRET + "EXTRA_TRAILING_BYTES_IGNORED"
+    key = base64.urlsafe_b64encode(long_secret.encode("utf-8")[:32])
+    from cryptography.fernet import Fernet
+
+    token = Fernet(key).encrypt(b"primary_99").decode("utf-8")
+    assert _client(long_secret).decrypt_barcode(token) == "primary_99"
+
+
+def test_decrypt_barcode_forged_token_raises():
+    with pytest.raises(ValueError):
+        _client().decrypt_barcode("gAAAAABnot_a_real_token_obviously_invalid==")
+
+
+def test_decrypt_barcode_wrong_secret_raises():
+    token = _encrypt("723917860", secret=SECRET)
+    other = "DIFFERENT_32_CHAR_SECRET_VALUE!!"  # 32 chars, different key
+    assert len(other) >= 32
+    with pytest.raises(ValueError):
+        _client(other).decrypt_barcode(token)
+
+
+def test_decrypt_barcode_short_secret_raises():
+    with pytest.raises(ValueError):
+        _client("too-short").decrypt_barcode("anything")


### PR DESCRIPTION
## Summary
TEvo's `/v9/orders` and `/v9/listings` return barcodes **Fernet-encrypted**; the key is `base64url(first 32 chars of the API-credential secret)`. Adds `EvoClient.decrypt_barcode()` implementing exactly that recipe.

- **Read-side only** — decodes data we already fetched; no upstream write (within the read-only-upstream rule).
- **Lazy import** of `cryptography` inside the method, so the broker read-pipeline (and `app.py`, which imports `evo_client`) still loads if the dep is absent on a host; only *calling* the method needs it.
- Adds `cryptography>=42,<46` to `requirements.txt` (Fernet = AES-128-CBC + HMAC; there's no stdlib path).
- `tests/test_evo_barcode.py`: round-trip, first-32-chars key derivation, forged/wrong-secret → `ValueError`, too-short-secret guard.

## ⚠️ Flags (please review before merge)
1. **Cross-lane:** `evo_client.py` + `requirements.txt` are the broker/shared lane, not D4 — flagging for that owner + A1.
2. **New native dependency** (`cryptography`) with build/deploy impact. **I could not import-validate it in the sandbox** (`_cffi_backend` missing here) — **CI `pytest` is the validation** (it installs requirements + runs the round-trip).
3. **No consumer wired yet** — this is just the decryption primitive. Open question: where should decrypted barcodes surface (a D1/D2 fulfillment/orders path)? `evo_client` doesn't currently expose a `/v9/orders` read method.

## Test plan
- [ ] CI `pytest tests/test_evo_barcode.py` green (validates the dep installs + the recipe round-trips)
- [ ] Confirm `cryptography` is acceptable in the Python service image
- [ ] Decide the consuming surface for decrypted barcodes

https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNYzQ8KVsFj9RKVXHxj7Jk)_