### PR TITLE
fix(p1): 4 critical bugs — URL corruption, TEvo param, scanner FK, Switch Profile

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ def _build_storefront_base_url() -> str:
         return render_url.rstrip("/")
     railway_dom = os.environ.get("RAILWAY_PUBLIC_DOMAIN")
     if railway_dom:
-        dom = railway_dom.strip().lstrip("https://").lstrip("http://")
+        dom = railway_dom.strip().removeprefix("https://").removeprefix("http://")
         return f"https://{dom}"
     return "https://vibepass-storefront-test.onrender.com"
 

--- a/d4_bridge/src/views/ClaimTicket.tsx
+++ b/d4_bridge/src/views/ClaimTicket.tsx
@@ -28,7 +28,7 @@ import { useToast } from '../context/ToastContext';
 
 export default function ClaimTicket() {
   const { transferId } = useParams();
-  const { user } = useAuth();
+  const { user, logout, openAuthModal } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
   const [transfer, setTransfer] = useState<Transfer | null>(null);
@@ -211,7 +211,13 @@ export default function ClaimTicket() {
                 This asset is registered for <strong>{transfer.receiverEmail}</strong>, but you are
                 identified as <strong>{user.email}</strong>.
               </p>
-              <button className="text-red-900 font-bold text-xs uppercase tracking-widest hover:underline">
+              <button
+                className="text-red-900 font-bold text-xs uppercase tracking-widest hover:underline"
+                onClick={async () => {
+                  await logout();
+                  openAuthModal();
+                }}
+              >
                 Switch Profile
               </button>
             </div>

--- a/evo_client.py
+++ b/evo_client.py
@@ -455,7 +455,9 @@ class EvoClient:
     ) -> dict[str, Any]:
         """GET /v9/performers/:id — Show. include_opponents=True adds
         a list of opponent teams (sports only)."""
-        params = {"include": True} if include_opponents else None
+        # TEvo array-style param: include[]=opponents (Python True would serialize
+        # as "True" which the API ignores; bracket notation is the correct form)
+        params = {"include[]": "opponents"} if include_opponents else None
         return self._get(f"/v9/performers/{performer_id}", params)
 
     # ========== Venues ==========

--- a/supabase/migrations/20260526020000_fix_checkins_scanned_by_nullable.sql
+++ b/supabase/migrations/20260526020000_fix_checkins_scanned_by_nullable.sql
@@ -1,0 +1,18 @@
+-- Migration: fix_checkins_scanned_by_nullable
+-- Author: A1
+-- Date: 2026-05-26
+-- Description: Fix NOT NULL + ON DELETE SET NULL contradiction on
+--   exos_event_checkins.scanned_by. The column was declared:
+--     scanned_by uuid NOT NULL REFERENCES auth.users (id) ON DELETE SET NULL
+--   This is self-contradictory: Postgres cannot SET NULL on a NOT NULL column.
+--   Any auth.users deletion that references an existing check-in row fails with
+--   a FK constraint violation. Fix: drop NOT NULL so SET NULL can work.
+-- Downstream: auth user deletion no longer errors for users who performed scans.
+--   Existing check-in rows are unchanged. scanned_by may be NULL going forward
+--   only if the scanner user is deleted — scanner identity is preserved for
+--   active users.
+-- Rollback: ALTER TABLE exos_event_checkins ALTER COLUMN scanned_by SET NOT NULL;
+--   (Only safe if no scanner-deleted rows exist)
+
+ALTER TABLE public.exos_event_checkins
+  ALTER COLUMN scanned_by DROP NOT NULL;


### PR DESCRIPTION
## Summary

Four P1 bugs from the full deep audit, all independently verified:

| File | Bug | Fix |
|---|---|---|
| `app.py:99` | `lstrip("https://")` strips individual characters — domains containing `h`,`t`,`p`,`s` get corrupted | `removeprefix("https://").removeprefix("http://")` |
| `evo_client.py:458` | `{"include": True}` — Python `True` serializes to string `"True"`, not a valid TEvo param | `{"include[]": "opponents"}` (bracket-array form TEvo expects) |
| `ClaimTicket.tsx:214` | "Switch Profile" button has no `onClick` — user with wrong account can never escape the conflict screen | `onClick={async () => { await logout(); openAuthModal(); }}` |
| `mig 20260526020000` | `exos_event_checkins.scanned_by` declared `NOT NULL` + `ON DELETE SET NULL` — mutually contradictory; any auth user deletion of a scanner user fails | Drop `NOT NULL` on `scanned_by` |

## Details

### `app.py` — URL base-URL corruption (Railway)
`str.lstrip(chars)` removes any combination of the given *characters* from the left, not the literal prefix string. A Railway domain like `"ssl-east.railway.app"` would have `s`, `l`, `-`, `e`, `a`, `t` stripped (any char in the string `"https://"`) producing a corrupted domain. Only affects Railway deploys (`RAILWAY_PUBLIC_DOMAIN` set); Render is unaffected. `removeprefix()` (Python 3.9+, we run 3.12) is the correct fix — it removes only if the full prefix matches.

### `evo_client.py` — TEvo `include_opponents` silently broken
Python `True` serializes to `"True"` in URL query strings via `requests` (or `httpx`). TEvo's API expects `include[]=opponents`. The endpoint appeared to work (no 4xx) but returned performer data without opponents. All callers relying on `include_opponents=True` were silently getting partial data.

### `ClaimTicket.tsx` — stuck "wrong user" state
When a ticket transfer is addressed to email A but the current user is signed in as email B, the conflict screen renders with a "Switch Profile" button. Without `onClick`, clicking it does nothing. The only escape was manual browser navigation. Fixed: `logout()` signs out the current session, `openAuthModal()` immediately prompts sign-in as the correct account.

### `exos_event_checkins.scanned_by` — schema contradiction
`NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL` is self-contradictory in every Postgres version. When an `auth.users` row is deleted, Postgres attempts to SET the FK column to NULL — but the NOT NULL constraint blocks it, causing the user deletion to fail with a foreign key violation. Since scanner identity is audit-optional (the check-in record should survive user deletion), dropping NOT NULL is correct.

## Test plan

- [ ] Apply `20260526020000_fix_checkins_scanned_by_nullable.sql` via `apply_migration`
- [ ] `app.py` — set `RAILWAY_PUBLIC_DOMAIN=ssl-east.railway.app` locally, confirm `_build_storefront_base_url()` returns `https://ssl-east.railway.app` (not mangled)
- [ ] `evo_client.py` — call `get_performer(id, include_opponents=True)`, confirm request URL contains `include%5B%5D=opponents` not `include=True`
- [ ] `ClaimTicket.tsx` — sign in as wrong user, navigate to `/claim/:id`, confirm "Switch Profile" triggers auth modal
- [ ] `exos_event_checkins` — `DELETE FROM auth.users WHERE id = <scanner_user_id>` should succeed and set `scanned_by = NULL` on affected rows

## No rebuild required for D4
These TSX changes are source-only. The static bundle (`static/bridge/`) needs a rebuild after merge — coordinate with D0 for the next bundle push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
