### PR TITLE
feat(d0/event): uniform per-source listing metrics (Min/P90/Tickets for all sources)

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -3786,6 +3786,15 @@
     if (body) body.innerHTML = '<div class="empty">loading cross-source metrics…</div>';
     if (meta) meta.textContent = 'loading…';
     const t0 = performance.now();
+    // Preferred: uniform per-source distribution computed on the fly for EVERY source
+    // (mig 20260603120000). Falls back to the legacy TEvo/SG panel until A1 applies it,
+    // so this is deploy-safe before the migration lands.
+    const resU = await rpcOrNull('get_event_all_source_listing_metrics', { p_event_id: eventId });
+    if (!resU.error && resU.data && Array.isArray(resU.data.sources) && resU.data.sources.length) {
+      renderAllSourceMetrics(resU.data, performance.now() - t0);
+      return;
+    }
+    // Legacy fallback (sets _lastCrossSource so the TD-snapshot / v3 re-render hooks work).
     const res = await rpcOrNull('get_event_cross_source_metrics', { p_event_id: eventId });
     if (res.error) {
       if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
@@ -3793,6 +3802,42 @@
       return;
     }
     renderCrossSourceMetrics(res.data || {}, performance.now() - t0);
+  }
+
+  // Uniform multi-source distribution table (mig 20260603120000): one consistent
+  // methodology for every source (TEvo · SG · SH · GT · VD · TP · TM) — listings,
+  // tickets, min, median, p90, owned median — computed live from each firehose's
+  // latest batch. Metric rows × source columns; null cells render "—".
+  function renderAllSourceMetrics(d, ms) {
+    const body = document.getElementById('crossSourceBody');
+    const meta = document.getElementById('crossSourceMeta');
+    if (!body) return;
+    const sources = (d && d.sources) || [];
+    if (meta) {
+      meta.textContent = (d && d.sg_event_id != null ? `sg_event_id ${d.sg_event_id} · ` : '')
+        + `all-source live distribution${ms != null ? ` · ${ms.toFixed(0)}ms` : ''}`;
+    }
+    const METRICS = [
+      { label: 'Listings count',    key: 'listings',     money: false },
+      { label: 'Tickets available', key: 'tickets',      money: false },
+      { label: 'Min price',         key: 'min',          money: true },
+      { label: 'Median price',      key: 'median',       money: true },
+      { label: 'P90 price',         key: 'p90',          money: true },
+      { label: 'Owned median',      key: 'owned_median', money: true },
+    ];
+    const fmt = (v, money) => (v == null ? '—' : (money ? '$' + T.fmtNum(Math.round(v)) : T.fmtNum(v)));
+    const tbl = document.createElement('table');
+    tbl.className = 'cross-src-tbl';
+    tbl.innerHTML = `<thead><tr><th>Metric</th>${sources.map(s => `<th class="num">${escapeHtml(s.label || s.key)}</th>`).join('')}</tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    METRICS.forEach(m => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${escapeHtml(m.label)}</td>`
+        + sources.map(s => `<td class="num">${fmt(s[m.key], m.money)}</td>`).join('');
+      tb.appendChild(tr);
+    });
+    body.innerHTML = '';
+    body.appendChild(tbl);
   }
 
   // Cache the last cross-source payload + overrides so we can re-render when v3

--- a/supabase/migrations/20260603120000_get_event_all_source_listing_metrics.sql
+++ b/supabase/migrations/20260603120000_get_event_all_source_listing_metrics.sql
@@ -1,0 +1,118 @@
+-- Migration 20260603120000 · lane:D0 (author) → A1 (apply) · writes:get_event_all_source_listing_metrics · reads:listings_snapshots,seatgeek_listings_snapshots,ticketsdata_listings_snapshots,seatgeek_event_xref,aq_event_map,ticketsdata_event_xref · pre:20260527140000 · auth:operator-approved 2026-06-03
+--
+-- D0 — uniform per-source listing distribution for the event Overview
+-- CROSS-SOURCE panel. The prior panel (get_event_cross_source_metrics)
+-- reads PRECOMPUTED metric tables (event_metrics / seatgeek_event_metrics),
+-- which only TEvo + SG populate — so SH/GT/VD/TP/TM showed blank Min/P90/Tickets.
+--
+-- This RPC computes the SAME distribution for EVERY source on the fly from the
+-- raw firehoses, so the table is fully populated with one consistent methodology:
+--   listings · tickets (Σqty) · min · median · p90 · owned_median
+--
+-- Window: the latest collection batch per source (rows within 30 min of that
+-- source's max(captured_at) for the event) — i.e. the current book, deduped to
+-- one poll cycle (never count(*) across the whole firehose: PROJECT_BIBLE §3).
+-- Non-parking listings, price > 0. Prices are all-in where the source has it
+-- (SG retail_price_all_in, TD price_with_fees); TEvo uses retail_price.
+--
+-- Bridge resolution (all from the tevo event id, server-side):
+--   SG  → seatgeek_event_xref.sg_event_id
+--   TD  → aq_event_map.aq_short_event_id → ticketsdata_event_xref(platform,event_id)
+--
+-- Return shape (FE renders a metric-rows × source-cols table; all 7 sources
+-- always present in fixed order, null cells where a source has no book):
+--   { event_id, sources:[ {key,label,listings,tickets,min,median,p90,owned_median}, … ] }
+
+CREATE OR REPLACE FUNCTION public.get_event_all_source_listing_metrics(p_event_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sg_event_id bigint;
+  v_result      jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  WITH
+  tevo_mx AS (SELECT max(captured_at) mx FROM public.listings_snapshots WHERE event_id = p_event_id),
+  tevo AS (
+    SELECT retail_price::numeric AS p, quantity AS q, is_owned AS owned
+    FROM public.listings_snapshots, tevo_mx
+    WHERE event_id = p_event_id AND tevo_mx.mx IS NOT NULL
+      AND captured_at >= tevo_mx.mx - interval '30 min'
+      AND section !~* 'parking|garage|lot' AND retail_price > 0
+  ),
+  sg_mx AS (SELECT max(captured_at) mx FROM public.seatgeek_listings_snapshots WHERE sg_event_id = v_sg_event_id),
+  sg AS (
+    SELECT retail_price_all_in::numeric AS p, quantity AS q, is_broker_owned AS owned
+    FROM public.seatgeek_listings_snapshots, sg_mx
+    WHERE sg_event_id = v_sg_event_id AND sg_mx.mx IS NOT NULL
+      AND captured_at >= sg_mx.mx - interval '30 min'
+      AND section !~* 'parking|garage|lot' AND retail_price_all_in > 0
+  ),
+  td AS (
+    SELECT lower(x.platform) AS plat, s.price_with_fees::numeric AS p, s.quantity AS q
+    FROM public.aq_event_map a
+    JOIN public.ticketsdata_event_xref x ON x.aq_short_event_id = a.aq_short_event_id
+    JOIN LATERAL (
+      SELECT max(captured_at) mx FROM public.ticketsdata_listings_snapshots
+      WHERE platform = x.platform AND event_id = x.event_id
+    ) m ON true
+    JOIN public.ticketsdata_listings_snapshots s
+      ON s.platform = x.platform AND s.event_id = x.event_id
+     AND s.captured_at >= m.mx - interval '30 min'
+    WHERE a.tevo_event_id = p_event_id
+      AND s.section !~* 'parking|garage|lot' AND s.price_with_fees > 0
+  ),
+  allrows AS (
+    SELECT 'tevo' AS src, p, q, owned FROM tevo
+    UNION ALL SELECT 'sg', p, q, owned FROM sg
+    UNION ALL SELECT plat, p, q, NULL::boolean FROM td
+  ),
+  agg AS (
+    SELECT src,
+      count(*)::int                                                    AS listings,
+      sum(q)::bigint                                                   AS tickets,
+      min(p)                                                           AS mn,
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY p)                   AS med,
+      percentile_cont(0.9) WITHIN GROUP (ORDER BY p)                   AS p90,
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY (CASE WHEN owned THEN p END)) AS owned_med
+    FROM allrows GROUP BY src
+  )
+  SELECT jsonb_build_object(
+    'event_id',    p_event_id,
+    'sg_event_id', v_sg_event_id,
+    'sources',
+      jsonb_agg(
+        jsonb_build_object(
+          'key',          o.k,
+          'label',        o.lbl,
+          'listings',     a.listings,
+          'tickets',      a.tickets,
+          'min',          round(a.mn),
+          'median',       round(a.med),
+          'p90',          round(a.p90),
+          'owned_median', round(a.owned_med)
+        ) ORDER BY o.ord)
+  )
+  INTO v_result
+  FROM (VALUES
+    ('tevo','TEvo',1),('sg','SG',2),('sh','SH',3),('gt','GT',4),
+    ('vd','VD',5),('tp','TP',6),('tm','TM',7)
+  ) o(k, lbl, ord)
+  LEFT JOIN agg a ON a.src = o.k;
+
+  RETURN coalesce(v_result, jsonb_build_object('event_id', p_event_id, 'sources', '[]'::jsonb));
+END
+$func$;
+
+REVOKE ALL ON FUNCTION public.get_event_all_source_listing_metrics(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_all_source_listing_metrics(integer) TO anon, authenticated;


### PR DESCRIPTION
## What

Fills the "empty by design" cells in the Overview **CROSS-SOURCE → Listings / Price** table — **Min, Median, P90, Tickets for *every* source** (TEvo · SG · SH · GT · VD · TP · TM), computed with one uniform methodology.

## Why they were empty

The legacy panel reads **precomputed** metric tables (`event_metrics` / `seatgeek_event_metrics`) that only TEvo + SG populate; TD platforms only had listings/median in `event_listing_snapshot_daily`. So SH/GT/VD/TP/TM showed blank Min/P90/Tickets.

## How

**New RPC `get_event_all_source_listing_metrics(p_event_id)`** (migration `20260603120000`, **lane: D0 author → A1 apply**) computes the distribution **on the fly from the raw firehoses** for all sources: `listings · tickets(Σqty) · min · median · p90 · owned_median`, over each source's **latest collection batch** (30-min window of its `max(captured_at)`, non-parking, price>0, all-in price where available). Bridges resolve server-side (SG via `seatgeek_event_xref`; TD via `aq_event_map → ticketsdata_event_xref`). Never `count(*)` across the firehose (PROJECT_BIBLE §3).

Validated on event 3091423 — all 7 sources populated:

| Source | Listings | Tickets | Min | Median | P90 | Owned med |
|---|---|---|---|---|---|---|
| TEvo | 442 | 1,950 | $25 | $134 | $993 | $123 |
| SG | 607 | 3,475 | $45 | $135 | $3,657 | $84 |
| SH | 3,526 | 21,473 | $41 | $170 | $330 | — |
| GT | 289 | 1,178 | $48 | $139 | $334 | — |
| VD | 844 | 3,617 | $42 | $161 | $654 | — |
| TP | 799 | 3,402 | $56 | $496 | $1,290 | — |
| TM | 247 | 4,984 | $42 | $140 | $347 | — |

## FE

`renderAllSourceMetrics` draws a uniform metric-rows × source-cols table (reuses existing `.cross-src-tbl` styling). **Deploy-safe**: tries the new RPC, falls back to the legacy TEvo/SG panel until A1 applies the migration; the new path doesn't set `_lastCrossSource`, so the legacy TD-snapshot/v3 re-render hooks no-op and can't clobber it.

## Notes
- **Migration needs A1 to apply** (D0 has no apply authority, bible §6). Until then the panel shows the legacy view; it upgrades automatically once applied.
- Realized-sale-median (a *sales* metric) intentionally stays out of this listings-distribution table; the Sales/Velocity sub-table is unchanged.
- Separate, still-open: the slot-ordering bug in `loadTdFreshness` (picks the `morning` partial slot) — that's a different fix.

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_