### PR TITLE
feat(d0/event): hide Seat Map tab when no map + filter broker street-addresses

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -115,6 +115,7 @@
     // fetchPayload (Path A / Path C v3) fails. PR #205 cross-source +
     // PR redesign localized weather + SG zones/splits all independent.
     loadCrossSourceMetrics(eventId).catch(e => console.error('[crossSource]', e));
+    loadSeatmapTabVisibility(eventId).catch(e => console.error('[seatmapTab]', e));
     loadWeatherLocalized(eventId).catch(e => console.error('[weatherLocalized]', e));
     loadSgZonesSplits(eventId).catch(e => console.error('[sgZonesSplits]', e));
     loadCrossPlatformSales(eventId).catch(e => console.error('[crossSales]', e));
@@ -2884,8 +2885,14 @@
 
   // Parking / non-seated pseudo-sections never match an SVG path (bible §3 parking
   // skip) — drop them so the legend's price scale isn't skewed by $30 parking spots.
+  // Brokers also list off-site lots as STREET ADDRESSES ("1440 W Washington Blvd",
+  // "1 Light St", "2121 S. Towne Center Pl") — number-first + a street suffix. Filter
+  // those too (a real section like "Terrace 12" has the number LAST, so it's safe).
   function _seatmapIsParking(section) {
-    return /parking|garage|valet|\blot\b|min walk|mi from venue|shuttle|tailgate/i.test(section || '');
+    const s = section || '';
+    if (/parking|garage|valet|\blot\b|min walk|mi from venue|shuttle|tailgate/i.test(s)) return true;
+    if (/^\s*\d[\d\s.,/&–-]*\s+\S.*\b(st|street|ave|avenue|blvd|boulevard|dr|drive|rd|road|pkwy|parkway|hwy|highway|ln|lane|ct|court|pl|place|plz|plaza|cir|circle|way)\b\.?/i.test(s)) return true;
+    return false;
   }
 
   // ----- Section → manifest matcher (venue-agnostic; manifest drives everything) -----
@@ -3032,6 +3039,27 @@
       if (prev == null || price < prev) floorByKey.set(key, price);
     });
     return Array.from(floorByKey, ([key, price]) => ({ tevo_section_name: key, retail_price: price }));
+  }
+
+  // Hide the Seat Map tab when the venue/config is known to have NO interactive map
+  // (seatmap_manifest.has_map=false, populated by the seatmap-manifest-sync cron).
+  // Conservative: only hides on a definitive negative — if the config isn't synced
+  // yet (no row), the tab stays and the runtime fetch decides.
+  async function loadSeatmapTabVisibility(eventId) {
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client) return;
+    const ev = await Auth.client.from('events')
+      .select('venue_id, configuration_id').eq('id', eventId).maybeSingle();
+    if (ev.error || !ev.data || ev.data.venue_id == null || ev.data.configuration_id == null) return;
+    const mr = await Auth.client.from('seatmap_manifest')
+      .select('has_map')
+      .eq('venue_id', ev.data.venue_id)
+      .eq('configuration_id', ev.data.configuration_id)
+      .maybeSingle();
+    if (!mr.error && mr.data && mr.data.has_map === false) {
+      const btn = document.querySelector('.event-tab[data-tab="seatmap"]');
+      if (btn) btn.style.display = 'none';
+    }
   }
 
   async function loadSeatmap(eventId) {

--- a/supabase/migrations/20260603170000_seatmap_manifest_s4kent_read.sql
+++ b/supabase/migrations/20260603170000_seatmap_manifest_s4kent_read.sql
@@ -1,0 +1,15 @@
+-- Migration 20260603170000 · lane:D0 (author) → operator-authorized apply 2026-06-03 · writes:seatmap_manifest RLS policy · reads:—
+--
+-- ## Already applied to prod — applied via MCP apply_migration 2026-06-03 (operator-authorized).
+--
+-- Lets the @s4kent terminal (authenticated, email-gated) read public.seatmap_manifest
+-- so the FE can hide the Seat Map tab on events whose venue/config has no map
+-- (has_map=false). Section names are non-sensitive; the email gate keeps it to the
+-- broker terminal, not any authenticated user. service_role (the sync edge fn) is
+-- unaffected (bypasses RLS).
+
+grant select on public.seatmap_manifest to authenticated;
+drop policy if exists seatmap_manifest_s4kent_read on public.seatmap_manifest;
+create policy seatmap_manifest_s4kent_read on public.seatmap_manifest
+  for select to authenticated
+  using ((auth.jwt() ->> 'email') like '%@s4kent.com');


### PR DESCRIPTION
## What

From the **mapping audit** (run against the new `seatmap_manifest` cache) across **MLB / MLS / NFL** and **NBA/NHL-arena concerts** — plus the two requested deliverables (street-address filter + `has_map` tab-hide).

## Audit result (reassuring)

Every category maps well — by a *strict number-only* proxy (which **under**counts, since it doesn't credit the name tier):

| Category | Sample venues | Proxy match |
|---|---|---|
| MLB | Angel Stadium, Oakland, American Family | 89–91% |
| MLS | Levi's, Yankee-NYCFC, M&T Bank | 83–100% |
| NFL | SoFi, AT&T (Cowboys), Northwest | 96–100% |
| NBA-arena concerts | United Center (PIT, Ariana, Rosalia…) | 89–96% |

The matcher (numeric / suffix / family / zone / name tiers) is solid across archetypes. The **one cross-cutting noise**: brokers list off-site parking lots as **street addresses** (`1440 W Washington Blvd`, `1 Light St`, `2121 S. Towne Center Pl`) — number-first + a street suffix — which slipped the parking filter and polluted the section list at every venue.

## Changes

1. **Street-address filter** — `_seatmapIsParking` now drops number-first addresses (`st/ave/blvd/dr/rd/pkwy/ln/ct/pl/cir/way`…). Safe vs real sections: `Terrace 12` has the number *last*, so it isn't matched. Node-checked: all 6 audit addresses filtered, all real sections (incl. `Terrace 12`) kept.
2. **Hide Seat Map tab when no map** (part c) — reads `seatmap_manifest.has_map`; hides only on a definitive negative (unsynced configs keep the tab). Needs the new **@s4kent read policy** on `seatmap_manifest` (mig `20260603170000`, applied operator-authorized).

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_