### PR TITLE
fix(store): surface playoff games + fallback in Featured rail

### DIFF
--- a/app.py
+++ b/app.py
@@ -5585,10 +5585,13 @@ def _section_featured(candidates: list,
         except (TypeError, ValueError):
             continue
         owned = c.get("owned_tickets_count") or 0
-        if owned <= 100:
-            # Global gate — every Featured event needs depth
-            continue
         playoff = _classify_playoff(c.get("name") or "")
+        if owned <= 100 and not playoff:
+            # Global depth gate for non-playoff events. Playoff games are
+            # exempt (operator directive 2026-05-26) — they're the highest-
+            # value NYC inventory even at thin owned counts (e.g. Knicks
+            # Game 7 sits at owned ~60, well under the regular-season bar).
+            continue
         rivalry = rivalry_by_eid.get(eid_int)
         holiday = holiday_by_eid.get(eid_int)
         marquee = _classify_marquee_competition(c.get("name") or "")
@@ -5679,12 +5682,19 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
 
     if not events_rows:
         return {"city": city, "days": day_cap, "count": 0, "events": []}
-    # Drop speculative names (CANCELLED / (If Necessary) / (Date TBD)) —
-    # playoff "may not happen" placeholders shouldn't surface to consumers
-    # via the movers strip. event_lifecycle.is_active stays true for these
-    # because the game *could* happen, so the name-string filter is the
-    # right layer. Mirrors search + home behavior.
-    events_rows = [e for e in events_rows if not _is_speculative_event_name(e.get("name"))]
+    # Drop speculative names (CANCELLED / (If Necessary)) — playoff "may not
+    # happen" placeholders normally shouldn't surface to consumers. EXCEPTION
+    # (operator directive 2026-05-26): playoff games keep their "(If Necessary)"
+    # slot in the movers strip — they're the highest-value NYC inventory (e.g.
+    # Knicks Game 7, $5,880 median) and are exactly what the Featured rail is
+    # for. Genuine CANCELLED games still drop, even playoff ones. This relaxes
+    # the filter ONLY for the movers strip; search + home still hide these.
+    events_rows = [
+        e for e in events_rows
+        if not _is_speculative_event_name(e.get("name"))
+        or (_classify_playoff(e.get("name"))
+            and "CANCELLED" not in (e.get("name") or "").upper())
+    ]
     if not events_rows:
         return {"city": city, "days": day_cap, "count": 0, "events": []}
     events_by_id = {int(e["id"]): e for e in events_rows if e.get("id")}
@@ -5875,7 +5885,11 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     # Every owned (>=1) event lands in `candidates` with its full signal
     # payload. Each section helper below filters this pool independently;
     # an event can qualify for 0, 1, or multiple sections.
+    # `all_owned_cards` collects EVERY owned event (incl. owned<=50) so the
+    # empty-rail fallback below has a pool to draw from when nothing clears
+    # the curation gates (operator directive 2026-05-26).
     candidates: list[dict] = []
+    all_owned_cards: list[dict] = []
     for eid, m in metrics_by_id.items():
         if eid in inactive:
             continue
@@ -5937,11 +5951,7 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             break
         b = perf_assets.get(away_pid) if away_pid else None
         owned_tickets = m.get("owned_tickets_count") or 0
-        if owned_tickets <= 50:
-            # Sections (except holidays) require owned > 50 for inventory depth;
-            # holidays is even tighter at > 100, applied in the section helper.
-            continue
-        candidates.append({
+        card = {
             "id": ev.get("id"),
             "name": ev.get("name"),
             "occurs_at_local": ev.get("occurs_at_local"),
@@ -5968,7 +5978,14 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             "owned_tickets_count": owned_tickets,
             "owned_median_retail": m.get("owned_median_retail"),
             "owned_share": m.get("owned_share"),
-        })
+        }
+        all_owned_cards.append(card)
+        if owned_tickets > 50:
+            # Sections (except holidays) require owned > 50 for inventory depth;
+            # holidays/specials are tighter at > 100, applied in the section
+            # helpers. Playoff games additionally bypass the owned>100 Featured
+            # gate (see _section_featured).
+            candidates.append(card)
 
     # ----- Specials enrichment: pull holiday-window matches + rivalry
     # tags. Both wrapped in try/except so a view-side failure degrades
@@ -6153,6 +6170,20 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     # other lists we have"). Holiday/rivalry events with owned > 100 that
     # don't qualify for Featured land here.
     specials = _consume(_section_specials(candidates, holiday_by_eid, rivalry_by_eid))
+
+    # Empty-rail fallback (operator directive 2026-05-26): never render a blank
+    # homepage. When nothing clears the curation gates — common in thin-
+    # inventory windows (offseason, between playoff rounds) — surface the
+    # soonest upcoming owned NYC events in the Featured rail so it always has
+    # something bookable. These qualify on recency + owned inventory alone, so
+    # they carry no curation chip (_featured_tag = "").
+    if not (featured or moving_fast or price_drops or climbing or specials):
+        fallback = sorted(all_owned_cards,
+                          key=lambda c: c.get("occurs_at_local") or "9999")[:cap]
+        for fc in fallback:
+            fc.setdefault("_featured_tag", "")
+            fc["_featured_kind"] = "fallback"
+        featured = fallback
 
     return {
         "city": city,

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -395,6 +395,131 @@ def test_is_tbd_helper_unit():
     assert app_module._is_tbd(None) is False
 
 
+# ---------- Featured rail: playoff exemption + empty-rail fallback ----------
+#
+# Operator directive 2026-05-26: the "Featured in NYC" rail (/api/store/movers)
+# was rendering empty because all current NYC owned inventory was either an
+# "(If Necessary)" playoff game (dropped as speculative) or below the owned-
+# count gates. Two behavior changes:
+#   1. Playoff games surface in the movers strip despite "(If Necessary)" and
+#      bypass the owned>100 Featured depth gate (highest-value NYC inventory).
+#   2. When NO rail qualifies, Featured falls back to the soonest upcoming
+#      owned NYC events so the homepage is never blank.
+# NOTE: this relaxation is scoped to the movers strip only — /api/store/home
+# and search still drop "(If Necessary)" games (see tests above).
+
+def test_section_featured_includes_playoff_under_owned_gate():
+    """Playoff game with owned <= 100 must still be Featured — playoff games
+    are exempt from the owned>100 depth gate."""
+    playoff = {
+        "id": 1,
+        "name": "Cleveland Cavaliers at New York Knicks (Game 7) (If Necessary)",
+        "owned_tickets_count": 61,           # < 100, would fail the gate
+        "owned_median_retail": 5880,
+        "occurs_at_local": "2026-05-31T20:00:00-04:00",
+    }
+    out = app_module._section_featured([playoff], {}, {})
+    assert [c["id"] for c in out] == [1]
+    assert out[0]["_featured_kind"] == "playoff"
+
+
+def test_section_featured_excludes_nonplayoff_under_owned_gate():
+    """Non-playoff event under owned 100 with sub-$50 median stays out — the
+    depth gate still applies to everything that isn't a playoff/holiday/
+    rivalry/marquee signal."""
+    ev = {
+        "id": 2, "name": "Some Concert",
+        "owned_tickets_count": 61, "owned_median_retail": 20,
+        "occurs_at_local": "2026-06-01T19:00:00-04:00",
+    }
+    assert app_module._section_featured([ev], {}, {}) == []
+
+
+def test_section_featured_premium_nonplayoff_still_included():
+    """Regression guard: a non-playoff event with owned>100 AND median>$50
+    is still Featured as 'premium' (existing behavior unchanged)."""
+    ev = {
+        "id": 3, "name": "Big Headliner",
+        "owned_tickets_count": 150, "owned_median_retail": 120,
+        "occurs_at_local": "2026-06-02T19:00:00-04:00",
+    }
+    out = app_module._section_featured([ev], {}, {})
+    assert [c["id"] for c in out] == [3]
+    assert out[0]["_featured_kind"] == "premium"
+
+
+def test_compute_movers_features_playoff_if_necessary():
+    """End-to-end: a playoff '(If Necessary)' game with owned 61 survives the
+    speculative-name filter AND the owned>100 gate, landing in Featured."""
+    db = _FakeDB({
+        "events": [_event(
+            1, name="Cleveland Cavaliers at New York Knicks (Game 7) (If Necessary)",
+            occurs="2026-05-31T20:00:00-04:00")],
+        "latest_event_metrics": [_lem(1, owned=61, retail_min=5880.0)],
+        "event_lifecycle": [_lc(1)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    assert 1 in [c["id"] for c in out["featured"]]
+    assert out["featured"][0]["_featured_kind"] == "playoff"
+
+
+def test_compute_movers_drops_cancelled_playoff():
+    """A CANCELLED playoff game must NOT surface — cancellation is terminal,
+    unlike '(If Necessary)' which merely may-not-be-played."""
+    db = _FakeDB({
+        "events": [_event(
+            1, name="Knicks at Pacers (Game 6) - CANCELLED",
+            occurs="2026-05-30T20:00:00-04:00")],
+        "latest_event_metrics": [_lem(1, owned=200, retail_min=900.0)],
+        "event_lifecycle": [_lc(1)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    # When the only event drops out, _compute_movers takes an early-return
+    # path that omits the rail keys entirely; the client treats missing keys
+    # as empty. Use .get so the assertion holds for both payload shapes.
+    all_ids = [c["id"] for rail in
+               ("featured", "moving_fast", "price_drops", "climbing", "specials")
+               for c in out.get(rail, [])]
+    assert 1 not in all_ids
+
+
+def test_compute_movers_fallback_to_soonest_when_all_rails_empty():
+    """Two thin-inventory non-playoff events (owned 49 + 9) clear no rail.
+    Featured falls back to the soonest upcoming owned events, soonest first,
+    tagged _featured_kind='fallback' with no curation chip."""
+    db = _FakeDB({
+        "events": [
+            _event(10, name="Don Toliver Concert", occurs="2026-06-05T19:30:00-04:00"),
+            _event(11, name="Cincinnati Reds at New York Mets",
+                   occurs="2026-05-28T19:10:00-04:00"),
+        ],
+        "latest_event_metrics": [_lem(10, owned=49), _lem(11, owned=9)],
+        "event_lifecycle": [_lc(10), _lc(11)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    assert out["moving_fast"] == [] and out["price_drops"] == [] and out["climbing"] == []
+    assert [c["id"] for c in out["featured"]] == [11, 10]  # May 28 before June 5
+    assert all(c.get("_featured_kind") == "fallback" for c in out["featured"])
+    assert all(c.get("_featured_tag") == "" for c in out["featured"])
+
+
+def test_compute_movers_no_fallback_when_a_rail_populated():
+    """When a rail already has events, the fallback does NOT fire — Featured
+    holds the curated playoff pick, not the thin-inventory long tail."""
+    db = _FakeDB({
+        "events": [
+            _event(1, name="Cavaliers at Knicks (Game 7) (If Necessary)",
+                   occurs="2026-05-31T20:00:00-04:00"),
+            _event(10, name="Low Inventory Concert", occurs="2026-06-05T19:30:00-04:00"),
+        ],
+        "latest_event_metrics": [_lem(1, owned=61, retail_min=5880.0), _lem(10, owned=9)],
+        "event_lifecycle": [_lc(1), _lc(10)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    assert [c["id"] for c in out["featured"]] == [1]
+    assert out["featured"][0]["_featured_kind"] == "playoff"
+
+
 def test_home_city_nyc_filters_correctly(store_home_client):
     """city=NYC restricts to NYC-area venues. Bronx + Flushing + Manhattan
     all pass; LA + Chicago must not."""


### PR DESCRIPTION
## Problem

The NYC **"Featured in NYC"** rail (`/api/store/movers`) was rendering empty. Diagnosis against live data (21-day window from 2026-05-26): only **4 owned NYC events** exist, and every one was excluded before reaching the Featured rail:

| Event | Owned | Median | Why dropped |
|---|---|---|---|
| Cavaliers @ Knicks **Game 7 (If Necessary)** | 61 | $5,880 | `(IF NECESSARY)` → speculative-name filter |
| Cavaliers @ Knicks **Game 5 (If Necessary)** | 2 | $2,139 | speculative + owned too low |
| Don Toliver (UBS Arena) | 49 | $370 | owned 49 ≤ 50 candidate gate |
| Reds @ Mets (Citi Field) | 9 | $64 | owned 9 ≤ 50 candidate gate |

With the candidate pool empty, **every** rail rendered empty and the whole movers strip hid. The curation gates (owned>100 for Featured, owned>50 for the pool) were tuned during peak season and now exclude all current thin playoff-season NYC inventory.

## Changes (scoped to `_compute_movers` / `_section_featured`)

1. **Playoff games surface despite "(If Necessary)"** and bypass the `owned>100` Featured depth gate — they're the highest-value NYC inventory. Genuine `CANCELLED` games (including playoff ones) still drop. This relaxation is **scoped to the movers strip only**; `/api/store/home` and search still hide `(If Necessary)` games (existing tests unchanged).
2. **Empty-rail fallback**: when no rail qualifies, Featured falls back to the soonest upcoming owned NYC events (no curation chip) so the homepage is never blank.

Net result on current data: the Knicks Game 7 playoff game now appears in Featured tagged "Playoffs".

## Test plan

- [x] `tests/test_store_home.py` — 7 new tests (playoff exemption, CANCELLED-playoff still drops, end-to-end playoff featuring, fallback-to-soonest, no-fallback-when-populated). 59 passed.
- [x] Existing `/api/store/home` speculative-filter tests still pass (home behavior unchanged).
- [x] `test_store_events.py` / `test_views_and_helpers.py` / `test_store_shares.py` pass.
- [ ] Verify "Featured in NYC" renders the Knicks Game 7 on the live storefront after deploy.

https://claude.ai/code/session_01TQTrhAnr3vv59GVvaHvuox

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQTrhAnr3vv59GVvaHvuox)_