### PR TITLE
fix(d0/event): middle/mezzanine + floor-GA zone aliases (Little Caesars)

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2910,6 +2910,11 @@
   const SEATMAP_ZONES = {
     fd: 'field box', rs: 'reserve', lg: 'loge box', td: 'top deck',
     dg: 'dugout', pl: 'pavilion', pr: 'pavilion', bl: 'baseline', mvp: 'mvp',
+    // middle level: brokers/SG call it M / Mezz / Mezzanine, the manifest may say
+    // "Middle" OR "Mezzanine" — expand to both tokens so either naming matches.
+    m: 'middle mezzanine', mez: 'middle mezzanine', mezz: 'middle mezzanine',
+    mezzanine: 'middle mezzanine', drm: 'middle mezzanine',
+    flga: 'floor', flrga: 'floor',  // floor-GA codes → the Floor family
   };
   // Parse a section/key → { num (leading-zeros stripped), suf (sub-section letter), fam }.
   // num = the section number; suf = a single A-H sub-section letter glued to the number


### PR DESCRIPTION
## What

Fixes Little Caesars Arena (concert "End Stage"). Its manifest names the middle level **`Middle 1-34`** (no "Mezzanine"), but brokers write `M7` and SeatGeek writes `mezzanine 7` — both collided with `Floor 7` and went unmatched.

## Fix

Zone aliases so either naming resolves (expansion only helps when that manifest has the family — venue-agnostic):
- `m` / `mez` / `mezz` / `mezzanine` / `drm` → `middle mezzanine` (matches a manifest that says **Middle OR Mezzanine**)
- `flga` / `flrga` → `floor` (floor-GA codes)

## Validation (Node, real manifest)

| | Result |
|---|---|
| Little Caesars EVO | **50/53 = 94%** |
| Little Caesars SG | **46/47 = 98%** |
| Mohegan / loanDepot / Dodger / Yankee | unchanged (no regression) |

Remaining misses are genuinely unmappable: `FLOOR`/`ga floor` (whole-floor GA, no single shape) and `Suite 44` (no suite shape in this manifest).

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_