### PR TITLE
security(a1): revoke D0+D1 confirmed anon policies (mig 20260526050000)

### DIFF
--- a/supabase/migrations/20260526030000_fix_sg_blindspot_cron_statement_timeout.sql
+++ b/supabase/migrations/20260526030000_fix_sg_blindspot_cron_statement_timeout.sql
@@ -1,0 +1,34 @@
+-- 20260526030000_fix_sg_blindspot_cron_statement_timeout.sql
+--
+-- A1-4 (D0 handoff, 2026-05-26): fix sg_blindspot_mv_refresh cron timing out.
+--
+-- ROOT CAUSE (verified empirically by D0, 2026-05-25):
+--   The cron body is a single DO block. Inside the block,
+--   `SET LOCAL statement_timeout = '5min'` runs AFTER the DO block statement
+--   has already started — it cannot retroactively re-arm the outer statement's
+--   timer. In effect the REFRESH runs without any timeout cap, and on cold cache
+--   it spins indefinitely without being killed.
+--   Last successful refresh: 2026-05-25 10:13 UTC → data stale 9h+ at time of
+--   D0 handoff.
+--
+-- FIX: move SET statement_timeout OUT of the DO block as a separate leading
+--   statement. pg_cron executes multi-statement commands sequentially; the first
+--   statement `SET statement_timeout = '10min'` takes effect before the DO block
+--   begins, so the DO block — and the REFRESH inside it — starts fresh with the
+--   configured 10-min budget.
+--
+-- PATTERN NOTE (§3 landmine): `SET LOCAL` inside a DO block does not re-arm
+--   the timer of the currently-running outer statement. Always place
+--   `SET statement_timeout` as a standalone statement before any DO block in
+--   pg_cron commands that need a non-default timeout.
+--
+-- ROLLBACK: re-run with the old DO-block body (puts SET LOCAL back inside),
+--   or SET statement_timeout = DEFAULT to clear the session var if needed.
+
+SELECT cron.unschedule('sg_blindspot_mv_refresh');
+
+SELECT cron.schedule(
+  'sg_blindspot_mv_refresh',
+  '3-59/10 * * * *',
+  $$SET statement_timeout = '10min'; DO $body$ BEGIN IF NOT public.cron_should_fire('sg_blindspot_mv_refresh') THEN RETURN; END IF; REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_sg_blindspot_movers; END $body$;$$
+);

--- a/supabase/migrations/20260526040000_tevo_blindspot_movers_matview.sql
+++ b/supabase/migrations/20260526040000_tevo_blindspot_movers_matview.sql
@@ -1,0 +1,130 @@
+-- 20260526040000_tevo_blindspot_movers_matview.sql
+--
+-- A1-5 (D0 handoff, 2026-05-26): materialize v_tevo_blindspot_movers.
+--
+-- PROBLEM: get_blind_spots_tevo_selling() reads v_tevo_blindspot_movers, which
+--   does a correlated subquery against listings_snapshots for each event + joins
+--   v_event_velocity_windows. Cold open of the Discovery page TEvo panel exceeds
+--   8s PostgREST timeout (measured >8s cold; ~1.1s warm). Same architectural root
+--   cause as the SG blindspot timeout fixed in 20260524120000_sg_blindspot_movers_matview.
+--
+-- FIX: mirror that migration exactly — materialize the view into
+--   mv_tevo_blindspot_movers, repoint the RPC, add a gated 10-min cron.
+--
+-- CAVEAT (D0 handoff): the TEvo panel also returns 0 rows because
+--   v_tevo_blindspot_movers INNER JOINs latest_event_metrics which covers only
+--   ~1.4% of upcoming non-major-sport events. This matview makes the RPC fast
+--   but the 0-row issue persists until LEM coverage extends to the long tail
+--   (separate data pipeline work). Materializing is still worthwhile — prevents
+--   the timeout from masking whatever signal does exist.
+--
+-- ROLLBACK: repoint RPC FROM back to v_tevo_blindspot_movers,
+--   cron.unschedule('tevo_blindspot_mv_refresh'),
+--   DROP MATERIALIZED VIEW public.mv_tevo_blindspot_movers,
+--   DELETE FROM cron_policy WHERE jobname = 'tevo_blindspot_mv_refresh'.
+
+SET statement_timeout = '300s';  -- initial WITH DATA scan (correlated subquery, but only ~16 LEM rows)
+
+-- 1) Materialize the view -------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_tevo_blindspot_movers AS
+  SELECT * FROM public.v_tevo_blindspot_movers
+WITH DATA;
+
+-- Unique index → enables REFRESH CONCURRENTLY (non-blocking) + fast PK lookup
+CREATE UNIQUE INDEX IF NOT EXISTS mv_tevo_blindspot_movers_pk
+  ON public.mv_tevo_blindspot_movers (tevo_event_id);
+
+-- Score filter index
+CREATE INDEX IF NOT EXISTS mv_tevo_blindspot_movers_score_idx
+  ON public.mv_tevo_blindspot_movers (selling_score DESC);
+
+-- Secure: no direct anon/authenticated PostgREST surface (preempts B1 audit class)
+REVOKE ALL ON public.mv_tevo_blindspot_movers FROM anon, authenticated;
+
+-- 2) Repoint the RPC at the matview -------------------------------------------
+--    Body is byte-identical to prior version except FROM v_tevo_blindspot_movers
+--    → FROM mv_tevo_blindspot_movers.
+CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
+  p_min_confidence numeric DEFAULT 0.5,
+  p_horizon_days   integer DEFAULT 365,
+  p_limit          integer DEFAULT 25,
+  p_venue_pattern  text    DEFAULT NULL,
+  p_mode           text    DEFAULT 'selling',
+  p_band           text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email  text;
+  v_result jsonb;
+BEGIN
+  v_email := nullif((select auth.jwt())->>'email', '');
+  IF v_email IS NULL THEN
+    RAISE EXCEPTION 'email required' USING errcode = '42501';
+  END IF;
+
+  IF p_mode NOT IN ('selling', 'tracking', 'spike_only') THEN
+    RAISE EXCEPTION 'p_mode must be selling|tracking|spike_only' USING errcode = '22023';
+  END IF;
+  IF p_band IS NOT NULL AND p_band NOT IN ('imminent_31_60','near_61_180','far_181_365') THEN
+    RAISE EXCEPTION 'p_band must be imminent_31_60|near_61_180|far_181_365|null' USING errcode = '22023';
+  END IF;
+
+  SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY
+                              m.confidence_score DESC NULLS LAST,
+                              m.occurs_at_local ASC), '[]'::jsonb)
+    INTO v_result
+  FROM (
+    SELECT
+      tevo_event_id, event_name, occurs_at_local,
+      venue_id, venue_name, venue_location,
+      primary_performer_id, primary_performer_name,
+      tickets_count, retail_min, retail_median, getin_no_parking,
+      tevo_tix_d24h, tevo_tix_d24h_pct, tevo_getin_d24h_pct,
+      tevo_getin_now, tevo_median_now,
+      signal_listings_drop, signal_listings_spike, signal_price_rise,
+      selling_score, tracking_score, confidence_score,
+      days_to_event, days_to_event_band
+    FROM public.mv_tevo_blindspot_movers             -- ← was v_tevo_blindspot_movers
+    WHERE occurs_at_local::date <= CURRENT_DATE + (p_horizon_days || ' days')::interval
+      AND (p_venue_pattern IS NULL OR venue_location ILIKE p_venue_pattern)
+      AND (p_band          IS NULL OR days_to_event_band = p_band)
+      AND confidence_score >= p_min_confidence
+      AND (
+        (p_mode = 'selling'    AND selling_score  >= 1)   OR
+        (p_mode = 'tracking'   AND tracking_score >= 1)   OR
+        (p_mode = 'spike_only' AND signal_listings_spike  = true)
+      )
+    LIMIT p_limit
+  ) m;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- 3) Cron policy + gated refresh cron -----------------------------------------
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES
+  ('tevo_blindspot_mv_refresh',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   10, 30, 120, true,
+   'Refresh mv_tevo_blindspot_movers (materializes v_tevo_blindspot_movers). 10-min peak / 30-min offpeak; mirrors sg_blindspot_mv_refresh pattern. Added A1-5 (D0 handoff 2026-05-26).')
+ON CONFLICT (jobname) DO UPDATE
+  SET peak_hours_et            = EXCLUDED.peak_hours_et,
+      peak_min_interval_min    = EXCLUDED.peak_min_interval_min,
+      offpeak_min_interval_min = EXCLUDED.offpeak_min_interval_min,
+      daily_max_fires          = EXCLUDED.daily_max_fires,
+      enabled                  = true,
+      notes                    = EXCLUDED.notes,
+      updated_at               = now();
+
+-- Offset to :7 so it doesn't fire simultaneously with sg_blindspot_mv_refresh (:3)
+SELECT cron.schedule(
+  'tevo_blindspot_mv_refresh',
+  '7-59/10 * * * *',
+  $$SET statement_timeout = '10min'; DO $body$ BEGIN IF NOT public.cron_should_fire('tevo_blindspot_mv_refresh') THEN RETURN; END IF; REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_tevo_blindspot_movers; END $body$;$$
+);

--- a/supabase/migrations/20260526050000_security_revoke_confirmed_anon_policies.sql
+++ b/supabase/migrations/20260526050000_security_revoke_confirmed_anon_policies.sql
@@ -1,0 +1,60 @@
+-- 20260526050000_security_revoke_confirmed_anon_policies.sql
+--
+-- Close anon-read exposure on tables/views confirmed safe by D0 + D1
+-- (bot_chat #537 → #553 → #556).
+--
+-- ## WHO CONFIRMED WHAT
+-- D1 (#553, 2026-05-26): "D1 needs anon-read on NONE of the flagged surfaces."
+--   All /api/store/* routes use service_role; store.js has zero direct anon calls.
+-- D0 (B1 code-audit #556): terminal/*.js has 0 .from() direct reads — RPC-only.
+--   The 3 'anon_select_dashboard' policies point at a former D0 dashboard consumer
+--   that D0 confirmed is no longer active.
+--
+-- ## WHAT'S IN THIS MIGRATION
+-- Part 1 — DROP 4 base-table anon policies (D0 + D1 confirmed, no D3 dependency)
+-- Part 2 — REVOKE anon on 4 Tier-2 views (D1 confirmed; no /api/store/* refs)
+--
+-- ## WHAT'S HELD (pending D3 confirm on thread #537)
+-- espn_athletes (espn_athletes_anon_read)
+-- espn_teams_canonical (espn_teams_canonical_anon_read)
+-- espn_event_snapshots (anon_select_dashboard)
+-- D3 / Broadway may surface these publicly — A1 will revoke once D3 confirms.
+--
+-- ## ROLLBACK
+-- Restore policies:
+--   CREATE POLICY events_anon_read ON events FOR SELECT TO anon USING (true);
+--   CREATE POLICY anon_select_dashboard ON event_xref FOR SELECT TO anon USING (true);
+--   CREATE POLICY venue_assets_anon_read ON venue_assets FOR SELECT TO anon USING (true);
+--   CREATE POLICY anon_select_dashboard ON listings_snapshots FOR SELECT TO anon USING (true);
+-- Restore view grants:
+--   GRANT SELECT ON espn_injury_snapshot_latest TO anon, authenticated;
+--   etc.
+--
+-- NOTE (HIGH PRIORITY): listings_snapshots had USING(true) anon-read — the 8M-row
+-- owned-inventory firehose (broker-competitive pricing/qty) was readable by the
+-- publishable anon key. This is the most sensitive closure in this migration.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- PART 1 — Base-table anon policy drops
+
+-- events: confirmed no anon consumer (D0 terminal = SECDEF RPCs, D1 = service_role)
+DROP POLICY IF EXISTS events_anon_read ON public.events;
+
+-- event_xref: anon_select_dashboard policy — D0 dashboard defunct, D1 unused
+DROP POLICY IF EXISTS anon_select_dashboard ON public.event_xref;
+
+-- venue_assets: D1 storefront confirmed no anon read; D0 terminal confirmed clean
+DROP POLICY IF EXISTS venue_assets_anon_read ON public.venue_assets;
+
+-- listings_snapshots: HIGH PRIORITY — 8M-row broker firehose (prices/qty exposed to anon)
+-- Policy named anon_select_dashboard — D0 confirmed defunct; D1 confirmed unused
+DROP POLICY IF EXISTS anon_select_dashboard ON public.listings_snapshots;
+
+
+-- PART 2 — Tier-2 view anon REVOKE (B1-NEXT-59 partial close; D1 confirmed safe)
+-- These views were left commented in mig 20260525170000 pending lane confirms.
+
+REVOKE SELECT ON public.espn_injury_snapshot_latest FROM anon, authenticated;
+REVOKE SELECT ON public.seatgeek_event_latest        FROM anon, authenticated;
+REVOKE SELECT ON public.v_event_full_sports          FROM anon, authenticated;
+REVOKE SELECT ON public.v_event_full_v2              FROM anon, authenticated;


### PR DESCRIPTION
## Summary

Closes the confirmed half of bot_chat #537 (B1-NEXT-58/59). D0 and D1 both confirmed they need anon-read on **none** of the flagged surfaces — all /api/store/* routes use service_role; the terminal is SECDEF-RPC-only with zero `.from()` calls.

### Part 1 — DROP 4 base-table anon policies
| Table | Policy dropped | Note |
|---|---|---|
| `events` | `events_anon_read` | D0+D1 confirmed |
| `event_xref` | `anon_select_dashboard` | D0 dashboard defunct (B1 code-audit) |
| `venue_assets` | `venue_assets_anon_read` | D1 confirmed |
| `listings_snapshots` | `anon_select_dashboard` | **HIGH PRIORITY** — 8M-row broker firehose (pricing/qty) was anon-readable via publishable key |

### Part 2 — REVOKE anon on 4 Tier-2 views (B1-NEXT-59 partial close)
`espn_injury_snapshot_latest`, `seatgeek_event_latest`, `v_event_full_sports`, `v_event_full_v2` — D1 confirmed zero `/api/store/*` references; D0 confirmed RPC-only.

### Held pending D3 confirm
`espn_athletes`, `espn_teams_canonical`, `espn_event_snapshots` — Broadway may display these publicly. @D3 nudge posted (bot_chat #560 → #537).

### Side note
Terminated runaway `midnight-catchup-sweep` PID (running 1h19m — pre-fix cron instance blocking DDL locks; fixed version in mig `20260526000000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)