### PR TITLE
fix(d0/event): zone-aware section matcher (Dodger + baseball venues)

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2877,18 +2877,36 @@
   function _smNorm(s) {
     return String(s == null ? '' : s).toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
   }
-  // Parse a section/key → { num (leading-zeros stripped), suf (≤3-letter suffix), fam (family tokens) }.
+  // Zone abbreviations brokers glue to a section number (esp. baseball): the manifest
+  // spells these out as family words, so we expand them to align. Multi-token where a
+  // level spans sub-families (Dodger field = Field Box / Infield Box / Preferred Field —
+  // all carry "field" or "box"). Venue-agnostic: an expansion only helps when that
+  // venue's manifest actually has the family; otherwise it's a harmless no-op.
+  const SEATMAP_ZONES = {
+    fd: 'field box', rs: 'reserve', lg: 'loge box', td: 'top deck',
+    dg: 'dugout', pl: 'pavilion', pr: 'pavilion', bl: 'baseline', mvp: 'mvp',
+  };
+  // Parse a section/key → { num (leading-zeros stripped), suf (sub-section letter), fam }.
+  // num = the section number; suf = a single A-H sub-section letter glued to the number
+  // (Yankee "117A"≠"117B"); fam = remaining words with zone codes expanded and generic
+  // markers (sec/section/ga) dropped. A trailing zone code (e.g. "12FD"→field) is treated
+  // as FAMILY, not a suffix — distinguished from a real suffix by "<digit><single a-h>$".
   function _smParse(s) {
     const n = _smNorm(s);
-    const m = n.match(/(\d+)\s*([a-z]{0,3})\s*$/);
-    if (!m) return { num: null, suf: '', fam: n };
-    const num = String(parseInt(m[1], 10));   // "014" → "14"
-    const suf = m[2] || '';
-    const fam = n.slice(0, m.index)
-      .replace(/\b(sec|section|ga)\b/g, ' ')   // generic bowl markers carry no family
-      .replace(/\bclubhouse\b/g, 'club house') // align broker abbrev → manifest vocab
-      .replace(/\s+/g, ' ').trim();
-    return { num, suf, fam };
+    const numM = n.match(/\d+/);
+    if (!numM) return { num: null, suf: '', fam: n };
+    const num = String(parseInt(numM[0], 10));      // first digit run; "014" → "14"
+    const sufM = n.match(/\d([a-h])$/);             // digit directly + one a-h letter = sub-section
+    const suf = sufM ? sufM[1] : '';
+    const nf = suf ? n.replace(/([a-h])$/, '') : n;
+    const fam = [];
+    (nf.match(/[a-z]+/g) || []).forEach(t => {
+      if (SEATMAP_ZONES[t]) fam.push(...SEATMAP_ZONES[t].split(' '));
+      else if (t === 'clubhouse') fam.push('club', 'house');
+      else if (/^(sec|section|ga)$/.test(t)) { /* generic — carries no family */ }
+      else fam.push(t);
+    });
+    return { num, suf, fam: fam.join(' ') };
   }
 
   // Build the per-venue manifest index (cached). Returns { byNumSuf, byNum, cache } or null.


### PR DESCRIPTION
## What

Extends the section→manifest matcher to handle **zone-coded** venues (esp. baseball), fixing the Dodger Stadium mapping issue.

## Problem

Dodger sections are `<number><zone-code>` (`12FD`, `102LG`, `305PL`, `10DG`), but the manifest spells zones out as **family words** (`Field Box 12`, `Loge Box 102`, `Left Field Pavilion 305`, `Dugout Club 10`). The matcher parsed the zone code as a *suffix*, so it never matched → almost nothing colored.

## Fix

- **Zone expansion**: `FD`→`field box`, `RS`→`reserve`, `LG`→`loge box`, `TD`→`top deck`, `DG`→`dugout`, `PL`/`PR`→`pavilion`, `BL`→`baseline`, `MVP`→`mvp`. Multi-token where a level spans sub-families (Dodger field = `Field Box` 1-25 / `Infield Box` 26-39 / `Preferred Field` 40-53 — all carry `field`/`box`). The number then disambiguates which family. **Venue-agnostic**: an expansion only helps when that manifest has the family; otherwise a no-op.
- **Parser rewrite**: `num` = first digit run (leading-zeros stripped); a real sub-section suffix (`117A`≠`117B`) is detected *only* as `<digit><single a-h>$`, so a trailing 2-letter zone (`12FD`) is treated as **family**, not suffix. Tiers unchanged (exact num+suf → num-only → family align → bowl default → grey).

## Validation (Node, real manifests + listings)

| Venue | Result |
|---|---|
| **Dodger EVO** | **81/82 = 99%** (only `GA-3` GA/standing unmatched) |
| **Dodger SG** | ~98% vs full manifest (uniform `num zone` — maps cleaner than EVO, confirming the SG>EVO observation) |
| loanDepot | 100% of mappable (unchanged) |
| Yankee (numeric+suffix) | 100% (no regression) |

Sample: `12FD→Field Box 12 · 102LG→Loge Box 102 · 305PL→Left Field Pavilion 305 · 5TD→Top Deck 5 · 26BL→Baseline Club 26`.

Note: confirmed SG section text is more uniform than EVO's broker free-text — a follow-up could default the map's coloring source to SG (or auto-pick the best-matching source per event).

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_