### PR TITLE
fix: relkind::text cast in health check fn (apply-time type error)

### DIFF
--- a/supabase/migrations/20260525180000_security_health_check_anon_exposed_relations.sql
+++ b/supabase/migrations/20260525180000_security_health_check_anon_exposed_relations.sql
@@ -64,7 +64,7 @@ AS $function$
               WHEN count(*) <= 5 THEN 'warn'
               ELSE 'fail' END,
          count(*)::numeric,
-         coalesce(string_agg(relkind || ':' || relname, ', ' ORDER BY relname), 'none')
+         coalesce(string_agg(relkind::text || ':' || relname, ', ' ORDER BY relname), 'none')
     FROM bad;
 $function$;
 

--- a/supabase/migrations/20260526000000_fix_broken_crons.sql
+++ b/supabase/migrations/20260526000000_fix_broken_crons.sql
@@ -1,0 +1,82 @@
+-- Migration: fix_broken_crons
+-- Author: A1
+-- Date: 2026-05-26
+-- Description: Fix 3 crons that have never succeeded:
+--   (1) midnight-catchup-sweep: SELECT public.midnight_catchup_sweep() inside a DO block
+--       has no destination → "query has no destination for result data". Fix: PERFORM.
+--   (2) weather_climatology_weekly: two SELECT fn() calls inside DO block have no
+--       destination. Fix: PERFORM both. The first call already uses PERFORM (correct);
+--       the two SELECTs that follow need the same treatment.
+--   (3) listings_aq_backfill_overnight: match_unmatched_listings_chunked(100, true)
+--       always hits the default 120s statement_timeout. Fix: SET LOCAL to 3min + reduce
+--       chunk from 100→25 so each call completes within the window.
+-- Downstream: data pipelines (weather backfill, listings AQ xref, midnight catchup) now run
+-- Rollback: cron.schedule() with the original bodies (see comments below each fix)
+-- Depends on: cron.job entries for all 3 jobnames existing (shipped in prior migrations)
+
+DO $outer$
+BEGIN
+
+  -- ----------------------------------------------------------------
+  -- FIX 1: midnight-catchup-sweep
+  -- Original body used SELECT public.midnight_catchup_sweep() inside a
+  -- DO block — functions returning rows need PERFORM in PL/pgSQL.
+  -- ----------------------------------------------------------------
+  PERFORM cron.schedule(
+    'midnight-catchup-sweep',
+    '20 3 * * *',
+    $cron$DO $body$
+BEGIN
+  IF NOT public.cron_should_fire('midnight-catchup-sweep') THEN RETURN; END IF;
+  SET LOCAL statement_timeout = '5min';
+  PERFORM public.midnight_catchup_sweep();
+END $body$;$cron$
+  );
+
+  -- ----------------------------------------------------------------
+  -- FIX 2: weather_climatology_weekly
+  -- Original body: PERFORM on first call (correct), then two bare SELECTs
+  -- inside the DO block that have no INTO destination → syntax error.
+  -- Fix: change both SELECT calls to PERFORM.
+  -- ----------------------------------------------------------------
+  PERFORM cron.schedule(
+    'weather_climatology_weekly',
+    '0 4 * * 0',
+    $cron$DO $body$
+BEGIN
+  IF NOT public.cron_should_fire('weather_climatology_weekly') THEN RETURN; END IF;
+  PERFORM weather_historical_retry_throttled(20);
+  PERFORM weather_historical_backfill_outdoor(
+    (current_date - interval '3 years')::date,
+    (current_date - interval '1 day')::date,
+    10);
+  PERFORM weather_historical_process();
+END $body$;$cron$
+  );
+
+  -- ----------------------------------------------------------------
+  -- FIX 3: listings_aq_backfill_overnight
+  -- match_unmatched_listings_chunked(100, true) always exceeds the
+  -- default 120s cron statement timeout. Two changes:
+  --   (a) SET LOCAL statement_timeout = '3min' to give it headroom
+  --   (b) Reduce chunk from 100→25 so each invocation is faster
+  -- The cron unschedules itself when events_remaining = 0 (preserved).
+  -- ----------------------------------------------------------------
+  PERFORM cron.schedule(
+    'listings_aq_backfill_overnight',
+    '2-14 4 * * *',
+    $cron$
+DO $body$
+DECLARE v_remaining int;
+BEGIN
+  SET LOCAL statement_timeout = '3min';
+  SELECT max(events_remaining) INTO v_remaining
+  FROM public.match_unmatched_listings_chunked(25, true);
+  IF coalesce(v_remaining, 0) = 0 THEN
+    PERFORM cron.unschedule('listings_aq_backfill_overnight');
+  END IF;
+END $body$;
+$cron$
+  );
+
+END $outer$;

--- a/supabase/migrations/20260526010000_sg_429_rate_mitigation.sql
+++ b/supabase/migrations/20260526010000_sg_429_rate_mitigation.sql
@@ -1,0 +1,71 @@
+-- Migration: sg_429_rate_mitigation
+-- Author: A1
+-- Date: 2026-05-26
+-- Description: Reduce SG 429 rate from ~58% average (CRITICAL — well above 15% alert
+--   threshold). Root cause: 4 new 60d+ polling crons (added mig 20260520200000) each
+--   fire 8 requests per 5-min slot, stacking with the existing priority pipeline and
+--   exceeding SG's 10-req/8s token bucket during burst windows. Afternoon window
+--   (UTC 17-19 / ET 1-4pm) shows 41-68% 429 rates; morning window is also affected.
+--
+--   Fix: reduce p_max_events from 8→4 in all 4 60d+ cron calls. Halves the per-slot
+--   burst from these crons. Expected improvement: ~50% reduction in 429s from 60d+
+--   crons → aggregate rate should drop from ~58% to target <20%.
+--
+--   Coverage impact: at 4 events/fire instead of 8, the full 60d+ cycle takes ~2 days
+--   instead of ~1 day — acceptable for far-out events (no urgency on Sep/Oct games).
+--
+--   Monitor with: SELECT * FROM v_sg_broker_429_health ORDER BY hour_bucket DESC;
+--   If pct_429 remains >20% after 24h, consider also pausing the afternoon window:
+--     UPDATE cron_policy SET enabled = false WHERE jobname LIKE 'sg_60d%_afternoon';
+--
+-- Downstream: SG data pipeline (60d+ events get less frequent polling but no data loss)
+-- Rollback: cron.schedule() with sg_broker_60d_plus_*_queue(8) — reverts to 8-batch
+
+DO $outer$
+BEGIN
+
+  -- Morning listings (UTC 4-9 = ET 12am-5am EDT)
+  PERFORM cron.schedule(
+    'sg_60d_listings_morning',
+    '1-59/5 4-9 * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_60d_listings_morning') THEN RETURN; END IF;
+      PERFORM public.sg_broker_60d_plus_listings_queue(4);
+    END $cronbody$;$cron$
+  );
+
+  -- Morning sales (same window, 2-min offset)
+  PERFORM cron.schedule(
+    'sg_60d_sales_morning',
+    '3-58/5 4-9 * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_60d_sales_morning') THEN RETURN; END IF;
+      PERFORM public.sg_broker_60d_plus_sales_queue(4);
+    END $cronbody$;$cron$
+  );
+
+  -- Afternoon listings (UTC 17-19 = ET 1-3pm EDT)
+  PERFORM cron.schedule(
+    'sg_60d_listings_afternoon',
+    '1-59/5 17-19 * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_60d_listings_afternoon') THEN RETURN; END IF;
+      PERFORM public.sg_broker_60d_plus_listings_queue(4);
+    END $cronbody$;$cron$
+  );
+
+  -- Afternoon sales (same window, 2-min offset)
+  PERFORM cron.schedule(
+    'sg_60d_sales_afternoon',
+    '3-58/5 17-19 * * *',
+    $cron$DO $cronbody$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_60d_sales_afternoon') THEN RETURN; END IF;
+      PERFORM public.sg_broker_60d_plus_sales_queue(4);
+    END $cronbody$;$cron$
+  );
+
+END $outer$;


### PR DESCRIPTION
## Summary
- `pg_class.relkind` is type `"char"`, not `text` — the `||` concat operator is ambiguous without an explicit cast
- Migration `20260525180000` failed on first apply attempt with `operator is not unique: "char" || unknown`; fixed to `relkind::text || ':'` before the successful apply
- File-only change to bring the on-disk migration in sync with what was actually applied to prod

## What was applied to prod
All 6 pending migrations have been applied (in this session):
- `20260525170000` — REVOKE anon SELECT on 14 security-definer views/matviews (SEC-HIGH/MED) ✅
- `20260525180000` — `_health_check_anon_exposed_relations()` diagnostic fn (with cast fix) ✅
- `20260525190000` — REVOKE anon/authenticated EXECUTE on 5 SECDEF fns ✅
- `20260526000000` — Fix 3 broken crons (midnight-catchup-sweep, weather_climatology_weekly, listings_aq_backfill_overnight) ✅
- `20260526010000` — Reduce 60d+ cron batch 8→4 (SG 429 rate mitigation) ✅
- `20260526020000` — DROP NOT NULL on exos_event_checkins.scanned_by ✅

## Post-apply verification
- `has_table_privilege('anon', 'v_event_price_arbitrage', 'SELECT')` → `false` ✅
- `_health_check_anon_exposed_relations()` → `warn / 4` (expected — Tier-2 views intentionally deferred per migration comment) ✅
- All 7 updated crons: `active=true`, correct schedules, `sg_60d_*` bodies show `queue(4)` ✅
- `exos_event_checkins.scanned_by` is_nullable → `YES` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)