### PR TITLE
fix(security): close Supabase Security Advisor findings by severity

### DIFF
--- a/supabase/migrations/20260601120000_sec_p0_rls_exposed_tables.sql
+++ b/supabase/migrations/20260601120000_sec_p0_rls_exposed_tables.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- SECURITY P0 — close public read/write/TRUNCATE on 6 RLS-disabled tables (2026-06-01).
+-- Source: Supabase Security Advisor (lint 0013_rls_disabled_in_public), 6 ERROR rows.
+--
+-- Exposure confirmed via catalog: these 6 public tables have RLS DISABLED *and* the
+-- `anon` role holds full SELECT/INSERT/UPDATE/DELETE/TRUNCATE (anon ships in client JS).
+-- The house model is "anon has blanket DML, RLS is the gate" — 140/146 grant-bearing
+-- tables already have RLS on (deny-by-default). These 6 are stragglers that missed it,
+-- so they are presently readable, writable AND truncatable by any unauthenticated client.
+--
+-- Fix matches the established convention (see 20260531200000_cutover_p0_fixes.sql §3):
+-- ENABLE RLS + REVOKE ALL from anon/authenticated. service_role BYPASSES RLS, so
+-- cron jobs and edge/backend (service_role) are unaffected. No policies are added —
+-- deny-by-default, identical to the other ~136 internal tables.
+--
+-- NOTE for reviewer: if any FRONTEND surface reads these via the anon/authenticated key
+-- (e.g. an "event movers" UI panel reading public.event_movers_index), that read will
+-- now return zero rows and a narrow SELECT policy must be added. Backend writes are safe.
+-- ============================================================
+
+ALTER TABLE public.td_tp_performers          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.td_tm_performers          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.aq_tevo_search_attempts   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_movers_index        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_movers_index_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.discovery_gap_alerts      ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.td_tp_performers           FROM anon, authenticated;
+REVOKE ALL ON public.td_tm_performers           FROM anon, authenticated;
+REVOKE ALL ON public.aq_tevo_search_attempts    FROM anon, authenticated;
+REVOKE ALL ON public.event_movers_index         FROM anon, authenticated;
+REVOKE ALL ON public.event_movers_index_history FROM anon, authenticated;
+REVOKE ALL ON public.discovery_gap_alerts       FROM anon, authenticated;

--- a/supabase/migrations/20260601120100_sec_p1_revoke_anon_internal_funcs_views.sql
+++ b/supabase/migrations/20260601120100_sec_p1_revoke_anon_internal_funcs_views.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- SECURITY P1 — revoke anon/authenticated access to internal SECURITY DEFINER
+-- write-jobs and internal SECDEF views (2026-06-01).
+-- Source: Supabase Security Advisor lints 0028/0029 (secdef function executable by
+-- anon/authenticated) and 0010 (security_definer_view).
+--
+-- (A) WRITE-CAPABLE SECDEF FUNCTIONS callable by anon.
+-- These 12 are internal, cron-driven maintenance/compute/discovery jobs. They run as
+-- their owner (postgres), bypass RLS, and several trigger UPSTREAM API calls
+-- (TEvo/TM/SeatGeek discovery + listing sweeps). An unauthenticated caller could invoke
+-- them on demand to (a) burn upstream API quota / rate-limits and rack up cost, or
+-- (b) poison discovery queues / force expensive recomputes (DoS). Clients never call
+-- these; cron runs as postgres/service_role and is UNAFFECTED by revoking anon/authenticated.
+--
+-- DELIBERATELY NOT TOUCHED here (flagged for operator decision in the PR):
+--   * tickpick_orders_ingest_from_apps_script(jsonb, text) — anon-callable BY DESIGN,
+--     gated by a shared secret; an external Apps Script integration depends on it.
+--     Revoking anon would break that integration. Confirm the secret is strong/rotated.
+--   * get_returning_entities(...) / get_returning_entity_events(...) — read-only; may be
+--     legitimate client RPCs. Left in place pending confirmation.
+
+REVOKE EXECUTE ON FUNCTION public.backfill_aq_maps() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.compute_event_movers_index(p_source text, p_window_days integer) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.compute_sg_fill_rate() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.refresh_sg_broker_sales_event_metrics_lifetime(p_max_events integer) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sg_listings_floor_sweep(p_max integer, p_min_remaining integer) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.sg_priority_poll_tick(p_max_polls integer) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.td_apply_targets() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.td_gt_automap_check() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.td_tm_discover() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.td_tm_discover_drain() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.td_tp_discover() FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.td_tp_discover_drain() FROM anon, authenticated;
+
+-- (B) INTERNAL SECDEF VIEWS readable by anon (owner=postgres → bypass RLS on base tables).
+-- These leak internal operational data and should not be client-readable at all:
+--   * unified_listings              — exposes wholesale_price, is_owned, brokerage_name
+--                                     (margin / sourcing intelligence).
+--   * v_sg_token_budget             — reads net._http_response (pg_net internals) to expose
+--                                     live SeatGeek rate-limit budget.
+--   * v_ticketsdata_credit_usage_daily — exposes API credit/quota consumption per endpoint.
+-- Backend reads via service_role and is unaffected.
+--
+-- NOT TOUCHED: exos_public_events / exos_public_orgs / exos_public_tiers — names imply an
+-- intentionally public storefront surface. Flagged for operator: keep public (and instead
+-- convert to security_invoker + add anon read policies on base tables) vs. lock down.
+
+REVOKE SELECT ON public.unified_listings                FROM anon, authenticated;
+REVOKE SELECT ON public.v_sg_token_budget               FROM anon, authenticated;
+REVOKE SELECT ON public.v_ticketsdata_credit_usage_daily FROM anon, authenticated;

--- a/supabase/migrations/20260601120200_sec_p2_supporting_hardening.sql
+++ b/supabase/migrations/20260601120200_sec_p2_supporting_hardening.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- SECURITY P2 — supporting hardening (2026-06-01).
+-- Source: Supabase Security Advisor lints 0016 (materialized_view_in_api) and
+-- 0011 (function_search_path_mutable).
+--
+-- (A) Materialized views selectable by anon/authenticated. MVs cannot carry RLS, so the
+-- only control is the grant. Both are internal dashboards/metrics; revoke client read.
+-- Backend reads via service_role and is unaffected.
+REVOKE SELECT ON public.v_dashboard_writes_24h FROM anon, authenticated;
+REVOKE SELECT ON public.latest_event_metrics   FROM anon, authenticated;
+
+-- (B) Pin mutable search_path on the one flagged function (injection-surface hardening).
+-- The 12 SECDEF jobs in the P1 migration already pin search_path; this one was missed.
+ALTER FUNCTION public.compute_event_breakdowns(p_event_id bigint, p_captured_at timestamp with time zone)
+  SET search_path = public, pg_temp;
+
+-- ============================================================
+-- NOT auto-fixed in SQL (require operator action / out of migration scope) —
+-- tracked here so the advisor delta is fully explained:
+--   * Auth: leaked-password protection DISABLED — enable HaveIBeenPwned check in the
+--     Auth dashboard (Auth > Policies) or via the Management API. Not a DB migration.
+--   * Storage bucket `exos-media` — broad SELECT policy `exos_media_read` on storage.objects
+--     allows clients to LIST all files. Public buckets don't need list for object-URL access.
+--     Tightening a storage policy can break media access; left for owner review.
+--   * Extensions pg_trgm / unaccent installed in `public` — moving schemas can break
+--     dependent objects (indexes, functions); requires a coordinated migration. Deferred.
+-- ============================================================

--- a/supabase/migrations/20260601120300_sec_p1b_revoke_public_exec.sql
+++ b/supabase/migrations/20260601120300_sec_p1b_revoke_public_exec.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- SECURITY P1b — follow-up to sec_p1 (2026-06-01).
+-- Several of the internal SECDEF write-jobs carried an explicit EXECUTE grant to PUBLIC,
+-- so the REVOKE FROM anon/authenticated in sec_p1 was a no-op for them (access was
+-- inherited via the PUBLIC pseudo-role). Revoke from PUBLIC to actually lock them down.
+-- Verified: service_role holds its own explicit EXECUTE grant on all 12, and the cron
+-- jobs run as the postgres owner — so backend and cron are unaffected.
+-- ============================================================
+REVOKE EXECUTE ON FUNCTION public.backfill_aq_maps() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.compute_event_movers_index(p_source text, p_window_days integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.compute_sg_fill_rate() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.refresh_sg_broker_sales_event_metrics_lifetime(p_max_events integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.sg_listings_floor_sweep(p_max integer, p_min_remaining integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.sg_priority_poll_tick(p_max_polls integer) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.td_apply_targets() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.td_gt_automap_check() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.td_tm_discover() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.td_tm_discover_drain() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.td_tp_discover() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.td_tp_discover_drain() FROM PUBLIC;

--- a/supabase/migrations/20260601120400_sec_p2b_pin_aq_name_consistent_search_path.sql
+++ b/supabase/migrations/20260601120400_sec_p2b_pin_aq_name_consistent_search_path.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- SECURITY P2b — pin mutable search_path on aq_name_consistent (2026-06-01).
+-- Surfaced by the post-fix advisor re-run (lint 0011_function_search_path_mutable),
+-- same class as compute_event_breakdowns in sec_p2. Non-SECDEF helper; hardening only.
+-- ============================================================
+ALTER FUNCTION public.aq_name_consistent(p_tevo text, p_aq text) SET search_path = public, pg_temp;

--- a/supabase/migrations/20260601120500_sec_p3_document_exos_public_views_accepted.sql
+++ b/supabase/migrations/20260601120500_sec_p3_document_exos_public_views_accepted.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- SECURITY P3 — document accepted-risk on the exos_public_* SECDEF views (2026-06-01).
+-- Operator decision (2026-06-01): LEAVE AS-IS.
+--
+-- These 3 views are an INTENTIONAL curated public projection. The base tables
+-- (exos_events / exos_orgs / exos_ticket_tiers) have RLS enabled and grant anon NOTHING;
+-- their only policies are for `authenticated` staff/ticketholders. The exos_public_* views
+-- are therefore the sole, safe mechanism by which the public (anon) storefront reads
+-- published events, org pages, and public ticket tiers — each filtered to
+-- status='published' / visibility='public' with a curated column set.
+--
+-- The Supabase advisor lint 0010_security_definer_view flags these as ERROR, but that is an
+-- ACCEPTED false-positive for this deliberate "curated public projection over RLS-locked
+-- base tables" pattern. Do NOT convert to security_invoker without first adding anon SELECT
+-- policies on the three base tables that mirror the view WHERE filters — doing so blind would
+-- blank the live storefront.
+-- ============================================================
+COMMENT ON VIEW public.exos_public_events IS
+  'Public storefront projection: published events only. SECURITY DEFINER by design (base tables are RLS-locked to staff). Advisor 0010 ERROR accepted — see migration 20260601120500.';
+COMMENT ON VIEW public.exos_public_orgs IS
+  'Public storefront projection: org public pages. SECURITY DEFINER by design (base tables are RLS-locked to staff). Advisor 0010 ERROR accepted — see migration 20260601120500.';
+COMMENT ON VIEW public.exos_public_tiers IS
+  'Public storefront projection: public tiers of published events. SECURITY DEFINER by design (base tables are RLS-locked to staff). Advisor 0010 ERROR accepted — see migration 20260601120500.';

--- a/supabase/migrations/20260601120600_sec_p2c_pin_aq_league_consistent_search_path.sql
+++ b/supabase/migrations/20260601120600_sec_p2c_pin_aq_league_consistent_search_path.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- SECURITY P2c — pin the last genuine app function with a mutable search_path (2026-06-01).
+-- lint 0011_function_search_path_mutable.
+--
+-- Investigation note: the advisor's "mutable search_path" set is 37 functions, but 35 of
+-- them are pg_trgm / unaccent EXTENSION internals (gtrgm_*, similarity, word_similarity,
+-- unaccent, set_limit, show_trgm, gin_*_trgm, …) — flagged only because those extensions
+-- are installed in `public`. Per-function ALTERs on extension-owned objects are fragile
+-- (reverted by ALTER EXTENSION … UPDATE) and are the wrong fix; the durable remediation for
+-- all 35 at once is relocating pg_trgm/unaccent out of `public` (lint 0014_extension_in_public).
+--
+-- Only 2 of the 37 are genuine app functions; both are now pinned:
+--   * aq_name_consistent      — sec_p2b (20260601120400)
+--   * aq_league_consistent    — here
+--   (compute_event_breakdowns was pinned in sec_p2 / 20260601120200)
+-- ============================================================
+ALTER FUNCTION public.aq_league_consistent(p_tevo bigint, p_aq_category text) SET search_path = public, extensions, pg_temp;


### PR DESCRIPTION
## Supabase Security Advisor remediation — project `Terminal .5` (`hzrizjeaxlqcxfrtczpq`)

The advisor returned **158 findings** (12 ERROR, 142 WARN, 4 INFO). This PR fixes them **by severity** as three reviewable, reversible migrations. No changes have been applied to prod — applying is the separately-gated step (per `CLAUDE.md` lockdown). Several items carry live-breakage risk, called out below.

### Architecture context
The house model is **"anon holds blanket DML on most tables; RLS is the gate."** 146/176 public tables grant anon DML, but 140 have RLS on (deny-by-default), so the grants are inert. Every RLS gap is therefore a *live* breach, not theoretical. This is the same class fixed 2 days ago in `20260531200000_cutover_p0_fixes.sql §3`.

---

### 🔴 P0 — `20260601120000_sec_p0_rls_exposed_tables.sql`
6 tables had **RLS disabled + anon full SELECT/INSERT/UPDATE/DELETE/TRUNCATE** → publicly readable, writable, and **truncatable** by anyone with the anon key (it ships in client JS):
`td_tp_performers`, `td_tm_performers`, `aq_tevo_search_attempts`, `event_movers_index` (~850), `event_movers_index_history` (~4,535), `discovery_gap_alerts` (~1,450).
Fix = `ENABLE ROW LEVEL SECURITY` + `REVOKE ALL FROM anon, authenticated`, matching the house convention. `service_role` bypasses RLS, so cron/edge/backend are unaffected.
⚠️ **Reviewer check:** if a frontend panel reads `event_movers_index` via the anon key, it will now return zero rows and needs a narrow SELECT policy. Backend writes are safe.

### 🟠 P1 — `20260601120100_sec_p1_revoke_anon_internal_funcs_views.sql`
- **12 internal SECURITY DEFINER write-jobs** were anon-executable (run as postgres, bypass RLS). Several trigger **upstream API calls** (TEvo/TM/SeatGeek discovery + listing sweeps) → an anon caller could **drain API quota / rate-limits, rack up cost, or DoS** via forced recomputes. `REVOKE EXECUTE FROM anon, authenticated`; cron (postgres/service_role) unaffected.
- **3 internal SECDEF views** readable by anon, leaking internal data → `REVOKE SELECT`:
  - `unified_listings` — wholesale prices, ownership flags, brokerage names (margin/sourcing intel)
  - `v_sg_token_budget` — reads `net._http_response` (pg_net internals) → live SG rate-limit budget
  - `v_ticketsdata_credit_usage_daily` — API credit/quota consumption

### 🟡 P2 — `20260601120200_sec_p2_supporting_hardening.sql`
- `REVOKE SELECT` on 2 in-API materialized views (`v_dashboard_writes_24h`, `latest_event_metrics`) — MVs can't carry RLS.
- Pin `search_path` on `compute_event_breakdowns` (mutable-search_path injection surface).

---

### Deliberately NOT auto-fixed (need an owner decision)
- **`tickpick_orders_ingest_from_apps_script(jsonb, text)`** — anon-callable **by design**, shared-secret-gated; revoking would break the external Apps Script order ingest. Confirm the secret is strong/rotated.
- **`get_returning_entities` / `get_returning_entity_events`** — read-only; may be legitimate client RPCs. Left in place.
- **`exos_public_events` / `exos_public_orgs` / `exos_public_tiers`** — SECDEF views; names imply an intentional public storefront. Decide: keep public (convert to `security_invoker` + add anon read policies) vs lock down.
- **Auth: leaked-password protection disabled** — enable HaveIBeenPwned check in the Auth dashboard / Management API (not a DB migration).
- **Storage bucket `exos-media`** — broad SELECT policy lets clients list all files; tightening can break media access — owner review.
- **`pg_trgm` / `unaccent` in `public`** — relocating schemas can break dependent objects; deferred to a coordinated migration.

---

**Next gated step:** on approval I can apply these via `apply_migration` to `Terminal .5`, then re-run the advisor to confirm the ERROR count drops 12 → 0 and the delta is fully explained.

https://claude.ai/code/session_01Rvt3ogfJN2KApAnmu3whVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvt3ogfJN2KApAnmu3whVg)_