### PR TITLE
fix(crons): fix 3 broken pg_cron jobs (SELECT→PERFORM, chunk+timeout)

### DIFF
--- a/supabase/migrations/20260526000000_fix_broken_crons.sql
+++ b/supabase/migrations/20260526000000_fix_broken_crons.sql
@@ -1,0 +1,46 @@
+-- Migration: fix_broken_crons
+-- Author: A1
+-- Date: 2026-05-26
+-- Description: Fix 3 broken crons that fail every run:
+--   midnight-catchup-sweep (SELECT→PERFORM),
+--   weather_climatology_weekly (2x SELECT→PERFORM),
+--   listings_aq_backfill_overnight (chunk size 100→25 + 3min timeout)
+-- Downstream: none
+-- Rollback: cron.schedule() with original body
+
+-- ============================================================
+-- 1. midnight-catchup-sweep — SELECT → PERFORM in DO block
+--    Root: midnight_catchup_sweep() returns rows; SELECT inside a DO block
+--          requires an INTO target or must be PERFORM.
+--    Schedule: 0 8 * * * (rescheduled from 0 0 * * * in 20260513185058)
+-- ============================================================
+SELECT cron.schedule(
+  'midnight-catchup-sweep',
+  '0 8 * * *',
+  $cmd$DO $body$ BEGIN IF NOT public.cron_should_fire('midnight-catchup-sweep') THEN RETURN; END IF; SET LOCAL statement_timeout = '5min'; PERFORM public.midnight_catchup_sweep(); END $body$;$cmd$
+);
+
+-- ============================================================
+-- 2. weather_climatology_weekly — 2× SELECT → PERFORM in DO block
+--    Root: weather_historical_backfill_outdoor() and weather_historical_process()
+--          return rows; SELECT inside a DO block requires INTO or PERFORM.
+--    Schedule: 0 6 * * 0 (unchanged)
+-- ============================================================
+SELECT cron.schedule(
+  'weather_climatology_weekly',
+  '0 6 * * 0',
+  $cmd$DO $body$ BEGIN PERFORM weather_historical_retry_throttled(20); PERFORM weather_historical_backfill_outdoor((current_date - interval '3 years')::date, (current_date - interval '1 day')::date, 10); PERFORM weather_historical_process(); END $body$;$cmd$
+);
+
+-- ============================================================
+-- 3. listings_aq_backfill_overnight — chunk 100 → 25 + 3min timeout
+--    Root: match_unmatched_listings_chunked(100, true) consistently exceeds
+--          the default 120s statement timeout. Smaller chunk + explicit timeout
+--          lets each firing complete within its cron slot.
+--    Schedule: 2-14 4 * * * (unchanged)
+-- ============================================================
+SELECT cron.schedule(
+  'listings_aq_backfill_overnight',
+  '2-14 4 * * *',
+  $cmd$DO $$ DECLARE v_remaining int; BEGIN SET LOCAL statement_timeout = '3min'; SELECT max(events_remaining) INTO v_remaining FROM public.match_unmatched_listings_chunked(25, true); IF coalesce(v_remaining, 0) = 0 THEN PERFORM cron.unschedule('listings_aq_backfill_overnight'); END IF; END $$;$cmd$
+);


### PR DESCRIPTION
## Summary

- **midnight-catchup-sweep**: `SELECT public.midnight_catchup_sweep()` → `PERFORM` inside DO block. Function returns rows; `SELECT` with no `INTO` destination is a PL/pgSQL error. Schedule kept as `0 8 * * *` (rescheduled in 20260513185058).
- **weather_climatology_weekly**: Two `SELECT` calls (`weather_historical_backfill_outdoor` and `weather_historical_process`) → `PERFORM` inside DO block. Same root cause. Schedule unchanged (`0 6 * * 0`).
- **listings_aq_backfill_overnight**: Added `SET LOCAL statement_timeout = '3min'` and reduced chunk arg `100 → 25`. `match_unmatched_listings_chunked(100, true)` consistently blows the 120s default. Smaller chunk fits within each cron slot. Schedule unchanged (`2-14 4 * * *`).

## Migration

`supabase/migrations/20260526000000_fix_broken_crons.sql` — uses `cron.schedule()` (upsert semantics) to replace each broken command in place.

## Test plan

- [ ] Apply migration to branch/staging and confirm `cron.job_run_details` shows `succeeded` for all three jobs on next fire
- [ ] Confirm `midnight-catchup-sweep` fires at 08:00 UTC and completes without error
- [ ] Confirm `weather_climatology_weekly` fires Sunday 06:00 UTC and all three weather functions execute
- [ ] Confirm `listings_aq_backfill_overnight` fires in the 04:02–04:14 UTC window and completes within 3 min per firing

https://claude.ai/code/session_01KMobGBj5AigLCDQisKm3Uv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMobGBj5AigLCDQisKm3Uv)_