### PR TITLE
fix(p3): auth 502 exception leak + purchaseDate null guard

### DIFF
--- a/app.py
+++ b/app.py
@@ -427,7 +427,11 @@ def require_auth(authorization: str | None = Header(None)):
             timeout=5,
         )
     except Exception as e:
-        raise HTTPException(502, f"auth check failed: {e}")
+        # Don't surface internal exception detail externally — may expose
+        # Supabase hostnames, connection error strings, or timeout messages
+        # that are useful to an attacker mapping our internal topology.
+        logging.getLogger(__name__).error("Auth check against Supabase failed: %s", e)
+        raise HTTPException(502, "auth check failed — upstream auth service unreachable")
     if not r.ok:
         raise HTTPException(401, "invalid session")
     user = r.json()

--- a/d4_bridge/src/lib/tickets.ts
+++ b/d4_bridge/src/lib/tickets.ts
@@ -51,7 +51,7 @@ export function mapTicket(row: any): Ticket {
     voidedAt: row.voided_at ? toTs(row.voided_at) : undefined,
     voidedBy: row.voided_by ?? undefined,
     voidedReason: row.voided_reason ?? undefined,
-    purchaseDate: toTs(row.created_at),
+    purchaseDate: row.created_at ? toTs(row.created_at) : undefined,
     lastReissueDate: row.last_reissue_at ? toTs(row.last_reissue_at) : undefined,
     checkInDate: row.check_in_at ? toTs(row.check_in_at) : undefined,
   };


### PR DESCRIPTION
## Summary

Two P3 (low-severity / cosmetic-risk) bugs from the deep audit:

| File | Bug | Fix |
|---|---|---|
| `app.py:430` | `raise HTTPException(502, f"auth check failed: {e}")` leaks internal exception detail (Supabase hostnames, timeout messages, etc.) in the 502 response body | Log internally via `logging.getLogger`; return generic `"upstream auth service unreachable"` body |
| `d4_bridge/src/lib/tickets.ts:54` | `purchaseDate: toTs(row.created_at)` — no null guard; if `created_at` is null, `toTs` returns epoch Timestamp(0), rendering as Jan 1 1970 in ticket views | `row.created_at ? toTs(row.created_at) : undefined` — matches the defensive pattern of every other timestamp field in `mapTicket` |

## Notes

- `created_at` has `DEFAULT now()` in the DB schema so the null path is low-probability, but the UI rendering consequence (Jan 1 1970 purchase date) is confusing enough to warrant the guard
- The 502 body leak is low-risk in practice since this endpoint is behind auth, but it's a hygiene issue that could surface Supabase's internal URLs or rate-limit error strings to a user who triggered a transient network failure
- Two other P3s noted in the audit (`sg-seller-webhook` fire-and-forget, TEvo error body verbatim in collect scripts) are left unaddressed — both involve acceptable architectural trade-offs documented inline in the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
