### PR TITLE
fix(p2): 6 medium bugs — rate limiter bypass, scanner race, sync loop, clone, TZ, N+1 RPCs

### DIFF
--- a/app.py
+++ b/app.py
@@ -599,7 +599,14 @@ class _RateLimitMiddleware(BaseHTTPMiddleware):
         xff = request.headers.get("x-forwarded-for") or ""
         ip = (xff.split(",")[0].strip() if xff else (request.client.host if request.client else "unknown")) or "unknown"
         n, w = self._bucket(path)
-        if not _ip_limiter.check(f"{ip}|{path}", n, w):
+        # Key is ip + bucket-prefix, NOT the full path. Using the raw path lets
+        # a bot cycle resource IDs (e.g. /api/store/events/1, /2, …) to get a
+        # fresh bucket per resource and bypass the per-IP cap entirely.
+        bucket_key = next(
+            (pfx for pfx, _, _ in self._BUCKETS if path.startswith(pfx)),
+            "*",
+        )
+        if not _ip_limiter.check(f"{ip}|{bucket_key}", n, w):
             return JSONResponse(
                 {"error": "rate limited", "retry_after_seconds": int(w)},
                 status_code=429,

--- a/d4_bridge/src/views/CreateEvent.tsx
+++ b/d4_bridge/src/views/CreateEvent.tsx
@@ -192,12 +192,19 @@ export default function CreateEvent() {
   // don't want the empty initial state to immediately overwrite a saved
   // draft on mount.
   const [autosaveReady, setAutosaveReady] = useState(false);
-  const restoredRef = useRef(false);
+  // Two separate refs instead of one:
+  //   draftCheckDoneRef — "have we run the draft check?" (prevents double run)
+  //   draftAppliedRef   — "did the user actually restore a saved draft?"
+  // Using a single ref for both purposes caused clone hydration to always be
+  // skipped: the draft-check effect set restoredRef=true unconditionally (even
+  // when no draft was found), so the clone condition always bailed early.
+  const draftCheckDoneRef = useRef(false);
+  const draftAppliedRef = useRef(false);
 
   // Restore-or-discard prompt on first paint.
   useEffect(() => {
-    if (restoredRef.current) return;
-    restoredRef.current = true;
+    if (draftCheckDoneRef.current) return;
+    draftCheckDoneRef.current = true;
     try {
       const raw = localStorage.getItem(draftKey);
       if (!raw) {
@@ -217,6 +224,7 @@ export default function CreateEvent() {
           setFormData((prev) => ({ ...prev, ...saved.formData }));
           setTicketTiers(saved.ticketTiers);
           if (Array.isArray(saved.promoCodes)) setPromoCodes(saved.promoCodes);
+          draftAppliedRef.current = true;  // only set when user confirmed
         } else {
           localStorage.removeItem(draftKey);
         }
@@ -252,7 +260,9 @@ export default function CreateEvent() {
   //     for published / cancelled events) — admins can clone drafts they
   //     have access to via the same rule.
   useEffect(() => {
-    if (!cloneFromId || restoredRef.current) return;
+    // Wait for draft check to complete (autosaveReady flips in its finally).
+    // Skip clone if user already restored a draft — draft takes precedence.
+    if (!cloneFromId || !autosaveReady || draftAppliedRef.current) return;
     let cancelled = false;
     (async () => {
       try {
@@ -335,10 +345,11 @@ export default function CreateEvent() {
     return () => {
       cancelled = true;
     };
-    // We deliberately run this only when cloneFromId is first read; the
-    // restored-from-localStorage flow takes precedence if there's a draft.
+    // Re-run when autosaveReady flips so clone hydration starts AFTER the
+    // draft check completes. draftAppliedRef is a ref so it doesn't need to
+    // be in deps; checking it inside prevents double hydration.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cloneFromId]);
+  }, [cloneFromId, autosaveReady]);
 
   useEffect(() => {
     if (!autosaveReady) return;
@@ -578,21 +589,26 @@ export default function CreateEvent() {
     }
 
     // Timing: parse all three potential dates and verify ordering.
+    // Use zonedWallClockToUtc (same as submit) so the future-check is done in
+    // the EVENT's timezone, not the browser's. Without this a Tokyo organizer
+    // validating an 8pm NY show would compare against 8pm Tokyo time.
+    const tz = formData.timezone || getBrowserTimezone();
     const startTimeStr = formData.timing.startTime || formData.date;
     if (!startTimeStr) return 'Please set the show start time.';
-    const startMs = new Date(startTimeStr).getTime();
-    if (!Number.isFinite(startMs)) return 'Show start time is invalid.';
+    const startUtcDate = zonedWallClockToUtc(startTimeStr, tz);
+    if (!startUtcDate) return 'Show start time is invalid.';
+    const startMs = startUtcDate.getTime();
     if (startMs < Date.now()) return 'Show start time must be in the future.';
 
     if (formData.timing.doorsOpen) {
-      const doorsMs = new Date(formData.timing.doorsOpen).getTime();
-      if (!Number.isFinite(doorsMs)) return 'Doors-open time is invalid.';
-      if (doorsMs > startMs) return 'Doors must open before the show starts.';
+      const doorsUtcDate = zonedWallClockToUtc(formData.timing.doorsOpen, tz);
+      if (!doorsUtcDate) return 'Doors-open time is invalid.';
+      if (doorsUtcDate.getTime() > startMs) return 'Doors must open before the show starts.';
     }
     if (formData.timing.endTime) {
-      const endMs = new Date(formData.timing.endTime).getTime();
-      if (!Number.isFinite(endMs)) return 'Show end time is invalid.';
-      if (endMs <= startMs) return 'Show end must be after the show start.';
+      const endUtcDate = zonedWallClockToUtc(formData.timing.endTime, tz);
+      if (!endUtcDate) return 'Show end time is invalid.';
+      if (endUtcDate.getTime() <= startMs) return 'Show end must be after the show start.';
     }
 
     // Tier validations.

--- a/d4_bridge/src/views/OrganizerCheckIn.tsx
+++ b/d4_bridge/src/views/OrganizerCheckIn.tsx
@@ -106,6 +106,12 @@ export default function OrganizerCheckIn() {
   // as scans land (this lane + others).
   const [insideVenue, setInsideVenue] = useState(0);
   const scannerRef = useRef<Html5Qrcode | null>(null);
+  // Holds the setTimeout ID for the deferred camera start so stopScanner()
+  // can cancel a pending start that hasn't fired yet. Without this, if
+  // stopScanner is called within the 50ms window, scannerRef.current is still
+  // null (timeout hasn't run) so stopScanner is a no-op, then the timeout
+  // fires and starts the camera with no owner to shut it down.
+  const startScannerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wasOfflineRef = useRef(isOffline);
 
   useEffect(() => {
@@ -179,16 +185,22 @@ export default function OrganizerCheckIn() {
     setSyncing(true);
     const successfulSyncs: string[] = [];
     try {
+      // Per-item try/catch so one failing replay doesn't abort the rest of the
+      // queue. With a single outer catch the first failure silently skipped
+      // all subsequent IDs (they'd also miss the successfulSyncs push so they'd
+      // stay queued indefinitely even though they hadn't been tried yet).
       for (const tId of pendingUpdates) {
-        // Replay an offline check-in. checkInTicket is forgiving on replay:
-        // a second flip of an already-used ticket returns {ok:false,
-        // reason:'used'} (no throw), so we still drop it from the queue.
-        // Only a real network/auth error throws and keeps it queued.
-        await checkInTicket(tId, 'manual', 'manual');
-        successfulSyncs.push(tId);
+        try {
+          // Replay an offline check-in. checkInTicket is forgiving on replay:
+          // a second flip of an already-used ticket returns {ok:false,
+          // reason:'used'} (no throw), so we still drop it from the queue.
+          // Only a real network/auth error throws and keeps it queued.
+          await checkInTicket(tId, 'manual', 'manual');
+          successfulSyncs.push(tId);
+        } catch (err) {
+          console.error(`Error syncing pending update ${tId}:`, err);
+        }
       }
-    } catch (err) {
-      console.error("Error syncing some pending updates", err);
     } finally {
       const remainingUpdates = pendingUpdates.filter(id => !successfulSyncs.includes(id));
       setPendingUpdates(remainingUpdates);
@@ -200,6 +212,13 @@ export default function OrganizerCheckIn() {
   // Tear down the live camera scanner safely. stop() rejects if the camera
   // isn't actively running, so guard on state and swallow that case.
   const stopScanner = async () => {
+    // Cancel any pending deferred start so the camera doesn't open after we
+    // shut down (the 50ms timeout may not have fired yet when stopScanner is
+    // called, e.g. on unmount or stop-button tap).
+    if (startScannerTimeoutRef.current !== null) {
+      clearTimeout(startScannerTimeoutRef.current);
+      startScannerTimeoutRef.current = null;
+    }
     const s = scannerRef.current;
     scannerRef.current = null;
     if (!s) return;
@@ -224,7 +243,8 @@ export default function OrganizerCheckIn() {
     // Html5QrcodeScanner widget required a second "Request Camera / Start"
     // tap that often never activated the camera on phones, and its fixed
     // 250px qrbox threw on narrow viewports (video < box) — both fixed here.
-    setTimeout(async () => {
+    startScannerTimeoutRef.current = setTimeout(async () => {
+      startScannerTimeoutRef.current = null;
       try {
         const html5Qr = new Html5Qrcode('reader');
         scannerRef.current = html5Qr;

--- a/supabase/functions/sg-to-tevo-search-bridge/index.ts
+++ b/supabase/functions/sg-to-tevo-search-bridge/index.ts
@@ -145,10 +145,20 @@ Deno.serve(async (req) => {
                                     : otherCandidates.slice(0, limit);
 
   const venueMap = new Map<number, number | null>();
-  for (const c of filtered) {
-    const { data } = await sb.rpc("cross_source_venue_resolve", { p_venue_name: c.sg_venue_name, p_city: c.sg_venue_city, p_state: c.sg_venue_state });
-    venueMap.set(c.sg_event_id, data ?? null);
-  }
+  // Parallel venue lookups — these are independent read RPCs so there's no
+  // benefit to serialising them. Sequential await-in-loop added latency
+  // proportional to `limit` (up to 20 round trips before the first TEvo
+  // search could start). Promise.all keeps all in flight at once.
+  await Promise.all(
+    filtered.map(async (c: any) => {
+      const { data } = await sb.rpc("cross_source_venue_resolve", {
+        p_venue_name: c.sg_venue_name,
+        p_city: c.sg_venue_city,
+        p_state: c.sg_venue_state,
+      });
+      venueMap.set(c.sg_event_id, data ?? null);
+    }),
+  );
 
   const samples: any[] = [];
   let matched = 0, noResults = 0, errored = 0, ownedAttempted = 0;


### PR DESCRIPTION
## Summary

Six P2 (medium) bugs from the deep audit. All independently verified from source code reading.

| File | Bug | Fix |
|---|---|---|
| `app.py:598` | Rate limiter keyed on full path — bots rotate `/api/store/events/1`, `/2`, ... for a fresh bucket per resource | Key on matched bucket prefix instead |
| `OrganizerCheckIn.tsx:182` | Outer try/catch around sync loop aborts all remaining IDs after first failure | Per-item try/catch inside loop; cleanup runs in finally |
| `OrganizerCheckIn.tsx:227` | `startScanner` setTimeout race: stopScanner called within 50ms window finds null ref → no-op; camera starts post-unmount with no owner | `startScannerTimeoutRef` lets stopScanner cancel the pending start |
| `CreateEvent.tsx:195` | Single `restoredRef` set true unconditionally in draft-check effect → clone hydration always skipped | Split into `draftCheckDoneRef` + `draftAppliedRef` (only set on confirm) |
| `CreateEvent.tsx:583` | `validate()` parses times with `new Date()` (browser TZ); submit uses `zonedWallClockToUtc` (event TZ) — inconsistent future-check | `validate()` uses `zonedWallClockToUtc` matching submit |
| `sg-to-tevo-search-bridge:148` | Sequential `for...of await` for up to 20 venue resolution RPCs | `Promise.all` — parallel independent reads |

## Details

### `app.py` — rate limiter bypass
The rate limiter builds a key as `f"{ip}|{path}"` where `path` is the full request URL path (e.g. `/api/store/events/17823401`). Each unique path gets its own rate-limit bucket. An automated scraper can enumerate `/api/store/events/1`, `/api/store/events/2`, etc. — each is a fresh slot, so the per-IP cap is never hit. Fix: normalize the key to the matched bucket prefix (`/api/store/` for any event endpoint) so all store reads for a given IP share one 60-req/60s bucket.

### `OrganizerCheckIn.tsx` — two independent bugs in the scanner
**Sync loop**: with the outer try/catch, if ID #1 succeeds and ID #2 throws, IDs #3–N are never attempted. Worse, they're not in `successfulSyncs` so they'd stay in the queue indefinitely even though they were never tried. Fix: move catch inside the loop.

**Camera race**: `setTimeout(fn, 50)` defers `scannerRef.current = html5Qr` by 50ms. If `stopScanner` is called before those 50ms elapse (unmount, stop-button tap), it reads `null` and exits early. The timeout then fires and starts the camera with no mechanism to stop it. Fix: store the timeout ID in a ref so `stopScanner` can `clearTimeout` it.

### `CreateEvent.tsx` — two independent bugs in form state
**Clone hydration**: a single ref `restoredRef` served as both "has draft check run?" (set at top of draft effect, always) and "was a draft applied?" (the clone effect's guard). Since the ref is always true after the draft check, cloning an event at `/create-event?clone=<id>` was silently always skipped. Fix: two refs with distinct semantics; `draftAppliedRef` is only set when user confirms the restore dialog.

**TZ validation**: `validate()` compared `new Date(startTimeStr).getTime()` to `Date.now()`. `new Date("2026-06-15T20:00")` is interpreted in the browser's local timezone. For an event configured in "America/New_York" opened by a Tokyo organizer, the future-check is off by up to ±12 hours. Fix: `zonedWallClockToUtc(startTimeStr, tz)` matches the exact UTC calculation that submit will store.

### `sg-to-tevo-search-bridge` — N+1 sequential RPCs
For each event in `filtered` (up to `limit`, default 20), the bridge fired one sequential `supabase.rpc("cross_source_venue_resolve")` call. With ~30ms per RPC, that's 600ms of pure wait time before any TEvo search request could start. These are independent reads — `Promise.all` reduces this to a single parallel batch.

## Test plan

- [ ] `app.py` — confirm `/api/store/events/12345` and `/api/store/events/99999` from same IP share a rate-limit bucket (both count against the `/api/store/` 60-req limit)
- [ ] `OrganizerCheckIn` sync — mock `checkInTicket` to throw on ID #2; confirm IDs #1 and #3 are still attempted and dequeued
- [ ] `OrganizerCheckIn` camera — tap "Start Scanner" then immediately tap "Stop"; confirm no camera permissions dialog opens after the stop
- [ ] `CreateEvent` clone — navigate to `/create-event?clone=<id>` with no existing draft; confirm form is pre-filled from source event
- [ ] `CreateEvent` TZ — set timezone to "America/New_York", open as a browser in UTC+9, set startTime to a time that is in the past in NYC but future in Tokyo; confirm validation rejects it
- [ ] `sg-to-tevo-search-bridge` — trace RPC calls; confirm venue resolutions are dispatched in parallel not sequentially

## No rebuild required separately
The D4 TSX changes need a bundle rebuild. Coordinate with D0 post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
