### PR TITLE
fix(d0/event): make seat-map section span full grid width

### DIFF
--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1899,6 +1899,10 @@ body[data-page="login"] {
 .td-tm-section { border-left-color: #6366f1; }   /* TM — indigo */
 
 /* ---------- Seat Map tab (Tevomaps interactive venue map + section filter) ---------- */
+/* main.wrap.event is a 12-col grid and .tab-pane is display:contents, so this section
+   sits directly in that grid — it must span all 12 cols or it collapses to ~1/12 width
+   (crushing the map into a sliver). Mirrors the other full-width event sections. */
+.wrap.event #seatmap-section { grid-column: 1 / -1; }
 #seatmap-section { background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 16px; }
 #seatmap-section .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
 .seatmap-layout { display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 16px; align-items: start; }


### PR DESCRIPTION
## What

Follow-up to #406/#407. The seat map's SVG was rendering and coloring correctly (57/72 sections matched), but it was **crushed into a ~122px sliver** — invisible against the dark shell.

## Root cause (confirmed via DOM inspection)

`main.wrap.event` is a **12-column grid** (`repeat(12, 1fr)`), and `.tab-pane { display: contents }`, so each `<section>` is placed *directly* into that grid. Every full-width event section declares `.wrap.event #id { grid-column: 1 / -1 }` — but `#seatmap-section` didn't, so it defaulted to a single column (~156px), crushing the 520px map into ~122px wide.

DOM check confirmed: `svg present: true`, `svg rect 122×520`, `section width: 156` — i.e. rendering was fine, layout was the bug.

## Fix

One line, mirroring the other full-width sections:
```css
.wrap.event #seatmap-section { grid-column: 1 / -1; }
```

After this the map gets the full `1fr` (minus the 360px filter column) and renders at full size.

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_