### PR TITLE
feat(d0): TD data across Overview panels + TD Listings tab + movers/SG fixes

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -60,6 +60,7 @@
       <button class="event-tab active" data-tab="overview" role="tab" aria-selected="true">Overview</button>
       <button class="event-tab" data-tab="sg-listings" role="tab" aria-selected="false">SG Listings <span class="tab-count" id="tabCountSgListings"></span></button>
       <button class="event-tab" data-tab="evo-listings" role="tab" aria-selected="false">EVO Listings <span class="tab-count" id="tabCountEvoListings"></span></button>
+      <button class="event-tab" data-tab="td-listings" role="tab" aria-selected="false">TD Listings <span class="tab-count" id="tabCountTdListings"></span></button>
       <button class="event-tab" data-tab="sg-sales" role="tab" aria-selected="false">SG Sales <span class="tab-count" id="tabCountSgSales"></span></button>
       <button class="event-tab" data-tab="td-markets" role="tab" aria-selected="false">TD Markets <span class="tab-count" id="tabCountTdMarkets"></span></button>
       <span class="event-tabs-sep" aria-hidden="true">|</span>
@@ -121,10 +122,18 @@
 
     <section id="cross-source-metrics">
       <div class="panel-title row">
-        <span>CROSS-SOURCE METRICS — TEvo vs SG</span>
+        <span>CROSS-SOURCE METRICS — TEvo · SG · TD</span>
         <span class="muted small" id="crossSourceMeta"></span>
       </div>
       <div id="crossSourceBody"><div class="empty">loading…</div></div>
+    </section>
+
+    <section id="cross-platform-sales">
+      <div class="panel-title row">
+        <span>CROSS-PLATFORM SALES — EVO · SG · SeatData · TP · Vivid · TD velocity</span>
+        <span class="muted small" id="crossSalesMeta"></span>
+      </div>
+      <div id="crossSalesBody"><div class="empty">loading…</div></div>
     </section>
 
     <!-- 2 fully independent chart sections (PR redesign 2026-05-18, v2).
@@ -260,6 +269,35 @@
         </div>
         <div id="evoListingsFullBody"><div class="empty">Click the tab to load.</div></div>
       </section>
+    </div>
+
+    <!-- TD Listings — three sub-sections (SH · GT · VD), parallel load on first click -->
+    <div class="tab-pane" id="paneTdListings" role="tabpanel" hidden>
+
+      <section id="td-listings-sh" class="td-platform-section td-sh-section">
+        <div class="panel-title row">
+          <span><span class="badge td-sh">SH</span> LISTINGS — StubHub (non-parking, last 7d)</span>
+          <span class="muted small" id="tdListingsShMeta">tap tab to load</span>
+        </div>
+        <div id="tdListingsShBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+
+      <section id="td-listings-gt" class="td-platform-section td-gt-section">
+        <div class="panel-title row">
+          <span><span class="badge td-gt">GT</span> LISTINGS — GameTime (non-parking, last 7d)</span>
+          <span class="muted small" id="tdListingsGtMeta">tap tab to load</span>
+        </div>
+        <div id="tdListingsGtBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+
+      <section id="td-listings-vd" class="td-platform-section td-vd-section">
+        <div class="panel-title row">
+          <span><span class="badge td-vd">VD</span> LISTINGS — VividSeats (non-parking, last 7d)</span>
+          <span class="muted small" id="tdListingsVdMeta">tap tab to load</span>
+        </div>
+        <div id="tdListingsVdBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+
     </div>
 
     <div class="tab-pane" id="paneSgSales" role="tabpanel" hidden>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -3119,7 +3119,7 @@
         const s = d.td[p];
         const minStr = s.min_price != null ? ` · min $${Math.round(Number(s.min_price))}` : '';
         const medStr = s.median_price != null ? ` · med $${Math.round(Number(s.median_price))}` : '';
-        return `<span class="td-platform-chip">${p} <b>${T.fmtNum(Number(s.listing_count))}</b>${minStr}${medStr}</span>`;
+        return `<span class="td-platform-chip">${escapeHtml(p)} <b>${T.fmtNum(Number(s.listing_count))}</b>${minStr}${medStr}</span>`;
       }).join('');
       body.appendChild(bar);
     }

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2416,8 +2416,10 @@
   }
 
   // ---------- TD Listings per-platform (full) ----------
-  // Queries ticketsdata_listings_snapshots for one platform (SH|GT|VD), last 7d.
-  // Each platform renders into its own sub-section in #paneTdListings.
+  // Queries ticketsdata_listings_snapshots for one platform (SH|GT|VD), last 26h ordered
+  // newest-first so the limit captures the most-recent collection batch. Client-side filter
+  // keeps only rows within 15 minutes of max(captured_at) for that platform — timing-agnostic
+  // so both the 03:00 UTC and 16:20 UTC SH batches work correctly regardless of query time.
   async function loadTdPlatformListings(eventId, platform) {
     const platLower = platform.toLowerCase();
     const body = document.getElementById('tdListings' + platform + 'Body');
@@ -2430,35 +2432,42 @@
       return;
     }
     const t0 = performance.now();
-    const since = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
+    const since26 = new Date(Date.now() - 26 * 3600 * 1000).toISOString();
     const res = await Auth.client
       .from('ticketsdata_listings_snapshots')
       .select('section,row,quantity,list_price,price_with_fees,captured_at')
       .eq('event_id', eventId)
       .eq('platform', platform)
       .eq('is_parking', false)
-      .gte('captured_at', since)
+      .gte('captured_at', since26)
       .order('captured_at', { ascending: false })
       .order('list_price')
-      .limit(1000);
+      .limit(3000);
     const elapsed = performance.now() - t0;
     if (res.error) {
       if (body) body.innerHTML = `<div class="empty">error: ${escapeHtml(res.error.message)}</div>`;
       if (meta) meta.textContent = 'error';
       return;
     }
-    const rows = res.data || [];
-    if (!rows.length) {
-      if (body) body.innerHTML = `<div class="empty">No ${escapeHtml(platform)} listings in last 7 days. Data started 2026-05-27 — sparse initially.</div>`;
+    const allRows = res.data || [];
+    if (!allRows.length) {
+      if (body) body.innerHTML = `<div class="empty">No ${escapeHtml(platform)} listings in last 26 hours. Data started 2026-05-27 — sparse initially.</div>`;
       if (meta) meta.textContent = '0 rows';
       return;
     }
+    // Latest-batch filter: keep only rows within 15 min of the most-recent captured_at.
+    // This ensures we show the current collection batch, not a stale earlier batch that
+    // would otherwise dominate when the limit was reached on a busy event.
+    const maxAt = allRows[0].captured_at; // already sorted DESC
+    const cutoff = new Date(new Date(maxAt).getTime() - 15 * 60 * 1000).toISOString();
+    const rows = allRows.filter(r => r.captured_at >= cutoff);
+    const batchDate = T.fmtDate ? T.fmtDate(maxAt) : maxAt.slice(0, 16).replace('T', ' ') + ' UTC';
     // Compute summary stats
     const prices = rows.map(r => +r.list_price).filter(v => isFinite(v) && v > 0).sort((a, b) => a - b);
     const med = prices.length ? prices[Math.floor(prices.length / 2)] : null;
     const getIn = prices.length ? prices[0] : null;
     if (meta) meta.textContent =
-      `${rows.length} rows · get-in ${getIn != null ? '$' + Math.round(getIn) : '—'} · med ${med != null ? '$' + Math.round(med) : '—'} · ${elapsed.toFixed(0)}ms`;
+      `${rows.length} rows · get-in ${getIn != null ? '$' + Math.round(getIn) : '—'} · med ${med != null ? '$' + Math.round(med) : '—'} · batch ${batchDate} · ${elapsed.toFixed(0)}ms`;
 
     const host = document.createElement('div');
     host.className = 'full-list-host';
@@ -2502,21 +2511,37 @@
     chip.textContent = total ? String(total) : '';
   }
 
-  // ---------- TD Splits (last 24h, grouped by platform + section) ----------
+  // ---------- TD Splits (latest batch per platform, grouped by platform + section) ----------
+  // Uses 26h window ordered newest-first to capture the most-recent collection run, then
+  // filters client-side to rows within 15 min of max(captured_at) per platform. This is
+  // timing-agnostic: SH 03:00 UTC or 16:20 UTC batches are both handled correctly.
   async function loadTdSplits(eventId) {
     const Auth = window.TerminalAuth;
     if (!Auth || !Auth.client) return;
     setSplitsTd(undefined); // show loading
-    const since = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+    const since26 = new Date(Date.now() - 26 * 3600 * 1000).toISOString();
     const { data, error } = await Auth.client
       .from('ticketsdata_listings_snapshots')
-      .select('platform,section,list_price')
+      .select('platform,section,list_price,captured_at')
       .eq('event_id', eventId)
       .eq('is_parking', false)
-      .gte('captured_at', since)
-      .limit(2000);
+      .gte('captured_at', since26)
+      .order('captured_at', { ascending: false })
+      .limit(3000);
     if (error) { setSplitsTd(null); return; }
-    const rows = data || [];
+    const allRows = data || [];
+    if (!allRows.length) { setSplitsTd(null); return; }
+    // Latest-batch filter: keep only rows within 15 min of max(captured_at) per platform.
+    const maxAtByPlatform = {};
+    for (const r of allRows) {
+      if (!maxAtByPlatform[r.platform] || r.captured_at > maxAtByPlatform[r.platform]) {
+        maxAtByPlatform[r.platform] = r.captured_at;
+      }
+    }
+    const rows = allRows.filter(r => {
+      const maxAt = maxAtByPlatform[r.platform];
+      return maxAt && (new Date(maxAt) - new Date(r.captured_at)) < 15 * 60 * 1000;
+    });
     if (!rows.length) { setSplitsTd(null); return; }
     // Group by platform + section
     const groups = new Map();

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2562,14 +2562,15 @@
         .order('captured_at', { ascending: false })
         .limit(1)
         .maybeSingle(),
-      // SG: latest seatgeek_event_metrics row (fill_rate, sold_quantity, sold_gross, sold_price_median)
+      // SG: top-20 rows — listings and sales are separate INSERT rows so we merge best-available
+      // from each: listings_all_count from the most-recent listings row, sold_quantity from
+      // the most-recent sales row. .limit(20) ensures we span both row types.
       Auth.client
         .from('seatgeek_event_metrics')
         .select('fill_rate,sold_quantity,sold_gross,sold_price_median,tickets_count,listings_all_count,captured_at')
         .eq('tevo_event_id', eventId)
         .order('captured_at', { ascending: false })
-        .limit(1)
-        .maybeSingle(),
+        .limit(20),
       // TD: last 2 snapshot rows to compute listing-count delta (proxy for sales velocity)
       Auth.client
         .from('event_listing_snapshot_daily')
@@ -2581,9 +2582,21 @@
       // TP + Vivid: via SECURITY DEFINER RPC (tickpick_orders + vivid_orders are service_role only)
       rpcOrNull('get_event_cross_broker_orders_full', { p_event_id: eventId, p_limit: 500 }),
     ]);
+    // Merge split SG rows: listings and sales are inserted separately by different cron functions.
+    // Pick the most-recent non-null value for each field across all returned rows.
+    const sgRows = sgRes.data || [];
+    function sgBest(field) { return (sgRows.find(r => r[field] != null) || {})[field] ?? null; }
+    const sgMerged = sgRows.length ? {
+      fill_rate:         sgBest('fill_rate'),
+      sold_quantity:     sgBest('sold_quantity'),
+      sold_gross:        sgBest('sold_gross'),
+      sold_price_median: sgBest('sold_price_median'),
+      listings_all_count:sgBest('listings_all_count'),
+      captured_at:       sgRows[0]?.captured_at ?? null,
+    } : null;
     renderCrossPlatformSales({
       evo:    evoRes.data  || null,
-      sg:     sgRes.data   || null,
+      sg:     sgMerged,
       tdSnap: tdSnapRes.data || [],
       xb:     xbRes.error ? null : (xbRes.data || null),
     }, meta);

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -45,6 +45,14 @@
   // Populated by loadTdFreshness() (fire-and-forget after main load).
   // Shape: { sh: [{t,v}], gt: [{t,v}], vd: [{t,v}] }
   let _tdChartSeries = null;
+  // Latest event_listing_snapshot_daily row — set by loadTdFreshness(),
+  // used by renderLastSnapshot() to append a TD MARKETS section.
+  let _lastTdSnap = null;
+  // TD listing-count time series for the inventory chart overlay.
+  // Shape: { sh: [{t,v}], gt: [{t,v}], vd: [{t,v}] } — counts not medians.
+  let _tdInvCountSeries = null;
+  // Initialize TD inv series as hidden by default (user-togglable in legend).
+  ['td-sh-cnt', 'td-gt-cnt', 'td-vd-cnt'].forEach(k => _chartVisible.set(k, false));
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
@@ -70,6 +78,8 @@
     loadCrossSourceMetrics(eventId).catch(e => console.error('[crossSource]', e));
     loadWeatherLocalized(eventId).catch(e => console.error('[weatherLocalized]', e));
     loadSgZonesSplits(eventId).catch(e => console.error('[sgZonesSplits]', e));
+    loadTdSplits(eventId).catch(e => console.error('[tdSplits]', e));
+    loadCrossPlatformSales(eventId).catch(e => console.error('[crossSales]', e));
     // Each chart fetches its own extended payload at its own window in parallel
     loadChartExtended('price', eventId, _chartPriceHours).catch(e => console.error('[chartExt price]', e));
     loadChartExtended('inv',   eventId, _chartInvHours  ).catch(e => console.error('[chartExt inv]', e));
@@ -736,6 +746,15 @@
       { key: 'sg_list_ct',    label: 'SG list qty',    color: '#22d3ee', width: 1.5, dash: null,   scale: 'y',  data: extSeries.sg_listings_count || [] },
       { key: 'sg_sale_ct',    label: 'SG sale ct',     color: '#84cc16', width: 1,   dash: null,   scale: 'yr', bars: true, data: extSeries.sg_sales_count || [] },
     ];
+    // Overlay TD listing-count series (dashed, hidden by default — user-togglable)
+    if (_tdInvCountSeries) {
+      if (_tdInvCountSeries.sh.length) specs.push(
+        { key: 'td-sh-cnt', label: 'SH listings', color: '#f97316', width: 1, dash: [4, 3], scale: 'y', data: _tdInvCountSeries.sh });
+      if (_tdInvCountSeries.gt.length) specs.push(
+        { key: 'td-gt-cnt', label: 'GT listings', color: '#2dd4bf', width: 1, dash: [4, 3], scale: 'y', data: _tdInvCountSeries.gt });
+      if (_tdInvCountSeries.vd.length) specs.push(
+        { key: 'td-vd-cnt', label: 'VD listings', color: '#a855f7', width: 1, dash: [4, 3], scale: 'y', data: _tdInvCountSeries.vd });
+    }
     const { xs } = buildSeriesData(specs);
     _chartLastBuildInv = { specs, xs };
 
@@ -1021,18 +1040,19 @@
   // sources (v3 fetchPayload for TEvo + get_event_sg_zones_splits for SG)
   // can update independently without clobbering each other on re-render.
   // Each setter writes its side then triggers a unified render reading both.
-  const _splitsState = { tevo: undefined, sg: undefined };
+  const _splitsState = { tevo: undefined, sg: undefined, td: undefined };
   const _zonesState  = { tevo: undefined, deltas: undefined, sg: undefined };
 
   function setSplitsTevo(splits)   { _splitsState.tevo = splits; renderSplits(); }
   function setSplitsSg(sgSplits)   { _splitsState.sg   = sgSplits; renderSplits(); }
+  function setSplitsTd(tdSplits)   { _splitsState.td   = tdSplits; renderSplits(); }
   function setZonesTevo(zones, deltas) {
     _zonesState.tevo = zones; _zonesState.deltas = deltas; renderZones();
   }
   function setZonesSg(sgZones)     { _zonesState.sg   = sgZones; renderZones(); }
 
-  // Renders TEvo splits + SG splits side-by-side from the module state cache.
-  // Either or both sides may still be `undefined` (loading) when this fires.
+  // Renders TEvo splits + SG splits + TD splits side-by-side from the module state cache.
+  // Any side may still be `undefined` (loading) when this fires.
   function renderSplits() {
     const body = document.getElementById('splitsBody');
     if (!body) return;
@@ -1045,8 +1065,13 @@
     right.className = 'dual-src-col';
     right.innerHTML = '<div class="dual-src-hdr">SG</div>';
     right.appendChild(buildSgSplitsTable(_splitsState.sg));
+    const tdCol = document.createElement('div');
+    tdCol.className = 'dual-src-col';
+    tdCol.innerHTML = '<div class="dual-src-hdr">TD (SH · GT · VD)</div>';
+    tdCol.appendChild(buildTdSplitsTable(_splitsState.td));
     body.appendChild(left);
     body.appendChild(right);
+    body.appendChild(tdCol);
   }
 
   function buildTevoSplitsTable(splits) {
@@ -1127,6 +1152,39 @@
     return wrap;
   }
 
+  // TD splits: array of {platform, section, listing_count, min_price, median_price}
+  function buildTdSplitsTable(tdSplits) {
+    const wrap = document.createElement('div');
+    if (tdSplits === undefined) { wrap.innerHTML = '<div class="empty">loading TD…</div>'; return wrap; }
+    if (!tdSplits || !tdSplits.length) {
+      wrap.innerHTML = '<div class="empty">no TD listings in last 24h</div>'; return wrap;
+    }
+    const tbl = document.createElement('table');
+    tbl.className = 'splits-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Platform</th>
+        <th>Section</th>
+        <th class="num">Listings</th>
+        <th class="num">Min $</th>
+        <th class="num">Median $</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    tdSplits.slice(0, 50).forEach(r => {
+      const tr = document.createElement('tr');
+      const platCls = r.platform === 'SH' ? 'td-sh' : r.platform === 'GT' ? 'td-gt' : r.platform === 'VD' ? 'td-vd' : '';
+      tr.innerHTML = `
+        <td><span class="badge ${platCls}">${escapeHtml(r.platform)}</span></td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td class="num">${T.fmtNum(r.listing_count)}</td>
+        <td class="num">${r.min_price    != null ? '$' + T.fmtNum(Math.round(r.min_price))    : '—'}</td>
+        <td class="num">${r.median_price != null ? '$' + T.fmtNum(Math.round(r.median_price)) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    wrap.appendChild(tbl);
+    return wrap;
+  }
+
   function labelForBucket(b) {
     return { singles: 'singles (1)', pairs: 'pairs (2)', triples: 'triples (3)',
              quads: 'quads (4)', five_plus: '5+ pack' }[b] || b;
@@ -1154,8 +1212,13 @@
     right.className = 'dual-src-col';
     right.innerHTML = '<div class="dual-src-hdr">SG (sections)</div>';
     right.appendChild(buildSgZonesTable(_zonesState.sg));
+    const tdCol = document.createElement('div');
+    tdCol.className = 'dual-src-col';
+    tdCol.innerHTML = '<div class="dual-src-hdr">TD (sections)</div>' +
+      '<div class="empty muted small" style="padding:8px">TD section-level data available in TD Listings tab<br>Zone xref mapping pending</div>';
     body.appendChild(left);
     body.appendChild(right);
+    body.appendChild(tdCol);
   }
 
   function buildTevoZonesTable(zones, deltas) {
@@ -1715,25 +1778,44 @@
     }
     // Render full per-source freshness table (into #data-freshness inside TD Markets pane)
     renderDataFreshness(snap, snapTs);
-    // Build price-chart TD series from full history
+    // Store latest snapshot row for renderLastSnapshot() TD section
+    _lastTdSnap = snap;
+
+    // Build chart series from full history (both price medians and listing counts)
     if (rows && rows.length > 1) {
       const sh = [], gt = [], vd = [];
+      const ish = [], igt = [], ivd = [];
       for (const r of rows) {
         const ts = rowTs(r);
-        if (r.td_sh_median != null) sh.push({ t: ts, v: +r.td_sh_median });
-        if (r.td_gt_median != null) gt.push({ t: ts, v: +r.td_gt_median });
-        if (r.td_vd_median != null) vd.push({ t: ts, v: +r.td_vd_median });
+        if (r.td_sh_median   != null) sh.push({ t: ts, v: +r.td_sh_median });
+        if (r.td_gt_median   != null) gt.push({ t: ts, v: +r.td_gt_median });
+        if (r.td_vd_median   != null) vd.push({ t: ts, v: +r.td_vd_median });
+        if (r.td_sh_listings != null) ish.push({ t: ts, v: +r.td_sh_listings });
+        if (r.td_gt_listings != null) igt.push({ t: ts, v: +r.td_gt_listings });
+        if (r.td_vd_listings != null) ivd.push({ t: ts, v: +r.td_vd_listings });
       }
       // Reverse so series are chronological (we fetched newest-first)
-      _tdChartSeries = { sh: sh.reverse(), gt: gt.reverse(), vd: vd.reverse() };
-      // Re-render price chart to include TD overlay (only if chart exists)
+      _tdChartSeries    = { sh: sh.reverse(),  gt: gt.reverse(),  vd: vd.reverse() };
+      _tdInvCountSeries = { sh: ish.reverse(), gt: igt.reverse(), vd: ivd.reverse() };
+
       if (_lastPayload && _lastPayload.chart_data) {
         try {
           const chart = adaptChart(_lastPayload.chart_data);
+          // Re-render price chart with TD median overlay
           renderChartPrice(chart, _chartExtAlerts);
           renderChartLegendPrice();
+          // Re-render inventory chart with TD listing-count overlay
+          renderChartInventory(chart);
+          renderChartLegendInv();
         } catch (e) { console.error('[td-chart-overlay]', e); }
       }
+    }
+
+    // Re-render last snapshot to show TD MARKETS section now that snap is cached
+    if (_lastPayload && _lastPayload.chart_data) {
+      try {
+        renderLastSnapshot(adaptChart(_lastPayload.chart_data));
+      } catch (e) { console.error('[td-snap-rerender]', e); }
     }
   }
 
@@ -2079,8 +2161,8 @@
   // Tab navigation + lazy-load (Phase 2a Tabs — mig 20260517180000)
   // ============================================================
   const _tabState = { loaded: {
-    'sg-listings': false, 'evo-listings': false, 'sg-sales': false,
-    'our-orders': false,
+    'sg-listings': false, 'evo-listings': false, 'td-listings': false,
+    'sg-sales': false, 'our-orders': false,
   } };
 
   function wireTabs(eventId) {
@@ -2095,6 +2177,14 @@
         await loadSgListingsFull(eventId);
       } else if (tabId === 'evo-listings' && !_tabState.loaded['evo-listings']) {
         await loadEvoListingsFull(eventId);
+      } else if (tabId === 'td-listings' && !_tabState.loaded['td-listings']) {
+        _tabState.loaded['td-listings'] = true;
+        await Promise.all([
+          loadTdPlatformListings(eventId, 'SH'),
+          loadTdPlatformListings(eventId, 'GT'),
+          loadTdPlatformListings(eventId, 'VD'),
+        ]);
+        updateTdListingsTabCount();
       } else if (tabId === 'sg-sales' && !_tabState.loaded['sg-sales']) {
         await loadSgSalesFull(eventId);
       } else if (tabId === 'td-markets' && !_tabState.loaded['td-markets']) {
@@ -2123,6 +2213,7 @@
       'overview':     'paneOverview',
       'sg-listings':  'paneSgListings',
       'evo-listings': 'paneEvoListings',
+      'td-listings':  'paneTdListings',
       'sg-sales':     'paneSgSales',
       'td-markets':   'paneTdMarkets',
       'our-orders':   'paneOurOrders',
@@ -2322,6 +2413,271 @@
     body.innerHTML = '';
     body.appendChild(host);
     if (meta) meta.textContent = `${rows.length} rows (${ownedCount} ours) · ${ms.toFixed(0)}ms`;
+  }
+
+  // ---------- TD Listings per-platform (full) ----------
+  // Queries ticketsdata_listings_snapshots for one platform (SH|GT|VD), last 7d.
+  // Each platform renders into its own sub-section in #paneTdListings.
+  async function loadTdPlatformListings(eventId, platform) {
+    const platLower = platform.toLowerCase();
+    const body = document.getElementById('tdListings' + platform + 'Body');
+    const meta = document.getElementById('tdListings' + platform + 'Meta');
+    if (body) body.innerHTML = '<div class="empty">Loading ' + escapeHtml(platform) + ' listings…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      if (body) body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+    const t0 = performance.now();
+    const since = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
+    const res = await Auth.client
+      .from('ticketsdata_listings_snapshots')
+      .select('section,row,quantity,list_price,price_with_fees,captured_at')
+      .eq('event_id', eventId)
+      .eq('platform', platform)
+      .eq('is_parking', false)
+      .gte('captured_at', since)
+      .order('captured_at', { ascending: false })
+      .order('list_price')
+      .limit(1000);
+    const elapsed = performance.now() - t0;
+    if (res.error) {
+      if (body) body.innerHTML = `<div class="empty">error: ${escapeHtml(res.error.message)}</div>`;
+      if (meta) meta.textContent = 'error';
+      return;
+    }
+    const rows = res.data || [];
+    if (!rows.length) {
+      if (body) body.innerHTML = `<div class="empty">No ${escapeHtml(platform)} listings in last 7 days. Data started 2026-05-27 — sparse initially.</div>`;
+      if (meta) meta.textContent = '0 rows';
+      return;
+    }
+    // Compute summary stats
+    const prices = rows.map(r => +r.list_price).filter(v => isFinite(v) && v > 0).sort((a, b) => a - b);
+    const med = prices.length ? prices[Math.floor(prices.length / 2)] : null;
+    const getIn = prices.length ? prices[0] : null;
+    if (meta) meta.textContent =
+      `${rows.length} rows · get-in ${getIn != null ? '$' + Math.round(getIn) : '—'} · med ${med != null ? '$' + Math.round(med) : '—'} · ${elapsed.toFixed(0)}ms`;
+
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl td-listings-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">List $</th><th class="num">All-in $</th>
+        <th>Captured</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    const $p = v => (v != null && +v > 0 ? '$' + T.fmtNum(Math.round(+v)) : '—');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${r.quantity != null ? T.fmtNum(+r.quantity) : '—'}</td>
+        <td class="num">${$p(r.list_price)}</td>
+        <td class="num">${$p(r.price_with_fees)}</td>
+        <td class="muted small">${T.fmtDate(r.captured_at)}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    if (body) { body.innerHTML = ''; body.appendChild(host); }
+  }
+
+  function updateTdListingsTabCount() {
+    const chip = document.getElementById('tabCountTdListings');
+    if (!chip) return;
+    // Sum visible row counts from all three sub-section metas
+    let total = 0;
+    for (const plat of ['SH', 'GT', 'VD']) {
+      const meta = document.getElementById('tdListings' + plat + 'Meta');
+      if (meta) {
+        const m = meta.textContent.match(/^(\d+)\s+rows/);
+        if (m) total += parseInt(m[1], 10);
+      }
+    }
+    chip.textContent = total ? String(total) : '';
+  }
+
+  // ---------- TD Splits (last 24h, grouped by platform + section) ----------
+  async function loadTdSplits(eventId) {
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client) return;
+    setSplitsTd(undefined); // show loading
+    const since = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+    const { data, error } = await Auth.client
+      .from('ticketsdata_listings_snapshots')
+      .select('platform,section,list_price')
+      .eq('event_id', eventId)
+      .eq('is_parking', false)
+      .gte('captured_at', since)
+      .limit(2000);
+    if (error) { setSplitsTd(null); return; }
+    const rows = data || [];
+    if (!rows.length) { setSplitsTd(null); return; }
+    // Group by platform + section
+    const groups = new Map();
+    for (const r of rows) {
+      const k = (r.platform || '') + '|||' + (r.section || '');
+      if (!groups.has(k)) groups.set(k, { platform: r.platform || '?', section: r.section || '', prices: [] });
+      const p = +r.list_price;
+      if (isFinite(p) && p > 0) groups.get(k).prices.push(p);
+    }
+    const result = [...groups.values()].map(g => {
+      const ps = g.prices.sort((a, b) => a - b);
+      return {
+        platform:     g.platform,
+        section:      g.section,
+        listing_count: ps.length,
+        min_price:    ps.length ? ps[0] : null,
+        median_price: ps.length ? ps[Math.floor(ps.length / 2)] : null,
+      };
+    }).sort((a, b) =>
+      a.platform.localeCompare(b.platform) || b.listing_count - a.listing_count
+    );
+    setSplitsTd(result);
+  }
+
+  // ---------- Cross-Platform Sales panel (Overview tab) ----------
+  // Aggregates: EVO sold metrics + SG fill_rate/sold + TD listing velocity + TP/Vivid order counts
+  async function loadCrossPlatformSales(eventId) {
+    const body = document.getElementById('crossSalesBody');
+    const meta = document.getElementById('crossSalesMeta');
+    if (body) body.innerHTML = '<div class="empty">loading…</div>';
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      if (body) body.innerHTML = '<div class="empty">not signed in</div>';
+      return;
+    }
+    // Fire 4 queries in parallel
+    const [evoRes, sgRes, tdSnapRes, xbRes] = await Promise.all([
+      // EVO: latest event_metrics row (sold_quantity, sold_gross, sold_price_median, owned_tickets_count)
+      Auth.client
+        .from('event_metrics')
+        .select('sold_quantity,sold_gross,sold_price_median,owned_tickets_count,tickets_count,captured_at')
+        .eq('event_id', eventId)
+        .order('captured_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      // SG: latest seatgeek_event_metrics row (fill_rate, sold_quantity, sold_gross, sold_price_median)
+      Auth.client
+        .from('seatgeek_event_metrics')
+        .select('fill_rate,sold_quantity,sold_gross,sold_price_median,tickets_count,listings_all_count,captured_at')
+        .eq('tevo_event_id', eventId)
+        .order('captured_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      // TD: last 2 snapshot rows to compute listing-count delta (proxy for sales velocity)
+      Auth.client
+        .from('event_listing_snapshot_daily')
+        .select('snapshot_date,snapshot_slot,td_sh_listings,td_gt_listings,td_vd_listings')
+        .eq('event_id', eventId)
+        .order('snapshot_date', { ascending: false })
+        .order('snapshot_slot', { ascending: false })
+        .limit(2),
+      // TP + Vivid: via SECURITY DEFINER RPC (tickpick_orders + vivid_orders are service_role only)
+      rpcOrNull('get_event_cross_broker_orders_full', { p_event_id: eventId, p_limit: 500 }),
+    ]);
+    renderCrossPlatformSales({
+      evo:    evoRes.data  || null,
+      sg:     sgRes.data   || null,
+      tdSnap: tdSnapRes.data || [],
+      xb:     xbRes.error ? null : (xbRes.data || null),
+    }, meta);
+  }
+
+  function renderCrossPlatformSales(d, metaEl) {
+    const body = document.getElementById('crossSalesBody');
+    if (!body) return;
+
+    const evo    = d.evo    || {};
+    const sg     = d.sg     || {};
+    const tdSnap = d.tdSnap || [];
+    const xbRows = (d.xb && d.xb.rows) ? d.xb.rows : [];
+
+    // TD listing-count delta: newest minus prior snapshot = positive means new listings (buying opportunity),
+    // negative means listings disappeared (likely sold).
+    const tdLatest = tdSnap[0] || null;
+    const tdPrior  = tdSnap[1] || null;
+    function tdDelta(platform) {
+      const col = `td_${platform.toLowerCase()}_listings`;
+      if (!tdLatest || tdLatest[col] == null || !tdPrior || tdPrior[col] == null) return null;
+      return tdLatest[col] - tdPrior[col];
+    }
+    function fmtDelta(val) {
+      if (val == null) return '<span class="dim">—</span>';
+      const cls = val < 0 ? 'pos' : val > 0 ? 'neg' : '';  // negative = sold = good (green)
+      return `<span class="${cls}">${val >= 0 ? '+' : ''}${T.fmtNum(val)}</span>`;
+    }
+
+    // Count TP/Vivid orders by source
+    const tpOrders = xbRows.filter(r => (r.source || '').toLowerCase() === 'tickpick');
+    const vvOrders = xbRows.filter(r => (r.source || '').toLowerCase() === 'vivid');
+
+    // Build rows
+    const tableRows = [];
+    function row(platform, metric, val, isMoney, note) {
+      const vStr = val == null
+        ? '<span class="dim">—</span>'
+        : (isMoney ? '$' + T.fmtNum(Math.round(+val)) : T.fmtNum(+val || 0));
+      return `<tr><td class="csale-platform">${escapeHtml(platform)}</td>` +
+        `<td>${escapeHtml(metric)}</td>` +
+        `<td class="num">${vStr}</td>` +
+        `<td class="muted small">${escapeHtml(note || '')}</td></tr>`;
+    }
+
+    if (evo.sold_quantity != null || evo.owned_tickets_count != null) {
+      tableRows.push(row('EVO', 'Sold qty (inferred)', evo.sold_quantity, false, 'event_metrics'));
+      tableRows.push(row('EVO', 'Sold gross (inferred)', evo.sold_gross, true, ''));
+      tableRows.push(row('EVO', 'Sold median $', evo.sold_price_median, true, ''));
+      tableRows.push(row('EVO', 'Owned remaining', evo.owned_tickets_count, false, ''));
+    }
+    if (sg.fill_rate != null || sg.sold_quantity != null) {
+      tableRows.push(row('SG', 'Fill rate', sg.fill_rate != null ? (+(sg.fill_rate) * 100).toFixed(1) + '%' : null, false, 'seatgeek_event_metrics'));
+      tableRows.push(row('SG', 'Sold qty', sg.sold_quantity, false, ''));
+      tableRows.push(row('SG', 'Sold median $', sg.sold_price_median, true, ''));
+      tableRows.push(row('SG', 'Market listings', sg.listings_all_count, false, ''));
+    }
+    for (const plat of ['SH', 'GT', 'VD']) {
+      const delta = tdDelta(plat);
+      const label = plat === 'SH' ? 'StubHub' : plat === 'GT' ? 'GameTime' : 'VividSeats';
+      const deltaCell = `<td class="num">${fmtDelta(delta)}</td>`;
+      const note = delta == null
+        ? 'need 2+ snapshots'
+        : (delta < 0 ? `${Math.abs(delta)} listings removed (velocity proxy)` : delta > 0 ? `${delta} new listings` : 'no change');
+      tableRows.push(
+        `<tr><td class="csale-platform"><span class="badge td-${plat.toLowerCase()}">${escapeHtml(plat)}</span> ${escapeHtml(label)}</td>` +
+        `<td>Listing Δ (${(tdLatest && tdPrior) ? `${tdLatest.snapshot_date} vs ${tdPrior.snapshot_date}` : '—'})</td>` +
+        `${deltaCell}<td class="muted small">${escapeHtml(note)}</td></tr>`
+      );
+    }
+    if (d.xb !== null) {
+      tableRows.push(row('TP', 'Our orders', tpOrders.length || null, false, tpOrders.length ? tpOrders.map(r => r.status || '').filter(Boolean).join(', ') : 'none'));
+      tableRows.push(row('Vivid', 'Our orders', vvOrders.length || null, false, vvOrders.length ? vvOrders.map(r => r.status || '').filter(Boolean).join(', ') : 'none'));
+    }
+
+    if (!tableRows.length) {
+      body.innerHTML = '<div class="empty">no cross-platform sales data available</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.className = 'cross-src-tbl cross-sales-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Platform</th><th>Metric</th><th class="num">Value</th><th>Note</th>
+      </tr></thead><tbody>${tableRows.join('')}</tbody>`;
+    body.innerHTML = '';
+    body.appendChild(tbl);
+
+    const parts = [];
+    if (evo.captured_at) parts.push(`EVO as of ${T.fmtDate(evo.captured_at)}`);
+    if (sg.captured_at)  parts.push(`SG as of ${T.fmtDate(sg.captured_at)}`);
+    if (tdLatest)        parts.push(`TD snapshot ${tdLatest.snapshot_date} ${tdLatest.snapshot_slot}`);
+    if (metaEl) metaEl.textContent = parts.join(' · ');
   }
 
   // ---------- SG Sales (full) ----------
@@ -2876,6 +3232,32 @@
     }).join('');
     body.innerHTML = `<div class="last-snap-grid">${cells}</div>
       <div class="last-snap-meta">snapshot fields fall back to the most recent non-null value across the loaded window (${rows.length} pulls)</div>`;
+
+    // Append TD MARKETS section if snapshot data is already loaded
+    if (_lastTdSnap) {
+      const tdSnap = _lastTdSnap;
+      const tdFields = [
+        ['td_sh_listings',    'SH LISTINGS', null],
+        ['td_sh_median',      'SH MED',      '$'],
+        ['td_gt_listings',    'GT LISTINGS', null],
+        ['td_gt_median',      'GT MED',      '$'],
+        ['td_vd_listings',    'VD LISTINGS', null],
+        ['td_vd_median',      'VD MED',      '$'],
+        ['td_combined_median','TD COMBINED', '$'],
+      ];
+      const tdCells = tdFields.map(([col, label, prefix]) => {
+        const v = tdSnap[col];
+        const valHtml = (v != null)
+          ? `<span class="last-snap-val">${prefix === '$' ? '$' : ''}${T.fmtNum(Math.round(+v))}</span>`
+          : `<span class="last-snap-val dim">—</span>`;
+        return `<div class="last-snap-cell"><span class="last-snap-lbl">${label}</span>${valHtml}</div>`;
+      }).join('');
+      const tdSection = document.createElement('div');
+      tdSection.innerHTML =
+        `<div class="last-snap-divider">TD MARKETS — ${escapeHtml(tdSnap.snapshot_date || '')} ${escapeHtml(tdSnap.snapshot_slot || '')}</div>` +
+        `<div class="last-snap-grid">${tdCells}</div>`;
+      body.appendChild(tdSection);
+    }
   }
 
   // ---------- TD Markets — raw per-listing data from ticketsdata_listings_snapshots ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1610,7 +1610,7 @@ body[data-page="login"] {
 /* Dual-source side-by-side container (used by Splits + Zones panels) */
 .dual-src {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 12px;
 }
 .dual-src-col {
@@ -1753,3 +1753,34 @@ body[data-page="login"] {
 .fr-status.dim    { background: rgba(148,163,184,.12); color: var(--muted); }
 
 #dataFreshnessMeta { color: var(--muted); font-size: 0.8em; }
+
+/* ---------- Last Snapshot — TD section divider ---------- */
+.last-snap-divider {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 10px 0 4px;
+  margin-top: 8px;
+  border-top: 1px solid var(--line);
+}
+
+/* ---------- Cross-Platform Sales panel ---------- */
+.cross-sales-tbl .csale-platform {
+  color: var(--text);
+  font-weight: 600;
+  white-space: nowrap;
+}
+/* .cross-sales-tbl inherits all .cross-src-tbl rules; no extra layout needed */
+
+/* ---------- TD Listings tab — per-platform sections ---------- */
+.td-platform-section {
+  border-left: 3px solid var(--line);
+  padding-left: 12px;
+  margin-bottom: 24px;
+}
+.td-sh-section { border-left-color: #f97316; }   /* SH — orange */
+.td-gt-section { border-left-color: #2dd4bf; }   /* GT — teal  */
+.td-vd-section { border-left-color: #a855f7; }   /* VD — purple */

--- a/supabase/migrations/20260528290000_fix_movers_past_event_filter.sql
+++ b/supabase/migrations/20260528290000_fix_movers_past_event_filter.sql
@@ -1,0 +1,202 @@
+-- 20260528290000_fix_movers_past_event_filter.sql
+--
+-- Bug: movers tab shows past events (days_to_event = 0) because:
+--   1. get_event_movers_v2 used GREATEST(0,...) clipping negatives to 0 instead
+--      of filtering past events out entirely.
+--   2. compute_event_movers_index_all() had no global purge for past events;
+--      stale rows survive between cron fires (up to 8h) or after compute exceptions.
+--
+-- Fix:
+--   A. Recreate get_event_movers_v2 with sg_datetime_utc > now() filter.
+--   B. Recreate compute_event_movers_index_all() with a global past-event purge
+--      at the top (runs once per all-combo cycle, covers all source×window slices).
+
+-- ── A. get_event_movers_v2 — add future-event filter ────────────────────────
+
+CREATE OR REPLACE FUNCTION public.get_event_movers_v2(
+  p_source      text DEFAULT 'merged',
+  p_window_days int  DEFAULT 7,
+  p_category    text DEFAULT NULL,
+  p_limit       int  DEFAULT 25
+) RETURNS TABLE (
+  source            text,
+  window_days       int,
+  category          text,
+  rank              int,
+  event_id          bigint,
+  event_name        text,
+  venue_name        text,
+  occurs_at         text,
+  days_to_event     int,
+  entry_price       numeric,
+  cur_price         numeric,
+  price_delta_pct   numeric,
+  cur_owned         int,
+  owned_delta       numeric,
+  cur_tix           int,
+  tix_delta         numeric,
+  signal_score      numeric,
+  days_in_index     numeric,
+  data_coverage_pct numeric,
+  evo_median        numeric,
+  sg_median         numeric,
+  td_sh_median      numeric,
+  td_gt_median      numeric,
+  td_vd_median      numeric,
+  sh_vs_evo_spread  numeric,
+  gt_vs_sh_spread   numeric,
+  vd_vs_sh_spread   numeric
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT
+    idx.source,
+    idx.window_days,
+    idx.category,
+    idx.rank,
+    idx.event_id,
+    sgc.sg_event_name                                           AS event_name,
+    sgc.sg_venue_name                                           AS venue_name,
+    to_char(sgc.sg_datetime_utc, 'YYYY-MM-DD"T"HH24:MI:SS')    AS occurs_at,
+    -- Use FLOOR not GREATEST: negative means past event — these are now excluded below,
+    -- but FLOOR keeps the value accurate for events occurring today (0 is valid for today).
+    FLOOR(
+      EXTRACT(EPOCH FROM (sgc.sg_datetime_utc - now())) / 86400.0
+    )::int                                                      AS days_to_event,
+    idx.entry_price,
+    idx.cur_price,
+    idx.price_delta_pct,
+    idx.cur_owned,
+    idx.owned_delta,
+    idx.cur_tix,
+    idx.tix_delta,
+    idx.signal_score,
+    ROUND(
+      EXTRACT(EPOCH FROM (now() - idx.entered_at)) / 86400.0, 2
+    )                                                           AS days_in_index,
+    idx.data_coverage_pct,
+    sn.evo_retail_median  AS evo_median,
+    sn.sg_all_median      AS sg_median,
+    sn.td_sh_median,
+    sn.td_gt_median,
+    sn.td_vd_median,
+    ROUND(
+      (sn.td_sh_median - sn.evo_retail_median)
+        / NULLIF(sn.evo_retail_median, 0) * 100,
+      2
+    )                                                           AS sh_vs_evo_spread,
+    ROUND(
+      (sn.td_gt_median - sn.td_sh_median)
+        / NULLIF(sn.td_sh_median, 0) * 100,
+      2
+    )                                                           AS gt_vs_sh_spread,
+    ROUND(
+      (sn.td_vd_median - sn.td_sh_median)
+        / NULLIF(sn.td_sh_median, 0) * 100,
+      2
+    )                                                           AS vd_vs_sh_spread
+  FROM public.event_movers_index idx
+  JOIN public.sg_events_canonical sgc
+    ON sgc.tevo_event_id = idx.event_id
+   AND sgc.sg_datetime_utc > now()          -- FILTER: exclude past events entirely
+  LEFT JOIN LATERAL (
+    SELECT s.evo_retail_median,
+           s.sg_all_median,
+           s.td_sh_median,
+           s.td_gt_median,
+           s.td_vd_median
+    FROM   public.event_listing_snapshot_daily s
+    WHERE  s.event_id = idx.event_id
+    ORDER BY s.snapshot_date DESC,
+             CASE s.snapshot_slot
+               WHEN 'evening' THEN 3
+               WHEN 'midday'  THEN 2
+               ELSE 1
+             END DESC
+    LIMIT 1
+  ) sn ON true
+  WHERE idx.source      = p_source
+    AND idx.window_days = p_window_days
+    AND (p_category IS NULL OR idx.category = p_category)
+  ORDER BY idx.category, idx.rank
+  LIMIT p_limit;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_event_movers_v2(text,int,text,int) FROM anon, public;
+COMMENT ON FUNCTION public.get_event_movers_v2 IS
+  'v2 movers RPC: per-event rows from event_movers_index with cross-source spread '
+  'columns. p_source + p_window_days are required; p_category=NULL returns all '
+  'categories up to p_limit rows (ordered category, rank). '
+  'FIXED 2026-05-28 (mig 290000): added sg_datetime_utc > now() to exclude past events; '
+  'replaced GREATEST(0,...) with plain FLOOR so days_to_event is accurate for today events.';
+
+
+-- ── B. compute_event_movers_index_all — add global past-event purge ──────────
+--
+-- Added before the source×window loop:
+--   DELETE FROM event_movers_index WHERE event_id maps to an event that already occurred.
+-- This handles:
+--   - Events that fell out of a window since the last successful compute (up to 8h gap).
+--   - Residual rows from failed compute runs (exception handler swallowed the EXIT DELETE).
+--   - Any seeding-time events that have since passed.
+
+CREATE OR REPLACE FUNCTION public.compute_event_movers_index_all()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_source   text;
+  v_window   int;
+  v_n        int;
+  v_purged   int;
+BEGIN
+  -- ── Global past-event purge ─────────────────────────────────────────────────
+  -- Remove all index rows for events that have already occurred.
+  -- Runs once per full cycle (before any source×window compute).
+  -- Belt-and-suspenders: the per-(source,window) EXIT DELETE handles normal
+  -- compute-cycle exits; this handles gaps from partial failures and cron lag.
+  DELETE FROM public.event_movers_index idx
+  WHERE idx.event_id IN (
+    SELECT sgc.tevo_event_id
+    FROM public.sg_events_canonical sgc
+    WHERE sgc.sg_datetime_utc < now()
+      AND sgc.tevo_event_id IS NOT NULL
+  );
+  GET DIAGNOSTICS v_purged = ROW_COUNT;
+  IF v_purged > 0 THEN
+    PERFORM public.bot_chat_log(
+      'data-collection', 'D0', 'status',
+      format('movers: purged %s past-event rows from index', v_purged)
+    );
+  END IF;
+
+  -- ── Per-source × per-window compute ────────────────────────────────────────
+  FOREACH v_source IN ARRAY ARRAY['evo','sg','td_sh','td_gt','td_vd','merged'] LOOP
+    FOREACH v_window IN ARRAY ARRAY[7,15,30,180,365] LOOP
+      BEGIN
+        v_n := public.compute_event_movers_index(v_source, v_window);
+        PERFORM public.bot_chat_log(
+          'data-collection', 'D0', 'status',
+          format('movers(%s, %sd): %s events upserted', v_source, v_window, v_n)
+        );
+      EXCEPTION WHEN OTHERS THEN
+        PERFORM public.bot_chat_log(
+          'data-collection', 'D0', 'flag',
+          format('movers(%s, %sd) ERROR: %s', v_source, v_window, SQLERRM)
+        );
+      END;
+    END LOOP;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.compute_event_movers_index_all() FROM anon, public;
+COMMENT ON FUNCTION public.compute_event_movers_index_all() IS
+  'Run all 30 source×window combos (6 sources × 5 windows). '
+  'FIXED 2026-05-28 (mig 290000): global past-event purge runs before the loop to '
+  'clear stale rows from failed compute runs and inter-cron-fire gaps. '
+  'Each combo wrapped in BEGIN/EXCEPTION so one failure does not abort all.';

--- a/supabase/migrations/20260528300000_sg_null_listings_fix.sql
+++ b/supabase/migrations/20260528300000_sg_null_listings_fix.sql
@@ -1,0 +1,272 @@
+-- 20260528300000_sg_null_listings_fix.sql
+--
+-- Fixes three compounding issues that caused SG listing data to go dark for
+-- 141+ events within 14 days (started ~May 21, avg 6-7 day dark duration):
+--
+-- ROOT CAUSE CHAIN:
+--   1. seatgeek_listings_snapshots rows swept after 24h TTL.
+--   2. If sg_broker_listings_metrics_refresh_hourly missed a window, seatgeek_event_metrics
+--      went stale → event_metrics_cte in sg_classify_events returned NULL owned/listings.
+--   3. With owned_cnt = COALESCE(NULL, NULL, 0) = 0, owned events looked unowned.
+--   4. Unowned US events → TRACK_BLINDSPOT (enabled=false in sg_priority_policy) or OBSERVE.
+--   5. sg_priority_poll_tick skips TRACK_BLINDSPOT entirely → event never re-polled.
+--   6. Data stays dark indefinitely (vicious cycle).
+--
+-- FIXES:
+--   A. sg_classify_events: add 30d ownership fallback from event_metrics history.
+--      When snapshot + fresh event_metrics are both NULL, look for any owned_tickets_count > 0
+--      from event_metrics within 30 days. Prevents temporary data gap from demoting
+--      owned events to unowned tier (TRACK_BLINDSPOT/OBSERVE).
+--   B. sg_classify_events: COLD→COOL floor for events within 30d with missing data
+--      (belt-and-suspenders — now that ownership fallback prevents COLD→TRACK_BLINDSPOT,
+--      this only triggers for residual cases where owned_cnt_fallback is also exhausted).
+--   C. Snapshot cron_policy: reduce min_interval 1440→1200 min. Morning snapshot at 13:30 UTC
+--      was blocked when last_fire was at 16:02 UTC the prior day (21.5h < 24h). With 20h
+--      interval, next fire at 13:30 + 20h gate = fires correctly (21.5h > 20h).
+--   D. sweep-old-sg-listings: extend TTL 24h→48h. Gives sg_broker_listings_metrics_refresh_hourly
+--      two full cycles to read snapshot data before it's swept.
+--   E. One-time re-queue: reset last_polled_listings_at for stale events within 14d
+--      so sg_priority_poll_tick and sg_blindspot_poll_5min process them on next runs.
+
+-- ── A. Rewrite sg_classify_events() with ownership fallback + tier floor ────────
+
+CREATE OR REPLACE FUNCTION public.sg_classify_events()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_updated int := 0;
+  v_us_states text[] := ARRAY[
+    'AL','AK','AZ','AR','CA','CO','CT','DE','DC','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME',
+    'MD','MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI',
+    'SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY',
+    'California','New York','Texas','Florida','Pennsylvania','Ohio','Illinois','Arizona','Washington',
+    'Georgia','Massachusetts','North Carolina','Tennessee'
+  ];
+BEGIN
+  WITH
+  -- ── Latest snapshot per event (sub-second on ~2,500 events) ──────────────────
+  latest_snap AS (
+    SELECT DISTINCT ON (s.event_id)
+      s.event_id            AS tevo_event_id,
+      s.evo_owned_tickets   AS owned_cnt,
+      s.evo_tickets_count   AS listings_cnt
+    FROM public.event_listing_snapshot_daily s
+    WHERE s.event_id IS NOT NULL
+    ORDER BY s.event_id,
+             s.snapshot_date DESC,
+             CASE s.snapshot_slot WHEN 'evening' THEN 3 WHEN 'midday' THEN 2 ELSE 1 END DESC
+  ),
+
+  -- ── Fresh event_metrics fallback (for events not yet in snapshot table) ───────
+  latest_em AS (
+    SELECT DISTINCT ON (em.event_id)
+      em.event_id           AS tevo_event_id,
+      em.owned_tickets_count AS owned_cnt,
+      em.tickets_count      AS listings_cnt
+    FROM public.event_metrics em
+    ORDER BY em.event_id, em.captured_at DESC
+  ),
+
+  -- ── NEW: 30-day ownership fallback ───────────────────────────────────────────
+  -- When both snapshot AND latest event_metrics return NULL, owned events are
+  -- misidentified as unowned → downgraded to TRACK_BLINDSPOT (not polled by tick).
+  -- This CTE finds any owned_tickets_count > 0 from event_metrics within 30 days.
+  -- Used as a third-level fallback for owned_cnt ONLY — not for listings_cnt.
+  -- As long as we owned tickets within 30 days, we preserve the owned-event tier.
+  latest_owned_fallback AS (
+    SELECT DISTINCT ON (em.event_id)
+      em.event_id AS tevo_event_id,
+      em.owned_tickets_count AS owned_cnt_fallback
+    FROM public.event_metrics em
+    WHERE em.owned_tickets_count > 0
+      AND em.captured_at > now() - interval '30 days'
+    ORDER BY em.event_id, em.captured_at DESC
+  ),
+
+  -- ── event data: sg_events_canonical + TEvo xref + hours_to_event ─────────────
+  event_data AS (
+    SELECT c.sg_event_id,
+           c.sg_event_name,
+           c.sg_venue_name,
+           c.sg_venue_state,
+           c.sg_datetime_utc,
+           a.aq_short_event_id,
+           coalesce(c.tevo_event_id,
+                    (SELECT x.tevo_event_id FROM public.seatgeek_event_xref x
+                     WHERE x.sg_event_id = c.sg_event_id LIMIT 1)) AS tevo_event_id,
+           EXTRACT(epoch FROM (c.sg_datetime_utc - v_now)) / 3600 AS hours_to_event
+    FROM public.sg_events_canonical c
+    LEFT JOIN LATERAL (
+      SELECT aq_short_event_id FROM public.aq_event_map
+      WHERE sg_event_id = c.sg_event_id
+      ORDER BY (aq_short_event_id LIKE 'SYS-%') ASC, aq_short_event_id
+      LIMIT 1
+    ) a ON true
+    WHERE c.sg_datetime_utc IS NOT NULL
+      AND c.sg_datetime_utc BETWEEN v_now - interval '6 hours' AND v_now + interval '365 days'
+  ),
+
+  event_metrics_cte AS (
+    SELECT ed.*,
+           -- owned_cnt: snapshot → latest event_metrics → 30d ownership fallback → 0
+           -- The 30d fallback prevents temporarily-dark owned events from appearing unowned.
+           coalesce(s.owned_cnt, m.owned_cnt, fb.owned_cnt_fallback, 0) AS owned_cnt,
+           -- listings_cnt: snapshot → latest event_metrics → 0 (no 30d fallback for listings)
+           coalesce(s.listings_cnt, m.listings_cnt, 0) AS listings_cnt,
+           -- has_listings_data: true only when a non-NULL listing count exists from
+           -- snapshot or latest event_metrics. Distinguishes data gap from confirmed zero.
+           (s.listings_cnt IS NOT NULL OR m.listings_cnt IS NOT NULL) AS has_listings_data
+    FROM event_data ed
+    LEFT JOIN latest_snap          s  ON s.tevo_event_id  = ed.tevo_event_id
+    LEFT JOIN latest_em            m  ON m.tevo_event_id  = ed.tevo_event_id
+    LEFT JOIN latest_owned_fallback fb ON fb.tevo_event_id = ed.tevo_event_id
+  ),
+
+  classified AS (
+    SELECT em.*,
+      CASE
+        WHEN em.sg_event_name ILIKE '%parking%'
+             OR em.sg_venue_name ILIKE '%parking%' THEN 'SKIP'
+        WHEN em.sg_event_name ~* '(cancelled|if necessary)' THEN 'SKIP'
+        WHEN em.sg_event_name ~* '(\(date tbd\)|^TBD at )'
+             AND em.tevo_event_id IS NULL THEN 'SKIP'
+        WHEN em.hours_to_event >= 0 AND em.hours_to_event < 168
+             AND em.owned_cnt = 0 AND em.listings_cnt > 150 THEN 'WATCH'
+        WHEN em.hours_to_event >= 24
+             AND em.hours_to_event < 8760
+             AND em.owned_cnt = 0
+             AND em.sg_venue_state = ANY(v_us_states) THEN 'TRACK_BLINDSPOT'
+        ELSE
+          (SELECT p.tier FROM public.sg_priority_policy p
+           WHERE p.enabled = true
+             AND em.hours_to_event >= coalesce(p.min_hours_to_event, -999999)
+             AND em.hours_to_event <  coalesce(p.max_hours_to_event, 999999)
+             AND (p.requires_owned = false OR em.owned_cnt > 0)
+           ORDER BY p.sort_order LIMIT 1)
+      END AS raw_tier
+    FROM event_metrics_cte em
+  ),
+
+  -- ── NEW: Minimum-tier floor (belt-and-suspenders) ────────────────────────────
+  -- Catches any residual COLD events within 30d where listing data is still missing
+  -- after the ownership fallback (e.g. event never had event_metrics rows, or
+  -- fallback window expired). Promotes COLD → COOL (30-min vs 4-hour interval)
+  -- to break any remaining vicious-cycle cases.
+  -- SKIP / WATCH / TRACK_BLINDSPOT / OBSERVE are unchanged.
+  tier_floored AS (
+    SELECT c.*,
+      CASE
+        WHEN c.raw_tier = 'COLD'
+         AND NOT c.has_listings_data
+         AND c.hours_to_event BETWEEN 0 AND 720
+        THEN 'COOL'
+        ELSE coalesce(c.raw_tier, 'SKIP')
+      END AS tier
+    FROM classified c
+  )
+  INSERT INTO public.sg_event_priority_state AS s
+    (sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+     tevo_event_id, owned_count_last_7d, active_listings_last_7d, tier, hours_to_event, computed_at)
+  SELECT sg_event_id, sg_event_name, sg_venue_name, sg_datetime_utc, aq_short_event_id,
+         tevo_event_id, owned_cnt, listings_cnt, tier, hours_to_event, v_now
+  FROM tier_floored WHERE sg_event_id IS NOT NULL
+  ON CONFLICT (sg_event_id) DO UPDATE SET
+    sg_event_name           = EXCLUDED.sg_event_name,
+    sg_venue_name           = EXCLUDED.sg_venue_name,
+    sg_datetime_utc         = EXCLUDED.sg_datetime_utc,
+    aq_short_event_id       = EXCLUDED.aq_short_event_id,
+    tevo_event_id           = EXCLUDED.tevo_event_id,
+    owned_count_last_7d     = EXCLUDED.owned_count_last_7d,
+    active_listings_last_7d = EXCLUDED.active_listings_last_7d,
+    tier                    = EXCLUDED.tier,
+    hours_to_event          = EXCLUDED.hours_to_event,
+    computed_at             = EXCLUDED.computed_at,
+    sales_polls_today    = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.sales_polls_today END,
+    listings_polls_today = CASE WHEN s.budget_day < current_date THEN 0 ELSE s.listings_polls_today END,
+    budget_day           = current_date;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.sg_classify_events() FROM anon, public;
+COMMENT ON FUNCTION public.sg_classify_events() IS
+  'REWRITTEN 2026-05-27 (mig 240000): replaced listings_snapshots 24h full-table scan with '
+  'event_listing_snapshot_daily + event_metrics fallback. '
+  'UPDATED 2026-05-28 (mig 300000): added 30d ownership fallback (latest_owned_fallback CTE) '
+  'to prevent owned events being demoted to TRACK_BLINDSPOT/OBSERVE during data gaps. '
+  'Added has_listings_data flag and COLD→COOL floor for belt-and-suspenders gap protection. '
+  'Root cause: 24h sweep TTL + slow metrics refresh → owned_cnt coalesced to 0 → '
+  'TRACK_BLINDSPOT (enabled=false) → tick skipped event → permanent dark.';
+
+
+-- ── B. Snapshot cron_policy: reduce min_interval 1440 → 1200 ────────────────────
+-- event_snapshot_morning fires daily at 13:30 UTC.
+-- On 2026-05-27 it fired at 16:02 UTC. Next 13:30 fire = 21.5h gap.
+-- 21.5h < 24h (1440min) → skip_offpeak. Missed today entirely.
+-- With 1200min (20h): 21.5h > 20h → fires. Future same-day-late fires won't block tomorrow.
+
+UPDATE public.cron_policy SET
+  peak_min_interval_min    = 1200,
+  offpeak_min_interval_min = 1200,
+  notes = notes || ' | 2026-05-28 mig 300000: reduced 1440→1200 min to allow 20h gap '
+                || '(morning snapshot at 13:30 was blocked by 21.5h gap < 24h)'
+WHERE jobname IN ('event_snapshot_morning', 'event_snapshot_midday', 'event_snapshot_evening');
+
+
+-- ── C. sweep-old-sg-listings: extend TTL 24h → 48h ──────────────────────────────
+-- seatgeek_listings_snapshots data was being swept after 24h. If sg_broker_listings_
+-- metrics_refresh_hourly ran late or missed a window, the snapshot data was gone
+-- before metrics could be updated — contributing to the ownership-loss cycle.
+-- 48h gives two full refresh cycles of buffer.
+-- Steady-state table size impact: ~2× (108 MB/run × 4 runs × 2 days = ~864 MB steady-state
+-- vs ~432 MB before). Well within budget at ~1.3M rows total.
+
+DO $sched$ BEGIN
+  PERFORM cron.schedule(
+    'sweep-old-sg-listings',
+    '15 3,9,15,21 * * *',
+    $cron$DO $b$ BEGIN
+      IF NOT public.cron_should_fire('sweep-old-sg-listings') THEN RETURN; END IF;
+      PERFORM public.sweep_old_sg_listings(48);
+    END $b$;$cron$
+  );
+END $sched$;
+
+UPDATE public.cron_policy SET
+  notes = 'SG listings sweep: DELETE seatgeek_listings_snapshots WHERE captured_at < now()-48h. '
+          '4x/day at 3:15/9:15/15:15/21:15 UTC. '
+          'Changed from 24h→48h TTL 2026-05-28 (mig 300000): prevents data gap between '
+          'SG poll and sg_broker_listings_metrics_refresh_hourly when refresh misses a window. '
+          '48h buffer = 2 full hourly refresh cycles. '
+          'Steady-state ~864 MB (was ~432 MB). First 48h run deletes prior 24h backlog.'
+WHERE jobname = 'sweep-old-sg-listings';
+
+
+-- ── D. One-time re-queue: reset stale last_polled_listings_at ────────────────────
+-- Events within 14d that haven't been polled in 23+ hours are immediately eligible
+-- on the next sg_priority_poll_tick and sg_blindspot_poll_5min runs.
+-- Targets: TRACK_BLINDSPOT, WATCH, COLD, OBSERVE (not SKIP/HOT/WARM/COOL).
+-- HOT/WARM/COOL are actively managed with short intervals — no reset needed.
+-- SKIP events are intentionally excluded from polling.
+-- Setting to now()-25h ensures eligibility on next tick without disrupting HOT/WARM events.
+
+UPDATE public.sg_event_priority_state SET
+  last_polled_listings_at = now() - interval '25 hours'
+WHERE sg_datetime_utc BETWEEN now() AND now() + interval '14 days'
+  AND tier NOT IN ('SKIP', 'HOT', 'WARM', 'COOL')
+  AND (last_polled_listings_at IS NULL
+       OR last_polled_listings_at < now() - interval '23 hours');
+
+-- Log the fix to bot_chat for tracking
+PERFORM public.bot_chat_log(
+  'data-collection', 'D0', 'status',
+  'mig 300000 applied: sg_classify_events rewritten (30d ownership fallback + COLD→COOL floor). '
+  'Snapshot cron_policy min_interval 1440→1200 min. '
+  'sweep-old-sg-listings TTL 24h→48h. '
+  'One-time re-queue: reset last_polled_listings_at for stale TRACK_BLINDSPOT/WATCH/COLD/OBSERVE events within 14d.'
+);

--- a/supabase/migrations/20260528310000_td_xref_backfill_via_aq_mapper.sql
+++ b/supabase/migrations/20260528310000_td_xref_backfill_via_aq_mapper.sql
@@ -1,0 +1,68 @@
+-- 20260528310000_td_xref_backfill_via_aq_mapper.sql
+--
+-- Backfill ticketsdata_event_xref for unmapped TD events using the existing
+-- aq_event_map direct-ID columns (tier1 of match_to_aq_event_id logic):
+--
+--   SH  → aq_event_map.sh_event_id     = ticketsdata_listings_snapshots.event_id
+--   VD  → aq_event_map.vivid_event_id  = ticketsdata_listings_snapshots.event_id
+--   GT  → aq_event_map.sg_event_id     = ticketsdata_listings_snapshots.event_id
+--         (GT uses SG-compatible event IDs in the listings feed)
+--
+-- Dry-run confirmed 27 new xref rows (SH=13, VD=12, GT=2) covering the
+-- highest-traffic unmapped events (BTS@Allegiant, OKC/Spurs, WNBA games,
+-- Don Toliver@Prudential, Los Fabulosos Cadillacs, etc.)
+--
+-- One event (Hell's Kitchen at Pantages, SH 157509976) resolves an
+-- aq_short_event_id but has no tevo_event_id in sg_events_canonical —
+-- it's a theatre/Broadway run not in the TEvo catalogue. Inserted with
+-- active=true so it stops appearing as "unmapped"; the snapshot JOIN on
+-- event_metrics won't find it, which is correct.
+--
+-- match_method = 'aq_event_map_tier1' to distinguish from 'events_api'
+-- entries added by the TD collection pipeline.
+
+INSERT INTO public.ticketsdata_event_xref
+  (event_id, platform, aq_short_event_id, match_method, active, created_at, updated_at)
+
+SELECT DISTINCT ON (u.event_id, u.platform)
+  u.event_id,
+  u.platform,
+  aem.aq_short_event_id,
+  'aq_event_map_tier1',
+  true,
+  now(),
+  now()
+FROM (
+  -- All distinct TD event_id+platform combos that have no active xref entry
+  SELECT DISTINCT tds.event_id, tds.platform
+  FROM public.ticketsdata_listings_snapshots tds
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.ticketsdata_event_xref tdx
+    WHERE tdx.event_id = tds.event_id AND tdx.active = true
+  )
+) u
+JOIN public.aq_event_map aem ON (
+    (u.platform = 'SH' AND aem.sh_event_id     = u.event_id)
+ OR (u.platform = 'VD' AND aem.vivid_event_id  = u.event_id)
+ OR (u.platform = 'GT' AND aem.sg_event_id     = u.event_id)
+)
+
+ON CONFLICT (event_id, platform) DO UPDATE SET
+  aq_short_event_id = EXCLUDED.aq_short_event_id,
+  match_method      = EXCLUDED.match_method,
+  active            = true,
+  updated_at        = now();
+
+-- Log result
+DO $$
+DECLARE v_n int;
+BEGIN
+  SELECT COUNT(*) INTO v_n
+  FROM public.ticketsdata_event_xref
+  WHERE match_method = 'aq_event_map_tier1';
+
+  PERFORM public.bot_chat_log(
+    'data-collection', 'D0', 'status',
+    format('mig 310000: backfilled %s TD xref rows via aq_event_map tier1 (SH sh_event_id, VD vivid_event_id, GT sg_event_id)', v_n)
+  );
+END $$;

--- a/supabase/migrations/20260528320000_sg_lifetime_sales_and_fill_rate.sql
+++ b/supabase/migrations/20260528320000_sg_lifetime_sales_and_fill_rate.sql
@@ -1,0 +1,193 @@
+-- 20260528320000_sg_lifetime_sales_and_fill_rate.sql
+--
+-- Fixes two gaps in seatgeek_event_metrics:
+--
+-- Action C — refresh_sg_broker_sales_event_metrics uses a 24h window, discarding
+--   7.5M rows of historical seatgeek_sales_snapshots data. New lifetime variant
+--   aggregates all-time sales scoped to active seatgeek_event_xref events (avoids
+--   full 7.5M-row scan). Scheduled daily at 04:05 UTC.
+--
+-- Action D — fill_rate stopped being populated after May 13 because neither
+--   refresh_sg_broker_listings_event_metrics nor _sales writes it (they INSERT
+--   separate rows). New compute_sg_fill_rate() UPDATE pass joins latest-sales-row
+--   with latest-listings-row per event and writes fill_rate. Scheduled hourly at :53.
+--
+-- Immediate backfill at migration apply time:
+--   1. refresh_sg_broker_sales_event_metrics_lifetime(500) — top-500 events by volume
+--   2. compute_sg_fill_rate() — writes fill_rate on all rows that now have both metrics
+
+
+-- ─── Part A: lifetime sales refresh function ──────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.refresh_sg_broker_sales_event_metrics_lifetime(
+  p_max_events integer DEFAULT 2000
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+  v_now  timestamptz := now();
+  v_count int := 0;
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'refresh_sg_broker_sales_event_metrics_lifetime: caller % not authorized', current_user;
+  END IF;
+
+  -- Scope to events we actively track (seatgeek_event_xref) to avoid scanning
+  -- all 7.5M rows. DISTINCT ON sg_sale_id deduplicates multi-pull snapshots.
+  WITH active_sg_events AS (
+    SELECT DISTINCT sg_event_id
+    FROM   public.seatgeek_event_xref
+    WHERE  sg_event_id IS NOT NULL
+  ),
+  deduped AS (
+    SELECT DISTINCT ON (s.sg_sale_id)
+      s.sg_event_id,
+      s.tevo_event_id,
+      s.sg_sale_id,
+      s.broadcast_price,
+      s.sale_at_utc
+    FROM   public.seatgeek_sales_snapshots s
+    JOIN   active_sg_events ase ON ase.sg_event_id = s.sg_event_id
+    ORDER  BY s.sg_sale_id, s.pulled_at DESC
+  ),
+  agg AS (
+    SELECT
+      d.sg_event_id,
+      COALESCE(
+        MAX(d.tevo_event_id),
+        (SELECT tevo_event_id FROM public.seatgeek_event_xref
+         WHERE sg_event_id = d.sg_event_id LIMIT 1)
+      )                                                                    AS tevo_event_id,
+      COUNT(DISTINCT d.sg_sale_id)                                         AS sold_quantity,
+      ROUND(SUM(d.broadcast_price)::numeric, 2)                            AS sold_gross,
+      MIN(d.broadcast_price)                                               AS sold_price_min,
+      PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY d.broadcast_price)::numeric AS sold_price_median,
+      ROUND(AVG(d.broadcast_price)::numeric, 2)                            AS sold_price_mean,
+      MAX(d.broadcast_price)                                               AS sold_price_max
+    FROM deduped d
+    GROUP  BY d.sg_event_id
+    HAVING COUNT(DISTINCT d.sg_sale_id) > 0
+    ORDER  BY COUNT(DISTINCT d.sg_sale_id) DESC
+    LIMIT  p_max_events
+  )
+  INSERT INTO public.seatgeek_event_metrics (
+    sg_event_id, tevo_event_id, captured_at,
+    sold_quantity, sold_gross,
+    sold_price_min, sold_price_median, sold_price_mean, sold_price_max
+  )
+  SELECT
+    sg_event_id, tevo_event_id, v_now,
+    sold_quantity, sold_gross,
+    sold_price_min, sold_price_median, sold_price_mean, sold_price_max
+  FROM agg
+  WHERE tevo_event_id IS NOT NULL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+
+-- ─── Part B: fill_rate compute function ──────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.compute_sg_fill_rate()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  IF current_user NOT IN ('service_role', 'postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'compute_sg_fill_rate: caller % not authorized', current_user;
+  END IF;
+
+  -- For each event: join most-recent sold_quantity row with most-recent
+  -- listings_all_tickets row and write fill_rate onto the sales row.
+  -- fill_rate = sold_qty / (sold_qty + listings_tickets)
+  WITH latest_sales AS (
+    SELECT DISTINCT ON (sg_event_id)
+      id, sg_event_id, sold_quantity
+    FROM   public.seatgeek_event_metrics
+    WHERE  sold_quantity IS NOT NULL
+    ORDER  BY sg_event_id, captured_at DESC
+  ),
+  latest_listings AS (
+    SELECT DISTINCT ON (sg_event_id)
+      sg_event_id, listings_all_tickets
+    FROM   public.seatgeek_event_metrics
+    WHERE  listings_all_tickets IS NOT NULL
+    ORDER  BY sg_event_id, captured_at DESC
+  )
+  UPDATE public.seatgeek_event_metrics m
+  SET    fill_rate = ls.sold_quantity::numeric
+                    / NULLIF(ls.sold_quantity + ll.listings_all_tickets, 0)
+  FROM   latest_sales ls
+  JOIN   latest_listings ll ON ll.sg_event_id = ls.sg_event_id
+  WHERE  m.id = ls.id
+    AND  ll.listings_all_tickets > 0;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+
+-- ─── Part C: cron schedules ───────────────────────────────────────────────────
+
+-- fill_rate: hourly at :53 (after listings :47 + sales :17)
+SELECT cron.schedule(
+  'sg_fill_rate_hourly',
+  '53 * * * *',
+  $$DO $body$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_fill_rate_hourly') THEN RETURN; END IF;
+      PERFORM public.compute_sg_fill_rate();
+    END $body$;$$
+);
+
+-- lifetime sales: daily at 04:05 UTC (off-peak, after nightly snapshot)
+SELECT cron.schedule(
+  'sg_lifetime_sales_daily',
+  '5 4 * * *',
+  $$DO $body$
+    BEGIN
+      IF NOT public.cron_should_fire('sg_lifetime_sales_daily') THEN RETURN; END IF;
+      PERFORM public.refresh_sg_broker_sales_event_metrics_lifetime(2000);
+      PERFORM public.compute_sg_fill_rate();
+    END $body$;$$
+);
+
+-- Register policies so cron_should_fire gate is aware of them
+INSERT INTO public.cron_policy (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min)
+VALUES
+  ('sg_fill_rate_hourly',    '{}'::int[], 50,   50),
+  ('sg_lifetime_sales_daily', '{}'::int[], 1200, 1200)
+ON CONFLICT (jobname) DO UPDATE SET
+  peak_hours_et            = EXCLUDED.peak_hours_et,
+  peak_min_interval_min    = EXCLUDED.peak_min_interval_min,
+  offpeak_min_interval_min = EXCLUDED.offpeak_min_interval_min;
+
+
+-- ─── Part D: immediate backfill ───────────────────────────────────────────────
+
+DO $$
+DECLARE
+  v_sales int;
+  v_fr    int;
+BEGIN
+  -- Top-500 events by all-time sales volume
+  v_sales := public.refresh_sg_broker_sales_event_metrics_lifetime(500);
+
+  -- Write fill_rate on all events that now have both sold_quantity + listings
+  v_fr := public.compute_sg_fill_rate();
+
+  PERFORM public.bot_chat_log(
+    'data-collection', 'D0', 'status',
+    format('mig 320000: lifetime sales backfill=%s events; fill_rate written=%s rows', v_sales, v_fr)
+  );
+END $$;

--- a/supabase/migrations/20260528330000_aq_maps_backfill_and_tevo_link.sql
+++ b/supabase/migrations/20260528330000_aq_maps_backfill_and_tevo_link.sql
@@ -1,0 +1,401 @@
+-- 20260528330000_aq_maps_backfill_and_tevo_link.sql
+--
+-- Fills cross-platform gaps in aq_event_map / aq_venue_map / aq_performer_map
+-- and adds a maintained backfill function + daily cron.
+--
+-- Problem: aq_event_map has no tevo_event_id column, so match_to_aq_event_id()
+-- falls through to slow venue+date fuzzy matching on every TEvo-sourced call.
+-- We already have tevo_event_id in sg_events_canonical (4,413 events linked).
+-- Adding the column and a tier-0 lookup makes the match essentially instant.
+--
+-- Fills (one-time backfill + ongoing daily maintenance):
+--   A. aq_event_map.tevo_event_id (new column) — 4,413 rows via sg_events_canonical
+--   B. aq_event_map.sg_event_id (missing) — 21 rows via sg_venue_name + date ±4h
+--   C. aq_event_map.venue_short_id (missing) — 629 rows via aq_venue_map name match
+--   D. aq_venue_map.tevo_venue_id (missing) — 228 venues via events.venue_name match
+--   E. aq_performer_map.tevo_performer_id (missing) — 81 performers via performer_name match
+--   F. match_to_aq_event_id() updated: tier0 = tevo_event_id direct lookup (fastest path)
+--   G. backfill_aq_maps() function + daily cron for ongoing maintenance
+
+
+-- ─── Part A: add tevo_event_id to aq_event_map ───────────────────────────────
+
+ALTER TABLE public.aq_event_map
+  ADD COLUMN IF NOT EXISTS tevo_event_id bigint;
+
+CREATE INDEX IF NOT EXISTS aq_event_map_tevo_event_id_idx
+  ON public.aq_event_map (tevo_event_id)
+  WHERE tevo_event_id IS NOT NULL;
+
+-- Fill from sg_events_canonical: sg_event_id → tevo_event_id
+UPDATE public.aq_event_map aem
+SET tevo_event_id = e.tevo_event_id
+FROM public.sg_events_canonical e
+WHERE e.sg_event_id = aem.sg_event_id
+  AND e.tevo_event_id IS NOT NULL
+  AND aem.tevo_event_id IS NULL;
+
+
+-- ─── Part B: fill aq_event_map.sg_event_id via sg_venue_name + date ──────────
+
+UPDATE public.aq_event_map aem
+SET sg_event_id = sub.sg_event_id
+FROM (
+  SELECT DISTINCT ON (aem2.aq_short_event_id)
+    aem2.aq_short_event_id,
+    e.sg_event_id
+  FROM public.aq_event_map aem2
+  JOIN public.sg_events_canonical e
+    ON lower(trim(e.sg_venue_name)) = lower(trim(aem2.venue_name))
+    AND aem2.event_date::timestamptz
+        BETWEEN e.sg_datetime_utc - interval '4 hours'
+            AND e.sg_datetime_utc + interval '4 hours'
+  WHERE aem2.sg_event_id IS NULL
+    AND e.sg_event_id IS NOT NULL
+  ORDER BY aem2.aq_short_event_id,
+    abs(extract(epoch FROM (aem2.event_date::timestamptz - e.sg_datetime_utc)))
+) sub
+WHERE aem.aq_short_event_id = sub.aq_short_event_id;
+
+-- Cascade: now fill tevo_event_id for the newly linked sg_event_ids
+UPDATE public.aq_event_map aem
+SET tevo_event_id = e.tevo_event_id
+FROM public.sg_events_canonical e
+WHERE e.sg_event_id = aem.sg_event_id
+  AND e.tevo_event_id IS NOT NULL
+  AND aem.tevo_event_id IS NULL;
+
+
+-- ─── Part C: fill aq_event_map.venue_short_id from aq_venue_map ──────────────
+
+UPDATE public.aq_event_map aem
+SET venue_short_id = sub.venue_short_id
+FROM (
+  SELECT DISTINCT ON (aem2.aq_short_event_id)
+    aem2.aq_short_event_id,
+    avm.venue_short_id
+  FROM public.aq_event_map aem2
+  JOIN public.aq_venue_map avm
+    ON lower(trim(avm.venue_name)) = lower(trim(aem2.venue_name))
+  WHERE aem2.venue_short_id IS NULL
+    AND aem2.venue_name IS NOT NULL
+  ORDER BY aem2.aq_short_event_id
+) sub
+WHERE aem.aq_short_event_id = sub.aq_short_event_id;
+
+
+-- ─── Part D: fill aq_venue_map.tevo_venue_id from events table ───────────────
+
+-- Pick the most-common venue_id per lowercase venue_name to handle duplicates
+UPDATE public.aq_venue_map avm
+SET tevo_venue_id = bv.venue_id
+FROM (
+  WITH counts AS (
+    SELECT lower(trim(venue_name)) AS vname_lower,
+           venue_id,
+           COUNT(*) AS n
+    FROM   public.events
+    WHERE  venue_id IS NOT NULL AND venue_name IS NOT NULL
+    GROUP  BY lower(trim(venue_name)), venue_id
+  )
+  SELECT DISTINCT ON (vname_lower) vname_lower, venue_id
+  FROM   counts
+  ORDER  BY vname_lower, n DESC
+) bv
+WHERE lower(trim(avm.venue_name)) = bv.vname_lower
+  AND avm.tevo_venue_id IS NULL;
+
+
+-- ─── Part E: fill aq_performer_map.tevo_performer_id from events table ───────
+
+UPDATE public.aq_performer_map apm
+SET tevo_performer_id = bp.performer_id
+FROM (
+  WITH counts AS (
+    SELECT lower(trim(primary_performer_name)) AS pname_lower,
+           primary_performer_id                AS performer_id,
+           COUNT(*)                            AS n
+    FROM   public.events
+    WHERE  primary_performer_id IS NOT NULL AND primary_performer_name IS NOT NULL
+    GROUP  BY lower(trim(primary_performer_name)), primary_performer_id
+  )
+  SELECT DISTINCT ON (pname_lower) pname_lower, performer_id
+  FROM   counts
+  ORDER  BY pname_lower, n DESC
+) bp
+WHERE lower(trim(apm.performer_name)) = bp.pname_lower
+  AND apm.tevo_performer_id IS NULL;
+
+
+-- ─── Part F: update match_to_aq_event_id — add tevo_event_id tier0 ───────────
+
+CREATE OR REPLACE FUNCTION public.match_to_aq_event_id(
+  p_source          text,
+  p_source_event_id bigint,
+  p_event_name      text,
+  p_venue_name      text,
+  p_event_date      timestamp with time zone,
+  p_lat             numeric DEFAULT NULL,
+  p_lon             numeric DEFAULT NULL,
+  p_source_venue_id bigint DEFAULT NULL
+)
+RETURNS TABLE(aq_short_event_id text, confidence numeric, match_method text)
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+  v_aq_id          text;
+  v_venue_short_id text;
+BEGIN
+  -- Tier 0: tevo_event_id direct lookup (fastest — resolves instantly when source is TEvo)
+  IF p_source_event_id IS NOT NULL AND p_source IN ('tevo', 'evo') THEN
+    SELECT a.aq_short_event_id INTO v_aq_id
+    FROM public.aq_event_map a
+    WHERE a.tevo_event_id = p_source_event_id
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 1.00::numeric(3,2), 'tier0_tevo_id'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Tier 1: platform-native event_id direct lookup
+  IF p_source_event_id IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE (p_source IN ('vivid')              AND a.vivid_event_id = p_source_event_id)
+       OR (p_source IN ('seatgeek','sg')      AND a.sg_event_id    = p_source_event_id)
+       OR (p_source IN ('stubhub','sh')       AND a.sh_event_id    = p_source_event_id)
+       OR (p_source IN ('ticketmaster','tm')  AND a.tm_event_id    = p_source_event_id)
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 1.00::numeric(3,2), 'tier1_direct_id'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Tier 1.5: source venue_id → aq_venue_map → venue_short_id → event date match
+  IF p_source_venue_id IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT m.venue_short_id INTO v_venue_short_id FROM public.aq_venue_map m
+    WHERE (p_source IN ('tickpick')         AND m.tickpick_venue_id = p_source_venue_id)
+       OR (p_source IN ('seatgeek','sg')    AND m.sg_venue_id       = p_source_venue_id)
+       OR (p_source IN ('tevo','evo')       AND m.tevo_venue_id     = p_source_venue_id)
+    LIMIT 1;
+    IF v_venue_short_id IS NOT NULL THEN
+      SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+      WHERE a.venue_short_id = v_venue_short_id
+        AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                          AND p_event_date + interval '6 hours'
+      ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+      LIMIT 1;
+      IF v_aq_id IS NOT NULL THEN
+        RETURN QUERY SELECT v_aq_id, 0.93::numeric(3,2), 'tier1_5_venue_id_date'::text;
+        RETURN;
+      END IF;
+    END IF;
+  END IF;
+
+  -- Tier 2: venue name exact + date ±6h
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE lower(trim(a.venue_name)) = lower(trim(p_venue_name))
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.95::numeric(3,2), 'tier2_venue_exact_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Tier 3: venue name fuzzy (similarity ≥ 0.7) + date ±6h
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE similarity(lower(coalesce(a.venue_name,'')), lower(coalesce(p_venue_name,''))) >= 0.7
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY similarity(lower(a.venue_name), lower(p_venue_name)) DESC,
+             abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date)))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.80::numeric(3,2), 'tier3_venue_fuzzy_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Tier 4: coordinate proximity + date ±6h
+  IF p_lat IS NOT NULL AND p_lon IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id
+    FROM public.aq_event_map a
+    JOIN public.venue_assets va ON lower(trim(va.venue_name)) = lower(trim(a.venue_name))
+    WHERE va.latitude  BETWEEN p_lat - 0.01 AND p_lat + 0.01
+      AND va.longitude BETWEEN p_lon - 0.02 AND p_lon + 0.02
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY (2 * 6371000 * asin(sqrt(
+       power(sin(radians((va.latitude  - p_lat)/2)), 2)
+       + cos(radians(p_lat)) * cos(radians(va.latitude))
+         * power(sin(radians((va.longitude - p_lon)/2)), 2)
+    )))
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.85::numeric(3,2), 'tier4_coord_date'::text;
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN;
+END;
+$$;
+
+
+-- ─── Part G: backfill_aq_maps() — maintenance function ───────────────────────
+
+CREATE OR REPLACE FUNCTION public.backfill_aq_maps()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+  v_ev_tevo  int := 0;
+  v_ev_sg    int := 0;
+  v_ev_vsid  int := 0;
+  v_venue    int := 0;
+  v_perf     int := 0;
+BEGIN
+  -- 1. aq_event_map.tevo_event_id from sg_events_canonical
+  UPDATE public.aq_event_map aem
+  SET tevo_event_id = e.tevo_event_id
+  FROM public.sg_events_canonical e
+  WHERE e.sg_event_id = aem.sg_event_id
+    AND e.tevo_event_id IS NOT NULL
+    AND aem.tevo_event_id IS NULL;
+  GET DIAGNOSTICS v_ev_tevo = ROW_COUNT;
+
+  -- 2. aq_event_map.sg_event_id via sg_venue_name + date (missing links)
+  UPDATE public.aq_event_map aem
+  SET sg_event_id = sub.sg_event_id
+  FROM (
+    SELECT DISTINCT ON (aem2.aq_short_event_id)
+      aem2.aq_short_event_id, e.sg_event_id
+    FROM public.aq_event_map aem2
+    JOIN public.sg_events_canonical e
+      ON lower(trim(e.sg_venue_name)) = lower(trim(aem2.venue_name))
+      AND aem2.event_date::timestamptz
+          BETWEEN e.sg_datetime_utc - interval '4 hours'
+              AND e.sg_datetime_utc + interval '4 hours'
+    WHERE aem2.sg_event_id IS NULL AND e.sg_event_id IS NOT NULL
+    ORDER BY aem2.aq_short_event_id,
+      abs(extract(epoch FROM (aem2.event_date::timestamptz - e.sg_datetime_utc)))
+  ) sub
+  WHERE aem.aq_short_event_id = sub.aq_short_event_id;
+  GET DIAGNOSTICS v_ev_sg = ROW_COUNT;
+
+  -- Cascade tevo_event_id for newly linked sg_event_ids
+  UPDATE public.aq_event_map aem
+  SET tevo_event_id = e.tevo_event_id
+  FROM public.sg_events_canonical e
+  WHERE e.sg_event_id = aem.sg_event_id
+    AND e.tevo_event_id IS NOT NULL
+    AND aem.tevo_event_id IS NULL;
+
+  -- 3. aq_event_map.venue_short_id from aq_venue_map
+  UPDATE public.aq_event_map aem
+  SET venue_short_id = sub.venue_short_id
+  FROM (
+    SELECT DISTINCT ON (aem2.aq_short_event_id)
+      aem2.aq_short_event_id, avm.venue_short_id
+    FROM public.aq_event_map aem2
+    JOIN public.aq_venue_map avm
+      ON lower(trim(avm.venue_name)) = lower(trim(aem2.venue_name))
+    WHERE aem2.venue_short_id IS NULL AND aem2.venue_name IS NOT NULL
+    ORDER BY aem2.aq_short_event_id
+  ) sub
+  WHERE aem.aq_short_event_id = sub.aq_short_event_id;
+  GET DIAGNOSTICS v_ev_vsid = ROW_COUNT;
+
+  -- 4. aq_venue_map.tevo_venue_id from events table
+  UPDATE public.aq_venue_map avm
+  SET tevo_venue_id = bv.venue_id
+  FROM (
+    WITH counts AS (
+      SELECT lower(trim(venue_name)) AS vname_lower, venue_id, COUNT(*) AS n
+      FROM   public.events
+      WHERE  venue_id IS NOT NULL AND venue_name IS NOT NULL
+      GROUP  BY lower(trim(venue_name)), venue_id
+    )
+    SELECT DISTINCT ON (vname_lower) vname_lower, venue_id
+    FROM   counts ORDER BY vname_lower, n DESC
+  ) bv
+  WHERE lower(trim(avm.venue_name)) = bv.vname_lower
+    AND avm.tevo_venue_id IS NULL;
+  GET DIAGNOSTICS v_venue = ROW_COUNT;
+
+  -- 5. aq_performer_map.tevo_performer_id from events table
+  UPDATE public.aq_performer_map apm
+  SET tevo_performer_id = bp.performer_id
+  FROM (
+    WITH counts AS (
+      SELECT lower(trim(primary_performer_name)) AS pname_lower,
+             primary_performer_id AS performer_id, COUNT(*) AS n
+      FROM   public.events
+      WHERE  primary_performer_id IS NOT NULL AND primary_performer_name IS NOT NULL
+      GROUP  BY lower(trim(primary_performer_name)), primary_performer_id
+    )
+    SELECT DISTINCT ON (pname_lower) pname_lower, performer_id
+    FROM   counts ORDER BY pname_lower, n DESC
+  ) bp
+  WHERE lower(trim(apm.performer_name)) = bp.pname_lower
+    AND apm.tevo_performer_id IS NULL;
+  GET DIAGNOSTICS v_perf = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'ev_tevo_id',    v_ev_tevo,
+    'ev_sg_id',      v_ev_sg,
+    'ev_venue_sid',  v_ev_vsid,
+    'venue_tevo_id', v_venue,
+    'perf_tevo_id',  v_perf
+  );
+END;
+$$;
+
+
+-- ─── Part H: daily maintenance cron ──────────────────────────────────────────
+
+SELECT cron.schedule(
+  'aq_maps_backfill_daily',
+  '0 5 * * *',
+  $$DO $body$
+    DECLARE v_result jsonb;
+    BEGIN
+      IF NOT public.cron_should_fire('aq_maps_backfill_daily') THEN RETURN; END IF;
+      v_result := public.backfill_aq_maps();
+      IF (v_result->>'ev_tevo_id')::int + (v_result->>'ev_sg_id')::int
+         + (v_result->>'venue_tevo_id')::int + (v_result->>'perf_tevo_id')::int > 0 THEN
+        PERFORM public.bot_chat_log('data-collection', 'D0', 'status',
+          format('aq_maps_backfill: %s', v_result::text));
+      END IF;
+    END $body$;$$
+);
+
+INSERT INTO public.cron_policy (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min)
+VALUES ('aq_maps_backfill_daily', '{}'::int[], 1200, 1200)
+ON CONFLICT (jobname) DO UPDATE SET
+  peak_hours_et            = EXCLUDED.peak_hours_et,
+  peak_min_interval_min    = EXCLUDED.peak_min_interval_min,
+  offpeak_min_interval_min = EXCLUDED.offpeak_min_interval_min;
+
+
+-- ─── Immediate backfill + status log ─────────────────────────────────────────
+
+DO $$
+DECLARE v_result jsonb;
+BEGIN
+  v_result := public.backfill_aq_maps();
+  PERFORM public.bot_chat_log(
+    'data-collection', 'D0', 'status',
+    format('mig 330000 aq_maps_backfill: %s', v_result::text)
+  );
+END $$;

--- a/supabase/migrations/20260528340000_fix_td_snapshot_12h_window.sql
+++ b/supabase/migrations/20260528340000_fix_td_snapshot_12h_window.sql
@@ -1,0 +1,190 @@
+-- 20260528340000_fix_td_snapshot_12h_window.sql
+--
+-- Bug: compute_event_listing_snapshot() uses a flat 12-hour window for
+-- ticketsdata_listings_snapshots. SH collector runs at ~03:00 UTC and ~16:20 UTC.
+-- The midday snapshot fires at ~16:09 UTC → 12h window starts at 04:09 UTC:
+--   - SH 03:00 batch → just outside the window (too old)
+--   - SH 16:20 batch → not yet captured when snapshot runs
+--   - VD 16:04 batch → inside window (squeaks in before snapshot)
+-- Result: td_sh_listings = 0 for all midday snapshots despite thousands of SH listings.
+--
+-- Fix: replace the flat 12h window with "latest batch per (event_id, platform)
+-- within 25 hours". For each platform+event, find max(captured_at) in the last 25h,
+-- then include all rows within 15 minutes of that max. This is timing-agnostic and
+-- never double-counts rows from multiple collection runs.
+
+CREATE OR REPLACE FUNCTION public.compute_event_listing_snapshot(
+  p_slot text DEFAULT 'midday'
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+  v_count int := 0;
+  v_jobname text;
+BEGIN
+  v_jobname := 'event_snapshot_' || p_slot;
+  IF p_slot NOT IN ('morning','midday','evening') THEN
+    v_jobname := 'event_snapshot_morning';
+  END IF;
+
+  IF NOT public.cron_should_fire(v_jobname) THEN RETURN 0; END IF;
+
+  INSERT INTO public.event_listing_snapshot_daily (
+    event_id, snapshot_slot, snapshot_date,
+    evo_tickets_count, evo_owned_tickets, evo_owned_median,
+    evo_retail_getin, evo_retail_median, evo_retail_mean,
+    evo_retail_min, evo_retail_max,
+    sg_all_listings, sg_all_tickets, sg_owned_tickets,
+    sg_owned_median, sg_all_median, sg_all_getin, sg_all_mean,
+    td_sh_listings, td_sh_median,
+    td_gt_listings, td_gt_median,
+    td_vd_listings, td_vd_median,
+    td_combined_median,
+    captured_at
+  )
+  SELECT
+    em.event_id,
+    p_slot,
+    CURRENT_DATE,
+    em.tickets_count,
+    em.owned_tickets_count,
+    em.owned_median_retail,
+    em.getin_price,
+    em.retail_median,
+    em.retail_mean,
+    em.retail_min,
+    em.retail_max,
+    sgm.listings_all_count,
+    sgm.listings_all_tickets,
+    sgm.listings_owned_tickets,
+    sgm.listings_owned_median,
+    sgm.listings_all_median,
+    sgm.listings_all_min,
+    sgm.listings_all_mean,
+    td.sh_listings,   td.sh_median,
+    td.gt_listings,   td.gt_median,
+    td.vd_listings,   td.vd_median,
+    LEAST(NULLIF(td.sh_median, 0), NULLIF(td.gt_median, 0), NULLIF(td.vd_median, 0)),
+    now()
+  FROM (
+    SELECT DISTINCT ON (event_id)
+      event_id, tickets_count, owned_tickets_count, owned_median_retail,
+      getin_price, retail_median, retail_mean, retail_min, retail_max
+    FROM public.event_metrics
+    ORDER BY event_id, captured_at DESC
+  ) em
+  LEFT JOIN (
+    SELECT DISTINCT ON (tevo_event_id)
+      tevo_event_id, listings_all_count, listings_all_tickets,
+      listings_owned_tickets, listings_owned_median,
+      listings_all_median, listings_all_min, listings_all_mean
+    FROM public.seatgeek_event_metrics
+    ORDER BY tevo_event_id, captured_at DESC
+  ) sgm ON sgm.tevo_event_id = em.event_id
+  LEFT JOIN (
+    -- ── TD: latest batch per (event_id, platform) within 25h ──────────────
+    -- Finds max(captured_at) per platform+event in the last 25 hours, then
+    -- includes all rows within 15 minutes of that max. This is timing-agnostic:
+    -- if SH collected 11h ago and 6 minutes in the future, we still get the
+    -- most recent batch without double-counting.
+    WITH latest_capture AS (
+      SELECT event_id, platform, MAX(captured_at) AS max_at
+      FROM public.ticketsdata_listings_snapshots
+      WHERE captured_at > now() - interval '25 hours'
+        AND is_parking = false
+        AND list_price > 0
+      GROUP BY event_id, platform
+    ),
+    latest_td AS (
+      SELECT tds.event_id, tds.platform, tds.list_price
+      FROM public.ticketsdata_listings_snapshots tds
+      JOIN latest_capture lc
+        ON  lc.event_id  = tds.event_id
+        AND lc.platform  = tds.platform
+        AND tds.captured_at >= lc.max_at - interval '15 minutes'
+      WHERE tds.is_parking = false
+        AND tds.list_price > 0
+    )
+    SELECT
+      sgc.tevo_event_id,
+      COUNT(*)            FILTER (WHERE lt.platform = 'SH')          AS sh_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.list_price)
+                          FILTER (WHERE lt.platform = 'SH')          AS sh_median,
+      COUNT(*)            FILTER (WHERE lt.platform = 'GT')          AS gt_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.list_price)
+                          FILTER (WHERE lt.platform = 'GT')          AS gt_median,
+      COUNT(*)            FILTER (WHERE lt.platform = 'VD')          AS vd_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.list_price)
+                          FILTER (WHERE lt.platform = 'VD')          AS vd_median
+    FROM latest_td lt
+    JOIN public.ticketsdata_event_xref tdx
+      ON  tdx.event_id = lt.event_id
+      AND tdx.active   = true
+    JOIN public.aq_event_map aem
+      ON  aem.aq_short_event_id = tdx.aq_short_event_id
+    JOIN public.sg_events_canonical sgc
+      ON  sgc.sg_event_id = aem.sg_event_id
+    GROUP BY sgc.tevo_event_id
+  ) td ON td.tevo_event_id = em.event_id
+  ON CONFLICT (event_id, snapshot_date, snapshot_slot) DO UPDATE SET
+    evo_tickets_count  = EXCLUDED.evo_tickets_count,
+    evo_owned_tickets  = EXCLUDED.evo_owned_tickets,
+    evo_owned_median   = EXCLUDED.evo_owned_median,
+    evo_retail_getin   = EXCLUDED.evo_retail_getin,
+    evo_retail_median  = EXCLUDED.evo_retail_median,
+    evo_retail_mean    = EXCLUDED.evo_retail_mean,
+    evo_retail_min     = EXCLUDED.evo_retail_min,
+    evo_retail_max     = EXCLUDED.evo_retail_max,
+    sg_all_listings    = EXCLUDED.sg_all_listings,
+    sg_all_tickets     = EXCLUDED.sg_all_tickets,
+    sg_owned_tickets   = EXCLUDED.sg_owned_tickets,
+    sg_owned_median    = EXCLUDED.sg_owned_median,
+    sg_all_median      = EXCLUDED.sg_all_median,
+    sg_all_getin       = EXCLUDED.sg_all_getin,
+    sg_all_mean        = EXCLUDED.sg_all_mean,
+    td_sh_listings     = EXCLUDED.td_sh_listings,
+    td_sh_median       = EXCLUDED.td_sh_median,
+    td_gt_listings     = EXCLUDED.td_gt_listings,
+    td_gt_median       = EXCLUDED.td_gt_median,
+    td_vd_listings     = EXCLUDED.td_vd_listings,
+    td_vd_median       = EXCLUDED.td_vd_median,
+    td_combined_median = EXCLUDED.td_combined_median,
+    captured_at        = EXCLUDED.captured_at;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+
+-- ─── Immediate re-run: backfill today's midday snapshot with correct SH data ──
+
+DO $$
+DECLARE
+  v_n int;
+BEGIN
+  -- Temporarily zero the cron gate interval so cron_should_fire allows an
+  -- immediate re-run (gate checks: (now - last_fire) < interval; 0 always passes).
+  UPDATE public.cron_policy
+  SET    offpeak_min_interval_min = 0,
+         peak_min_interval_min    = 0
+  WHERE  jobname = 'event_snapshot_midday';
+
+  -- Re-run midday — ON CONFLICT DO UPDATE rewrites the existing rows with
+  -- corrected SH data now that the 25h latest-batch window is in place.
+  v_n := public.compute_event_listing_snapshot('midday');
+
+  -- Restore the original 20-hour interval
+  UPDATE public.cron_policy
+  SET    offpeak_min_interval_min = 1200,
+         peak_min_interval_min    = 1200
+  WHERE  jobname = 'event_snapshot_midday';
+
+  PERFORM public.bot_chat_log(
+    'data-collection', 'D0', 'status',
+    format('mig 340000: td_snapshot 12h→latest-batch fix applied; midday re-run wrote %s rows', v_n)
+  );
+END $$;


### PR DESCRIPTION
## Summary

### Migrations (applied in prior session, PR already included)
- **mig 280000** — `authenticated` SELECT on `ticketsdata_listings_snapshots`
- **mig 290000** — movers: filter past events from `get_event_movers_v2`; global past-event purge in `compute_event_movers_index_all`
- **mig 300000** — SG null-listings vicious-cycle fix: 30d ownership fallback in `sg_classify_events`, snapshot cron_policy 1440→1200 min, sweep TTL 24h→48h, one-time re-queue for stale events

### Frontend — event detail page enrichment
- **Last Event Snapshot** — appends `TD MARKETS` divider row (SH/GT/VD listings + medians) from `event_listing_snapshot_daily`; reuses `_lastTdSnap` set by `loadTdFreshness()` — no extra fetch
- **Inventory & Sales chart** — three dashed series (SH/GT/VD listing count over time, hidden by default); built from `_tdInvCountSeries` populated in `loadTdFreshness()`
- **Cross-Source Metrics title** — updated to `TEvo · SG · TD`
- **Splits panel** — three columns (TEvo · SG · TD); TD groups `ticketsdata_listings_snapshots` last 24h client-side by `platform+section`, computes min/median per group
- **Zones panel** — third TD placeholder column ("zone xref mapping pending")
- **NEW: Cross-Platform Sales panel** — EVO sold metrics + SG fill_rate/sold + TD listing Δ velocity + TP/Vivid order counts via `get_event_cross_broker_orders_full` SECDEF RPC
- **NEW: TD Listings tab** — SH / GT / VD sub-sections, parallel lazy-load on first open, 7d window, non-parking, per-platform colored left-border badge
- **style.css** — `dual-src` grid `1fr 1fr` → `1fr 1fr 1fr`; new rules for `.last-snap-divider`, `.td-platform-section`, `.td-sh/gt/vd-section`, `.csale-platform`

No new migrations needed — all DB access already in place.

## Test plan

- [ ] Overview tab loads without JS errors
- [ ] Last Event Snapshot: TD MARKETS row visible (data) / `—` cells (no data) — no crash
- [ ] Inventory chart legend shows SH/GT/VD dashed series (togglable)
- [ ] Splits: three columns render at reasonable width
- [ ] Cross-Platform Sales: EVO + SG rows; TD Δ chips colored (green = sold, red = new inventory); TP/Vivid rows
- [ ] TD Listings tab: three platform sections load in parallel; SH orange / GT teal / VD purple accents
- [ ] TD Markets tab (existing): no regression
- [ ] Events with no TD data: graceful empty states throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)