### PR TITLE
feat(d0/event): multi-source seat map with per-source selector

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -421,29 +421,30 @@
       </section>
     </div>
 
-    <!-- Seat Map — interactive TEvo venue seatmap as a section/price filter.
+    <!-- Seat Map — interactive TEvo venue seatmap as a multi-source section/price filter.
          Renders maps.ticketevolution.com/{venue_id}/{configuration_id}/map.svg via the
-         vendored @ticketevolution/seatmaps-client UMD bundle (window.Tevomaps).
-         Sections are colored by our EVO listing floors; clicking a section filters the
-         per-section listing table below. Lazy-loads on first tab activation. -->
+         vendored @ticketevolution/seatmaps-client UMD bundle (window.Tevomaps). The source
+         selector re-colors the map by ONE source's floors at a time (TEvo · SG · SH · GT ·
+         VD) via updateTicketGroups(); the listing table below shows that same source.
+         Clicking a section filters the table. Lazy-loads on first tab activation. -->
     <div class="tab-pane" id="paneSeatmap" role="tabpanel" hidden>
       <section id="seatmap-section">
         <div class="panel-title row">
-          <span>SEAT MAP — TEvo venue map · colored by EVO listing floor</span>
+          <span>SEAT MAP — venue map · colored by selected source's listing floor</span>
           <span class="muted small" id="seatmapMeta">tap tab to load</span>
         </div>
-        <div class="seatmap-layout">
-          <div class="seatmap-mapwrap">
-            <div id="seatmapHost" class="seatmap-host"></div>
-          </div>
-          <div class="seatmap-side">
-            <div class="seatmap-side-hd row">
-              <span id="seatmapSelLabel">Click a section to filter listings</span>
-              <button type="button" id="seatmapResetBtn" class="seatmap-reset" hidden>Reset</button>
-            </div>
-            <div id="seatmapListBody"><div class="empty">—</div></div>
-          </div>
+        <div class="seatmap-toolbar row">
+          <span class="seatmap-src-label">Source on map:</span>
+          <span class="seatmap-src-sel" id="seatmapSourceSel"></span>
         </div>
+        <div class="seatmap-mapwrap">
+          <div id="seatmapHost" class="seatmap-host"></div>
+        </div>
+        <div class="seatmap-side-hd row">
+          <span id="seatmapSelLabel">Click a section to filter listings</span>
+          <button type="button" id="seatmapResetBtn" class="seatmap-reset" hidden>Reset</button>
+        </div>
+        <div id="seatmapListBody"><div class="empty">—</div></div>
       </section>
     </div>
   </main>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2796,17 +2796,66 @@
     if (meta) meta.textContent = `${rows.length} rows (${ownedCount} ours) · ${ms.toFixed(0)}ms`;
   }
 
-  // ---------- Seat Map (interactive TEvo venue map as a section/price filter) ----------
+  // ---------- Seat Map (interactive TEvo venue map · multi-source section/price filter) ----------
   // The vendored @ticketevolution/seatmaps-client UMD bundle exposes window.Tevomaps.
-  // venueId/configurationId come straight from public.events; the section→floor
-  // ticketGroups are derived from the EVO listings firehose (reusing the same RPC the
-  // "EVO Listings" tab uses). Clicking a section on the SVG calls onSelection, which
-  // filters the per-section listing table on the right. Lazy-loaded on first activation.
+  // venueId/configurationId come from public.events; the map is rendered once, then the
+  // SOURCE SELECTOR (TEvo · SeatGeek · StubHub · GameTime · VividSeats) re-colors it by
+  // ONE source's floors at a time via updateTicketGroups() — never collectively. Each
+  // source's per-section floors are joined to the map's manifest section names via the
+  // trailing-token remap. Clicking a section filters the per-source listing table below.
+  // All sources' RPCs take the tevo event_id and resolve the cross-source bridge server-side.
   let _seatmapApi = null;
-  let _seatmapRows = [];        // raw EVO listing rows for the per-section table
+  let _seatmapEventId = null;
+  let _seatmapRemap = null;     // tail → full manifest section name (venue/config-scoped, cached)
+  let _seatmapSource = 'EVO';   // which source currently colors the map
+  let _seatmapRowsBySource = {};// key → normalized rows [{section,row,quantity,retail_price,is_owned}]
   let _seatmapSelected = [];    // section names currently selected on the map
-  let _seatmapResetWired = false;
+  let _seatmapWired = false;    // selector + reset listeners attached once
+  let _seatmapConfigName = '';
+  let _seatmapVenueLabel = '';
   const SEATMAP_MAPS_DOMAIN = 'https://maps.ticketevolution.com';  // lib default; we read the same manifest
+  // Source registry — TP excluded (zone-only, no section granularity); TM excluded
+  // (primary/box-office, no section-level resale listings for these events).
+  const SEATMAP_SOURCES = [
+    { key: 'EVO', label: 'TEvo' },
+    { key: 'SG',  label: 'SeatGeek' },
+    { key: 'SH',  label: 'StubHub' },
+    { key: 'GT',  label: 'GameTime' },
+    { key: 'VD',  label: 'VividSeats' },
+  ];
+
+  // Fetch one source's listings (by tevo event id — every RPC resolves the bridge itself)
+  // and normalize to a common shape. Prices use each source's all-in field where available.
+  async function _seatmapFetchSource(eventId, key) {
+    if (key === 'EVO') {
+      const r = await rpcOrNull('get_event_evo_listings_full', { p_event_id: eventId });
+      return ((r && r.data && r.data.rows) || []).map(x => ({
+        section: x.section, row: x.row, quantity: x.quantity,
+        retail_price: x.retail_price, is_owned: !!x.is_owned,
+      }));
+    }
+    if (key === 'SG') {
+      const r = await rpcOrNull('get_event_sg_listings_full', { p_event_id: eventId });
+      return ((r && r.data && r.data.rows) || []).map(x => ({
+        section: x.section, row: x.row, quantity: x.quantity,
+        retail_price: (x.retail_price_all_in != null ? x.retail_price_all_in : x.broadcast_price),
+        is_owned: !!x.is_broker_owned,
+      }));
+    }
+    // SH / GT / VD via TicketsData
+    const r = await rpcOrNull('get_event_td_listings', { p_tevo_event_id: eventId, p_platform: key, p_hours: 26 });
+    const rows = Array.isArray(r && r.data) ? r.data : [];
+    return rows.map(x => ({
+      section: x.section, row: x.row, quantity: x.quantity,
+      retail_price: (x.price_with_fees != null && Number(x.price_with_fees) > 0 ? x.price_with_fees : x.list_price),
+      is_owned: false,
+    }));
+  }
+
+  function _seatmapSrcLabel(key) {
+    const s = SEATMAP_SOURCES.find(x => x.key === key);
+    return s ? s.label : key;
+  }
 
   // Parking / non-seated pseudo-sections never match an SVG path (bible §3 parking
   // skip) — drop them so the legend's price scale isn't skewed by $30 parking spots.
@@ -2880,6 +2929,7 @@
 
   async function loadSeatmap(eventId) {
     _tabState.loaded['seatmap'] = true;
+    _seatmapEventId = eventId;
     const meta = document.getElementById('seatmapMeta');
     const host = document.getElementById('seatmapHost');
     const listBody = document.getElementById('seatmapListBody');
@@ -2917,18 +2967,21 @@
       if (listBody) listBody.innerHTML = '';
       return;
     }
+    _seatmapConfigName = evRes.data.configuration_name || '';
+    _seatmapVenueLabel = `venue ${venueId} · config ${configurationId}` + (_seatmapConfigName ? ` (${_seatmapConfigName})` : '');
 
-    // (2) EVO listing floors → ticketGroups (reuses the EVO Listings tab RPC), remapped
-    //     from our bare section tokens to the manifest's full section names.
-    const lstRes = await rpcOrNull('get_event_evo_listings_full', { p_event_id: eventId });
-    _seatmapRows = (lstRes && lstRes.data && lstRes.data.rows) || [];
-    const remap = await _seatmapBuildSectionRemap(venueId, configurationId);
-    const ticketGroups = _seatmapTicketGroups(_seatmapRows, remap);
-    const ourTails = new Set(
-      _seatmapRows.filter(r => r.section && !_seatmapIsParking(r.section)).map(r => _seatmapTail(r.section)),
-    );
+    // (2) Manifest remap (venue/config-scoped — built once, shared by every source).
+    _seatmapRemap = await _seatmapBuildSectionRemap(venueId, configurationId);
+    _seatmapRowsBySource = {};
+    _seatmapSource = 'EVO';
+    _seatmapSelected = [];
 
-    // (3) Build the interactive map. build() is async in v5 → may resolve undefined.
+    // (3) Default source = TEvo. Build the map ONCE with its floors; later source
+    //     switches re-color via updateTicketGroups() rather than rebuilding the SVG.
+    const evoRows = await _seatmapFetchSource(eventId, 'EVO');
+    _seatmapRowsBySource['EVO'] = evoRows;
+    const ticketGroups = _seatmapTicketGroups(evoRows, _seatmapRemap);
+
     host.innerHTML = '';
     try {
       const factory = new window.Tevomaps.SeatmapFactory({
@@ -2947,17 +3000,66 @@
       return;
     }
 
-    if (meta) {
-      const mapped = remap
-        ? `${ticketGroups.length}/${ourTails.size} sections on map`
-        : `${ticketGroups.length} sections (manifest unavailable — no coloring)`;
-      meta.textContent = `venue ${venueId} · config ${configurationId}`
-        + (evRes.data.configuration_name ? ` (${evRes.data.configuration_name})` : '')
-        + ` · ${mapped}`;
-    }
-    _seatmapSelected = [];
+    wireSeatmapControls();
+    renderSeatmapSelector();
     renderSeatmapList();
-    wireSeatmapReset();
+    updateSeatmapMeta(ticketGroups.length);
+    _seatmapProbeSources(eventId);   // fire-and-forget: enable/disable + count the other sources
+  }
+
+  // Switch which source colors the map. Re-colors via updateTicketGroups() (no SVG rebuild)
+  // and swaps the listing table to that source. One source at a time — never merged.
+  async function selectSeatmapSource(key) {
+    if (!_seatmapApi || key === _seatmapSource) return;
+    _seatmapSource = key;
+    _seatmapSelected = [];
+    renderSeatmapSelector();
+    const meta = document.getElementById('seatmapMeta');
+    if (meta) meta.textContent = `${_seatmapVenueLabel} · loading ${_seatmapSrcLabel(key)}…`;
+
+    let rows = _seatmapRowsBySource[key];
+    if (!rows) {
+      rows = await _seatmapFetchSource(_seatmapEventId, key);
+      _seatmapRowsBySource[key] = rows;
+    }
+    const ticketGroups = _seatmapTicketGroups(rows, _seatmapRemap);
+    if (typeof _seatmapApi.updateTicketGroups === 'function') {
+      try { _seatmapApi.updateTicketGroups(ticketGroups); } catch (_) { /* ignore */ }
+    }
+    renderSeatmapSelector();   // refresh active state
+    renderSeatmapList();
+    updateSeatmapMeta(ticketGroups.length);
+  }
+
+  // Build the source selector buttons (active = current source; disabled once a source
+  // is known to have 0 listings for this event). Idempotent — re-rendered on every change.
+  function renderSeatmapSelector() {
+    const host = document.getElementById('seatmapSourceSel');
+    if (!host) return;
+    host.innerHTML = SEATMAP_SOURCES.map(s => {
+      const rows = _seatmapRowsBySource[s.key];
+      const known = rows !== undefined;
+      const empty = known && rows.length === 0;
+      const cnt = known ? ` <span class="sm-src-cnt">${rows.length}</span>` : '';
+      const cls = ['sm-src-btn'];
+      if (s.key === _seatmapSource) cls.push('active');
+      if (empty) cls.push('disabled');
+      return `<button type="button" class="${cls.join(' ')}" data-src="${s.key}"${empty ? ' disabled' : ''}>${escapeHtml(s.label)}${cnt}</button>`;
+    }).join('');
+  }
+
+  // Probe the non-default sources in the background so the selector can show per-source
+  // counts and disable empties — without blocking the initial TEvo render.
+  async function _seatmapProbeSources(eventId) {
+    for (const s of SEATMAP_SOURCES) {
+      if (s.key === 'EVO' || _seatmapRowsBySource[s.key] !== undefined) continue;
+      try {
+        _seatmapRowsBySource[s.key] = await _seatmapFetchSource(eventId, s.key);
+      } catch (_) {
+        _seatmapRowsBySource[s.key] = [];
+      }
+      renderSeatmapSelector();
+    }
   }
 
   // Library fires this with the full set of currently-selected section names.
@@ -2974,18 +3076,31 @@
     renderSeatmapList();
   }
 
-  // The library returns selected sections as full manifest names; our rows carry bare
-  // tokens — compare both via _seatmapTail so the filter matches regardless of form.
+  function updateSeatmapMeta(mappedCount) {
+    const meta = document.getElementById('seatmapMeta');
+    if (!meta) return;
+    const rows = _seatmapRowsBySource[_seatmapSource] || [];
+    const tails = new Set(rows.filter(r => r.section && !_seatmapIsParking(r.section)).map(r => _seatmapTail(r.section)));
+    const mapped = _seatmapRemap
+      ? `${mappedCount}/${tails.size} sections on map`
+      : `${mappedCount} sections (manifest unavailable — no coloring)`;
+    meta.textContent = `${_seatmapVenueLabel} · ${_seatmapSrcLabel(_seatmapSource)} · ${mapped}`;
+  }
+
+  // Renders the CURRENT source's listings; clicking a map section filters by tail
+  // (library returns full manifest names, our rows carry bare tokens → compare via tail).
   function renderSeatmapList() {
     const body = document.getElementById('seatmapListBody');
     if (!body) return;
     const selTails = _seatmapSelected.map(_seatmapTail);
-    let rows = _seatmapRows.filter(r => r.section && !_seatmapIsParking(r.section));
+    const all = _seatmapRowsBySource[_seatmapSource] || [];
+    let rows = all.filter(r => r.section && !_seatmapIsParking(r.section));
     if (selTails.length) rows = rows.filter(r => selTails.includes(_seatmapTail(r.section)));
     rows = rows.slice().sort((a, b) => Number(a.retail_price) - Number(b.retail_price));
 
     if (!rows.length) {
-      body.innerHTML = `<div class="empty">${sel.length ? 'No EVO listings in the selected section(s).' : 'No EVO listings to show.'}</div>`;
+      const src = _seatmapSrcLabel(_seatmapSource);
+      body.innerHTML = `<div class="empty">${selTails.length ? `No ${escapeHtml(src)} listings in the selected section(s).` : `No ${escapeHtml(src)} listings for this event.`}</div>`;
       return;
     }
     const host = document.createElement('div');
@@ -2995,7 +3110,7 @@
     tbl.innerHTML = `
       <thead><tr>
         <th>Section</th><th>Row</th><th class="num">Qty</th>
-        <th class="num">Retail</th><th>Type</th>
+        <th class="num">Price</th><th>Type</th>
       </tr></thead><tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
     rows.slice(0, 300).forEach(r => {
@@ -3014,20 +3129,29 @@
     body.appendChild(host);
   }
 
-  function wireSeatmapReset() {
-    if (_seatmapResetWired) return;
-    const btn = document.getElementById('seatmapResetBtn');
-    if (!btn) return;
-    btn.addEventListener('click', () => {
-      // Deselect each section on the map; the lib echoes onSelection back to us.
-      if (_seatmapApi && typeof _seatmapApi.deselectSection === 'function') {
-        _seatmapSelected.slice().forEach(s => {
-          try { _seatmapApi.deselectSection(s); } catch (_) { /* ignore */ }
-        });
-      }
-      onSeatmapSelection([]);
-    });
-    _seatmapResetWired = true;
+  // Wire the source selector + reset once (delegated; survives selector re-renders).
+  function wireSeatmapControls() {
+    if (_seatmapWired) return;
+    const sel = document.getElementById('seatmapSourceSel');
+    if (sel) {
+      sel.addEventListener('click', (e) => {
+        const btn = e.target.closest('.sm-src-btn');
+        if (!btn || btn.disabled) return;
+        selectSeatmapSource(btn.dataset.src);
+      });
+    }
+    const reset = document.getElementById('seatmapResetBtn');
+    if (reset) {
+      reset.addEventListener('click', () => {
+        if (_seatmapApi && typeof _seatmapApi.deselectSection === 'function') {
+          _seatmapSelected.slice().forEach(s => {
+            try { _seatmapApi.deselectSection(s); } catch (_) { /* ignore */ }
+          });
+        }
+        onSeatmapSelection([]);
+      });
+    }
+    _seatmapWired = true;
   }
 
   // ---------- TD Listings per-platform (full) ----------

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1905,20 +1905,35 @@ body[data-page="login"] {
 .wrap.event #seatmap-section { grid-column: 1 / -1; }
 #seatmap-section { background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 16px; }
 #seatmap-section .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
-.seatmap-layout { display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 16px; align-items: start; }
+
+/* Source selector — picks which single source colors the map (not collective). */
+.seatmap-toolbar { gap: 10px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+.seatmap-src-label { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+.seatmap-src-sel { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+.sm-src-btn {
+  font-family: var(--mono); font-size: 12px; color: var(--text);
+  background: var(--panel-2); border: 1px solid var(--line); border-radius: 4px;
+  padding: 4px 10px; cursor: pointer; line-height: 1.4;
+}
+.sm-src-btn:hover { border-color: var(--accent); }
+.sm-src-btn.active { background: var(--accent); color: var(--bg); border-color: var(--accent); font-weight: 600; }
+.sm-src-btn.disabled, .sm-src-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.sm-src-cnt { opacity: 0.7; font-size: 10px; margin-left: 2px; }
+
+/* Map on top (full width), listings below. */
 .seatmap-mapwrap {
   /* TEvo SVG maps are authored for a light surface — keep the map area light so the
      venue outline + section labels stay legible against the dark terminal shell. */
   background: #f7f7f7; border: 1px solid var(--line); border-radius: 6px;
-  min-height: 520px; overflow: hidden;
+  min-height: 560px; overflow: hidden; margin-bottom: 12px;
 }
-.seatmap-host { width: 100%; height: 520px; }
+.seatmap-host { width: 100%; height: 560px; }
 .seatmap-host svg { width: 100%; height: 100%; }
-.seatmap-side { display: flex; flex-direction: column; min-width: 0; }
 .seatmap-side-hd {
   font-family: var(--mono); font-size: 11px; color: var(--text);
   padding: 6px 8px; margin-bottom: 8px; background: var(--panel-2);
   border: 1px solid var(--line); border-radius: 4px; line-height: 1.4;
+  display: flex; justify-content: space-between; align-items: center;
 }
 .seatmap-reset {
   font-family: var(--mono); font-size: 11px; color: var(--bg);
@@ -1927,8 +1942,3 @@ body[data-page="login"] {
 }
 .seatmap-reset:hover { filter: brightness(1.1); }
 #seatmapListBody .empty { color: var(--muted); padding: 12px; text-align: center; }
-
-@media (max-width: 1100px) {
-  .seatmap-layout { grid-template-columns: 1fr; }
-  .seatmap-side { max-height: 420px; overflow-y: auto; }
-}


### PR DESCRIPTION
## What

Turns the Seat Map into a **multi-source** view: **map on top (full width)**, a **source selector**, and the selected source's **listings below**. The selector picks which *single* source colors the map — never all collectively — and swaps the listing table to match.

- **Sources:** TEvo · SeatGeek · StubHub · GameTime · VividSeats. **TP excluded** (zone-only granularity), **TM excluded** (no section-level resale for these events).
- Each source fetches by **tevo event_id** (every RPC resolves the cross-source bridge server-side): `get_event_evo_listings_full`, `get_event_sg_listings_full`, `get_event_td_listings(p_platform)`. Rows normalized to a common shape; prices use each source's all-in field.
- Source switch re-colors via `updateTicketGroups()` (no SVG rebuild) — instant; rows cached per source.
- Background-probes the other sources to show **per-source counts** and disable sources with no listings for the event.

## Mapping coverage (investigated per your ask)

All resale sources use the same MSG numeric section vocabulary, so the existing manifest tail-remap covers them:

| Source | distinct sections | maps to seat map |
|---|---|---|
| GameTime | 70 | 100% |
| VividSeats | 77 | 99% |
| StubHub | 85 | ~90% |
| SeatGeek | 78 | ~95%* |

\* The only non-mapping residue is **inherently zone-level** (`lower level`, `100 Level`, `Club Gold`, generic "fan"/"signature" buckets) — aggregate listings with no single seat shape. They still show in the listing table but can't color a section. Matching against the full 212-key manifest (not just TEvo's inventory) catches all the numbered sections.

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_