### PR TITLE
fix(d0/event): filter number+direction addresses (MLB 30-team audit)

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2892,6 +2892,9 @@
     const s = section || '';
     if (/parking|garage|valet|\blot\b|min walk|mi from venue|shuttle|tailgate/i.test(s)) return true;
     if (/^\s*\d[\d\s.,/&–-]*\s+\S.*\b(st|street|ave|avenue|blvd|boulevard|dr|drive|rd|road|pkwy|parkway|hwy|highway|ln|lane|ct|court|pl|place|plz|plaza|cir|circle|way)\b\.?/i.test(s)) return true;
+    // number + compass direction + word = a street address even without a street suffix
+    // ("840 N. Broadway", "61 E Elizabeth", "516 N. 2nd Ave"). Real sections aren't shaped this way.
+    if (/^\s*\d+\s+[nsew]\b\.?\s+[a-z0-9]/i.test(s)) return true;
     return false;
   }
 


### PR DESCRIPTION
## What

Audited **one upcoming event per MLB team (all 30 parks)** against the `seatmap_manifest` cache.

## Result: healthy across the league

**No numbered seated section fails at any park.** The strict number-only proxy scored 63–100%, but the entire gap is things the app already handles or that have no map shape:
- **Parking lots** (`LOT B`, `MLK LOT`) — filtered in-app via `\blot\b`.
- **GA / named** (`GA`, `SRO`, `Bleacher`, `Delta Deck`) — mapped in-app by the name tier (proxy doesn't credit it).
- **Street addresses** — mostly filtered; a few slipped when they had **no street suffix**.
- **Cryptic broker codes** (`DMNDN`, `BDELTA`, `DCBOXD`) — unmappable shorthand.

## Fix

Add a **number+direction** address rule to `_seatmapIsParking` for the no-suffix slip-throughs (`840 N. Broadway`, `61 E Elizabeth`, `516 N. 2nd Ave`). Node-checked: catches them; real sections (`Field Box 12`, `Terrace 12`, `305PL`, `Upper 209`, …) stay.

This whole 30-team audit ran with **zero manual manifest pasting** — straight off the `seatmap_manifest` cache.

https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab

---
_Generated by [Claude Code](https://claude.ai/code/session_017VeZ4HYtU3VvZpYiB955ab)_