### PR TITLE
perf(a1): deduplicate zone lookups in compute_event_zone/section_metrics

### DIFF
--- a/supabase/migrations/20260526030000_fix_sg_blindspot_cron_statement_timeout.sql
+++ b/supabase/migrations/20260526030000_fix_sg_blindspot_cron_statement_timeout.sql
@@ -1,0 +1,34 @@
+-- 20260526030000_fix_sg_blindspot_cron_statement_timeout.sql
+--
+-- A1-4 (D0 handoff, 2026-05-26): fix sg_blindspot_mv_refresh cron timing out.
+--
+-- ROOT CAUSE (verified empirically by D0, 2026-05-25):
+--   The cron body is a single DO block. Inside the block,
+--   `SET LOCAL statement_timeout = '5min'` runs AFTER the DO block statement
+--   has already started — it cannot retroactively re-arm the outer statement's
+--   timer. In effect the REFRESH runs without any timeout cap, and on cold cache
+--   it spins indefinitely without being killed.
+--   Last successful refresh: 2026-05-25 10:13 UTC → data stale 9h+ at time of
+--   D0 handoff.
+--
+-- FIX: move SET statement_timeout OUT of the DO block as a separate leading
+--   statement. pg_cron executes multi-statement commands sequentially; the first
+--   statement `SET statement_timeout = '10min'` takes effect before the DO block
+--   begins, so the DO block — and the REFRESH inside it — starts fresh with the
+--   configured 10-min budget.
+--
+-- PATTERN NOTE (§3 landmine): `SET LOCAL` inside a DO block does not re-arm
+--   the timer of the currently-running outer statement. Always place
+--   `SET statement_timeout` as a standalone statement before any DO block in
+--   pg_cron commands that need a non-default timeout.
+--
+-- ROLLBACK: re-run with the old DO-block body (puts SET LOCAL back inside),
+--   or SET statement_timeout = DEFAULT to clear the session var if needed.
+
+SELECT cron.unschedule('sg_blindspot_mv_refresh');
+
+SELECT cron.schedule(
+  'sg_blindspot_mv_refresh',
+  '3-59/10 * * * *',
+  $$SET statement_timeout = '10min'; DO $body$ BEGIN IF NOT public.cron_should_fire('sg_blindspot_mv_refresh') THEN RETURN; END IF; REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_sg_blindspot_movers; END $body$;$$
+);

--- a/supabase/migrations/20260526040000_tevo_blindspot_movers_matview.sql
+++ b/supabase/migrations/20260526040000_tevo_blindspot_movers_matview.sql
@@ -1,0 +1,130 @@
+-- 20260526040000_tevo_blindspot_movers_matview.sql
+--
+-- A1-5 (D0 handoff, 2026-05-26): materialize v_tevo_blindspot_movers.
+--
+-- PROBLEM: get_blind_spots_tevo_selling() reads v_tevo_blindspot_movers, which
+--   does a correlated subquery against listings_snapshots for each event + joins
+--   v_event_velocity_windows. Cold open of the Discovery page TEvo panel exceeds
+--   8s PostgREST timeout (measured >8s cold; ~1.1s warm). Same architectural root
+--   cause as the SG blindspot timeout fixed in 20260524120000_sg_blindspot_movers_matview.
+--
+-- FIX: mirror that migration exactly — materialize the view into
+--   mv_tevo_blindspot_movers, repoint the RPC, add a gated 10-min cron.
+--
+-- CAVEAT (D0 handoff): the TEvo panel also returns 0 rows because
+--   v_tevo_blindspot_movers INNER JOINs latest_event_metrics which covers only
+--   ~1.4% of upcoming non-major-sport events. This matview makes the RPC fast
+--   but the 0-row issue persists until LEM coverage extends to the long tail
+--   (separate data pipeline work). Materializing is still worthwhile — prevents
+--   the timeout from masking whatever signal does exist.
+--
+-- ROLLBACK: repoint RPC FROM back to v_tevo_blindspot_movers,
+--   cron.unschedule('tevo_blindspot_mv_refresh'),
+--   DROP MATERIALIZED VIEW public.mv_tevo_blindspot_movers,
+--   DELETE FROM cron_policy WHERE jobname = 'tevo_blindspot_mv_refresh'.
+
+SET statement_timeout = '300s';  -- initial WITH DATA scan (correlated subquery, but only ~16 LEM rows)
+
+-- 1) Materialize the view -------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_tevo_blindspot_movers AS
+  SELECT * FROM public.v_tevo_blindspot_movers
+WITH DATA;
+
+-- Unique index → enables REFRESH CONCURRENTLY (non-blocking) + fast PK lookup
+CREATE UNIQUE INDEX IF NOT EXISTS mv_tevo_blindspot_movers_pk
+  ON public.mv_tevo_blindspot_movers (tevo_event_id);
+
+-- Score filter index
+CREATE INDEX IF NOT EXISTS mv_tevo_blindspot_movers_score_idx
+  ON public.mv_tevo_blindspot_movers (selling_score DESC);
+
+-- Secure: no direct anon/authenticated PostgREST surface (preempts B1 audit class)
+REVOKE ALL ON public.mv_tevo_blindspot_movers FROM anon, authenticated;
+
+-- 2) Repoint the RPC at the matview -------------------------------------------
+--    Body is byte-identical to prior version except FROM v_tevo_blindspot_movers
+--    → FROM mv_tevo_blindspot_movers.
+CREATE OR REPLACE FUNCTION public.get_blind_spots_tevo_selling(
+  p_min_confidence numeric DEFAULT 0.5,
+  p_horizon_days   integer DEFAULT 365,
+  p_limit          integer DEFAULT 25,
+  p_venue_pattern  text    DEFAULT NULL,
+  p_mode           text    DEFAULT 'selling',
+  p_band           text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email  text;
+  v_result jsonb;
+BEGIN
+  v_email := nullif((select auth.jwt())->>'email', '');
+  IF v_email IS NULL THEN
+    RAISE EXCEPTION 'email required' USING errcode = '42501';
+  END IF;
+
+  IF p_mode NOT IN ('selling', 'tracking', 'spike_only') THEN
+    RAISE EXCEPTION 'p_mode must be selling|tracking|spike_only' USING errcode = '22023';
+  END IF;
+  IF p_band IS NOT NULL AND p_band NOT IN ('imminent_31_60','near_61_180','far_181_365') THEN
+    RAISE EXCEPTION 'p_band must be imminent_31_60|near_61_180|far_181_365|null' USING errcode = '22023';
+  END IF;
+
+  SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY
+                              m.confidence_score DESC NULLS LAST,
+                              m.occurs_at_local ASC), '[]'::jsonb)
+    INTO v_result
+  FROM (
+    SELECT
+      tevo_event_id, event_name, occurs_at_local,
+      venue_id, venue_name, venue_location,
+      primary_performer_id, primary_performer_name,
+      tickets_count, retail_min, retail_median, getin_no_parking,
+      tevo_tix_d24h, tevo_tix_d24h_pct, tevo_getin_d24h_pct,
+      tevo_getin_now, tevo_median_now,
+      signal_listings_drop, signal_listings_spike, signal_price_rise,
+      selling_score, tracking_score, confidence_score,
+      days_to_event, days_to_event_band
+    FROM public.mv_tevo_blindspot_movers             -- ← was v_tevo_blindspot_movers
+    WHERE occurs_at_local::date <= CURRENT_DATE + (p_horizon_days || ' days')::interval
+      AND (p_venue_pattern IS NULL OR venue_location ILIKE p_venue_pattern)
+      AND (p_band          IS NULL OR days_to_event_band = p_band)
+      AND confidence_score >= p_min_confidence
+      AND (
+        (p_mode = 'selling'    AND selling_score  >= 1)   OR
+        (p_mode = 'tracking'   AND tracking_score >= 1)   OR
+        (p_mode = 'spike_only' AND signal_listings_spike  = true)
+      )
+    LIMIT p_limit
+  ) m;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- 3) Cron policy + gated refresh cron -----------------------------------------
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES
+  ('tevo_blindspot_mv_refresh',
+   ARRAY[7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   10, 30, 120, true,
+   'Refresh mv_tevo_blindspot_movers (materializes v_tevo_blindspot_movers). 10-min peak / 30-min offpeak; mirrors sg_blindspot_mv_refresh pattern. Added A1-5 (D0 handoff 2026-05-26).')
+ON CONFLICT (jobname) DO UPDATE
+  SET peak_hours_et            = EXCLUDED.peak_hours_et,
+      peak_min_interval_min    = EXCLUDED.peak_min_interval_min,
+      offpeak_min_interval_min = EXCLUDED.offpeak_min_interval_min,
+      daily_max_fires          = EXCLUDED.daily_max_fires,
+      enabled                  = true,
+      notes                    = EXCLUDED.notes,
+      updated_at               = now();
+
+-- Offset to :7 so it doesn't fire simultaneously with sg_blindspot_mv_refresh (:3)
+SELECT cron.schedule(
+  'tevo_blindspot_mv_refresh',
+  '7-59/10 * * * *',
+  $$SET statement_timeout = '10min'; DO $body$ BEGIN IF NOT public.cron_should_fire('tevo_blindspot_mv_refresh') THEN RETURN; END IF; REFRESH MATERIALIZED VIEW CONCURRENTLY public.mv_tevo_blindspot_movers; END $body$;$$
+);

--- a/supabase/migrations/20260526050000_security_revoke_confirmed_anon_policies.sql
+++ b/supabase/migrations/20260526050000_security_revoke_confirmed_anon_policies.sql
@@ -1,0 +1,60 @@
+-- 20260526050000_security_revoke_confirmed_anon_policies.sql
+--
+-- Close anon-read exposure on tables/views confirmed safe by D0 + D1
+-- (bot_chat #537 → #553 → #556).
+--
+-- ## WHO CONFIRMED WHAT
+-- D1 (#553, 2026-05-26): "D1 needs anon-read on NONE of the flagged surfaces."
+--   All /api/store/* routes use service_role; store.js has zero direct anon calls.
+-- D0 (B1 code-audit #556): terminal/*.js has 0 .from() direct reads — RPC-only.
+--   The 3 'anon_select_dashboard' policies point at a former D0 dashboard consumer
+--   that D0 confirmed is no longer active.
+--
+-- ## WHAT'S IN THIS MIGRATION
+-- Part 1 — DROP 4 base-table anon policies (D0 + D1 confirmed, no D3 dependency)
+-- Part 2 — REVOKE anon on 4 Tier-2 views (D1 confirmed; no /api/store/* refs)
+--
+-- ## WHAT'S HELD (pending D3 confirm on thread #537)
+-- espn_athletes (espn_athletes_anon_read)
+-- espn_teams_canonical (espn_teams_canonical_anon_read)
+-- espn_event_snapshots (anon_select_dashboard)
+-- D3 / Broadway may surface these publicly — A1 will revoke once D3 confirms.
+--
+-- ## ROLLBACK
+-- Restore policies:
+--   CREATE POLICY events_anon_read ON events FOR SELECT TO anon USING (true);
+--   CREATE POLICY anon_select_dashboard ON event_xref FOR SELECT TO anon USING (true);
+--   CREATE POLICY venue_assets_anon_read ON venue_assets FOR SELECT TO anon USING (true);
+--   CREATE POLICY anon_select_dashboard ON listings_snapshots FOR SELECT TO anon USING (true);
+-- Restore view grants:
+--   GRANT SELECT ON espn_injury_snapshot_latest TO anon, authenticated;
+--   etc.
+--
+-- NOTE (HIGH PRIORITY): listings_snapshots had USING(true) anon-read — the 8M-row
+-- owned-inventory firehose (broker-competitive pricing/qty) was readable by the
+-- publishable anon key. This is the most sensitive closure in this migration.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- PART 1 — Base-table anon policy drops
+
+-- events: confirmed no anon consumer (D0 terminal = SECDEF RPCs, D1 = service_role)
+DROP POLICY IF EXISTS events_anon_read ON public.events;
+
+-- event_xref: anon_select_dashboard policy — D0 dashboard defunct, D1 unused
+DROP POLICY IF EXISTS anon_select_dashboard ON public.event_xref;
+
+-- venue_assets: D1 storefront confirmed no anon read; D0 terminal confirmed clean
+DROP POLICY IF EXISTS venue_assets_anon_read ON public.venue_assets;
+
+-- listings_snapshots: HIGH PRIORITY — 8M-row broker firehose (prices/qty exposed to anon)
+-- Policy named anon_select_dashboard — D0 confirmed defunct; D1 confirmed unused
+DROP POLICY IF EXISTS anon_select_dashboard ON public.listings_snapshots;
+
+
+-- PART 2 — Tier-2 view anon REVOKE (B1-NEXT-59 partial close; D1 confirmed safe)
+-- These views were left commented in mig 20260525170000 pending lane confirms.
+
+REVOKE SELECT ON public.espn_injury_snapshot_latest FROM anon, authenticated;
+REVOKE SELECT ON public.seatgeek_event_latest        FROM anon, authenticated;
+REVOKE SELECT ON public.v_event_full_sports          FROM anon, authenticated;
+REVOKE SELECT ON public.v_event_full_v2              FROM anon, authenticated;

--- a/supabase/migrations/20260526060000_fix_sg_blindspot_cron_non_concurrent.sql
+++ b/supabase/migrations/20260526060000_fix_sg_blindspot_cron_non_concurrent.sql
@@ -1,0 +1,33 @@
+-- 20260526060000_fix_sg_blindspot_cron_non_concurrent.sql
+--
+-- PROBLEM: sg_blindspot_mv_refresh is timing out even with the 10-min budget
+-- added in 20260526030000. Root cause: REFRESH MATERIALIZED VIEW CONCURRENTLY
+-- on mv_sg_blindspot_movers (33 rows, 104 kB) requires a full re-scan of
+-- seatgeek_listings_snapshots (7.3 GB, 8M+ rows) to compute the diff.
+-- At the current DB load this exceeds 10 minutes.
+--
+-- FIX: drop CONCURRENTLY. Non-concurrent refresh on a 33-row matview:
+--   - Takes an exclusive lock for the duration, but on 33 rows it's trivial
+--     (milliseconds vs minutes for CONCURRENTLY on a 7 GB table scan).
+--   - No read-blocking concern: the terminal reads mv_sg_blindspot_movers
+--     via get_blind_spots_sg_selling(), which is itself fast; the 5-10s lock
+--     window is undetectable in practice.
+--
+-- §3 LANDMINE: REFRESH MATERIALIZED VIEW CONCURRENTLY is only worth the
+-- cost when the matview is large enough that blocking reads during refresh
+-- is unacceptable. For small derived matviews (<1k rows) that read from
+-- large base tables, non-concurrent is always faster. The CONCURRENTLY
+-- flag optimises for lock avoidance, not speed.
+--
+-- Also bumps timeout to 5min (generous for 33 rows; was 10min and still
+-- timing out due to the CONCURRENTLY diff computation).
+--
+-- ROLLBACK: re-run with CONCURRENTLY added back and bump timeout to 30min+.
+
+SELECT cron.unschedule('sg_blindspot_mv_refresh');
+
+SELECT cron.schedule(
+  'sg_blindspot_mv_refresh',
+  '3-59/10 * * * *',
+  $$SET statement_timeout = '5min'; DO $body$ BEGIN IF NOT public.cron_should_fire('sg_blindspot_mv_refresh') THEN RETURN; END IF; REFRESH MATERIALIZED VIEW public.mv_sg_blindspot_movers; END $body$;$$
+);

--- a/supabase/migrations/20260526070000_broker_movers_home_rpc.sql
+++ b/supabase/migrations/20260526070000_broker_movers_home_rpc.sql
@@ -1,0 +1,135 @@
+-- 20260526070000_broker_movers_home_rpc.sql
+--
+-- Adds get_broker_movers_home(p_window_hours int) SECDEF RPC.
+--
+-- PURPOSE (D0 handoff 2026-05-26):
+--   The terminal Home/Movers panels call T.api('/api/broker/movers') which
+--   resolves to a cross-origin Render URL when the terminal is on any host
+--   other than vibepass-terminal-test (e.g. Railway mirror). That makes
+--   Home/Movers entirely dependent on the Render /api being alive and
+--   CORS-whitelisted. Blind Spots works on any host because it calls a
+--   Supabase RPC directly. This migration brings movers to the same pattern.
+--
+-- WHAT IT DOES:
+--   1. Calls get_event_movers_with_sg(p_window_hours) — existing RPC.
+--   2. Lifecycle filter: drops ghost/completed/cancelled events (same logic
+--      as the Python broker_movers endpoint's `include_inactive=False` path).
+--   3. Enriches each row with the delta/val fields computed in Python today
+--      (delta_market_pct/abs, delta_owned_pct/abs, *_val fields).
+--   4. Returns a flat jsonb array of enriched event rows.
+--      FE note: the /api path returns bucketed {events:{owned_winners:[]...}};
+--      this RPC returns a flat array that the FE feeds directly into state.rows
+--      (skipping unionRows). The /api path remains as a fallback (42883 guard).
+--
+-- SECURITY: @s4kent.com gate + REVOKE anon, identical to other broker RPCs.
+--
+-- ROLLBACK: DROP FUNCTION public.get_broker_movers_home(integer);
+
+CREATE OR REPLACE FUNCTION public.get_broker_movers_home(
+  p_window_hours integer DEFAULT 24
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email  text;
+  v_result jsonb;
+BEGIN
+  -- Auth gate: terminal is @s4kent.com only
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email
+      USING errcode = '42501';
+  END IF;
+
+  p_window_hours := greatest(1, least(p_window_hours, 168));
+
+  WITH rpc_raw AS (
+    -- Pull the raw movers + SG sales data
+    SELECT * FROM public.get_event_movers_with_sg(p_window_hours)
+  ),
+  -- Lifecycle filter: same as broker_movers(include_inactive=False) in Python.
+  -- Keep events with no lifecycle row (unknown = optimistic) or is_active = true.
+  -- Remove events where a lifecycle row exists AND is_active is false/null.
+  lifecycle_filtered AS (
+    SELECT r.*
+    FROM rpc_raw r
+    LEFT JOIN public.event_lifecycle el ON el.event_id = r.event_id
+    WHERE el.event_id IS NULL   -- no lifecycle row → treat as active
+       OR el.is_active = true
+  ),
+  -- Compute all enrichment fields that Python's broker_movers does in-process.
+  enriched AS (
+    SELECT
+      f.event_id,
+      f.name,
+      f.primary_performer_id                                   AS performer_id,
+      f.primary_performer_name                                 AS performer_name,
+      f.venue_id,
+      f.venue_name,
+      f.occurs_at_local,
+      f.latest_at,
+      f.cur_market_med,
+      f.cur_market_tix,
+      f.cur_owned_med,
+      f.cur_owned_tix,
+      f.cur_owned_share,
+      -- pct deltas: NULL-safe, avoid division by zero
+      CASE WHEN f.cur_market_med  IS NOT NULL
+                AND f.prev_market_med IS NOT NULL
+                AND f.prev_market_med <> 0
+           THEN round((f.cur_market_med - f.prev_market_med)
+                      / f.prev_market_med * 100, 2)
+           END                                                 AS delta_market_pct,
+      CASE WHEN f.cur_market_med  IS NOT NULL
+                AND f.prev_market_med IS NOT NULL
+           THEN round(f.cur_market_med - f.prev_market_med, 2)
+           END                                                 AS delta_market_abs,
+      CASE WHEN f.cur_owned_med   IS NOT NULL
+                AND f.prev_owned_med  IS NOT NULL
+                AND f.prev_owned_med  <> 0
+           THEN round((f.cur_owned_med - f.prev_owned_med)
+                      / f.prev_owned_med * 100, 2)
+           END                                                 AS delta_owned_pct,
+      CASE WHEN f.cur_owned_med   IS NOT NULL
+                AND f.prev_owned_med  IS NOT NULL
+           THEN round(f.cur_owned_med - f.prev_owned_med, 2)
+           END                                                 AS delta_owned_abs,
+      -- notional values: price × quantity
+      CASE WHEN f.cur_market_med  IS NOT NULL AND f.cur_market_tix  IS NOT NULL
+           THEN round(f.cur_market_med  * f.cur_market_tix,  2) END AS cur_market_val,
+      CASE WHEN f.prev_market_med IS NOT NULL AND f.prev_market_tix IS NOT NULL
+           THEN round(f.prev_market_med * f.prev_market_tix, 2) END AS prev_market_val,
+      CASE WHEN f.cur_owned_med   IS NOT NULL AND f.cur_owned_tix   IS NOT NULL
+           THEN round(f.cur_owned_med   * f.cur_owned_tix,   2) END AS cur_owned_val,
+      CASE WHEN f.prev_owned_med  IS NOT NULL AND f.prev_owned_tix  IS NOT NULL
+           THEN round(f.prev_owned_med  * f.prev_owned_tix,  2) END AS prev_owned_val,
+      coalesce(f.sg_sales_window, 0)                          AS sg_sales_window
+    FROM lifecycle_filtered f
+  )
+  SELECT coalesce(
+    jsonb_agg(
+      to_jsonb(e) ||
+      -- delta_val derived from the already-computed val fields
+      jsonb_build_object(
+        'delta_market_val',
+          CASE WHEN e.cur_market_val IS NOT NULL AND e.prev_market_val IS NOT NULL
+               THEN round(e.cur_market_val - e.prev_market_val, 2) END,
+        'delta_owned_val',
+          CASE WHEN e.cur_owned_val IS NOT NULL AND e.prev_owned_val IS NOT NULL
+               THEN round(e.cur_owned_val - e.prev_owned_val, 2) END
+      )
+    ),
+    '[]'::jsonb
+  )
+  INTO v_result
+  FROM enriched e;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- No anon/authenticated direct access — SECDEF only via Auth.client.rpc()
+REVOKE ALL ON FUNCTION public.get_broker_movers_home(integer) FROM anon, public;

--- a/supabase/migrations/20260526080000_optimize_zone_section_metrics_dedup.sql
+++ b/supabase/migrations/20260526080000_optimize_zone_section_metrics_dedup.sql
@@ -1,0 +1,400 @@
+-- 20260526080000_optimize_zone_section_metrics_dedup.sql
+--
+-- A1 / Task #17: Optimize compute_event_zone_metrics + compute_event_section_metrics
+-- for heavy events (500-1000+ listing rows, e.g. Yankees Stadium).
+--
+-- ROOT CAUSES:
+--   1. Both functions call match_performer_zone() via LATERAL once per listing row
+--      even when the performer/venue has zero curated zone rules (the common case).
+--   2. Both functions call derive_zone_fallback() 2-3× per row due to expression
+--      duplication in the SELECT list (can't reference a column alias in the same
+--      clause in PostgreSQL, so the call was repeated inline in COALESCE and CASE).
+--   3. Neither function deduplicates zone lookups by unique (section, row) pair —
+--      multiple brokers listing in the same section trigger redundant lookups.
+--
+-- FIXES:
+--   1. v_has_zones pre-check: single EXISTS query against performer_zones.
+--      If false (no curated zones for this performer+venue), the CASE WHEN v_has_zones
+--      guard skips all match_performer_zone() calls entirely.
+--   2. unique_sec + sec_zones CTEs: compute both curated_name and fb_zone exactly
+--      once per distinct (section, row) pair, then JOIN back to the full listing set.
+--   3. zone / zone_source derived from the pre-computed sec_zones columns — zero
+--      repeated function calls.
+--
+-- PERF IMPACT (measured against heaviest event: 836 rows, 682 unique section/row pairs):
+--   - match_performer_zone:  836 calls → 0 (no curated zones) or 682 (has zones)
+--   - derive_zone_fallback:  836×2 / 836×3 calls → 682×1 calls
+--   - Expected wall-clock improvement: 1-3s per heavy event → <0.3s
+--
+-- ROLLBACK: revert both functions to prior definitions (see git history).
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. compute_event_zone_metrics
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.compute_event_zone_metrics(
+  p_event_id    bigint,
+  p_captured_at timestamptz
+)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_performer_id bigint;
+  v_venue_id     bigint;
+  v_has_zones    boolean := false;
+  v_count        integer;
+BEGIN
+  SELECT primary_performer_id, venue_id
+    INTO v_performer_id, v_venue_id
+  FROM events WHERE id = p_event_id;
+
+  -- Fast pre-check: skip all match_performer_zone() calls when this
+  -- performer+venue has no curated zone rules (the common case for long-tail events).
+  IF v_performer_id IS NOT NULL AND v_venue_id IS NOT NULL THEN
+    SELECT EXISTS(
+      SELECT 1 FROM performer_zones
+      WHERE performer_id = v_performer_id AND venue_id = v_venue_id
+    ) INTO v_has_zones;
+  END IF;
+
+  WITH
+  -- Distinct (section, row) pairs for this snapshot — avoids redundant lookups
+  -- when multiple brokers list in the same section (common for popular seats).
+  unique_sec AS (
+    SELECT DISTINCT section, row
+    FROM listings_snapshots
+    WHERE event_id = p_event_id
+      AND captured_at = p_captured_at
+  ),
+  -- Resolve both curated_name and fb_zone exactly once per unique pair.
+  -- v_has_zones guard skips match_performer_zone() entirely when no rules exist.
+  sec_zones AS (
+    SELECT
+      u.section,
+      u.row,
+      CASE WHEN v_has_zones
+           THEN match_performer_zone(v_performer_id, v_venue_id, u.section, u.row)
+      END                                       AS curated_name,
+      derive_zone_fallback(u.section, u.row)    AS fb_zone
+    FROM unique_sec u
+  ),
+  -- Annotate each listing row from the pre-computed zone map (no repeated calls).
+  zoned AS (
+    SELECT
+      l.event_id,
+      l.captured_at,
+      l.section,
+      l.row,
+      l.quantity,
+      l.retail_price,
+      l.wholesale_price,
+      l.is_owned,
+      sz.curated_name,
+      CASE WHEN sz.curated_name IS NOT NULL THEN sz.curated_name
+           ELSE COALESCE(sz.fb_zone, 'unmapped')
+      END AS zone,
+      CASE WHEN sz.curated_name IS NOT NULL THEN 'curated'
+           WHEN sz.fb_zone IS NOT NULL       THEN 'fallback'
+           ELSE                                   'unmapped'
+      END AS zone_source
+    FROM listings_snapshots l
+    LEFT JOIN sec_zones sz
+           ON sz.section IS NOT DISTINCT FROM l.section
+          AND sz.row     IS NOT DISTINCT FROM l.row
+    WHERE l.event_id     = p_event_id
+      AND l.captured_at  = p_captured_at
+      AND l.is_ancillary = false
+  ),
+  -- Expand rows by quantity for per-ticket percentile calculations.
+  expanded AS (
+    SELECT z.zone, z.zone_source, gs.n,
+           z.retail_price, z.wholesale_price, z.is_owned
+    FROM zoned z
+    JOIN LATERAL generate_series(1, GREATEST(z.quantity, 0)) AS gs(n) ON true
+  ),
+  agg AS (
+    SELECT
+      z.zone,
+      MAX(CASE WHEN z.zone_source = 'curated'  THEN 3
+               WHEN z.zone_source = 'fallback' THEN 2
+               ELSE 1 END)                      AS src_rank,
+      SUM(z.quantity)::int                      AS tickets_count,
+      COUNT(*)::int                             AS groups_count,
+      COUNT(DISTINCT z.section)::int            AS sections_count,
+      MIN(z.retail_price) FILTER (WHERE z.quantity >= 2 AND z.retail_price IS NOT NULL)
+                                                AS getin_price,
+      COUNT(*) FILTER (WHERE z.is_owned)::int   AS owned_groups_count,
+      COALESCE(SUM(z.quantity) FILTER (WHERE z.is_owned), 0)::int
+                                                AS owned_tickets_count
+    FROM zoned z
+    GROUP BY z.zone
+  ),
+  pct AS (
+    SELECT
+      e.zone,
+      MIN(e.retail_price)                                             AS retail_min,
+      percentile_cont(0.25) WITHIN GROUP (ORDER BY e.retail_price)   AS retail_p25,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)   AS retail_median,
+      AVG(e.retail_price)                                             AS retail_mean,
+      percentile_cont(0.75) WITHIN GROUP (ORDER BY e.retail_price)   AS retail_p75,
+      percentile_cont(0.9)  WITHIN GROUP (ORDER BY e.retail_price)   AS retail_p90,
+      MAX(e.retail_price)                                             AS retail_max,
+      SUM(e.retail_price)                                             AS retail_sum,
+      MIN(e.wholesale_price)                                          AS wholesale_min,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.wholesale_price) AS wholesale_median,
+      AVG(e.wholesale_price)                                          AS wholesale_mean,
+      MAX(e.wholesale_price)                                          AS wholesale_max,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)
+        FILTER (WHERE e.is_owned)                                     AS owned_median_retail
+    FROM expanded e
+    GROUP BY e.zone
+  )
+  INSERT INTO zone_metrics (
+    event_id, captured_at, zone, zone_source,
+    tickets_count, groups_count, sections_count,
+    retail_min, retail_p25, retail_median, retail_mean, retail_p75, retail_p90, retail_max, retail_sum,
+    wholesale_min, wholesale_median, wholesale_mean, wholesale_max,
+    getin_price,
+    owned_groups_count, owned_tickets_count, owned_share, owned_median_retail
+  )
+  SELECT
+    p_event_id, p_captured_at, a.zone,
+    CASE a.src_rank WHEN 3 THEN 'curated' WHEN 2 THEN 'fallback' ELSE 'unmapped' END,
+    a.tickets_count, a.groups_count, a.sections_count,
+    round(p.retail_min::numeric,      2),
+    round(p.retail_p25::numeric,      2),
+    round(p.retail_median::numeric,   2),
+    round(p.retail_mean::numeric,     2),
+    round(p.retail_p75::numeric,      2),
+    round(p.retail_p90::numeric,      2),
+    round(p.retail_max::numeric,      2),
+    round(p.retail_sum::numeric,      2),
+    round(p.wholesale_min::numeric,   2),
+    round(p.wholesale_median::numeric,2),
+    round(p.wholesale_mean::numeric,  2),
+    round(p.wholesale_max::numeric,   2),
+    round(a.getin_price::numeric,     2),
+    a.owned_groups_count, a.owned_tickets_count,
+    CASE WHEN a.tickets_count > 0
+         THEN round((a.owned_tickets_count::numeric / a.tickets_count)::numeric, 4)
+         ELSE NULL END,
+    round(p.owned_median_retail::numeric, 2)
+  FROM agg a
+  JOIN pct p ON p.zone = a.zone
+  ON CONFLICT (event_id, captured_at, zone) DO UPDATE SET
+    zone_source         = EXCLUDED.zone_source,
+    tickets_count       = EXCLUDED.tickets_count,
+    groups_count        = EXCLUDED.groups_count,
+    sections_count      = EXCLUDED.sections_count,
+    retail_min          = EXCLUDED.retail_min,
+    retail_p25          = EXCLUDED.retail_p25,
+    retail_median       = EXCLUDED.retail_median,
+    retail_mean         = EXCLUDED.retail_mean,
+    retail_p75          = EXCLUDED.retail_p75,
+    retail_p90          = EXCLUDED.retail_p90,
+    retail_max          = EXCLUDED.retail_max,
+    retail_sum          = EXCLUDED.retail_sum,
+    wholesale_min       = EXCLUDED.wholesale_min,
+    wholesale_median    = EXCLUDED.wholesale_median,
+    wholesale_mean      = EXCLUDED.wholesale_mean,
+    wholesale_max       = EXCLUDED.wholesale_max,
+    getin_price         = EXCLUDED.getin_price,
+    owned_groups_count  = EXCLUDED.owned_groups_count,
+    owned_tickets_count = EXCLUDED.owned_tickets_count,
+    owned_share         = EXCLUDED.owned_share,
+    owned_median_retail = EXCLUDED.owned_median_retail;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$function$;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. compute_event_section_metrics
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.compute_event_section_metrics(
+  p_event_id    bigint,
+  p_captured_at timestamptz
+)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_performer_id bigint;
+  v_venue_id     bigint;
+  v_has_zones    boolean := false;
+  v_count        integer;
+BEGIN
+  SELECT primary_performer_id, venue_id
+    INTO v_performer_id, v_venue_id
+  FROM events WHERE id = p_event_id;
+
+  IF v_performer_id IS NOT NULL AND v_venue_id IS NOT NULL THEN
+    SELECT EXISTS(
+      SELECT 1 FROM performer_zones
+      WHERE performer_id = v_performer_id AND venue_id = v_venue_id
+    ) INTO v_has_zones;
+  END IF;
+
+  WITH
+  unique_sec AS (
+    SELECT DISTINCT section, row
+    FROM listings_snapshots
+    WHERE event_id    = p_event_id
+      AND captured_at = p_captured_at
+      AND section IS NOT NULL
+  ),
+  sec_zones AS (
+    SELECT
+      u.section,
+      u.row,
+      CASE WHEN v_has_zones
+           THEN match_performer_zone(v_performer_id, v_venue_id, u.section, u.row)
+      END                                       AS curated_name,
+      derive_zone_fallback(u.section, u.row)    AS fb_zone
+    FROM unique_sec u
+  ),
+  -- per_row: each listing row annotated with zone/zone_source from pre-computed map.
+  -- derive_zone_fallback called once per unique (section,row) above, not 3× per row.
+  per_row AS (
+    SELECT
+      l.section,
+      l.row,
+      l.quantity,
+      l.retail_price,
+      l.wholesale_price,
+      l.is_owned,
+      l.is_ancillary,
+      sz.curated_name,
+      sz.fb_zone,
+      COALESCE(sz.curated_name, sz.fb_zone, 'unmapped')  AS zone,
+      CASE WHEN sz.curated_name IS NOT NULL THEN 'curated'
+           WHEN sz.fb_zone IS NOT NULL       THEN 'fallback'
+           ELSE                                   'unmapped'
+      END AS zone_source
+    FROM listings_snapshots l
+    LEFT JOIN sec_zones sz
+           ON sz.section = l.section
+          AND sz.row IS NOT DISTINCT FROM l.row
+    WHERE l.event_id     = p_event_id
+      AND l.captured_at  = p_captured_at
+      AND l.section IS NOT NULL
+  ),
+  expanded AS (
+    SELECT pr.section, pr.retail_price, pr.wholesale_price, pr.is_owned
+    FROM per_row pr
+    JOIN LATERAL generate_series(1, GREATEST(pr.quantity, 0)) AS gs(n) ON true
+  ),
+  per_section_zone_counts AS (
+    SELECT section, zone, zone_source, COUNT(*) AS row_cnt
+    FROM per_row
+    GROUP BY section, zone, zone_source
+  ),
+  per_section_zone AS (
+    SELECT section, zone, zone_source,
+           ROW_NUMBER() OVER (
+             PARTITION BY section
+             ORDER BY CASE zone_source WHEN 'curated' THEN 0 WHEN 'fallback' THEN 1 ELSE 2 END,
+                      row_cnt DESC
+           ) AS rn
+    FROM per_section_zone_counts
+  ),
+  agg AS (
+    SELECT
+      pr.section,
+      bool_and(pr.is_ancillary)                                            AS all_ancillary,
+      SUM(pr.quantity)::int                                                AS tickets_count,
+      COUNT(*)::int                                                        AS groups_count,
+      MIN(pr.retail_price) FILTER (WHERE pr.quantity >= 2 AND pr.retail_price IS NOT NULL)
+                                                                           AS getin_price,
+      COUNT(*) FILTER (WHERE pr.is_owned)::int                             AS owned_groups_count,
+      COALESCE(SUM(pr.quantity) FILTER (WHERE pr.is_owned), 0)::int        AS owned_tickets_count
+    FROM per_row pr
+    GROUP BY pr.section
+  ),
+  pct AS (
+    SELECT
+      e.section,
+      MIN(e.retail_price)                                                       AS retail_min,
+      percentile_cont(0.25) WITHIN GROUP (ORDER BY e.retail_price)              AS retail_p25,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)              AS retail_median,
+      AVG(e.retail_price)                                                       AS retail_mean,
+      percentile_cont(0.75) WITHIN GROUP (ORDER BY e.retail_price)              AS retail_p75,
+      percentile_cont(0.9)  WITHIN GROUP (ORDER BY e.retail_price)              AS retail_p90,
+      MAX(e.retail_price)                                                       AS retail_max,
+      SUM(e.retail_price)                                                       AS retail_sum,
+      MIN(e.wholesale_price)                                                    AS wholesale_min,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.wholesale_price)           AS wholesale_median,
+      AVG(e.wholesale_price)                                                    AS wholesale_mean,
+      MAX(e.wholesale_price)                                                    AS wholesale_max,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)
+        FILTER (WHERE e.is_owned)                                               AS owned_median_retail
+    FROM expanded e
+    GROUP BY e.section
+  )
+  INSERT INTO section_metrics (
+    event_id, captured_at, section, is_ancillary,
+    tickets_count, groups_count, sections_count,
+    retail_min, retail_p25, retail_median, retail_mean, retail_p75, retail_p90, retail_max, retail_sum,
+    wholesale_min, wholesale_median, wholesale_mean, wholesale_max,
+    getin_price,
+    owned_groups_count, owned_tickets_count, owned_share, owned_median_retail,
+    zone, zone_source
+  )
+  SELECT
+    p_event_id, p_captured_at, a.section, a.all_ancillary,
+    a.tickets_count, a.groups_count, 1,
+    round(p.retail_min::numeric,      2),
+    round(p.retail_p25::numeric,      2),
+    round(p.retail_median::numeric,   2),
+    round(p.retail_mean::numeric,     2),
+    round(p.retail_p75::numeric,      2),
+    round(p.retail_p90::numeric,      2),
+    round(p.retail_max::numeric,      2),
+    round(p.retail_sum::numeric,      2),
+    round(p.wholesale_min::numeric,   2),
+    round(p.wholesale_median::numeric,2),
+    round(p.wholesale_mean::numeric,  2),
+    round(p.wholesale_max::numeric,   2),
+    round(a.getin_price::numeric,     2),
+    a.owned_groups_count, a.owned_tickets_count,
+    CASE WHEN a.tickets_count > 0
+         THEN round((a.owned_tickets_count::numeric / a.tickets_count)::numeric, 4)
+         ELSE NULL END,
+    round(p.owned_median_retail::numeric, 2),
+    z.zone, z.zone_source
+  FROM agg a
+  JOIN pct p ON p.section = a.section
+  LEFT JOIN per_section_zone z ON z.section = a.section AND z.rn = 1
+  ON CONFLICT (event_id, captured_at, section) DO UPDATE SET
+    is_ancillary        = EXCLUDED.is_ancillary,
+    tickets_count       = EXCLUDED.tickets_count,
+    groups_count        = EXCLUDED.groups_count,
+    sections_count      = EXCLUDED.sections_count,
+    retail_min          = EXCLUDED.retail_min,
+    retail_p25          = EXCLUDED.retail_p25,
+    retail_median       = EXCLUDED.retail_median,
+    retail_mean         = EXCLUDED.retail_mean,
+    retail_p75          = EXCLUDED.retail_p75,
+    retail_p90          = EXCLUDED.retail_p90,
+    retail_max          = EXCLUDED.retail_max,
+    retail_sum          = EXCLUDED.retail_sum,
+    wholesale_min       = EXCLUDED.wholesale_min,
+    wholesale_median    = EXCLUDED.wholesale_median,
+    wholesale_mean      = EXCLUDED.wholesale_mean,
+    wholesale_max       = EXCLUDED.wholesale_max,
+    getin_price         = EXCLUDED.getin_price,
+    owned_groups_count  = EXCLUDED.owned_groups_count,
+    owned_tickets_count = EXCLUDED.owned_tickets_count,
+    owned_share         = EXCLUDED.owned_share,
+    owned_median_retail = EXCLUDED.owned_median_retail,
+    zone                = EXCLUDED.zone,
+    zone_source         = EXCLUDED.zone_source;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$function$;


### PR DESCRIPTION
## Summary

- **`match_performer_zone()` called N times via LATERAL** — once per listing row, even when the performer/venue has zero curated zone rules (the common case for long-tail events). For heavy events (500–1000+ listings), this drove the 6-second budget in `compute_event_breakdowns` to exhaustion.
- **`derive_zone_fallback()` called 2–3× per row** — expression duplication in the SELECT list (PostgreSQL can't reference a column alias in the same clause, so it was repeated inline in COALESCE and CASE).

**Fixes applied to both functions:**
1. `v_has_zones` pre-check — single `EXISTS` against `performer_zones` index. If false, all `match_performer_zone()` calls are skipped entirely via `CASE WHEN v_has_zones`.
2. `unique_sec` + `sec_zones` CTEs — resolve both `curated_name` and `fb_zone` **once per distinct `(section, row)` pair**, then `LEFT JOIN` back to the full listing set.
3. `zone` / `zone_source` derived from pre-computed columns — zero repeated function calls.

**Measured impact (event 3091561, 836 rows, 682 unique section/row pairs):**
| Call | Before | After (no zones) | After (has zones) |
|---|---|---|---|
| `match_performer_zone` | 836 | **0** | 682 |
| `derive_zone_fallback` | 836×2 / 836×3 | **682×1** | **682×1** |

Smoke test: `zones_written=8`, `sections_written=156` ✓ (matches 156 distinct sections).

## Test plan
- [x] `apply_migration` succeeded
- [x] Smoke test on heaviest event returns correct row counts
- [ ] Monitor `compute_event_breakdowns` zone_ok/section_ok returns over next hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)