### PR TITLE
fix(tests): make store_home fixture date relative (CI time-bomb)

### DIFF
--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -179,9 +179,17 @@ def _lem(eid: int, owned: int = 100, retail_min: float = 50.0,
     }
 
 
-def _event(eid: int, name: str = None, occurs: str = "2026-06-01T19:00:00-04:00",
+def _event(eid: int, name: str = None, occurs: str = None,
            venue_location: str = "New York, NY", performer_id: int = 16303,
            performer_name: str = "Test Team") -> dict:
+    # Relative default (not hardcoded) so the fixture event stays in the future
+    # regardless of when the suite runs — store_home filters to upcoming events
+    # via .gte("occurs_at_local", today). A fixed date silently became "past"
+    # (the 2026-06-01 literal turned into a time-bomb on 2026-06-02). Same fix
+    # already applied to the curation-order fixture (see _occurs() ~L291).
+    if occurs is None:
+        from datetime import date as _date, timedelta as _td
+        occurs = f"{(_date.today() + _td(days=30)).isoformat()}T19:00:00-04:00"
     return {
         "id": eid,
         "name": name or f"Test Event {eid}",


### PR DESCRIPTION
## Why

`main`'s CI has been **red on `pytest` for every PR since 2026-06-02** — including the unrelated #425. Root cause is a date time-bomb, not any PR's changes.

## Root cause

- `/api/store/home` returns **upcoming events only** — `app.py:6281` filters `.gte("occurs_at_local", today_iso)` where `today_iso = datetime.now(utc).date()`.
- The test fixture `_event()` (`tests/test_store_home.py:182`) hardcoded `occurs="2026-06-01T19:00:00-04:00"`.
- On/after **2026-06-02** that date is in the past → the fixture event is filtered out → endpoint returns `count: 0` → **8 `test_home_*` tests fail** (`assert 0 == 1`, plus downstream `IndexError`/`KeyError` on the empty result).

CI's `--maxfail=1` masked the scope by stopping at the first failure.

## Fix

Make `_event()`'s default `occurs` **relative** (`today() + 30d`) — the exact pattern already applied to the curation-order fixture in the same file (`_occurs()` ~L291, whose comment already documents this class of bug). **No production code touched** — test fixture only.

```python
def _event(eid, name=None, occurs=None, ...):
    if occurs is None:
        from datetime import date as _date, timedelta as _td
        occurs = f"{(_date.today() + _td(days=30)).isoformat()}T19:00:00-04:00"
```

The inline-date *movers* tests (L901–907/L1000) are unaffected — their fake DB ignores `.gte()`, so they never depended on the date.

## Verification

- `tests/test_store_home.py`: **52 passed** (was 8 failing).
- Full `pytest tests/`: **223 passed, 12 skipped** (CI previously bailed at 163 + 1 failed via `--maxfail=1`).

## Notes

- Surfaced while investigating #425's CI; this failure is **pre-existing and independent** of that PR. Opened separately per operator direction to unblock everyone's CI rather than fold a cross-lane fix into the alerts PR.
- D1-lane test; flagging the lane owner via this PR.

https://claude.ai/code/session_01JNtrtaDgpY7RcxHcin6jHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNtrtaDgpY7RcxHcin6jHT)_