### PR TITLE
fix(d0): SG Listings tab — limit to last pull (FE + RPC)

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2573,8 +2573,16 @@
       if (countChip) countChip.textContent = '0';
       return;
     }
-    const rows = d.rows || [];
-    if (meta) meta.textContent = `${rows.length} rows · ${ms.toFixed(0)}ms · sg_event_id ${d.sg_event_id}`;
+    const allRows = d.rows || [];
+    // RPC dedups DISTINCT ON (sglid) across a 7-day window, so a listing keeps
+    // its LAST-SEEN captured_at — listings that vanished days ago still appear,
+    // stamped with stale pull times. That's the "multiple captured" symptom.
+    // Limit to the last pull: each poll writes one uniform captured_at, so the
+    // current board = rows whose captured_at equals the max across the result.
+    const lastPull = allRows.reduce((m, r) => (r.captured_at > m ? r.captured_at : m), '');
+    const rows = lastPull ? allRows.filter(r => r.captured_at === lastPull) : allRows;
+    const pullLabel = lastPull ? T.fmtDate(lastPull) : '—';
+    if (meta) meta.textContent = `${rows.length} listings · last pull ${pullLabel} · ${ms.toFixed(0)}ms · sg_event_id ${d.sg_event_id}`;
     if (countChip) countChip.textContent = String(rows.length);
     if (!rows.length) {
       body.innerHTML = '<div class="empty">no SG listings in last 7 days</div>';

--- a/supabase/migrations/20260601120000_sg_listings_full_last_pull.sql
+++ b/supabase/migrations/20260601120000_sg_listings_full_last_pull.sql
@@ -1,0 +1,93 @@
+-- Migration 20260601120000 · lane:D0 (author) → A1 (apply) · writes:get_event_sg_listings_full · reads:seatgeek_listings_snapshots,seatgeek_event_xref · pre:20260518030000 · auth:pending operator approval
+-- ============================================================================
+-- Migration 20260601120000 — SG Listings tab RPC: trim to the LAST PULL
+--
+-- Lane:     D0 (author) → A1 (apply)
+-- Touches:  get_event_sg_listings_full (W, CREATE OR REPLACE),
+--           seatgeek_listings_snapshots (R), seatgeek_event_xref (R)
+-- Pre-reqs: 20260518030000 (prior uncapped definition of this fn)
+--
+-- Problem: the prior body dedups DISTINCT ON (sglid) across a 7-DAY window,
+-- so every listing keeps its LAST-SEEN captured_at. Listings that left the
+-- board days ago still return, stamped with stale pull times — the tab shows
+-- one event's listings spread across many "Captured" timestamps (e.g. Guardians
+-- @ Yankees sg 17691547: 4353 rows over 20 pulls vs 563 in the latest pull).
+--
+-- Fix: scope to the most recent pull only. Each poll writes one uniform
+-- captured_at, so the current board = rows whose captured_at = max(captured_at)
+-- within the 7-day window. DISTINCT ON (sglid) retained as a cheap guard against
+-- a duplicate sglid inside a single pull. Output now also returns last_pull so
+-- the FE can label freshness without scanning rows. Mirrors the client-side
+-- guard shipped in PR #394 (static/terminal/event.js renderSgListingsFull) —
+-- once applied, the FE filter is a no-op (all rows already share captured_at).
+--
+-- Everything else unchanged: signature, email gate, SECDEF, REVOKE/GRANT,
+-- sg_event_id bridge, no_sg_bridge hidden-state, p_limit floor.
+-- ============================================================================
+--
+-- ## Pending operator apply via apply_migration
+
+CREATE OR REPLACE FUNCTION public.get_event_sg_listings_full(
+  p_event_id integer,
+  p_limit    integer DEFAULT 100000
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_last_pull   timestamptz;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'no_sg_bridge', 'count', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  -- Resolve the latest pull timestamp within the 7-day window (indexed scan
+  -- on sg_event_id + captured_at). NULL when no listings captured for the event.
+  SELECT max(captured_at) INTO v_last_pull
+  FROM public.seatgeek_listings_snapshots
+  WHERE sg_event_id = v_sg_event_id
+    AND captured_at > now() - interval '7 days';
+
+  IF v_last_pull IS NULL THEN
+    RETURN jsonb_build_object('count', 0, 'sg_event_id', v_sg_event_id, 'last_pull', NULL, 'rows', '[]'::jsonb);
+  END IF;
+
+  WITH latest AS (
+    SELECT DISTINCT ON (sglid)
+      sglid, captured_at, section, row, quantity,
+      retail_price_all_in, broadcast_price,
+      delivery_method, stock_type, is_broker_owned, is_instant_download,
+      market_source, splits, in_hand_date
+    FROM public.seatgeek_listings_snapshots
+    WHERE sg_event_id = v_sg_event_id
+      AND captured_at = v_last_pull
+    ORDER BY sglid, captured_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sg_event_id', v_sg_event_id,
+    'last_pull', v_last_pull,
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.broadcast_price ASC NULLS LAST, l.section, l.row), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY broadcast_price ASC NULLS LAST, section, row LIMIT greatest(1, p_limit)) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_sg_listings_full(integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_sg_listings_full(integer, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_sg_listings_full(integer, integer) IS
+  'D0 event-page tabs — SG listings for an event, scoped to the LAST PULL only (captured_at = max within 7d), deduped on sglid, price-ascending. Returns last_pull for FE freshness. Email-gated. Supersedes the 7-day last-seen window (mig 20260601120000).';

--- a/supabase/migrations/20260601130000_sg_poller_soonest_first.sql
+++ b/supabase/migrations/20260601130000_sg_poller_soonest_first.sql
@@ -1,0 +1,90 @@
+-- ============================================================
+-- Migration 20260601130000 — SG listings poller: soonest-event-first priority
+--
+-- Lane:     A1 (collector) — drafted by D0 at operator request, A1 to review + apply
+-- Touches:  sg_listings_poll_tick (W, CREATE OR REPLACE) — reads sg_event_priority_state,
+--           collector_cadence (via collector_band), net._http_response, sg_broker_pending (W)
+-- Pre-reqs: 20260531160000 (band-driven poller this revises), collector_band(), collector_cadence
+--
+-- Problem (diagnosed by D0 2026-06-01, bot_chat 995, PR #394):
+-- the band poller's selection orders ONLY by `last_polled_listings_at ASC NULLS FIRST`.
+-- That re-qualifies 429-stranded events (the intent in MIG-D) but carries NO
+-- hours-to-event urgency, so when the eligible set exceeds the per-tick budget
+-- (observed: 1,614 eligible vs ~150 polls/hr at p_max=5 x 30 ticks), stale far-out
+-- events rank ahead of imminent games. Live evidence: Cleveland Guardians @ NY
+-- Yankees sg 17691547/48/49 at 28/52/70h to event (le7d band = 60min) had NOT
+-- polled in ~22h (last_fired NULL, listings_polls_today=0); 1,275 stale far-out
+-- events ranked ahead of them, only 61 eligible events were within 72h.
+--
+-- Fix: make event urgency the PRIMARY sort key — soonest sg_datetime_utc first —
+-- then keep `last_polled ASC NULLS FIRST` as the tiebreak (preserves the 429
+-- re-qualification behaviour within an urgency tier). Eligibility is unchanged
+-- (per-band required_min still gates WHO is due); this only reorders WHO goes
+-- first when the tick budget is scarce. Far-out events still drain on remaining
+-- capacity — their bands are long (d15_30=720min, d31p=1440min) so they tolerate
+-- waiting behind the ~61 near-term events, which comfortably fit under the
+-- 150-poll/hr ceiling.
+--
+-- Only the ORDER BY changes; token guard, rate-aware backoff, band join, WHERE,
+-- fire/insert/stamp loop, and the last_polled-only-on-200 contract (in
+-- sg_broker_listings_process) are all preserved verbatim from 20260531160000.
+--
+-- Follow-on levers (NOT done here — left to A1's judgement): raising p_max or
+-- adding a dedicated near-term fast lane if the far-out backlog still lags; and
+-- the occasional deadlock on the `UPDATE sg_event_priority_state` from concurrent
+-- ticks (3/24h observed) — could serialize via FOR UPDATE SKIP LOCKED on select.
+-- ============================================================
+--
+-- ## Pending operator apply via apply_migration
+
+CREATE OR REPLACE FUNCTION public.sg_listings_poll_tick(p_max int DEFAULT 20, p_min_remaining int DEFAULT 3)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','extensions','pg_temp'
+AS $function$
+DECLARE
+  v_token     text := public.get_app_secret('SEATGEEK_API_TOKEN');
+  v_remaining int;
+  r           RECORD;
+  v_req       bigint;
+  v_now       timestamptz := clock_timestamp();
+  v_count     int := 0;
+BEGIN
+  IF v_token IS NULL OR v_token = '' THEN RETURN 0; END IF;
+
+  -- Rate-aware backoff: only on a FRESH low reading (~10s window). Stale/none => fire.
+  SELECT (h.headers->>'ratelimit-remaining')::int INTO v_remaining
+  FROM public.sg_broker_pending p
+  JOIN net._http_response h ON h.id = p.request_id
+  WHERE h.headers ? 'ratelimit-remaining' AND h.created > v_now - interval '10 seconds'
+  ORDER BY h.id DESC LIMIT 1;
+  IF v_remaining IS NOT NULL AND v_remaining < p_min_remaining THEN RETURN 0; END IF;
+
+  FOR r IN
+    SELECT s.sg_event_id
+    FROM public.sg_event_priority_state s
+    JOIN LATERAL public.collector_band('SG','listings',
+           EXTRACT(epoch FROM (s.sg_datetime_utc - v_now))/3600.0) c ON true
+    WHERE s.tier <> 'SKIP'
+      AND s.sg_datetime_utc > v_now - interval '6 hours'
+      AND ( s.last_polled_listings_at IS NULL
+            OR s.last_polled_listings_at < v_now - make_interval(mins => c.required_min) )
+      AND ( s.last_fired_listings_at IS NULL
+            OR s.last_fired_listings_at < v_now - interval '90 seconds' )   -- don't re-fire a pending request
+    -- CHANGED (mig 20260601130000): urgency first so imminent games never starve
+    -- behind stale far-out events; last_polled ASC kept as the 429 re-qualify tiebreak.
+    ORDER BY s.sg_datetime_utc ASC, s.last_polled_listings_at ASC NULLS FIRST, s.sg_event_id
+    LIMIT p_max
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/listings?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000
+    ) INTO v_req;
+    INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+      VALUES (r.sg_event_id, 'listings', v_req, v_now);
+    UPDATE public.sg_event_priority_state
+      SET last_fired_listings_at = v_now, listings_polls_today = listings_polls_today + 1
+      WHERE sg_event_id = r.sg_event_id;
+    v_count := v_count + 1;
+  END LOOP;
+  RETURN v_count;
+END $function$;
+REVOKE ALL ON FUNCTION public.sg_listings_poll_tick(int,int) FROM anon, PUBLIC;


### PR DESCRIPTION
## Problem

The SG Listings tab showed one event's listings stamped with **many different "Captured" timestamps**. For *Cleveland Guardians at New York Yankees* (6/2, sg `17691547`) it rendered **4,353 rows spanning all 20 pulls** in the last 7 days.

## Root cause

`get_event_sg_listings_full` dedups `DISTINCT ON (sglid)` over a **7-day window**, keeping each listing at its **last-seen** `captured_at`. So a listing that left the board days ago still appears, stamped with its stale pull time — not a snapshot of the current board.

## Fix (two layers)

1. **FE (ships now, D0 lane)** — `renderSgListingsFull` filters to the most recent pull client-side. Each poll writes one uniform `captured_at` (verified vs prod), so this is an exact "last pull" snapshot — **563 rows** instead of 4,353. Meta line now reads `N listings · last pull <time>`.
2. **RPC (D0-authored → A1 applies)** — `20260601120000_sg_listings_full_last_pull.sql` moves the trim server-side (`captured_at = max(...)` within 7d), returns `last_pull`, price-ascending. Cuts payload ~4.3k → ~563 rows. **Pending operator apply.**

## Collector fix — found while checking this game's grab vs the crons

The SG listings poller (`sg_listings_poll_tick`, A1 collector lane) was **starving near-term events** after the 2026-05-31 cron cutover: these 3 games are 28/52/70h out (`le7d` band wants 60-min polling) but hadn't polled in ~22h (`last_fired` NULL, `listings_polls_today` 0). The cron is healthy; the selection orders by `last_polled ASC` with **no urgency weighting**, so a 1,614-event eligible backlog put **1,275 stale far-out events ahead** of the imminent games.

- `20260601130000_sg_poller_soonest_first.sql` (lane:A1, drafted by D0 at operator request) — adds `sg_datetime_utc ASC` as the primary sort. Verified read-only: the 3 games move from behind 1,275 events to rank **29/52/60**. Filed to A1 as **bot_chat 995/996**. **Pending A1 review + apply.**

## Test

- `node --check static/terminal/event.js` ✅
- RPC + poller selection both validated read-only against prod (sg `17691547`).

https://claude.ai/code/session_012snzvtAgd8xdHGA5nigusu