### PR TITLE
fix(security): let SeatDataClient resolve creds via Vault, not env-only

### DIFF
--- a/app.py
+++ b/app.py
@@ -3743,16 +3743,18 @@ def broker_event_cadences(event_id: int, _=Depends(require_auth)):
 # migration 20260509060000. Going over those caps requires bumping BOTH the
 # DB defaults AND the seatdata_client.py constants.
 #
-# Auth: requires SEATDATA_API_KEY env var. Set it in Railway:
-#   railway variables --set SEATDATA_API_KEY=<key>
-# Routes return 503 if the key is missing rather than crashing the app.
+# Auth: SEATDATA_API_KEY resolved via SeatDataClient's chain:
+#   1. SEATDATA_API_KEY env var (Railway / Render)
+#   2. Supabase Vault via get_app_secret('SEATDATA_API_KEY')
+# Routes return 503 if the key is missing from both env and vault.
 
 def _get_seatdata_client():
-    """Lazy import + instantiation. Returns None if SEATDATA_API_KEY is missing."""
-    if not os.environ.get("SEATDATA_API_KEY"):
+    """Lazy import + instantiation. Returns None if SEATDATA_API_KEY not found anywhere."""
+    from seatdata_client import SeatDataClient, SeatDataError
+    try:
+        return SeatDataClient(db=require_sb())
+    except SeatDataError:
         return None
-    from seatdata_client import SeatDataClient
-    return SeatDataClient(db=require_sb())
 
 
 @app.get("/api/seatdata/account")

--- a/d2_dashboard/main.py
+++ b/d2_dashboard/main.py
@@ -199,6 +199,24 @@ def require_auth(authorization: str | None = Header(None)):
 
 # ---------- Client factories (lazy — only init when called) ----------
 
+def _vault_secret(name: str) -> str | None:
+    """Fetch a secret from Supabase Vault via get_app_secret RPC.
+    Returns None when Supabase is unavailable or the secret is unset."""
+    sb = _sb()
+    if sb is None:
+        return None
+    try:
+        res = sb.rpc("get_app_secret", {"p_name": name}).execute()
+        data = res.data
+        if isinstance(data, str):
+            return data or None
+        if isinstance(data, dict):
+            return data.get("get_app_secret") or data.get("value") or None
+    except Exception:
+        pass
+    return None
+
+
 def _env_first(*names: str) -> str | None:
     """Return the first set env var from `names`. Lets us accept either the
     vault-canonical key (TEVO_API_TOKEN) or the legacy storefront key
@@ -284,24 +302,24 @@ def _tickpick_client():
 
 def _vivid_client():
     from vivid_client import VividClient
-    token = os.environ.get("VIVID_API_TOKEN")
+    token = os.environ.get("VIVID_API_TOKEN") or _vault_secret("VIVID_API_TOKEN")
     if not token:
         return None
     return VividClient(token)
 
 
 def _seatdata_client():
-    from seatdata_client import SeatDataClient
-    api_key = os.environ.get("SEATDATA_API_KEY")
-    if not api_key:
+    from seatdata_client import SeatDataClient, SeatDataError
+    try:
+        return SeatDataClient(db=_sb())
+    except SeatDataError:
         return None
-    return SeatDataClient(api_key=api_key)
 
 
 def _gotickets_client():
     from gotickets_client import GoTicketsClient
-    access_id = os.environ.get("GOTICKETS_ACCESS_ID")
-    api_secret = os.environ.get("GOTICKETS_API_SECRET")
+    access_id = os.environ.get("GOTICKETS_ACCESS_ID") or _vault_secret("GOTICKETS_ACCESS_ID")
+    api_secret = os.environ.get("GOTICKETS_API_SECRET") or _vault_secret("GOTICKETS_API_SECRET")
     if not (access_id and api_secret):
         return None
     return GoTicketsClient(access_id, api_secret)


### PR DESCRIPTION
## Summary

- **app.py `_get_seatdata_client()`**: removed the premature `os.environ.get("SEATDATA_API_KEY")` guard. `SeatDataClient.__init__` already has a three-step chain (explicit arg → env var → Supabase Vault via `get_app_secret`). The old guard short-circuited before vault was ever tried. Now we just call `SeatDataClient(db=require_sb())` and catch `SeatDataError` if no key is found anywhere — callers still get `None` and return 503 unchanged.

- **d2_dashboard/main.py**: added `_vault_secret(name)` helper that calls `get_app_secret` RPC via `_sb()`. Wired it as `env-or-vault` fallback in `_vivid_client()` (VIVID_API_TOKEN) and `_gotickets_client()` (GOTICKETS_ACCESS_ID, GOTICKETS_API_SECRET). Migrated `_seatdata_client()` to `SeatDataClient(db=_sb())` so it also resolves via vault.

## Test plan

- [ ] `python -m pytest tests/ -x -q --ignore=tests/test_broadway_client_live.py` — 218 passed, 9 skipped (pre-existing `test_evo_barcode` skipped due to broken `cryptography` build in this env, unrelated to this change)
- [ ] Manually confirm: if `SEATDATA_API_KEY` is unset in env but present in Vault, `/api/seatdata/account` returns data instead of 503

https://claude.ai/code/session_01MThwDVsZf9BDQ6vBogBtAM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MThwDVsZf9BDQ6vBogBtAM)_