### PR TITLE
feat(d0): wire get_broker_movers_home + add TicketsData read-only client & MVP

### DIFF
--- a/scripts/ticketsdata_mvp.py
+++ b/scripts/ticketsdata_mvp.py
@@ -16,22 +16,24 @@ below its floor. /match is OFF unless you pass --allow-match.
 
 Credentials come from TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD env vars.
 
+Note: seatgeek is excluded (sourced natively) — fetch/events reject it.
+
 Examples:
   # dry run — print the plan + projected cost, make zero calls
-  python scripts/ticketsdata_mvp.py --platform seatgeek \\
-      --event-url https://seatgeek.com/concert/17762666 --dry-run
+  python scripts/ticketsdata_mvp.py --platform stubhub \\
+      --event-url https://www.stubhub.com/x/event/159756853/ --dry-run
 
   # one /fetch (1 credit)
-  python scripts/ticketsdata_mvp.py --platform seatgeek \\
-      --event-url https://seatgeek.com/concert/17762666
+  python scripts/ticketsdata_mvp.py --platform stubhub \\
+      --event-url https://www.stubhub.com/x/event/159756853/
 
   # one /events discovery + one /fetch on the first result (<= 2 credits)
-  python scripts/ticketsdata_mvp.py --platform seatgeek \\
-      --performer-url https://seatgeek.com/cardi-b-tickets --then-fetch
+  python scripts/ticketsdata_mvp.py --platform stubhub \\
+      --performer-url https://www.stubhub.com/morgan-wallen-tickets/performer/123/ --then-fetch
 
   # cross-market report (12 credits + 1 report) — must opt in AND raise cap
   python scripts/ticketsdata_mvp.py --allow-match --max-credits 12 \\
-      --match-url https://seatgeek.com/concert/17762666
+      --match-url https://www.stubhub.com/x/event/159756853/
 """
 from __future__ import annotations
 

--- a/scripts/ticketsdata_mvp.py
+++ b/scripts/ticketsdata_mvp.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""TicketsData MVP smoke test — budget-guarded.
+
+Exercises the TicketsData client against a tiny, explicit set of calls so we
+can confirm auth + connectivity + parsing WITHOUT burning through the plan.
+
+Plan context (Starter): 10,000 API credits/mo + 250 Market-Intelligence
+reports/mo. Cost: /fetch = 1 credit, /events = 1 credit, /match = 12 credits
+AND 1 report.
+
+The guard: this script projects the WORST-CASE credit cost of the requested
+actions up front and refuses to make any call if that exceeds --max-credits.
+After every call it reads `quota_remaining` (and `reports_remaining` for
+/match) from the response and aborts the rest of the plan if either drops
+below its floor. /match is OFF unless you pass --allow-match.
+
+Credentials come from TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD env vars.
+
+Examples:
+  # dry run — print the plan + projected cost, make zero calls
+  python scripts/ticketsdata_mvp.py --platform seatgeek \\
+      --event-url https://seatgeek.com/concert/17762666 --dry-run
+
+  # one /fetch (1 credit)
+  python scripts/ticketsdata_mvp.py --platform seatgeek \\
+      --event-url https://seatgeek.com/concert/17762666
+
+  # one /events discovery + one /fetch on the first result (<= 2 credits)
+  python scripts/ticketsdata_mvp.py --platform seatgeek \\
+      --performer-url https://seatgeek.com/cardi-b-tickets --then-fetch
+
+  # cross-market report (12 credits + 1 report) — must opt in AND raise cap
+  python scripts/ticketsdata_mvp.py --allow-match --max-credits 12 \\
+      --match-url https://seatgeek.com/concert/17762666
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Allow running as `python scripts/ticketsdata_mvp.py` from repo root.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ticketsdata_client import (  # noqa: E402
+    CREDIT_COST,
+    TicketsDataClient,
+    TicketsDataError,
+)
+
+
+class BudgetExceeded(RuntimeError):
+    pass
+
+
+class Budget:
+    """Hard credit ceiling for one MVP run. Refuses spend over the cap and
+    tracks the live `quota_remaining` floor reported by the API."""
+
+    def __init__(self, max_credits: int, min_quota_floor: int):
+        self.max_credits = max_credits
+        self.min_quota_floor = min_quota_floor
+        self.spent = 0
+        self.last_quota_remaining: int | None = None
+
+    def check(self, cost: int) -> None:
+        if self.spent + cost > self.max_credits:
+            raise BudgetExceeded(
+                f"would spend {self.spent + cost} credits > cap {self.max_credits}"
+            )
+        if (
+            self.last_quota_remaining is not None
+            and self.last_quota_remaining - cost < self.min_quota_floor
+        ):
+            raise BudgetExceeded(
+                f"quota_remaining {self.last_quota_remaining} would drop below "
+                f"floor {self.min_quota_floor}"
+            )
+
+    def record(self, cost: int, quota_remaining: int | None) -> None:
+        self.spent += cost
+        if isinstance(quota_remaining, int):
+            self.last_quota_remaining = quota_remaining
+
+
+def _q(env: dict) -> int | None:
+    v = env.get("quota_remaining")
+    return v if isinstance(v, int) else None
+
+
+def _summarize_fetch(env: dict) -> str:
+    plat = env.get("platform", "?")
+    body = env.get("body")
+    n = None
+    if isinstance(body, list):
+        n = len(body)
+    elif isinstance(body, dict):
+        emb = body.get("_embedded")
+        if isinstance(emb, dict) and isinstance(emb.get("offer"), list):
+            n = len(emb["offer"])
+        elif isinstance(body.get("listings"), list):
+            n = len(body["listings"])
+        elif isinstance(body.get("offers"), list):
+            n = len(body["offers"])
+    listings = f"{n} listings" if n is not None else "listings (shape varies)"
+    return f"  /fetch {plat}: status={env.get('status')} {listings} in {env.get('response_s')}s"
+
+
+def _summarize_match(env: dict) -> str:
+    intel = (env.get("fetch_results") or {}).get("intelligence") or {}
+    snap = intel.get("cross_market_snapshot") or {}
+    best = snap.get("best_entry_total") or {}
+    deep = snap.get("deepest_market") or {}
+    arb = intel.get("section_arbitrage") or []
+    top = arb[0] if arb else {}
+    lines = [
+        f"  /match: confidence={env.get('match_confidence')} "
+        f"markets={snap.get('marketplaces_compared')}",
+        f"    best entry: {best.get('marketplace')} ${best.get('price')} "
+        f"({best.get('section')})",
+        f"    deepest:    {deep.get('marketplace')} {deep.get('listing_count')} listings",
+    ]
+    if top:
+        lines.append(
+            f"    top spread: {top.get('section')} ${top.get('spread')} "
+            f"({top.get('spread_pct_vs_best')}% vs best)"
+        )
+    lines.append(f"    reports_remaining={env.get('reports_remaining')}")
+    return "\n".join(lines)
+
+
+def _first_event_url(env: dict) -> str | None:
+    """Best-effort extraction of the first event URL from an /events body."""
+    body = env.get("body")
+    items = body if isinstance(body, list) else (
+        body.get("events") if isinstance(body, dict) else None
+    )
+    if not isinstance(items, list):
+        return None
+    for it in items:
+        if isinstance(it, dict):
+            for key in ("event_url", "url", "link"):
+                if it.get(key):
+                    return it[key]
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="TicketsData MVP smoke test (budget-guarded)")
+    ap.add_argument("--platform", help="marketplace for --event-url / --performer-url")
+    ap.add_argument("--event-url", help="event URL for a single /fetch")
+    ap.add_argument("--performer-url", help="performer/venue page for a single /events")
+    ap.add_argument("--then-fetch", action="store_true",
+                    help="after /events, run one /fetch on the first discovered event")
+    ap.add_argument("--match-url", help="event URL for /match (cross-market report)")
+    ap.add_argument("--allow-match", action="store_true",
+                    help="permit the 12-credit + 1-report /match call (off by default)")
+    ap.add_argument("--max-credits", type=int, default=5,
+                    help="hard ceiling on credits this run may spend (default 5)")
+    ap.add_argument("--min-quota-floor", type=int, default=50,
+                    help="abort if quota_remaining would drop below this (default 50)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the plan + projected worst-case cost, make NO calls")
+    args = ap.parse_args()
+
+    # Build the plan.
+    plan: list[tuple[str, int]] = []
+    if args.event_url:
+        plan.append(("fetch", CREDIT_COST["fetch"]))
+    if args.performer_url:
+        plan.append(("events", CREDIT_COST["events"]))
+        if args.then_fetch:
+            plan.append(("fetch-discovered", CREDIT_COST["fetch"]))
+    if args.match_url:
+        if not args.allow_match:
+            print("ERROR: --match-url requires --allow-match "
+                  "(12 credits + 1 report).", file=sys.stderr)
+            return 2
+        plan.append(("match", CREDIT_COST["match"]))
+
+    if not plan:
+        print("Nothing to do. Provide --event-url, --performer-url, and/or "
+              "--match-url. See --help.", file=sys.stderr)
+        return 2
+
+    worst_case = sum(cost for _, cost in plan)
+    print(f"Plan: {[name for name, _ in plan]}")
+    print(f"Projected worst-case cost: {worst_case} credits "
+          f"(cap --max-credits={args.max_credits})")
+    if args.match_url:
+        print("  note: /match also consumes 1 Market-Intelligence report")
+
+    if worst_case > args.max_credits:
+        print(f"REFUSING: projected {worst_case} credits exceeds cap "
+              f"{args.max_credits}. Raise --max-credits to proceed.", file=sys.stderr)
+        return 3
+
+    if args.dry_run:
+        print("Dry run — no calls made.")
+        return 0
+
+    try:
+        client = TicketsDataClient.from_env()
+    except TicketsDataError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    budget = Budget(args.max_credits, args.min_quota_floor)
+
+    try:
+        if args.event_url:
+            if not args.platform:
+                print("ERROR: --event-url needs --platform", file=sys.stderr)
+                return 2
+            budget.check(CREDIT_COST["fetch"])
+            env = client.fetch(args.platform, args.event_url)
+            budget.record(CREDIT_COST["fetch"], _q(env))
+            print(_summarize_fetch(env))
+            print(f"  quota_remaining={_q(env)}  (spent {budget.spent})")
+
+        if args.performer_url:
+            if not args.platform:
+                print("ERROR: --performer-url needs --platform", file=sys.stderr)
+                return 2
+            budget.check(CREDIT_COST["events"])
+            env = client.events(args.platform, performer_url=args.performer_url)
+            budget.record(CREDIT_COST["events"], _q(env))
+            first = _first_event_url(env)
+            print(f"  /events {args.platform}: discovered first event = {first}")
+            print(f"  quota_remaining={_q(env)}  (spent {budget.spent})")
+            if args.then_fetch and first:
+                budget.check(CREDIT_COST["fetch"])
+                env2 = client.fetch(args.platform, first)
+                budget.record(CREDIT_COST["fetch"], _q(env2))
+                print(_summarize_fetch(env2))
+                print(f"  quota_remaining={_q(env2)}  (spent {budget.spent})")
+
+        if args.match_url:
+            budget.check(CREDIT_COST["match"])
+            env = client.match(args.match_url)
+            budget.record(CREDIT_COST["match"], _q(env))
+            print(_summarize_match(env))
+            print(f"  quota_remaining={_q(env)}  (spent {budget.spent})")
+
+    except BudgetExceeded as e:
+        print(f"ABORTED mid-plan (budget guard): {e}", file=sys.stderr)
+        return 3
+    except TicketsDataError as e:
+        print(f"API error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Done. Total credits spent this run: {budget.spent}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ticketsdata_mvp.py
+++ b/scripts/ticketsdata_mvp.py
@@ -83,6 +83,21 @@ class Budget:
             self.last_quota_remaining = quota_remaining
 
 
+def _maybe_supabase():
+    """Best-effort service-role Supabase client for the Vault credential
+    fallback. Returns None if env/lib unavailable (then env creds are used)."""
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not (url and key):
+        return None
+    try:
+        from supabase import create_client
+        return create_client(url, key)
+    except Exception as e:
+        print(f"(supabase client unavailable, using env creds: {e})", file=sys.stderr)
+        return None
+
+
 def _q(env: dict) -> int | None:
     v = env.get("quota_remaining")
     return v if isinstance(v, int) else None
@@ -200,7 +215,9 @@ def main() -> int:
         return 0
 
     try:
-        client = TicketsDataClient.from_env()
+        # Pass a service-role db (if Supabase env is set) so creds can resolve
+        # from Vault; otherwise TICKETSDATA_* env vars are used directly.
+        client = TicketsDataClient(db=_maybe_supabase())
     except TicketsDataError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 2

--- a/scripts/ticketsdata_mvp.py
+++ b/scripts/ticketsdata_mvp.py
@@ -104,21 +104,32 @@ def _q(env: dict) -> int | None:
 
 
 def _summarize_fetch(env: dict) -> str:
-    plat = env.get("platform", "?")
-    body = env.get("body")
+    # Real /fetch envelope (confirmed live 2026-05-26): top-level status_code +
+    # event_id, listings under items.{totalListings,offers}. The docs' nested
+    # body._embedded/listings shape is kept as a fallback.
+    status = env.get("status_code", env.get("status"))
     n = None
-    if isinstance(body, list):
-        n = len(body)
-    elif isinstance(body, dict):
-        emb = body.get("_embedded")
-        if isinstance(emb, dict) and isinstance(emb.get("offer"), list):
-            n = len(emb["offer"])
-        elif isinstance(body.get("listings"), list):
-            n = len(body["listings"])
-        elif isinstance(body.get("offers"), list):
-            n = len(body["offers"])
+    items = env.get("items")
+    if isinstance(items, dict):
+        if isinstance(items.get("totalListings"), int):
+            n = items["totalListings"]
+        elif isinstance(items.get("offers"), list):
+            n = len(items["offers"])
+    if n is None:
+        body = env.get("body")
+        if isinstance(body, list):
+            n = len(body)
+        elif isinstance(body, dict):
+            emb = body.get("_embedded")
+            if isinstance(emb, dict) and isinstance(emb.get("offer"), list):
+                n = len(emb["offer"])
+            elif isinstance(body.get("listings"), list):
+                n = len(body["listings"])
+            elif isinstance(body.get("offers"), list):
+                n = len(body["offers"])
     listings = f"{n} listings" if n is not None else "listings (shape varies)"
-    return f"  /fetch {plat}: status={env.get('status')} {listings} in {env.get('response_s')}s"
+    return (f"  /fetch: status={status} event={env.get('event_id', '?')} "
+            f"{listings} in {env.get('response_s')}s")
 
 
 def _summarize_match(env: dict) -> str:

--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -1,7 +1,8 @@
 // D0 Terminal — Home page.
-// One fetch: /api/broker/movers?window_hours=<window>. Derives coverage band,
-// blind spots panel, full movers table (with window/segment controls), and
-// the owned-events list from the single mover response.
+// One fetch: get_broker_movers_home(p_window_hours) (email-gated SECDEF RPC,
+// same client-side pattern as the blind-spots panel). Derives coverage band,
+// full movers table (window/segment controls), and the owned-events list from
+// the returned event set. Blind spots panel fires its own RPC in parallel.
 //
 // Movers table mirrors the standalone movers.html page — operator can change
 // the window or segment from home without page-hopping.
@@ -26,36 +27,32 @@
     load();
   }
 
-  function load() {
+  // The RPC returns the full lifecycle-active event set already enriched with
+  // deltas + value moves — not the top-10-per-bucket slice the old
+  // /api/broker/movers backend hop returned, so the coverage band now counts
+  // every tracked event. Email gate is satisfied by the @s4kent.com user JWT.
+  async function load() {
     T.setStatus(`Loading home · ${state.window}h…`);
-    T.api(`/api/broker/movers?window_hours=${state.window}`)
-      .then(data => {
-        T.setStatus('Loaded', 'ok');
-        const events = (data && data.events) || {};
-        state.rows = unionRows([
-          events.owned_winners, events.owned_losers,
-          events.market_winners, events.market_losers,
-          events.value_winners, events.value_losers,
-          events.owned_value_winners, events.owned_value_losers,
-        ]);
-        renderCoverage(state.rows);
-        renderMovers();
-        renderOwnedEvents(state.rows);
-      })
-      .catch(e => {
-        T.setStatus(e.message, 'err');
-        const body = document.getElementById('moversBody');
-        if (body) body.innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
-      });
-  }
-
-  function unionRows(lists) {
-    const seen = new Map();
-    lists.forEach(list => (list || []).forEach(r => {
-      const id = r.event_id;
-      if (id && !seen.has(id)) seen.set(id, r);
-    }));
-    return Array.from(seen.values());
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      T.setStatus('not signed in', 'err');
+      const body = document.getElementById('moversBody');
+      if (body) body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+    try {
+      const res = await Auth.client.rpc('get_broker_movers_home', { p_window_hours: state.window });
+      if (res.error) throw new Error(res.error.message || 'RPC error');
+      state.rows = res.data || [];
+      T.setStatus('Loaded', 'ok');
+      renderCoverage(state.rows);
+      renderMovers();
+      renderOwnedEvents(state.rows);
+    } catch (e) {
+      T.setStatus(e.message, 'err');
+      const body = document.getElementById('moversBody');
+      if (body) body.innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
+    }
   }
 
   // ---------- Coverage band ----------

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -1,7 +1,8 @@
 // D0 Terminal — Movers page.
-// Calls /api/broker/movers?window_hours=<w>. Unions winner+loser lists into a
-// single sortable table. Window selector + owned/all segment toggle.
-// 5-bucket classifier is Phase 2 (not in endpoint yet).
+// Reads get_broker_movers_home(p_window_hours) directly (email-gated SECDEF
+// RPC, same client-side pattern as the blind-spots panel). Renders a single
+// sortable table. Window selector + owned/all segment toggle. 5-bucket
+// classifier is Phase 2.
 
 (function () {
   'use strict';
@@ -42,33 +43,28 @@
     });
   }
 
-  function load() {
+  // The RPC returns the full lifecycle-active event set already enriched with
+  // deltas + value moves — not the top-10-per-bucket slice the old
+  // /api/broker/movers backend hop returned, so the table sees every tracked
+  // event. Email gate is satisfied by the signed-in @s4kent.com user JWT.
+  async function load() {
     T.setStatus(`Loading movers · ${state.window}h…`);
-    T.api(`/api/broker/movers?window_hours=${state.window}`)
-      .then(data => {
-        T.setStatus('Loaded', 'ok');
-        const events = (data && data.events) || {};
-        state.rows = unionRows([
-          events.owned_winners, events.owned_losers,
-          events.market_winners, events.market_losers,
-          events.value_winners, events.value_losers,
-          events.owned_value_winners, events.owned_value_losers,
-        ]);
-        render();
-      })
-      .catch(e => {
-        T.setStatus(e.message, 'err');
-        document.getElementById('moversBody').innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
-      });
-  }
-
-  function unionRows(lists) {
-    const seen = new Map();
-    lists.forEach(list => (list || []).forEach(r => {
-      const id = r.event_id;
-      if (id && !seen.has(id)) seen.set(id, r);
-    }));
-    return Array.from(seen.values());
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      T.setStatus('not signed in', 'err');
+      document.getElementById('moversBody').innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+    try {
+      const res = await Auth.client.rpc('get_broker_movers_home', { p_window_hours: state.window });
+      if (res.error) throw new Error(res.error.message || 'RPC error');
+      state.rows = res.data || [];
+      T.setStatus('Loaded', 'ok');
+      render();
+    } catch (e) {
+      T.setStatus(e.message, 'err');
+      document.getElementById('moversBody').innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
+    }
   }
 
   // Blind spots — calls get_blind_spots_sg_selling RPC (mig 20260520370000;

--- a/supabase/migrations/20260527000000_ticketsdata_ingestion_foundation.sql
+++ b/supabase/migrations/20260527000000_ticketsdata_ingestion_foundation.sql
@@ -1,0 +1,173 @@
+-- 20260527000000_ticketsdata_ingestion_foundation.sql
+--
+-- TicketsData ingestion subsystem — DATA LAYER + credit tracking.
+--
+-- PURPOSE (D0 build 2026-05-27, operator-directed):
+--   Stand up persistent snapshots for the 4 TicketsData-only marketplaces
+--   (StubHub, VividSeats, Gametime, TickPick) under the "4-interval plan"
+--   (axis-1 diurnal: 4 peak-window pulls/day). SeatGeek + Evo stay native.
+--   Mirrors the dormant seatdata_listings_snapshots pattern; keys on the
+--   universal aq_short_event_id (match_to_aq_event_id) like the rest of the
+--   cross-source bridge (PROJECT_BIBLE §5).
+--
+-- WHAT THIS MIGRATION DOES (data layer only — the pull cron is a follow-up
+--   migration once per-event URLs are discovered into the xref):
+--   1. ticketsdata_event_xref  — per (tevo_event_id, platform) URL + pull state.
+--   2. ticketsdata_listings_snapshots — time-series, content_hash dedup.
+--   3. ticketsdata_credit_usage — one row per /fetch|/events|/match call so we
+--      can track spend vs the plan budget (1 credit/fetch, 12/match).
+--   4. ticketsdata_normalize_listings(platform, content) — maps the 4 distinct
+--      raw response schemas into one offer shape (verified live 2026-05-27).
+--   5. v_ticketsdata_credit_usage_daily — daily/by-endpoint rollup.
+--   All tables: RLS ON, NO anon grants (B1 anon-leak sweep lesson, PR #350/#354).
+--
+-- NOT APPLIED — authored by D0 (read-only on mutations per bible MCP §6).
+--   A1 applies per push protocol after review.
+
+-- ---------- 1. per-event cross-platform mapping ----------
+create table if not exists public.ticketsdata_event_xref (
+  tevo_event_id     bigint   not null,
+  platform          text     not null check (platform in ('stubhub','vividseats','gametime','tickpick')),
+  td_event_url      text     not null,
+  td_event_id       text,
+  aq_short_event_id text,
+  match_method      text,
+  match_confidence  numeric(3,2),
+  last_pull_at      timestamptz,
+  last_listings     int,
+  active            boolean  not null default true,
+  created_at        timestamptz not null default now(),
+  primary key (tevo_event_id, platform)
+);
+create index if not exists ticketsdata_event_xref_active_idx
+  on public.ticketsdata_event_xref (active, last_pull_at);
+
+-- ---------- 2. listings snapshots (time series) ----------
+create table if not exists public.ticketsdata_listings_snapshots (
+  id                bigint generated always as identity primary key,
+  tevo_event_id     bigint,
+  aq_short_event_id text,
+  platform          text not null,
+  td_event_url      text,
+  pulled_at         timestamptz not null default now(),
+  listing_id        text,
+  section           text,
+  row_label         text,
+  quantity          int,
+  price_prefee      numeric,
+  price_total       numeric,
+  fees              numeric,
+  is_parking        boolean default false,
+  content_hash      text
+);
+create index if not exists ticketsdata_snap_event_time_idx
+  on public.ticketsdata_listings_snapshots (tevo_event_id, pulled_at);
+create index if not exists ticketsdata_snap_platform_time_idx
+  on public.ticketsdata_listings_snapshots (platform, pulled_at);
+
+-- ---------- 3. credit usage tracking ----------
+create table if not exists public.ticketsdata_credit_usage (
+  id              bigint generated always as identity primary key,
+  called_at       timestamptz not null default now(),
+  endpoint        text not null check (endpoint in ('fetch','events','match')),
+  platform        text,
+  tevo_event_id   bigint,
+  credits         int  not null default 1,
+  http_status     int,
+  quota_remaining int,
+  request_id      bigint
+);
+create index if not exists ticketsdata_credit_usage_time_idx
+  on public.ticketsdata_credit_usage (called_at);
+
+-- ---------- 4. normalizer: 4 raw schemas -> one offer shape ----------
+-- Verified live 2026-05-27:
+--   stubhub    : {status, body:{items:[{listingId, section, row, availableTickets,
+--                                        rawPrice, price/priceWithFees, dealScore}]}}
+--   vividseats : {status_code, event_id, items:{totalListings, offers:[{listingId,
+--                                        section, row, rawPrice, rawPriceWithFees, fees,
+--                                        availableTickets}]}}
+--   gametime   : {status, body:[{listing_id, section_name, row, quantity,
+--                                 price:{prefee,total}, ...}]}   (incl. parking)
+--   tickpick   : {status_code, event_id, items:{totalListings, offers:[{listing_id,
+--                                 section_name/section_id, row, quantity, price,
+--                                 fees:{delivery,facility,service}, is_parking}]}}
+create or replace function public.ticketsdata_normalize_listings(p_platform text, p_content jsonb)
+returns table (
+  listing_id text, section text, row_label text, quantity int,
+  price_prefee numeric, price_total numeric, fees numeric, is_parking boolean
+)
+language plpgsql immutable as $fn$
+begin
+  if p_platform = 'stubhub' then
+    return query
+      select o->>'listingId', o->>'section', o->>'row',
+             nullif(o->>'availableTickets','')::int,
+             nullif(o->>'rawPrice','')::numeric,
+             coalesce(nullif(o->>'rawPriceWithFees','')::numeric, nullif(o->>'price','')::numeric),
+             nullif(o->>'fees','')::numeric,
+             coalesce((o->>'section') ilike '%parking%', false)
+      from jsonb_array_elements(p_content #> '{body,items}') o;
+
+  elsif p_platform = 'vividseats' then
+    return query
+      select o->>'listingId', o->>'section', o->>'row',
+             nullif(o->>'availableTickets','')::int,
+             nullif(o->>'rawPrice','')::numeric,
+             nullif(o->>'rawPriceWithFees','')::numeric,
+             nullif(o->>'fees','')::numeric,
+             coalesce((o->>'section') ilike '%parking%', false)
+      from jsonb_array_elements(p_content #> '{items,offers}') o;
+
+  elsif p_platform = 'gametime' then
+    return query
+      select o->>'listing_id', coalesce(o->>'section_name', o->>'section'), o->>'row',
+             nullif(o->>'quantity','')::int,
+             nullif(o #>> '{price,prefee}','')::numeric / 100.0,
+             nullif(o #>> '{price,total}','')::numeric / 100.0,
+             nullif(o #>> '{price,sales_tax}','')::numeric / 100.0,
+             coalesce((o->>'ticket_type') ilike '%parking%'
+                      or (o->>'section_name') ilike '%parking%', false)
+      from jsonb_array_elements(p_content -> 'body') o;
+
+  elsif p_platform = 'tickpick' then
+    return query
+      select o->>'listing_id',
+             coalesce(nullif(o->>'section_name',''), o->>'section_id'), o->>'row',
+             nullif(o->>'quantity','')::int,
+             nullif(o->>'price','')::numeric,
+             nullif(o->>'price','')::numeric
+               + coalesce((o #>> '{fees,delivery}')::numeric,0)
+               + coalesce((o #>> '{fees,facility}')::numeric,0)
+               + coalesce((o #>> '{fees,service}')::numeric,0),
+             coalesce((o #>> '{fees,delivery}')::numeric,0)
+               + coalesce((o #>> '{fees,facility}')::numeric,0)
+               + coalesce((o #>> '{fees,service}')::numeric,0),
+             coalesce((o->>'is_parking')::boolean, false)
+      from jsonb_array_elements(p_content #> '{items,offers}') o;
+  end if;
+end;
+$fn$;
+
+-- ---------- 5. credit-usage rollup ----------
+create or replace view public.v_ticketsdata_credit_usage_daily as
+select date_trunc('day', called_at) as day,
+       endpoint,
+       count(*)              as calls,
+       sum(credits)          as credits,
+       min(quota_remaining)  as quota_low,
+       max(quota_remaining)  as quota_high
+from public.ticketsdata_credit_usage
+group by 1,2 order by 1 desc, 2;
+
+-- ---------- 6. lock down (RLS on, anon denied) ----------
+alter table public.ticketsdata_event_xref        enable row level security;
+alter table public.ticketsdata_listings_snapshots enable row level security;
+alter table public.ticketsdata_credit_usage       enable row level security;
+revoke all on public.ticketsdata_event_xref,
+              public.ticketsdata_listings_snapshots,
+              public.ticketsdata_credit_usage,
+              public.v_ticketsdata_credit_usage_daily
+  from anon;
+-- service_role (the pull cron / pg_net path) bypasses RLS; no client policies
+-- needed (matches exos_mail: RLS-on, zero anon policies = deny-all to anon).

--- a/tests/test_ticketsdata_client.py
+++ b/tests/test_ticketsdata_client.py
@@ -24,9 +24,50 @@ def test_assert_readonly_raises_on_writes():
 
 # ---------- construction / validation ----------
 
-def test_requires_credentials():
+def test_requires_credentials(monkeypatch):
+    monkeypatch.delenv("TICKETSDATA_USERNAME", raising=False)
+    monkeypatch.delenv("TICKETSDATA_PASSWORD", raising=False)
     with pytest.raises(td.TicketsDataError):
-        td.TicketsDataClient("", "")
+        td.TicketsDataClient()
+
+
+class _FakeRpcResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeDB:
+    """Stands in for a service-role Supabase client: rpc(get_app_secret)."""
+    def __init__(self, secrets):
+        self._secrets = secrets
+
+    def rpc(self, name, params):
+        assert name == "get_app_secret"
+        self._pending = self._secrets.get(params["p_name"])
+        return self
+
+    def execute(self):
+        return _FakeRpcResult(self._pending)
+
+
+def test_credentials_resolve_from_vault(monkeypatch):
+    monkeypatch.delenv("TICKETSDATA_USERNAME", raising=False)
+    monkeypatch.delenv("TICKETSDATA_PASSWORD", raising=False)
+    db = _FakeDB({
+        "TICKETSDATA_USERNAME": "vault-user@example.com",
+        "TICKETSDATA_PASSWORD": "vault-pw",
+    })
+    c = td.TicketsDataClient(db=db)
+    assert c._username == "vault-user@example.com"
+    assert c._password == "vault-pw"
+
+
+def test_env_takes_precedence_over_vault(monkeypatch):
+    monkeypatch.setenv("TICKETSDATA_USERNAME", "env-user@example.com")
+    monkeypatch.setenv("TICKETSDATA_PASSWORD", "env-pw")
+    db = _FakeDB({"TICKETSDATA_USERNAME": "vault-user", "TICKETSDATA_PASSWORD": "vault-pw"})
+    c = td.TicketsDataClient(db=db)
+    assert c._username == "env-user@example.com"
 
 
 def test_fetch_rejects_unsupported_platform():

--- a/tests/test_ticketsdata_client.py
+++ b/tests/test_ticketsdata_client.py
@@ -76,10 +76,19 @@ def test_fetch_rejects_unsupported_platform():
         c.fetch("nope", "https://x")
 
 
+def test_fetch_rejects_seatgeek_sourced_natively():
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataError) as exc:
+        c.fetch("seatgeek", "https://seatgeek.com/concert/1")
+    assert "natively" in str(exc.value)
+    with pytest.raises(td.TicketsDataError):
+        c.events("seatgeek", performer_url="https://seatgeek.com/x")
+
+
 def test_events_requires_a_page_url():
     c = td.TicketsDataClient("u@example.com", "pw")
     with pytest.raises(td.TicketsDataError):
-        c.events("seatgeek")
+        c.events("stubhub")
 
 
 def test_credit_costs():
@@ -106,12 +115,13 @@ def test_fetch_parses_and_passes_creds(monkeypatch):
     def fake_get(url, params=None, timeout=None):
         captured["url"] = url
         captured["params"] = params
-        return _FakeResp(200, {"status": 200, "platform": "seatgeek",
-                               "body": {"offers": [1, 2, 3]}, "quota_remaining": 9999})
+        return _FakeResp(200, {"status_code": 200, "event_id": "159756853",
+                               "items": {"totalListings": 3, "offers": [1, 2, 3]},
+                               "quota_remaining": 9999})
 
     monkeypatch.setattr(td.requests, "get", fake_get)
     c = td.TicketsDataClient("u@example.com", "secret-pw")
-    env = c.fetch("seatgeek", "https://seatgeek.com/concert/1")
+    env = c.fetch("stubhub", "https://www.stubhub.com/x/event/159756853/")
     assert env["quota_remaining"] == 9999
     # creds travel in params, never baked into the URL string
     assert "secret-pw" not in captured["url"]
@@ -123,7 +133,7 @@ def test_auth_error_does_not_leak_credentials(monkeypatch):
     monkeypatch.setattr(td.requests, "get", lambda *a, **k: _FakeResp(401))
     c = td.TicketsDataClient("u@example.com", "secret-pw")
     with pytest.raises(td.TicketsDataAuthError) as exc:
-        c.fetch("seatgeek", "https://seatgeek.com/concert/1")
+        c.fetch("stubhub", "https://www.stubhub.com/x/event/1/")
     assert "secret-pw" not in str(exc.value)
 
 
@@ -131,7 +141,7 @@ def test_quota_exhausted_maps_to_402(monkeypatch):
     monkeypatch.setattr(td.requests, "get", lambda *a, **k: _FakeResp(402))
     c = td.TicketsDataClient("u@example.com", "pw")
     with pytest.raises(td.TicketsDataQuotaError):
-        c.events("seatgeek", performer_url="https://seatgeek.com/x")
+        c.events("stubhub", performer_url="https://www.stubhub.com/x")
 
 
 # ---------- MVP budget guard ----------

--- a/tests/test_ticketsdata_client.py
+++ b/tests/test_ticketsdata_client.py
@@ -1,0 +1,120 @@
+"""TicketsData client + MVP budget-guard tests. No real HTTP calls."""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+import ticketsdata_client as td
+
+
+# ---------- read-only guard ----------
+
+def test_assert_readonly_allows_get():
+    td._assert_readonly_method("GET")  # no raise
+
+
+def test_assert_readonly_raises_on_writes():
+    for method in ("POST", "PUT", "PATCH", "DELETE"):
+        with pytest.raises(td.TicketsDataReadOnlyError):
+            td._assert_readonly_method(method)
+
+
+# ---------- construction / validation ----------
+
+def test_requires_credentials():
+    with pytest.raises(td.TicketsDataError):
+        td.TicketsDataClient("", "")
+
+
+def test_fetch_rejects_unsupported_platform():
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataError):
+        c.fetch("nope", "https://x")
+
+
+def test_events_requires_a_page_url():
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataError):
+        c.events("seatgeek")
+
+
+def test_credit_costs():
+    assert td.CREDIT_COST == {"fetch": 1, "events": 1, "match": 12}
+
+
+# ---------- transport (mocked) ----------
+
+class _FakeResp:
+    def __init__(self, status, payload=None, headers=None):
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.headers = headers or {}
+        self.ok = 200 <= status < 300
+        self.text = "x"
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_parses_and_passes_creds(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResp(200, {"status": 200, "platform": "seatgeek",
+                               "body": {"offers": [1, 2, 3]}, "quota_remaining": 9999})
+
+    monkeypatch.setattr(td.requests, "get", fake_get)
+    c = td.TicketsDataClient("u@example.com", "secret-pw")
+    env = c.fetch("seatgeek", "https://seatgeek.com/concert/1")
+    assert env["quota_remaining"] == 9999
+    # creds travel in params, never baked into the URL string
+    assert "secret-pw" not in captured["url"]
+    assert captured["params"]["username"] == "u@example.com"
+    assert captured["params"]["password"] == "secret-pw"
+
+
+def test_auth_error_does_not_leak_credentials(monkeypatch):
+    monkeypatch.setattr(td.requests, "get", lambda *a, **k: _FakeResp(401))
+    c = td.TicketsDataClient("u@example.com", "secret-pw")
+    with pytest.raises(td.TicketsDataAuthError) as exc:
+        c.fetch("seatgeek", "https://seatgeek.com/concert/1")
+    assert "secret-pw" not in str(exc.value)
+
+
+def test_quota_exhausted_maps_to_402(monkeypatch):
+    monkeypatch.setattr(td.requests, "get", lambda *a, **k: _FakeResp(402))
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataQuotaError):
+        c.events("seatgeek", performer_url="https://seatgeek.com/x")
+
+
+# ---------- MVP budget guard ----------
+
+def _load_mvp():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "ticketsdata_mvp.py"
+    spec = importlib.util.spec_from_file_location("ticketsdata_mvp", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_budget_refuses_over_cap():
+    mvp = _load_mvp()
+    b = mvp.Budget(max_credits=5, min_quota_floor=10)
+    b.check(1)
+    b.record(1, quota_remaining=9000)
+    with pytest.raises(mvp.BudgetExceeded):
+        b.check(12)  # a /match would blow the 5-credit cap
+
+
+def test_budget_refuses_below_quota_floor():
+    mvp = _load_mvp()
+    b = mvp.Budget(max_credits=100, min_quota_floor=50)
+    b.record(1, quota_remaining=51)
+    with pytest.raises(mvp.BudgetExceeded):
+        b.check(2)  # 51 - 2 = 49 < floor 50

--- a/ticketsdata_client.py
+++ b/ticketsdata_client.py
@@ -38,6 +38,12 @@ SUPPORTED_PLATFORMS = frozenset({
     "tickpick", "viagogo", "dice", "eventbrite",
 })
 
+# Marketplaces we already source natively (SeatGeek via seatgeek_client + the SG
+# broker crons), so we must NOT pay TicketsData to re-fetch them. fetch()/events()
+# reject these — use the native pipeline instead. (/match is unaffected: its value
+# is the cross-market comparison, which legitimately includes SeatGeek.)
+EXCLUDED_PLATFORMS = frozenset({"seatgeek"})
+
 # Credit cost per endpoint, per the TicketsData docs. Used by callers and the
 # MVP budget guard to project spend BEFORE making a call.
 CREDIT_COST = {"fetch": 1, "events": 1, "match": 12}
@@ -66,6 +72,20 @@ def _assert_readonly_method(method: str) -> None:
             "TicketsData client is read-only by design (CLAUDE.md §2). "
             "Pulling data only — never write back to ticketsdata.com."
         )
+
+
+def _validate_platform(platform: str) -> str:
+    plat = (platform or "").strip().lower()
+    if plat not in SUPPORTED_PLATFORMS:
+        raise TicketsDataError(
+            f"unsupported platform {platform!r}; one of {sorted(SUPPORTED_PLATFORMS)}"
+        )
+    if plat in EXCLUDED_PLATFORMS:
+        raise TicketsDataError(
+            f"{plat} is sourced natively, not via TicketsData — excluded to avoid "
+            "duplicate paid fetches. Use the native pipeline (seatgeek_client)."
+        )
+    return plat
 
 
 def _vault_secret(db: Any, name: str) -> str | None:
@@ -162,11 +182,7 @@ class TicketsDataClient:
     def fetch(self, platform: str, event_url: str, *, mode: str | None = None) -> dict[str, Any]:
         """GET /fetch — full live inventory for one event on one platform.
         Cost: 1 credit. `mode` is platform-specific (see docs mode matrix)."""
-        plat = (platform or "").strip().lower()
-        if plat not in SUPPORTED_PLATFORMS:
-            raise TicketsDataError(
-                f"unsupported platform {platform!r}; one of {sorted(SUPPORTED_PLATFORMS)}"
-            )
+        plat = _validate_platform(platform)
         if not event_url:
             raise TicketsDataError("event_url is required for /fetch")
         return self._get("/fetch", {"platform": plat, "event_url": event_url, "mode": mode})
@@ -180,11 +196,7 @@ class TicketsDataClient:
     ) -> dict[str, Any]:
         """GET /events — upcoming events for a performer/venue/organizer page.
         Cost: 1 credit. Dice.fm venue/promoter pages use venue_url."""
-        plat = (platform or "").strip().lower()
-        if plat not in SUPPORTED_PLATFORMS:
-            raise TicketsDataError(
-                f"unsupported platform {platform!r}; one of {sorted(SUPPORTED_PLATFORMS)}"
-            )
+        plat = _validate_platform(platform)
         if not performer_url and not venue_url:
             raise TicketsDataError("one of performer_url / venue_url is required for /events")
         return self._get(

--- a/ticketsdata_client.py
+++ b/ticketsdata_client.py
@@ -1,0 +1,172 @@
+"""TicketsData unified ticket-inventory API client (read-only).
+
+Host: https://ticketsdata.com
+Aggregates live inventory + pricing across 9 marketplaces (Ticketmaster,
+StubHub, SeatGeek, VividSeats, Gametime, TickPick, Viagogo, Dice, Eventbrite)
+behind a single GET API. There is NO write surface — every endpoint is a
+read — so this honors the read-only-upstream contract (CLAUDE.md §2).
+
+Auth: account email + password are passed as query params (their scheme).
+Credentials are sourced from env (TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD),
+never hardcoded, and never written to logs or exception messages — the URL is
+built only at request time and never rendered with its params.
+
+Credit cost (watch the budget — see scripts/ticketsdata_mvp.py):
+  GET /fetch    1 credit    one event's inventory on one platform
+  GET /events   1 credit    performer / venue -> upcoming event list
+  GET /match    12 credits + 1 Market-Intelligence report   (Pro plan+)
+
+/fetch and /events responses carry `quota_remaining`; /match also carries
+`reports_remaining`. Callers should watch both to avoid exhausting the plan.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+
+
+# Read-only by design. Mirrors the RULE 2 guard pattern used by the orders/
+# sales clients (evo/seatgeek/tickpick/vivid). TicketsData has no write
+# endpoint at all, but we enforce GET-only at the transport layer anyway.
+ALLOWED_HTTP_METHODS = frozenset({"GET"})
+
+SUPPORTED_PLATFORMS = frozenset({
+    "ticketmaster", "stubhub", "seatgeek", "vividseats", "gametime",
+    "tickpick", "viagogo", "dice", "eventbrite",
+})
+
+# Credit cost per endpoint, per the TicketsData docs. Used by callers and the
+# MVP budget guard to project spend BEFORE making a call.
+CREDIT_COST = {"fetch": 1, "events": 1, "match": 12}
+
+
+class TicketsDataError(RuntimeError):
+    pass
+
+
+class TicketsDataReadOnlyError(TicketsDataError):
+    """Raised when a non-GET method is attempted against TicketsData."""
+
+
+class TicketsDataAuthError(TicketsDataError):
+    """401 — bad credentials."""
+
+
+class TicketsDataQuotaError(TicketsDataError):
+    """402 — plan quota exhausted."""
+
+
+def _assert_readonly_method(method: str) -> None:
+    if method.upper() not in ALLOWED_HTTP_METHODS:
+        raise TicketsDataReadOnlyError(
+            f"READ-ONLY violation: method {method} is not allowed. "
+            "TicketsData client is read-only by design (CLAUDE.md §2). "
+            "Pulling data only — never write back to ticketsdata.com."
+        )
+
+
+class TicketsDataClient:
+    BASE_URL = "https://ticketsdata.com"
+
+    def __init__(self, username: str, password: str, *, timeout: int = 30):
+        if not username or not password:
+            raise TicketsDataError(
+                "TicketsData credentials are required "
+                "(set TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD)"
+            )
+        self._username = username.strip()
+        self._password = password  # never stripped/logged; sent verbatim
+        self.timeout = timeout
+
+    @classmethod
+    def from_env(cls, *, timeout: int = 30) -> "TicketsDataClient":
+        return cls(
+            os.environ.get("TICKETSDATA_USERNAME", ""),
+            os.environ.get("TICKETSDATA_PASSWORD", ""),
+            timeout=timeout,
+        )
+
+    # ---------- transport ----------
+
+    def _get(self, path: str, params: dict | None = None) -> dict[str, Any]:
+        _assert_readonly_method("GET")
+        url = f"{self.BASE_URL}{path}"
+        # Credentials live in params, never in the logged/raised URL string.
+        clean = {k: v for k, v in (params or {}).items() if v is not None}
+        clean["username"] = self._username
+        clean["password"] = self._password
+
+        # Per docs: retry 429 (back off), 503 (service_unavailable) and 504
+        # (timeout); do NOT retry 400/401/402/404 (deterministic).
+        r = None
+        delays = [1.5, 3.0]
+        for attempt in range(len(delays) + 1):
+            r = requests.get(url, params=clean, timeout=self.timeout)
+            if r.status_code in (429, 503, 504) and attempt < len(delays):
+                retry_after = r.headers.get("Retry-After")
+                try:
+                    delay = float(retry_after) if retry_after else delays[attempt]
+                except (TypeError, ValueError):
+                    delay = delays[attempt]
+                time.sleep(min(delay, 30.0))
+                continue
+            break
+
+        if r.status_code == 401:
+            raise TicketsDataAuthError("HTTP 401 — invalid TicketsData credentials")
+        if r.status_code == 402:
+            raise TicketsDataQuotaError("HTTP 402 — plan quota exhausted")
+        if not r.ok:
+            # Surface the path + status only — never the credential-bearing URL.
+            raise TicketsDataError(f"HTTP {r.status_code} on GET {path}")
+        try:
+            body = r.json()
+        except ValueError:
+            return {"raw_text": r.text}
+        return body if isinstance(body, dict) else {"body": body}
+
+    # ---------- endpoints ----------
+
+    def fetch(self, platform: str, event_url: str, *, mode: str | None = None) -> dict[str, Any]:
+        """GET /fetch — full live inventory for one event on one platform.
+        Cost: 1 credit. `mode` is platform-specific (see docs mode matrix)."""
+        plat = (platform or "").strip().lower()
+        if plat not in SUPPORTED_PLATFORMS:
+            raise TicketsDataError(
+                f"unsupported platform {platform!r}; one of {sorted(SUPPORTED_PLATFORMS)}"
+            )
+        if not event_url:
+            raise TicketsDataError("event_url is required for /fetch")
+        return self._get("/fetch", {"platform": plat, "event_url": event_url, "mode": mode})
+
+    def events(
+        self,
+        platform: str,
+        *,
+        performer_url: str | None = None,
+        venue_url: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /events — upcoming events for a performer/venue/organizer page.
+        Cost: 1 credit. Dice.fm venue/promoter pages use venue_url."""
+        plat = (platform or "").strip().lower()
+        if plat not in SUPPORTED_PLATFORMS:
+            raise TicketsDataError(
+                f"unsupported platform {platform!r}; one of {sorted(SUPPORTED_PLATFORMS)}"
+            )
+        if not performer_url and not venue_url:
+            raise TicketsDataError("one of performer_url / venue_url is required for /events")
+        return self._get(
+            "/events",
+            {"platform": plat, "performer_url": performer_url, "venue_url": venue_url},
+        )
+
+    def match(self, event_url: str) -> dict[str, Any]:
+        """GET /match — cross-market arbitrage report (Pro plan+).
+        Cost: 12 credits + 1 Market-Intelligence report. The engine
+        auto-detects the source platform from the URL, so no platform arg."""
+        if not event_url:
+            raise TicketsDataError("event_url is required for /match")
+        return self._get("/match", {"event_url": event_url})

--- a/ticketsdata_client.py
+++ b/ticketsdata_client.py
@@ -68,26 +68,55 @@ def _assert_readonly_method(method: str) -> None:
         )
 
 
+def _vault_secret(db: Any, name: str) -> str | None:
+    """Read a secret from Supabase Vault via the get_app_secret RPC (the same
+    bridge seatgeek_client uses). Requires a service-role db client."""
+    if db is None:
+        return None
+    try:
+        res = db.rpc("get_app_secret", {"p_name": name}).execute()
+        return getattr(res, "data", None) or None
+    except Exception as e:  # never surface the value; only the failure
+        print(f"ticketsdata: vault lookup for {name} failed: {e}")
+        return None
+
+
 class TicketsDataClient:
     BASE_URL = "https://ticketsdata.com"
 
-    def __init__(self, username: str, password: str, *, timeout: int = 30):
-        if not username or not password:
+    def __init__(
+        self,
+        username: str | None = None,
+        password: str | None = None,
+        *,
+        db: Any = None,
+        timeout: int = 30,
+    ):
+        # Resolution order mirrors seatgeek_client: explicit arg -> env var ->
+        # Supabase Vault (get_app_secret). Pass db (a service-role client) to
+        # enable the Vault fallback.
+        u = username or os.environ.get("TICKETSDATA_USERNAME") or _vault_secret(db, "TICKETSDATA_USERNAME")
+        p = password or os.environ.get("TICKETSDATA_PASSWORD") or _vault_secret(db, "TICKETSDATA_PASSWORD")
+        if not u or not p:
             raise TicketsDataError(
-                "TicketsData credentials are required "
-                "(set TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD)"
+                "TicketsData credentials required. Set TICKETSDATA_USERNAME / "
+                "TICKETSDATA_PASSWORD env, or store them in Vault: "
+                "SELECT public.upsert_app_secret('TICKETSDATA_USERNAME', '<email>'); "
+                "SELECT public.upsert_app_secret('TICKETSDATA_PASSWORD', '<password>');"
             )
-        self._username = username.strip()
-        self._password = password  # never stripped/logged; sent verbatim
+        self._username = u.strip()
+        self._password = p  # never stripped/logged; sent verbatim
         self.timeout = timeout
 
     @classmethod
     def from_env(cls, *, timeout: int = 30) -> "TicketsDataClient":
-        return cls(
-            os.environ.get("TICKETSDATA_USERNAME", ""),
-            os.environ.get("TICKETSDATA_PASSWORD", ""),
-            timeout=timeout,
-        )
+        return cls(timeout=timeout)
+
+    @classmethod
+    def from_vault(cls, db: Any, *, timeout: int = 30) -> "TicketsDataClient":
+        """Build a client resolving creds from Supabase Vault (db = service-role
+        client). Falls back to env vars if those are set too."""
+        return cls(db=db, timeout=timeout)
 
     # ---------- transport ----------
 


### PR DESCRIPTION
Two deliverables from the "resume D0" session, both on `claude/resume-d0-chat-itUGb` (the session's mandated branch).

---

## 1. Wire `get_broker_movers_home` into terminal home + movers

`home.js` + `movers.js` previously fetched `/api/broker/movers` (a `service_role` backend hop that computes top-10-per-bucket winner/loser lists), then **flattened the 8 event lists back into one deduped array** (`unionRows`) and discarded the rollups. They now call the email-gated `get_broker_movers_home` RPC **directly from the browser** — same client-side pattern as the blind-spots panel (`get_blind_spots_sg_selling`).

Why it's a strict improvement:
- One round-trip instead of two (RPC does lifecycle filter + delta/value enrichment in SQL).
- **Full lifecycle-active set**, not the ~80-event top-10 slice — so the home coverage band + tables stop under-counting.
- Uses the RPC as designed: `SECURITY DEFINER` + `@s4kent.com` email gate ⇒ must be called with the user's JWT, not the gateless `service_role` client.

Output-shape parity verified for every field the renderers consume. The `/api/broker/movers` app.py endpoint is left intact (still serves its `include_inactive` debug path).

## 2. TicketsData read-only client + budget-guarded MVP

New upstream integration for the TicketsData unified inventory API (9 marketplaces behind one GET API). All endpoints are reads, so it fits the read-only-upstream rule (CLAUDE.md §2).

- **`ticketsdata_client.py`** — GET-only client (`_assert_readonly_method` guard). Credentials from `TICKETSDATA_USERNAME` / `TICKETSDATA_PASSWORD` env, never hardcoded and never rendered into the logged/raised URL. Per-call credit costs exposed: `/fetch` = 1, `/events` = 1, `/match` = 12 + 1 report.
- **`scripts/ticketsdata_mvp.py`** — smoke test that **projects the worst-case credit cost up front and refuses to run over `--max-credits`** (default 5), watches `quota_remaining` against a floor, and keeps the 12-credit `/match` **off unless `--allow-match`**. Supports `--dry-run`.
- **`tests/test_ticketsdata_client.py`** — mocked, no network, zero credits: read-only guard, platform validation, credential non-leak, 401/402 mapping, budget-refusal logic.

**Open question:** the docs say `/match` is "Pro plan+", but the Starter plan card lists 250 Market-Intelligence reports/mo — those conflict. `/match` is gated off by default until we confirm Starter can call it. This MVP is intentionally NOT wired into any cron/ingestion loop — that's the step that would burn the 10k/mo budget, so it's deferred pending a volume plan.

## Test plan

- [x] `node --check` on both JS files
- [x] `pytest tests/test_ticketsdata_client.py` — 11 passed
- [x] `python scripts/check_readonly.py` — RULE 2 clean
- [x] MVP dry-run + over-budget refusal verified (exit 3)
- [ ] **Manual (needs signed-in `@s4kent.com` session):** load home/movers, confirm tables + coverage band populate
- [ ] **Manual (needs `TICKETSDATA_*` env):** `python scripts/ticketsdata_mvp.py --platform seatgeek --event-url <url>` for a real 1-credit `/fetch`