### PR TITLE
security(review): A1 prod post-#369 review + CI least-privilege hardening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,11 @@ on:
   push:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN (B1 security review 2026-05-26). CI only reads the
+# repo to check out + run tests; no step writes via the token.
+permissions:
+  contents: read
+
 jobs:
   pytest:
     name: pytest (Python)

--- a/.github/workflows/uptime-check.yml
+++ b/.github/workflows/uptime-check.yml
@@ -15,6 +15,13 @@ on:
     - cron: '*/5 * * * *'   # every 5 minutes
   workflow_dispatch:          # manual trigger for testing
 
+# Least-privilege GITHUB_TOKEN (B1 security review 2026-05-26, PR #369 follow-up).
+# The failure path opens an issue (needs issues:write); nothing writes code.
+# Without this block the token inherits the repo-wide default permission set.
+permissions:
+  contents: read
+  issues: write
+
 concurrency:
   group: uptime-check
   cancel-in-progress: true

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -43,7 +43,6 @@
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
 | B1-NEXT-11 | Op | Leaked `CRON_SECRET` in git history (commit `5297739`). Value rotated but repo is public → internet-readable. | Operator decides: `git filter-repo` + force-push window, OR accept (rotated, contained blast radius). G-1. |
-| B1-NEXT-56 | A1 (B1) | **Anon-readable definer views/matviews leak** (B1 sweep 2026-05-25). 14 `security_invoker=false` + anon-granted objects (postgres-owned, bypass RLS): broker-intel LIVE (`v_event_price_arbitrage` 3681 anon rows) + 2 matviews uncovered by the harness + latent order-PII (`unified_orders`). Same default-grant gotcha as #298, on views. | **PR #350** (REVOKE 14 FROM anon). Awaiting A1 merge + operator apply. |
 
 ### SEC-MED (defense-in-depth)
 
@@ -63,6 +62,8 @@
 
 | ID | Lane | Finding/Task | Action |
 |---|---|---|---|
+| B1-NEXT-61 | A1 | `listings_aq_backfill_overnight` cron (mig `20260526000000` FIX-3) omits the `cron_should_fire()` policy gate PROJECT_BIBLE §7 mandates (the other 2 fixes in that migration have it). Runs as postgres + self-unschedules → convention, not security. | A1 add the gate on next reschedule. B1 review F3 (`docs/security-review-2026-05-26-post-pr369.md`). |
+| B1-NEXT-62 | D4 | `exos_event_checkins.scanned_by` now nullable (mig `20260526020000`) — correct fix, but scanner attribution is lost if the scanner's `auth.users` row is later deleted. | Optional: denormalize a `scanned_by_email` text snapshot at scan time for a durable door-audit. B1 review F4. |
 | B1-NEXT-4 | B1 | Evaluate CodeQL / SAST for FastAPI + edge functions. | Research + decision doc |
 | B1-NEXT-6 | B1 | Egress payload review on `*_public` / `/api/store/*` RPCs. (Partial pass via war-games W-3 2026-05-17; rotational.) | Quarterly sweep against war_games_playbook W-3 + W-4 |
 | B1-NEXT-10 | A1 | Migration slot collisions: `20260515300000` (3 files), `20260515320000` (2 files), `20260515340000` (2 files — caught 2026-05-18, kanban missed it). None applied via `apply_migration` (`schema_migrations` empty for all). | Rename to next free slots in a future cleanup PR. **Risk-check first**: some may have been applied via direct `execute_sql` — verify via function/object presence before rename. |
@@ -490,7 +491,7 @@ Defense-in-depth follow-ups identified during the Phase-2 monitoring sweep. Each
 - **[B1-NEXT-4] [SEC-LOW]** Evaluate CodeQL / SAST for FastAPI + edge functions. Decide whether to add as a CI workflow.
 - **[B1-NEXT-5] [SEC-MED]** Vault orphans check — `release_health_check()` row for `get_app_secret` allowlist entries not actually referenced in any prod fn / cron / edge-fn. Punch-list item from [docs/release-discipline.md](docs/release-discipline.md) §7.
 - **[B1-NEXT-6] [SEC-LOW]** Egress payload review — sample anon-callable RPC responses for accidental wholesale/broker field exposure ([LANE_DISCIPLINE.md §D1](LANE_DISCIPLINE.md) wall rules). Periodically review `*_public` RPCs.
-- **[B1-NEXT-7] [SEC-HIGH]** RLS gap on 3 tables — `cron_pause_state_20260514`, `sg_event_priority_state`, `sg_priority_policy` have `rowsecurity=false`, 0 policies, anon SELECT GRANT. Same pattern as Phase-1 `aq_venue_map`/`aq_performer_map` gap (fixed in PR #110). Author fix migration `<ts>_security_rls_gap_close_3_tables.sql`. Cross-lane: 1st table is C1's (cron pause snapshot), other 2 are A1's (SG pipeline).
+- **[B1-NEXT-7] [SEC-HIGH] ✅ CLOSED** (B1 verified 2026-05-26 via Phase-2 anon-permissive-policy sweep — **0** anon-readable tables have `rowsecurity=false`; these 3 have since had RLS enabled, no fix migration needed). Original: RLS gap on `cron_pause_state_20260514`, `sg_event_priority_state`, `sg_priority_policy`.
 - **[B1-NEXT-8] [SEC-MED]** §6 retrofit on `_health_check_pg_net_errors()` (A1's, added by PR #115). File PR comment to A1 per cross-lane patch protocol. Read-only diagnostic but defense-in-depth retrofit warranted.
 - **[B1-NEXT-9] [SEC-MED]** §6 retrofit on `get_broker_event_page(integer, integer)` (A1's, added by PR #115). Body is already gated by `auth.jwt()->>'email'`; §6 guard is belt-and-suspenders. File PR comment to A1.
 - **[B1-NEXT-10] [SEC-LOW]** Migration slot collision audit — `20260515300000` (3 files), `20260515320000` (2 files) collide. MIGRATION_CONVENTIONS.md §3 bump-by-30-or-50 rule not followed. Not security-class but flags discipline drift; recommend filenames be renamed to next free slots in a future cleanup PR.

--- a/docs/security-review-2026-05-26-post-pr369.md
+++ b/docs/security-review-2026-05-26-post-pr369.md
@@ -1,0 +1,52 @@
+# Security review — A1 prod changes (post-PR #369)
+
+**Reviewer:** B1 · **Date:** 2026-05-26 · **Scope:** everything applied to prod / merged to `main` in A1's `v1.0.0-beta automation checkpoint` (PR [#369](https://github.com/JulianS4K/Terminal-2/pull/369), merged 2026-05-26).
+
+## TL;DR
+
+**Security-clean.** Zero new attack surface — no new tables, views, materialized views, SECURITY DEFINER functions, or anon/authenticated grants were introduced. No real secrets in CI. The one DB schema change (`scanned_by` nullable) is a correct fix that *unblocks* auth-user deletion. Two actionable findings, both **SEC-LOW CI least-privilege hardening**, fixed in this same PR. Two minor notes filed to KANBAN.
+
+The B1 anon-leak sweep that rode in the same checkpoint (migs `20260525170000/180000/190000`, PRs #350/#352/#354) is **verified applied + live**: anon can no longer read `unified_orders` / `v_event_price_arbitrage` / `latest_event_metrics`, and the 5 residual ungated SECDEF fns are no longer anon-executable.
+
+## Scope reviewed
+
+| Item | Type | Verdict |
+|---|---|---|
+| `20260526000000_fix_broken_crons.sql` | cron reschedule ×3 | clean (1 convention note) |
+| `20260526010000_sg_429_rate_mitigation.sql` | cron reschedule ×4 | clean (net security positive) |
+| `20260526020000_fix_checkins_scanned_by_nullable.sql` | `ALTER … DROP NOT NULL` | correct fix (1 audit note) |
+| `.github/workflows/uptime-check.yml` | new CI | **finding F1** (fixed here) |
+| `.github/workflows/tests.yml` | modified CI | **finding F2** (fixed here) |
+| `.github/workflows/release-please.yml` | new CI | clean |
+
+## Findings
+
+### F1 — `uptime-check.yml` had no `permissions:` block · SEC-LOW → **FIXED in this PR**
+The failure path runs `gh issue create` with `secrets.GITHUB_TOKEN`. With no top-level `permissions:` block, the token inherits the **repo-wide default** permission set rather than least-privilege. A compromised dependency in that job would therefore wield whatever the repo default grants (potentially read/write-all). Fix: pinned to `contents: read` + `issues: write`. The heredoc issue-body and Slack payload interpolate only controlled values (HTTP status code, timestamps, `GITHUB_*` env) — **no command/script-injection vector**.
+
+### F2 — `tests.yml` had no `permissions:` block · SEC-LOW → **FIXED in this PR**
+The CI test job checks out + runs pytest/tsc; it never writes via the token. Pinned to `contents: read`. (Secrets check: pytest uses fake `SUPABASE_*` values; the Vite build uses the *publishable* anon key or a placeholder — no real credential exposure.)
+
+### F3 — `fix_broken_crons` FIX-3 omits the `cron_should_fire()` gate · SEC-LOW (convention) → KANBAN
+`listings_aq_backfill_overnight`'s new body sets `statement_timeout` + calls `match_unmatched_listings_chunked(25, true)` but does **not** wrap with the `cron_should_fire()` policy gate that PROJECT_BIBLE.md §7 mandates (the other two fixes in the same migration do). Not a security hole — the cron runs as `postgres`, no anon surface, and it self-unschedules at `events_remaining = 0` — but it bypasses the conservation/work-check gate. A1 lane; fix on the next reschedule.
+
+### F4 — `exos_event_checkins.scanned_by` loses scanner attribution on user deletion · SEC-LOW (audit) → KANBAN
+The fix (`DROP NOT NULL`) is **correct**: the prior `NOT NULL … ON DELETE SET NULL` was self-contradictory and blocked deletion of any auth user who had ever scanned (an offboarding/GDPR blocker). `SET NULL` + nullable preserves the check-in row and nulls only the scanner FK. Residual: if a scanner's `auth.users` row is later deleted, that historical check-in's scanner identity is lost. If a durable door-audit trail is required, denormalize a `scanned_by_email` text snapshot at scan time (D4/exos lane).
+
+## Verification (live, 2026-05-26)
+
+```sql
+-- anon-exposed definer relations: 18 (pre-sweep) → 4 (only the deferred Tier-2 event views)
+-- ungated anon-exec SECDEF fns (#354 set): 0
+-- has_table_privilege('anon', 'public.unified_orders', 'SELECT')          = false
+-- has_table_privilege('anon', 'public.v_event_price_arbitrage', 'SELECT') = false
+-- has_table_privilege('anon', 'public.latest_event_metrics', 'SELECT')    = false
+```
+
+## Open items routed to KANBAN / lanes
+
+- **B1-NEXT-56** (view leak) → closed-by-deletion (applied via #369).
+- **B1-NEXT-7** (RLS gap on 3 tables) → closed-by-deletion (Phase-2 verified 0 RLS-off anon tables).
+- **F3** → new KANBAN row, A1 lane (cron gate on `listings_aq_backfill_overnight`).
+- **F4** → new KANBAN row, D4 lane (denormalized scanner snapshot, optional).
+- **B1-NEXT-59** (still open): 4 Tier-2 event views remain anon-readable — D0/D1 confirm before the ready REVOKE block in `20260525170000` is uncommented.


### PR DESCRIPTION
## B1 security review — A1 prod changes (post-#369)

Operator-requested security review of A1's `v1.0.0-beta automation checkpoint` (#369), with fixes teed up for the next A1 merge.

### Verdict: security-clean ✅
Zero new attack surface across the 6 migrations applied + 3 CI workflows — no new tables/views/matviews/SECDEF fns/anon grants, no real secrets in CI. The B1 anon-leak sweep that rode in #369 (#350/#352/#354) is **verified live in prod**: anon can no longer read `unified_orders` / `v_event_price_arbitrage` / `latest_event_metrics`; the 5 residual ungated SECDEF fns are no longer anon-executable.

### What this PR changes
**CI least-privilege hardening** (the only actionable findings):
- `uptime-check.yml` → `permissions: { contents: read, issues: write }`. The failure path runs `gh issue create` with `GITHUB_TOKEN`; with no explicit block it inherited the repo-wide default. Heredoc/Slack payloads interpolate only controlled values (HTTP code, timestamps) — no injection.
- `tests.yml` → `permissions: { contents: read }`. Read-only CI; no token writes.
- `release-please.yml` — already least-privilege, untouched.

**Docs**: `docs/security-review-2026-05-26-post-pr369.md` (full review + verification).

**KANBAN**:
- Closure-by-deletion: **B1-NEXT-56** (view leak — applied via #369).
- **B1-NEXT-7** marked ✅ CLOSED — Phase-2 verified 0 RLS-off anon tables.
- New: **B1-NEXT-61** (A1 — `fix_broken_crons` FIX-3 missing `cron_should_fire()` gate), **B1-NEXT-62** (D4 — `scanned_by` durable-audit snapshot, optional).

### Notes for A1 (not fixed here — your/D4 lane)
- **F3 / B1-NEXT-61**: `listings_aq_backfill_overnight` reschedule omits the policy gate. Convention, not security (runs as postgres, self-unschedules).
- **F4 / B1-NEXT-62**: `scanned_by` nullable is the *correct* fix (unblocks user deletion); only note is scanner attribution lost if a scanner user is later deleted.

### Still open (separate)
B1-NEXT-59 — 4 Tier-2 event views remain anon-readable pending D0/D1 confirm; B1-NEXT-57 — wire `_health_check_anon_exposed_relations()` into `release_health_check` on the next coordinated revision.

No DB changes in this PR (CI + docs only) — nothing to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
