### PR TITLE
feat(terminal): user alert subscriptions — Alerts tab (event/performer/venue)

### DIFF
--- a/static/terminal/alerts.js
+++ b/static/terminal/alerts.js
@@ -1,0 +1,251 @@
+// alerts.js — shared "Alerts" tab module for the D0 terminal.
+// Mounted by event.js / performer.js / venue.js on first activation of their
+// Alerts tab. One subscription = one trigger on this scope. The trigger picker
+// is data-driven from get_alert_metric_catalog() so any tracked dataset the
+// backend exposes becomes alertable with no FE change.
+//
+// Backend: mig 20260603180000 (get_alert_metric_catalog / list_user_alerts /
+// create_user_alert / set_user_alert_active / delete_user_alert). Phase 1 =
+// create/manage only; delivery (Phase 2) is gated.
+(function () {
+  'use strict';
+
+  const OPERATOR_LABELS = {
+    drop_pct:     'drops by',
+    rise_pct:     'rises by',
+    below:        'falls below',
+    above:        'rises above',
+    available:    'becomes available',
+    any_change:   'changes',
+    crosses_into: 'triggers',
+  };
+  const COOLDOWNS = [
+    [15, '15 min'], [60, '1 hour'], [360, '6 hours'], [720, '12 hours'], [1440, '24 hours'],
+  ];
+  const needsThreshold = (op) => ['drop_pct', 'rise_pct', 'below', 'above'].includes(op);
+  const PARAM_LABEL = { zone: 'Zone', section: 'Section', city: 'City' };
+
+  function rpc(name, args) {
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken || !Auth.getAccessToken()) {
+      return Promise.resolve({ error: { message: 'sign in to use alerts (no auth in localhost dev)' } });
+    }
+    return Auth.client.rpc(name, args);
+  }
+
+  function el(tag, attrs, ...kids) {
+    const n = document.createElement(tag);
+    if (attrs) for (const k in attrs) {
+      if (k === 'class') n.className = attrs[k];
+      else if (k === 'text') n.textContent = attrs[k];
+      else if (k.startsWith('on') && typeof attrs[k] === 'function') n.addEventListener(k.slice(2), attrs[k]);
+      else if (attrs[k] != null) n.setAttribute(k, attrs[k]);
+    }
+    for (const kid of kids) if (kid != null) n.append(kid.nodeType ? kid : document.createTextNode(kid));
+    return n;
+  }
+
+  function unitFor(metric, op) {
+    if (op === 'drop_pct' || op === 'rise_pct') return '%';
+    return metric.threshold_unit || '';
+  }
+
+  function alertSummary(a, catalog) {
+    const m = catalog[a.metric_key];
+    const label = m ? m.label : a.metric_key;
+    const opLabel = OPERATOR_LABELS[a.operator] || a.operator;
+    let s = `${label} ${opLabel}`;
+    if (needsThreshold(a.operator) && a.threshold != null) {
+      const unit = unitFor(m || {}, a.operator);
+      if (unit === '$') s += ` $${a.threshold}`;
+      else if (unit === '%') s += ` ${a.threshold}%`;
+      else s += unit ? ` ${a.threshold} ${unit}` : ` ${a.threshold}`;
+    }
+    const pk = m && m.param_kind;
+    if (pk && a.params && a.params[pk]) s += ` (${PARAM_LABEL[pk] || pk}: ${a.params[pk]})`;
+    const chans = (a.channels || []).join(' + ');
+    const cd = (COOLDOWNS.find((c) => c[0] === a.cooldown_minutes) || [null, `${a.cooldown_minutes}m`])[1];
+    return `${s} · ${chans} · every ${cd}`;
+  }
+
+  // ---- create form -----------------------------------------------------------
+  function buildForm(ctx, metrics, onCreated) {
+    const byKey = ctx.catalog;
+
+    const metricSel = el('select', { class: 'alert-input', id: ctx.uid('metric') });
+    metrics.forEach((m) => metricSel.append(el('option', { value: m.metric_key }, m.label)));
+
+    const opSel        = el('select', { class: 'alert-input', id: ctx.uid('op') });
+    const thrWrap      = el('label', { class: 'alert-field', hidden: '' });
+    const thrInput     = el('input', { class: 'alert-input', type: 'number', step: 'any', min: '0', placeholder: '0' });
+    const thrUnit      = el('span', { class: 'alert-unit muted' });
+    thrWrap.append(el('span', { class: 'alert-flabel', text: 'Threshold' }), el('span', { class: 'row' }, thrInput, thrUnit));
+
+    const paramWrap    = el('label', { class: 'alert-field', hidden: '' });
+    const paramInput   = el('input', { class: 'alert-input', type: 'text', placeholder: '' });
+    const paramLabel   = el('span', { class: 'alert-flabel' });
+    paramWrap.append(paramLabel, paramInput);
+
+    function syncMetric() {
+      const m = byKey[metricSel.value];
+      opSel.innerHTML = '';
+      (m.allowed_operators || []).forEach((op) =>
+        opSel.append(el('option', { value: op }, OPERATOR_LABELS[op] || op)));
+      opSel.value = m.default_operator && m.allowed_operators.includes(m.default_operator)
+        ? m.default_operator : (m.allowed_operators[0] || '');
+      // param field
+      if (m.param_kind) {
+        paramWrap.hidden = false;
+        paramLabel.textContent = PARAM_LABEL[m.param_kind] || m.param_kind;
+        paramInput.placeholder = m.param_kind === 'city' ? 'e.g. New York' : 'e.g. 100 Level';
+      } else { paramWrap.hidden = true; paramInput.value = ''; }
+      syncOp();
+    }
+    function syncOp() {
+      const m = byKey[metricSel.value];
+      const op = opSel.value;
+      if (needsThreshold(op)) {
+        thrWrap.hidden = false;
+        const u = unitFor(m, op);
+        thrUnit.textContent = u;
+        thrInput.placeholder = (op === 'drop_pct' || op === 'rise_pct') ? '15' : '';
+      } else { thrWrap.hidden = true; thrInput.value = ''; }
+    }
+    metricSel.addEventListener('change', syncMetric);
+    opSel.addEventListener('change', syncOp);
+
+    // channels
+    const prefillEmail = (window.TerminalAuth && window.TerminalAuth.user && window.TerminalAuth.user.email) || '';
+    const emailCb   = el('input', { type: 'checkbox', checked: '' });
+    const emailIn   = el('input', { class: 'alert-input', type: 'email', placeholder: 'you@example.com', value: prefillEmail });
+    const smsCb     = el('input', { type: 'checkbox' });
+    const smsIn     = el('input', { class: 'alert-input', type: 'tel', placeholder: '+1 555 123 4567', hidden: '' });
+    smsCb.addEventListener('change', () => { smsIn.hidden = !smsCb.checked; });
+    emailCb.addEventListener('change', () => { emailIn.hidden = !emailCb.checked; });
+
+    const cdSel = el('select', { class: 'alert-input' });
+    COOLDOWNS.forEach(([v, lbl]) => cdSel.append(el('option', { value: v }, lbl)));
+    cdSel.value = '720';
+
+    const err = el('div', { class: 'alert-err', hidden: '' });
+    const createBtn = el('button', { class: 'alert-btn', type: 'button' }, 'Create alert');
+
+    createBtn.addEventListener('click', async () => {
+      err.hidden = true;
+      const m = byKey[metricSel.value];
+      const op = opSel.value;
+      const channels = [];
+      if (emailCb.checked) channels.push('email');
+      if (smsCb.checked) channels.push('sms');
+      if (!channels.length) { err.hidden = false; err.textContent = 'Pick at least one channel.'; return; }
+      const params = {};
+      if (m.param_kind && paramInput.value.trim()) params[m.param_kind] = paramInput.value.trim();
+      createBtn.disabled = true; createBtn.textContent = 'Creating…';
+      const res = await rpc('create_user_alert', {
+        p_scope_type: ctx.scopeType,
+        p_scope_id: ctx.scopeId,
+        p_metric_key: m.metric_key,
+        p_operator: op,
+        p_threshold: needsThreshold(op) && thrInput.value !== '' ? Number(thrInput.value) : null,
+        p_params: params,
+        p_channels: channels,
+        p_notify_email: emailCb.checked ? emailIn.value.trim() : null,
+        p_notify_phone: smsCb.checked ? smsIn.value.trim() : null,
+        p_cooldown_minutes: Number(cdSel.value),
+        p_scope_label: ctx.scopeLabel || null,
+      });
+      createBtn.disabled = false; createBtn.textContent = 'Create alert';
+      if (res.error) { err.hidden = false; err.textContent = res.error.message || 'Could not create alert.'; return; }
+      onCreated(res.data);
+    });
+
+    syncMetric();
+
+    const fields = el('div', { class: 'alert-form-grid' },
+      el('label', { class: 'alert-field' }, el('span', { class: 'alert-flabel', text: 'Alert me when' }), metricSel),
+      el('label', { class: 'alert-field' }, el('span', { class: 'alert-flabel', text: 'Condition' }), opSel),
+      thrWrap,
+      paramWrap,
+      el('div', { class: 'alert-field' },
+        el('span', { class: 'alert-flabel', text: 'Notify via' }),
+        el('div', { class: 'alert-channels' },
+          el('label', { class: 'alert-chan' }, emailCb, ' Email'), emailIn,
+          el('label', { class: 'alert-chan' }, smsCb, ' SMS'), smsIn)),
+      el('label', { class: 'alert-field' }, el('span', { class: 'alert-flabel', text: 'At most once per' }), cdSel),
+    );
+    return el('div', { class: 'alert-create' },
+      el('div', { class: 'panel-title', text: 'CREATE ALERT' }), fields, err, createBtn);
+  }
+
+  // ---- existing list ---------------------------------------------------------
+  function renderList(ctx, listEl, alerts) {
+    listEl.innerHTML = '';
+    if (!alerts.length) {
+      listEl.append(el('div', { class: 'empty', text: 'No alerts yet for this ' + ctx.scopeType + '.' }));
+      return;
+    }
+    alerts.forEach((a) => listEl.append(rowFor(ctx, a)));
+  }
+  function rowFor(ctx, a) {
+    const summary = el('span', { class: 'alert-row-summary' + (a.active ? '' : ' off') }, alertSummary(a, ctx.catalog));
+    const toggle = el('button', { class: 'alert-mini', type: 'button' }, a.active ? 'Pause' : 'Resume');
+    const del    = el('button', { class: 'alert-mini danger', type: 'button' }, 'Delete');
+    const row = el('div', { class: 'alert-row' }, summary, el('span', { class: 'alert-row-actions' }, toggle, del));
+    toggle.addEventListener('click', async () => {
+      toggle.disabled = true;
+      const res = await rpc('set_user_alert_active', { p_id: a.id, p_active: !a.active });
+      toggle.disabled = false;
+      if (res.error) return;
+      a.active = res.data.active;
+      summary.classList.toggle('off', !a.active);
+      toggle.textContent = a.active ? 'Pause' : 'Resume';
+    });
+    del.addEventListener('click', async () => {
+      del.disabled = true;
+      const res = await rpc('delete_user_alert', { p_id: a.id });
+      if (res.error) { del.disabled = false; return; }
+      row.remove();
+    });
+    return row;
+  }
+
+  // ---- public API ------------------------------------------------------------
+  async function mount(scopeType, scopeId, scopeLabel, rootEl) {
+    if (!rootEl || rootEl.__alertsMounted) return;
+    rootEl.__alertsMounted = true;
+    let seq = 0;
+    const ctx = {
+      scopeType, scopeId: Number(scopeId), scopeLabel, catalog: {},
+      uid: (s) => `alrt_${scopeType}_${s}_${++seq}`,
+    };
+    rootEl.innerHTML = '<div class="empty">Loading alerts…</div>';
+
+    const [cat, list] = await Promise.all([
+      rpc('get_alert_metric_catalog', { p_scope_type: scopeType }),
+      rpc('list_user_alerts', { p_scope_type: scopeType, p_scope_id: ctx.scopeId }),
+    ]);
+    if (cat.error) {
+      rootEl.innerHTML = '';
+      rootEl.append(el('div', { class: 'empty', text: cat.error.message || 'Alerts unavailable.' }));
+      rootEl.__alertsMounted = false;
+      return;
+    }
+    const metrics = cat.data || [];
+    metrics.forEach((m) => { ctx.catalog[m.metric_key] = m; });
+
+    const listEl = el('div', { class: 'alert-list' });
+    const form = buildForm(ctx, metrics, (created) => {
+      // prepend the new alert
+      const existing = listEl.querySelector('.empty');
+      if (existing) existing.remove();
+      listEl.prepend(rowFor(ctx, created));
+    });
+
+    rootEl.innerHTML = '';
+    rootEl.append(form, el('div', { class: 'alert-existing' },
+      el('div', { class: 'panel-title', text: 'YOUR ALERTS' }), listEl));
+    renderList(ctx, listEl, (list && list.data) || []);
+  }
+
+  window.TerminalAlerts = { mount };
+})();

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -70,6 +70,8 @@
       <button class="event-tab" data-tab="td-markets" role="tab" aria-selected="false">TD Markets <span class="tab-count" id="tabCountTdMarkets"></span></button>
       <span class="event-tabs-sep" aria-hidden="true">|</span>
       <button class="event-tab" data-tab="our-orders" role="tab" aria-selected="false">Our Orders <span class="tab-count" id="tabCountOurOrders"></span></button>
+      <span class="event-tabs-sep" aria-hidden="true">|</span>
+      <button class="event-tab" data-tab="alerts" role="tab" aria-selected="false">🔔 Alerts <span class="tab-count" id="tabCountAlerts"></span></button>
     </nav>
 
     <div class="tab-pane active" id="paneOverview" role="tabpanel">
@@ -447,6 +449,10 @@
         <div id="seatmapListBody"><div class="empty">—</div></div>
       </section>
     </div>
+
+    <div class="tab-pane" id="paneAlerts" role="tabpanel" hidden>
+      <section class="panel"><div class="alerts-root"><div class="empty">Click the tab to load.</div></div></section>
+    </div>
   </main>
 
   <script src="lib/supabase.js"></script>
@@ -455,6 +461,7 @@
   <script src="auth.js"></script>
   <script src="app.js"></script>
   <script src="nav.js"></script>
+  <script src="alerts.js"></script>
   <script src="event.js"></script>
 </body>
 </html>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -2549,7 +2549,7 @@
     'sg-listings': false, 'evo-listings': false,
     'sh-listings': false, 'gt-listings': false, 'vd-listings': false,
     'tp-listings': false, 'tm-listings': false,
-    'sg-sales': false, 'our-orders': false,
+    'sg-sales': false, 'our-orders': false, 'alerts': false,
   } };
 
   function wireTabs(eventId) {
@@ -2600,6 +2600,10 @@
           loadCrossBrokerFull(eventId),
         ]);
         updateOurOrdersTabCount();
+      } else if (tabId === 'alerts' && !_tabState.loaded['alerts']) {
+        _tabState.loaded['alerts'] = true;
+        const label = document.getElementById('evTitle')?.textContent || '';
+        window.TerminalAlerts?.mount('event', eventId, label, document.querySelector('#paneAlerts .alerts-root'));
       }
     });
   }
@@ -2623,6 +2627,7 @@
       'td-markets':   'paneTdMarkets',
       'seatmap':      'paneSeatmap',
       'our-orders':   'paneOurOrders',
+      'alerts':       'paneAlerts',
     };
     Object.entries(paneIds).forEach(([id, paneId]) => {
       const pane = document.getElementById(paneId);

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -52,6 +52,7 @@
       <button class="event-tab" data-tab="blindspots" role="tab" aria-selected="false">Blind Spots <span class="tab-count" id="tabCountBlindspots"></span></button>
       <button class="event-tab active" data-tab="market" role="tab" aria-selected="true">Market Carpet <span class="tab-count" id="tabCountMarket"></span></button>
       <button class="event-tab" data-tab="espn"       role="tab" aria-selected="false">ESPN Context</button>
+      <button class="event-tab" data-tab="alerts"     role="tab" aria-selected="false">🔔 Alerts</button>
     </nav>
 
     <!-- Overview pane: rollup KPIs + ESPN form strip -->
@@ -130,12 +131,17 @@
       </section>
     </div>
 
+    <div class="tab-pane" id="panePerfAlerts" role="tabpanel" hidden>
+      <section class="panel"><div class="alerts-root"><div class="empty">tap tab to load</div></div></section>
+    </div>
+
   </main>
 
   <script src="lib/supabase.js"></script>
   <script src="auth.js"></script>
   <script src="app.js"></script>
   <script src="nav.js"></script>
+  <script src="alerts.js"></script>
   <script src="performer.js"></script>
 </body>
 </html>

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -126,7 +126,7 @@
   }
 
   // ---------- Tab nav ----------
-  const _tabState = { loaded: { espn: false, market: false }, performerId: null, portfolio: null };
+  const _tabState = { loaded: { espn: false, market: false, alerts: false }, performerId: null, portfolio: null };
 
   function wireTabs(performerId) {
     _tabState.performerId = performerId;
@@ -141,6 +141,10 @@
         await loadEspnContext(performerId);
       } else if (tabId === 'market' && !_tabState.loaded.market) {
         await loadMarketCarpet();
+      } else if (tabId === 'alerts' && !_tabState.loaded.alerts) {
+        _tabState.loaded.alerts = true;
+        const label = document.getElementById('phName')?.textContent || '';
+        window.TerminalAlerts?.mount('performer', performerId, label, document.querySelector('#panePerfAlerts .alerts-root'));
       }
     });
   }
@@ -151,6 +155,7 @@
     blindspots: 'paneBlindspots',
     market:     'paneMarket',
     espn:       'paneEspn',
+    alerts:     'panePerfAlerts',
   };
 
   function activateTab(tabId) {

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1942,3 +1942,43 @@ body[data-page="login"] {
 }
 .seatmap-reset:hover { filter: brightness(1.1); }
 #seatmapListBody .empty { color: var(--muted); padding: 12px; text-align: center; }
+
+/* ===== User Alerts tab (alerts.js — event/performer/venue) ===== */
+.alerts-root { font-family: var(--sans); }
+.alerts-root .panel-title { font-family: var(--mono); font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 10px; }
+.alert-create { border-bottom: 1px solid var(--line); padding-bottom: 16px; margin-bottom: 16px; }
+.alert-form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 12px; }
+.alert-field { display: flex; flex-direction: column; gap: 4px; }
+.alert-flabel { font-family: var(--mono); font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+.alert-input {
+  background: var(--bg); color: var(--text); border: 1px solid var(--line);
+  border-radius: 4px; padding: 7px 9px; font-family: var(--sans); font-size: 13px; width: 100%;
+}
+.alert-input:focus { outline: none; border-color: var(--accent); }
+.alert-unit { font-family: var(--mono); font-size: 12px; padding-left: 6px; align-self: center; }
+.alert-field .row { display: flex; align-items: center; }
+.alert-channels { display: flex; flex-direction: column; gap: 6px; }
+.alert-chan { display: inline-flex; align-items: center; gap: 5px; font-size: 13px; color: var(--text); cursor: pointer; }
+.alert-btn {
+  margin-top: 14px; background: var(--accent); color: #0a0a0a; border: none; border-radius: 4px;
+  padding: 8px 18px; font-family: var(--mono); font-size: 12px; font-weight: 600; cursor: pointer;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.alert-btn:hover { filter: brightness(1.1); }
+.alert-btn:disabled { opacity: 0.5; cursor: default; }
+.alert-err { color: var(--neg); font-size: 12px; margin-top: 10px; font-family: var(--mono); }
+.alert-list { display: flex; flex-direction: column; gap: 6px; }
+.alert-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 9px 11px; border: 1px solid var(--line); border-radius: 4px; background: var(--panel);
+}
+.alert-row-summary { font-size: 13px; color: var(--text); }
+.alert-row-summary.off { color: var(--dim); text-decoration: line-through; }
+.alert-row-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.alert-mini {
+  background: transparent; color: var(--muted); border: 1px solid var(--line);
+  border-radius: 4px; padding: 4px 10px; font-family: var(--mono); font-size: 11px; cursor: pointer;
+}
+.alert-mini:hover { color: var(--text); border-color: var(--muted); }
+.alert-mini.danger:hover { color: var(--neg); border-color: var(--neg); }
+.alert-mini:disabled { opacity: 0.5; cursor: default; }

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -55,6 +55,7 @@
       <button class="event-tab" data-tab="sg"         role="tab" aria-selected="false">SG Activity</button>
       <button class="event-tab" data-tab="competing"  role="tab" aria-selected="false">Competing Events</button>
       <button class="event-tab active" data-tab="market" role="tab" aria-selected="true">Market Carpet <span class="tab-count" id="tabCountVenueMarket"></span></button>
+      <button class="event-tab" data-tab="alerts" role="tab" aria-selected="false">🔔 Alerts</button>
     </nav>
 
     <!-- Overview pane: rollup KPIs only -->
@@ -157,12 +158,17 @@
       </section>
     </div>
 
+    <div class="tab-pane" id="vPaneAlerts" role="tabpanel" hidden>
+      <section class="panel"><div class="alerts-root"><div class="empty">select a tab to load</div></div></section>
+    </div>
+
   </main>
 
   <script src="lib/supabase.js"></script>
   <script src="auth.js"></script>
   <script src="app.js"></script>
   <script src="nav.js"></script>
+  <script src="alerts.js"></script>
   <script src="venue.js"></script>
 </body>
 </html>

--- a/static/terminal/venue.js
+++ b/static/terminal/venue.js
@@ -16,6 +16,7 @@
   const _vTabState = {
     marketLoaded:     false,
     competingLoaded:  false,
+    alertsLoaded:     false,
     venueEvents:      null,
     venueAggregate:   {},
     compRadius:       50,
@@ -144,6 +145,7 @@
     sg:         'vPaneSg',
     competing:  'vPaneCompeting',
     market:     'vPaneMarket',
+    alerts:     'vPaneAlerts',
   };
 
   function wireTabs() {
@@ -162,6 +164,11 @@
       }
       if (tabId === 'competing' && !_vTabState.competingLoaded) {
         initCompetingPanel();
+      }
+      if (tabId === 'alerts' && !_vTabState.alertsLoaded) {
+        _vTabState.alertsLoaded = true;
+        const label = document.getElementById('vhName')?.textContent || '';
+        window.TerminalAlerts?.mount('venue', getVenueId(), label, document.querySelector('#vPaneAlerts .alerts-root'));
       }
     });
     document.getElementById('venueTabs').removeAttribute('hidden');

--- a/supabase/functions/_shared/email-templates/watchlist-daily-summary.html
+++ b/supabase/functions/_shared/email-templates/watchlist-daily-summary.html
@@ -1,0 +1,162 @@
+<!--
+  watchlist-daily-summary.html — Daily Watchlist Summary email template (D0 / notifications).
+
+  WHAT THIS IS
+    The HTML body for the once-a-day watchlist digest. Rendered server-side by
+    filling the {{TOKENS}} below, then queued into public.exos_mail (to_email,
+    subject, html) and sent by the exos-mail-drain edge fn via Resend — the same
+    transactional path exos uses today. This file is the *template*; the render +
+    per-user enqueue + daily cron are the Phase-2 wiring (gated, see footer note).
+
+  RENDER CONTRACT (tokens)
+    Scalars:
+      {{RECIPIENT_NAME}}     greeting name (fallback: "there")
+      {{SUMMARY_DATE}}       e.g. "Friday, June 5"
+      {{WATCHED_COUNT}}      # events on the watchlist this digest covers
+      {{ALERTS_FIRED}}       # of the user's alert rules that fired in last 24h
+      {{MANAGE_URL}}         link to the terminal watchlist/alerts page
+      {{UNSUBSCRIBE_URL}}    one-click unsubscribe (CAN-SPAM, required)
+      {{SENDER_ADDRESS}}     physical mailing address (CAN-SPAM, required)
+    Conditional blocks — render the inner HTML only when the condition holds,
+    otherwise drop the whole block:
+      <!-- IF:ALERTS_FIRED -->     ... <!-- ENDIF:ALERTS_FIRED -->
+      <!-- IF:HAS_EVENTS -->       ... <!-- ENDIF:HAS_EVENTS -->
+      <!-- IF:EMPTY -->            ... <!-- ENDIF:EMPTY -->
+    Repeatable event row — emit one copy of the block between the markers per
+    watched event, substituting the per-row tokens:
+      <!-- ROW:START --> ... <!-- ROW:END -->
+        {{EV_NAME}}        event name
+        {{EV_WHEN}}        date + time, e.g. "Sat Jun 7 · 7:30 PM"
+        {{EV_VENUE}}       venue + city
+        {{EV_URL}}         deep link to the event page
+        {{EV_GETIN}}       current get-in price, formatted "$123" (or "—")
+        {{EV_GETIN_DELTA}} 24h change, formatted "▼ 12%" / "▲ 5%" / "—"
+        {{EV_DELTA_COLOR}} hex for the delta text: green #16a34a (cheaper),
+                           red #dc2626 (pricier), grey #737373 (flat/none)
+        {{EV_LISTINGS}}    active listing count, e.g. "412"
+        {{EV_LISTINGS_DELTA}} 24h listings change, e.g. "+38" / "-12" / "—"
+        {{EV_SIGNAL}}      short badge text or "" (e.g. "TOP MOVER",
+                           "NEW LOW", "SELLING FAST", "ALERT HIT")
+        {{EV_SIGNAL_BG}}   badge background hex (accent #fbbf24 for alert hits,
+                           else #2a2a2a)
+  NOTE: every dynamic value must be HTML-escaped by the renderer (event names
+  are user/upstream data). Layout is table-based + inline-styled for email-client
+  compatibility (no fl/grid, no <style> reliance).
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <meta name="x-apple-disable-message-reformatting">
+  <title>Daily Watchlist Summary</title>
+</head>
+<body style="margin:0; padding:0; background:#0a0a0a; -webkit-text-size-adjust:100%;">
+
+  <!-- preheader (hidden preview line) -->
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:#0a0a0a; font-size:1px; line-height:1px;">
+    Your watchlist for {{SUMMARY_DATE}} — {{WATCHED_COUNT}} events, {{ALERTS_FIRED}} alerts fired.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0a0a0a;">
+    <tr>
+      <td align="center" style="padding:24px 12px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px; max-width:600px; background:#141414; border:1px solid #2a2a2a; border-radius:8px; overflow:hidden;">
+
+          <!-- ===== header ===== -->
+          <tr>
+            <td style="padding:24px 28px 16px 28px; border-bottom:1px solid #2a2a2a;">
+              <div style="font-family:'SF Mono',Menlo,Consolas,monospace; font-size:12px; letter-spacing:1px; color:#fbbf24; text-transform:uppercase;">TERMINAL</div>
+              <div style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:22px; font-weight:700; color:#e5e5e5; padding-top:6px;">Daily Watchlist Summary</div>
+              <div style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:13px; color:#737373; padding-top:4px;">{{SUMMARY_DATE}} · {{WATCHED_COUNT}} events watched</div>
+            </td>
+          </tr>
+
+          <!-- ===== alerts-fired band (conditional) ===== -->
+          <!-- IF:ALERTS_FIRED -->
+          <tr>
+            <td style="padding:14px 28px; background:rgba(251,191,36,0.10); border-bottom:1px solid #2a2a2a;">
+              <span style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:14px; color:#fbbf24; font-weight:600;">🔔 {{ALERTS_FIRED}} of your alerts triggered in the last 24h.</span>
+              <span style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:14px; color:#a3a3a3;"> They’re marked below.</span>
+            </td>
+          </tr>
+          <!-- ENDIF:ALERTS_FIRED -->
+
+          <!-- ===== events table (conditional) ===== -->
+          <!-- IF:HAS_EVENTS -->
+          <tr>
+            <td style="padding:8px 16px 4px 16px;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+
+                <!-- ROW:START -->
+                <tr>
+                  <td style="padding:14px 12px; border-bottom:1px solid #222;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <!-- left: event identity -->
+                        <td valign="top" style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif;">
+                          <a href="{{EV_URL}}" style="color:#e5e5e5; font-size:15px; font-weight:600; text-decoration:none;">{{EV_NAME}}</a>
+                          <span style="display:inline-block; margin-left:8px; padding:1px 7px; border-radius:4px; background:{{EV_SIGNAL_BG}}; color:#0a0a0a; font-size:10px; font-weight:700; letter-spacing:0.5px; vertical-align:middle;">{{EV_SIGNAL}}</span>
+                          <div style="font-size:12px; color:#737373; padding-top:3px;">{{EV_WHEN}} · {{EV_VENUE}}</div>
+                        </td>
+                        <!-- right: price + listings -->
+                        <td valign="top" align="right" style="font-family:'SF Mono',Menlo,Consolas,monospace; white-space:nowrap; padding-left:12px;">
+                          <div style="font-size:16px; color:#e5e5e5; font-weight:600;">{{EV_GETIN}}</div>
+                          <div style="font-size:12px; color:{{EV_DELTA_COLOR}}; padding-top:2px;">{{EV_GETIN_DELTA}}</div>
+                          <div style="font-size:11px; color:#737373; padding-top:4px;">{{EV_LISTINGS}} listings ({{EV_LISTINGS_DELTA}})</div>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <!-- ROW:END -->
+
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td align="center" style="padding:18px 28px 8px 28px;">
+              <a href="{{MANAGE_URL}}" style="display:inline-block; background:#fbbf24; color:#0a0a0a; font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:13px; font-weight:700; text-decoration:none; padding:10px 22px; border-radius:6px;">View full watchlist →</a>
+            </td>
+          </tr>
+          <!-- ENDIF:HAS_EVENTS -->
+
+          <!-- ===== empty state (conditional) ===== -->
+          <!-- IF:EMPTY -->
+          <tr>
+            <td align="center" style="padding:36px 28px; font-family:-apple-system,'Segoe UI',Roboto,sans-serif;">
+              <div style="font-size:15px; color:#a3a3a3;">No movement on your watchlist today.</div>
+              <div style="font-size:13px; color:#737373; padding-top:6px;">We’ll keep watching and ping you when something moves.</div>
+              <div style="padding-top:18px;">
+                <a href="{{MANAGE_URL}}" style="display:inline-block; background:#2a2a2a; color:#e5e5e5; font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:13px; font-weight:600; text-decoration:none; padding:10px 22px; border-radius:6px;">Manage watchlist →</a>
+              </div>
+            </td>
+          </tr>
+          <!-- ENDIF:EMPTY -->
+
+          <!-- ===== footer ===== -->
+          <tr>
+            <td style="padding:18px 28px 24px 28px; border-top:1px solid #2a2a2a;">
+              <div style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:12px; color:#737373; line-height:1.6;">
+                You’re receiving this daily summary because you added events to your Terminal watchlist.
+                <br>
+                <a href="{{MANAGE_URL}}" style="color:#9ca3af; text-decoration:underline;">Manage preferences</a>
+                &nbsp;·&nbsp;
+                <a href="{{UNSUBSCRIBE_URL}}" style="color:#9ca3af; text-decoration:underline;">Unsubscribe</a>
+              </div>
+              <div style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:11px; color:#525252; padding-top:10px;">{{SENDER_ADDRESS}}</div>
+            </td>
+          </tr>
+
+        </table>
+
+        <div style="font-family:-apple-system,'Segoe UI',Roboto,sans-serif; font-size:11px; color:#404040; padding-top:16px;">Terminal · market intelligence</div>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/supabase/migrations/20260603180000_user_alerts.sql
+++ b/supabase/migrations/20260603180000_user_alerts.sql
@@ -1,0 +1,253 @@
+-- Migration 20260603180000 · lane:A1 (author, operator-routed D0 FE work) → PENDING operator apply · writes:alert_metric_catalog + user_alerts tables + user-alert mgmt RPCs · reads:auth.uid()
+--
+-- ## NOT YET APPLIED TO PROD — authored as a file only (CLAUDE.md lockdown rule 1).
+--    Phase 1 of the user alert system: the CREATE/MANAGE surface behind the D0
+--    terminal "Alerts" tab (event / performer / venue). Lets an authenticated
+--    terminal user (auth.uid()) subscribe to ANY tracked dataset as an alert
+--    trigger and choose email / SMS.
+--
+--    Phase 2 (separate, gated migration — NOT in this file): evaluate_user_alerts()
+--    on the snapshot tick + Twilio/ESP delivery + TCPA/CAN-SPAM consent fields.
+--    Sending is outward-facing → operator-gated go-live.
+--
+-- Design notes:
+--  * alert_metric_catalog — the data-driven trigger list. One row per alertable
+--    metric per scope level. The FE builds its dropdowns from
+--    get_alert_metric_catalog(); making a new tracked dataset alertable is an
+--    INSERT here, no code change ("all tracked datasets are valid alert reasons").
+--  * user_alerts — one subscription per row, owned by auth.uid(), RLS-isolated.
+--  * Operators: drop_pct / rise_pct (manual % — the user-entered number),
+--    below / above (manual threshold in the metric's unit), available (qty > 0),
+--    any_change, crosses_into (e.g. enters top movers). Whether a threshold is
+--    required is derived from the operator (alert_operator_needs_threshold()).
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. metric catalog (data-driven trigger list)
+-- ----------------------------------------------------------------------------
+create table if not exists public.alert_metric_catalog (
+  metric_key        text primary key,
+  scope_type        text not null check (scope_type in ('event','performer','venue')),
+  label             text not null,
+  value_kind        text not null,                 -- price | count | pct | index | temp | event | signal
+  allowed_operators text[] not null,
+  default_operator  text not null,
+  threshold_unit    text,                          -- '$' | '%' | '°F' | 'tickets' | 'sales' | null
+  param_kind        text,                          -- null | 'zone' | 'section' | 'city'
+  source_note       text,                          -- which table/RPC backs this (for catalogue/lineage)
+  sort_order        int not null default 100,
+  active            boolean not null default true
+);
+comment on table public.alert_metric_catalog is
+  'Data-driven catalog of alertable metrics per scope level (event/performer/venue). FE dropdowns build from get_alert_metric_catalog(). Add a row to make a new tracked dataset alertable — no code change. Phase 1 of the user alert system (mig 20260603180000).';
+
+insert into public.alert_metric_catalog
+  (metric_key, scope_type, label, value_kind, allowed_operators, default_operator, threshold_unit, param_kind, source_note, sort_order)
+values
+  -- EVENT level ------------------------------------------------------------
+  ('evt_price_floor',      'event','Lowest ask price',              'price','{drop_pct,rise_pct,below,above}','drop_pct','$',      null,     'event_metrics.min_price / get_event_zones_public',        10),
+  ('evt_price_median',     'event','Median ask price',              'price','{drop_pct,rise_pct,below,above}','below',   '$',      null,     'event_metrics median',                                    20),
+  ('evt_get_in',           'event','Get-in (cheapest, any qty)',    'price','{below,drop_pct}',              'below',   '$',      null,     'listings_snapshots floor',                                30),
+  ('evt_zone_floor',       'event','Lowest ask in a zone',          'price','{below,drop_pct,available}',    'below',   '$',      'zone',   'zone_metrics / get_event_zones_public',                   40),
+  ('evt_section_available','event','Any ticket in a section',       'count','{available}',                   'available','tickets','section','event_section_row_snapshots',                             50),
+  ('evt_listings_total',   'event','Total active listings',         'count','{below,above,any_change}',      'below',   'tickets',null,     'event_metrics.listing_count',                             60),
+  ('evt_listings_sg',      'event','SeatGeek listing count',        'count','{below,above,any_change}',      'any_change','tickets',null,   'seatgeek_event_metrics',                                  70),
+  ('evt_listings_evo',     'event','TEvo listing count',            'count','{below,above,any_change}',      'any_change','tickets',null,   'event_metrics (evo)',                                     80),
+  ('evt_listings_td',      'event','TicketsData listing count',     'count','{below,above,any_change}',      'any_change','tickets',null,   'ticketsdata_listings_snapshots',                          90),
+  ('evt_new_sale',         'event','New sale recorded',             'event','{any_change}',                  'any_change',null,    null,     'seatgeek_sales_snapshots / evo_orders',                  100),
+  ('evt_sales_velocity',   'event','Sales in last 24h',             'count','{above,below}',                 'above',   'sales',  null,     'seatgeek_event_metrics.sold_*',                          110),
+  ('evt_mover',            'event','Enters top movers',             'index','{crosses_into}',                'crosses_into',null,  null,     'event_movers_index',                                     120),
+  ('evt_weather_temp',     'event','Forecast temperature',          'temp', '{below,above}',                 'below',   '°F',     null,     'weather_forecast / get_event_weather_localized',         130),
+  ('evt_weather_precip',   'event','Precipitation chance',          'pct',  '{above}',                       'above',   '%',      null,     'weather_forecast',                                       140),
+  ('evt_sentiment',        'event','Event sentiment score',         'index','{drop_pct,rise_pct,below,above,any_change}','any_change',null,null,'event_sentiment',                                   150),
+  ('evt_injury',           'event','New injury (linked teams)',     'signal','{any_change}',                 'any_change',null,    null,     'espn_injuries_snapshots',                                160),
+  ('evt_news',             'event','New news item',                 'signal','{any_change}',                 'any_change',null,    null,     'espn_news',                                              170),
+  ('evt_arb_gap',          'event','Cross-source value gap appears','signal','{any_change,available}',       'any_change',null,    null,     'discovery_gap_alerts',                                   180),
+  -- PERFORMER level --------------------------------------------------------
+  ('perf_new_event',       'performer','New event announced',       'event','{any_change,available}',        'any_change',null,    'city',   'events / search_events_by_date',                          10),
+  ('perf_portfolio_move',  'performer','Portfolio median price move','price','{drop_pct,rise_pct}',          'drop_pct','%',       null,     'get_broker_performer_page',                               20),
+  ('perf_any_event_floor', 'performer','Any upcoming event floor drops','price','{drop_pct,below}',          'drop_pct','%',       null,     'event_metrics across performer',                          30),
+  ('perf_mover',           'performer','Becomes a top mover',        'index','{crosses_into}',               'crosses_into',null,  null,     'event_movers_index',                                      40),
+  ('perf_injury',          'performer','New injury',                'signal','{any_change}',                 'any_change',null,    null,     'espn_injuries_snapshots',                                 50),
+  ('perf_news',            'performer','New news item',             'signal','{any_change}',                 'any_change',null,    null,     'espn_news',                                               60),
+  ('perf_popularity',      'performer','Popularity score change',   'index','{rise_pct,drop_pct,any_change}','any_change','%',     null,     'performer_metadata.popularity_score',                     70),
+  -- VENUE level ------------------------------------------------------------
+  ('ven_new_event',        'venue','New event at venue',            'event','{any_change,available}',        'any_change',null,    null,     'get_events_by_venue_public',                              10),
+  ('ven_competing',        'venue','Competing event added nearby',  'event','{any_change}',                  'any_change',null,    null,     'find_competing_events',                                   20),
+  ('ven_owned_price',      'venue','Owned inventory price move',    'price','{drop_pct,below}',              'drop_pct','%',       null,     'event_metrics owned',                                     30),
+  ('ven_availability',     'venue','Availability across venue',     'count','{below,above,any_change}',      'any_change','tickets',null,    'listings_snapshots by venue',                             40),
+  ('ven_mover',            'venue','A venue event enters top movers','index','{crosses_into}',               'crosses_into',null,  null,     'event_movers_index',                                      50)
+on conflict (metric_key) do update set
+  scope_type        = excluded.scope_type,
+  label             = excluded.label,
+  value_kind        = excluded.value_kind,
+  allowed_operators = excluded.allowed_operators,
+  default_operator  = excluded.default_operator,
+  threshold_unit    = excluded.threshold_unit,
+  param_kind        = excluded.param_kind,
+  source_note       = excluded.source_note,
+  sort_order        = excluded.sort_order,
+  active            = excluded.active;
+
+-- ----------------------------------------------------------------------------
+-- 2. user subscriptions
+-- ----------------------------------------------------------------------------
+create table if not exists public.user_alerts (
+  id               bigint generated always as identity primary key,
+  owner_id         uuid not null default auth.uid(),
+  scope_type       text not null check (scope_type in ('event','performer','venue')),
+  scope_id         bigint not null,
+  scope_label      text,                                              -- denormalized for display
+  metric_key       text not null references public.alert_metric_catalog(metric_key),
+  operator         text not null check (operator in ('drop_pct','rise_pct','below','above','available','any_change','crosses_into')),
+  threshold        numeric,                                           -- required iff operator needs it
+  params           jsonb  not null default '{}'::jsonb,               -- e.g. {"zone":"100 Level"} / {"city":"New York"}
+  channels         text[] not null default '{email}'::text[] check (channels <@ array['email','sms'] and array_length(channels,1) >= 1),
+  notify_email     text,
+  notify_phone     text,
+  cooldown_minutes int  not null default 720 check (cooldown_minutes >= 0),
+  active           boolean not null default true,
+  last_fired_at    timestamptz,
+  expires_at       timestamptz,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+comment on table public.user_alerts is
+  'User-defined alert subscriptions, owned by auth.uid() and RLS-isolated. One row = one trigger on one scope (event/performer/venue). Created/managed via the D0 terminal Alerts tab. Phase 2 evaluator (gated) scans active rows on the snapshot tick. Mig 20260603180000.';
+
+create index if not exists user_alerts_owner_scope_idx on public.user_alerts (owner_id, scope_type, scope_id) where active;
+create index if not exists user_alerts_scope_idx       on public.user_alerts (scope_type, scope_id)           where active;  -- evaluator scan (phase 2)
+
+-- ----------------------------------------------------------------------------
+-- 3. RLS — defense in depth (the RPCs below are SECDEF and filter by auth.uid(),
+--    but RLS protects any direct PostgREST table access).
+-- ----------------------------------------------------------------------------
+alter table public.user_alerts          enable row level security;
+alter table public.alert_metric_catalog enable row level security;
+
+drop policy if exists user_alerts_owner_all on public.user_alerts;
+create policy user_alerts_owner_all on public.user_alerts
+  for all to authenticated
+  using (owner_id = auth.uid()) with check (owner_id = auth.uid());
+
+drop policy if exists alert_catalog_read on public.alert_metric_catalog;
+create policy alert_catalog_read on public.alert_metric_catalog
+  for select to authenticated using (active);
+
+-- ----------------------------------------------------------------------------
+-- 4. helpers + management RPCs (SECDEF, granted to authenticated)
+-- ----------------------------------------------------------------------------
+create or replace function public.alert_operator_needs_threshold(p_operator text)
+returns boolean language sql immutable as
+$$ select p_operator in ('drop_pct','rise_pct','below','above') $$;
+
+create or replace function public.get_alert_metric_catalog(p_scope_type text)
+returns setof public.alert_metric_catalog
+language sql stable security definer set search_path = public, pg_temp as
+$$ select * from public.alert_metric_catalog
+   where active and scope_type = p_scope_type
+   order by sort_order, label $$;
+
+create or replace function public.list_user_alerts(p_scope_type text, p_scope_id bigint)
+returns setof public.user_alerts
+language sql stable security definer set search_path = public, pg_temp as
+$$ select * from public.user_alerts
+   where owner_id = auth.uid() and scope_type = p_scope_type and scope_id = p_scope_id
+   order by created_at desc $$;
+
+create or replace function public.create_user_alert(
+  p_scope_type       text,
+  p_scope_id         bigint,
+  p_metric_key       text,
+  p_operator         text,
+  p_threshold        numeric     default null,
+  p_params           jsonb       default '{}'::jsonb,
+  p_channels         text[]      default array['email'],
+  p_notify_email     text        default null,
+  p_notify_phone     text        default null,
+  p_cooldown_minutes int         default 720,
+  p_scope_label      text        default null,
+  p_expires_at       timestamptz default null
+) returns public.user_alerts
+language plpgsql security definer set search_path = public, pg_temp as
+$$
+declare
+  v_uid    uuid := auth.uid();
+  v_metric public.alert_metric_catalog;
+  v_row    public.user_alerts;
+begin
+  if v_uid is null then
+    raise exception 'not authenticated';
+  end if;
+
+  select * into v_metric from public.alert_metric_catalog
+   where metric_key = p_metric_key and scope_type = p_scope_type and active;
+  if not found then
+    raise exception 'unknown or inactive metric % for scope %', p_metric_key, p_scope_type;
+  end if;
+
+  if not (p_operator = any (v_metric.allowed_operators)) then
+    raise exception 'operator % not allowed for metric %', p_operator, p_metric_key;
+  end if;
+
+  if public.alert_operator_needs_threshold(p_operator) and p_threshold is null then
+    raise exception 'operator % requires a threshold', p_operator;
+  end if;
+
+  if 'sms' = any (p_channels) and coalesce(nullif(trim(p_notify_phone), ''), '') = '' then
+    raise exception 'SMS channel requires a phone number';
+  end if;
+  if 'email' = any (p_channels) and coalesce(nullif(trim(p_notify_email), ''), '') = '' then
+    raise exception 'email channel requires an email address';
+  end if;
+
+  insert into public.user_alerts
+    (owner_id, scope_type, scope_id, scope_label, metric_key, operator, threshold,
+     params, channels, notify_email, notify_phone, cooldown_minutes, expires_at)
+  values
+    (v_uid, p_scope_type, p_scope_id, p_scope_label, p_metric_key, p_operator, p_threshold,
+     coalesce(p_params, '{}'::jsonb), p_channels, p_notify_email, p_notify_phone,
+     p_cooldown_minutes, p_expires_at)
+  returning * into v_row;
+
+  return v_row;
+end $$;
+
+create or replace function public.set_user_alert_active(p_id bigint, p_active boolean)
+returns public.user_alerts
+language plpgsql security definer set search_path = public, pg_temp as
+$$
+declare v_row public.user_alerts;
+begin
+  update public.user_alerts
+     set active = p_active, updated_at = now()
+   where id = p_id and owner_id = auth.uid()
+  returning * into v_row;
+  if not found then raise exception 'alert % not found', p_id; end if;
+  return v_row;
+end $$;
+
+create or replace function public.delete_user_alert(p_id bigint)
+returns boolean
+language plpgsql security definer set search_path = public, pg_temp as
+$$
+declare n int;
+begin
+  delete from public.user_alerts where id = p_id and owner_id = auth.uid();
+  get diagnostics n = row_count;
+  return n > 0;
+end $$;
+
+-- ----------------------------------------------------------------------------
+-- 5. grants
+-- ----------------------------------------------------------------------------
+grant select on public.alert_metric_catalog to authenticated;
+grant execute on function public.alert_operator_needs_threshold(text)                                              to authenticated;
+grant execute on function public.get_alert_metric_catalog(text)                                                    to authenticated;
+grant execute on function public.list_user_alerts(text, bigint)                                                    to authenticated;
+grant execute on function public.create_user_alert(text, bigint, text, text, numeric, jsonb, text[], text, text, int, text, timestamptz) to authenticated;
+grant execute on function public.set_user_alert_active(bigint, boolean)                                            to authenticated;
+grant execute on function public.delete_user_alert(bigint)                                                         to authenticated;
+
+commit;


### PR DESCRIPTION
## What

**Phase 1** of the user alert system — the **create/manage surface**. Adds a 🔔 **Alerts** tab to the **event / performer / venue** pages of the D0 terminal. An authenticated terminal user (`auth.uid()`) can subscribe to **any tracked dataset** as an alert trigger and choose **email / SMS**.

Built by **A1** under operator override routing D0-lane FE work (`CLAUDE.md §4`).

## How it satisfies the directive

- **"All tracked datasets are valid alert reasons"** → the trigger picker is **data-driven** from `get_alert_metric_catalog()`. Making a new dataset alertable is an `INSERT` into `alert_metric_catalog` — **no FE change**. Seeded with ~30 metrics across scopes (price floor/median, listing counts per source, zone/section availability, sales velocity, movers, weather, sentiment, injuries, news, arb gaps; performer new-event/portfolio/popularity; venue new-event/competing/owned/availability).
- **"Percentage drops → manual number"** → `drop_pct`/`rise_pct` operators expose a manual `%` input; `below`/`above` expose a manual threshold in the metric's unit (`$`/tickets/°F/%).
- **"Tab at event/performer/venue level"** → wired into all three pages' existing tab system; logic lives in one shared module `static/terminal/alerts.js`.

## Changes

| File | Change |
|---|---|
| `supabase/migrations/20260603180000_user_alerts.sql` | **Authored, NOT applied.** `alert_metric_catalog` + `user_alerts` (RLS, owner = `auth.uid()`) + SECDEF RPCs (`get_alert_metric_catalog`, `list_user_alerts`, `create_user_alert`, `set_user_alert_active`, `delete_user_alert`), granted to `authenticated`. |
| `static/terminal/alerts.js` | New shared Alerts-tab module (picker, conditional threshold/param inputs, email+SMS, pause/delete). |
| `event/performer/venue .html` + `.js` | Tab button + pane + `TerminalAlerts.mount(...)` on first activation. |
| `style.css` | Themed alert form/list styles (`.alert-*`). |

## ⚠️ Gated / not included

- **Migration is authored only — prod application awaits operator sign-off** (lockdown rule 1). The tab can't function end-to-end until the RPCs are live.
- **Phase 2 (separate, gated):** `evaluate_user_alerts()` on the snapshot tick + Twilio/ESP delivery + **TCPA (SMS) / CAN-SPAM (email) consent** fields. Sending is outward-facing → operator-gated go-live. No messages are sent by this change.

## Verification done

- `node --check` passes on all four JS files.
- No new root/governance `.md` (docs-registry CI gate, `§6`) — only a migration + static FE.
- RLS isolates rows per `auth.uid()`; SECDEF RPCs also filter by `auth.uid()` (defense in depth).

https://claude.ai/code/session_01JNtrtaDgpY7RcxHcin6jHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNtrtaDgpY7RcxHcin6jHT)_