### PR TITLE
feat(d0): daily aggregate metrics at performer + venue level (home/away split)

### DIFF
--- a/supabase/migrations/20260604120000_entity_metrics_daily.sql
+++ b/supabase/migrations/20260604120000_entity_metrics_daily.sql
@@ -122,12 +122,23 @@ BEGIN
            d.*
     FROM public.events e
     CROSS JOIN LATERAL unnest(e.performer_ids) AS u(pid)
-    JOIN public.v_canonical_performer cp ON cp.tevo_performer_id = u.pid
+    -- dedupe v_canonical_performer to ONE row per performer: the view can emit
+    -- >1 row for a tevo_performer_id (differing name / what_event_type), which
+    -- would both split the 'all' group (duplicate PK) AND fan-out the join
+    -- (double-counting inventory sums). Prefer the row with a non-null type.
+    JOIN (
+      SELECT DISTINCT ON (tevo_performer_id)
+             tevo_performer_id, tevo_performer_name, what_event_type, home_venue_ids
+      FROM public.v_canonical_performer
+      ORDER BY tevo_performer_id, what_event_type NULLS LAST
+    ) cp ON cp.tevo_performer_id = u.pid
     JOIN _eld d ON d.event_id = e.id
   ),
   rolled AS (
-    -- 'all' split: every performer, every event
-    SELECT performer_id, performer_name, what_event_type, 'all'::text AS split,
+    -- 'all' split: every performer, every event (group by id only — name/type are
+    -- functionally dependent post-dedupe; min() keeps one row per performer)
+    SELECT performer_id, min(performer_name) AS performer_name,
+           min(what_event_type) AS what_event_type, 'all'::text AS split,
            count(DISTINCT event_id)::int                                              AS event_count,
            sum(evo_tickets_count)::int                                                AS evo_tickets_total,
            sum(evo_owned_tickets)::int                                                AS evo_owned_tickets_total,
@@ -140,10 +151,10 @@ BEGIN
            percentile_cont(0.9) WITHIN GROUP (ORDER BY amalgam_median)                AS price_p90,
            sum(coalesce(evo_owned_median, evo_retail_median) * evo_owned_tickets)     AS owned_book_notional
     FROM pe
-    GROUP BY performer_id, performer_name, what_event_type
+    GROUP BY performer_id
     UNION ALL
     -- 'home'/'away' splits: sports performers only
-    SELECT performer_id, performer_name, what_event_type, ha,
+    SELECT performer_id, min(performer_name), min(what_event_type), ha,
            count(DISTINCT event_id)::int,
            sum(evo_tickets_count)::int, sum(evo_owned_tickets)::int,
            sum(sg_all_tickets)::int,    sum(sg_owned_tickets)::int,
@@ -153,7 +164,7 @@ BEGIN
            sum(coalesce(evo_owned_median, evo_retail_median) * evo_owned_tickets)
     FROM pe
     WHERE ha IS NOT NULL
-    GROUP BY performer_id, performer_name, what_event_type, ha
+    GROUP BY performer_id, ha
   )
   INSERT INTO public.performer_metrics_daily
     (performer_id, snapshot_date, split, performer_name, what_event_type, event_count,

--- a/supabase/migrations/20260604120000_entity_metrics_daily.sql
+++ b/supabase/migrations/20260604120000_entity_metrics_daily.sql
@@ -243,6 +243,10 @@ $func$;
 GRANT EXECUTE ON FUNCTION public.get_performer_metrics_daily(bigint, integer, text) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.get_venue_metrics_daily(bigint, integer)           TO authenticated;
 
+-- refresh fn is a SECDEF writer with no email gate → keep it off PUBLIC/anon
+-- (cron runs as owner, unaffected). Mirrors the D4 write-path revoke pattern.
+REVOKE EXECUTE ON FUNCTION public.refresh_entity_metrics_daily(date) FROM PUBLIC;
+
 -- ============================================================================
 -- 4. Cron — refresh today + yesterday every 4h
 --    (idempotent; later runs upgrade the row as evening slots land, and the

--- a/supabase/migrations/20260604120000_entity_metrics_daily.sql
+++ b/supabase/migrations/20260604120000_entity_metrics_daily.sql
@@ -172,7 +172,7 @@ BEGIN
     (venue_id, snapshot_date, venue_name, event_count,
      evo_tickets_total, evo_owned_tickets_total, sg_all_tickets_total, sg_owned_tickets_total,
      getin_min, getin_median, price_min, price_median, price_p90, owned_book_notional)
-  SELECT e.venue_id, p_date, max(v.name), count(DISTINCT d.event_id)::int,
+  SELECT e.venue_id, p_date, max(e.venue_name), count(DISTINCT d.event_id)::int,
          sum(d.evo_tickets_count)::int, sum(d.evo_owned_tickets)::int,
          sum(d.sg_all_tickets)::int,    sum(d.sg_owned_tickets)::int,
          min(d.amalgam_getin),          percentile_cont(0.5) WITHIN GROUP (ORDER BY d.amalgam_getin),
@@ -181,7 +181,6 @@ BEGIN
          sum(coalesce(d.evo_owned_median, d.evo_retail_median) * d.evo_owned_tickets)
   FROM public.events e
   JOIN _eld d ON d.event_id = e.id
-  LEFT JOIN public.venues v ON v.id = e.venue_id
   WHERE e.venue_id IS NOT NULL
   GROUP BY e.venue_id;
   GET DIAGNOSTICS v_ven = ROW_COUNT;

--- a/supabase/migrations/20260604120000_entity_metrics_daily.sql
+++ b/supabase/migrations/20260604120000_entity_metrics_daily.sql
@@ -1,0 +1,270 @@
+-- Migration 20260604120000 · lane:D0 (author) → A1 (apply) · writes:performer_metrics_daily,venue_metrics_daily,refresh_entity_metrics_daily,get_performer_metrics_daily,get_venue_metrics_daily,cron(entity-metrics-daily-refresh) · reads:event_listing_snapshot_daily,events,v_canonical_performer,venues · pre:event_listing_snapshot_daily must exist (compute_event_listing_snapshot) · auth:OPERATOR-APPROVAL REQUIRED before apply_migration (creates tables + a cron + backfills history)
+--
+-- D0 — DAILY AGGREGATE METRICS at the performer + venue level.
+--
+-- Problem: event_listing_snapshot_daily gives us one daily metrics row per
+-- EVENT (3 intraday slots: morning/midday/evening). We had per-event daily
+-- history and single-row rolling baselines (performer_baselines / venue_baselines),
+-- but no DAILY TIMESERIES at the performer- or venue-level to chart how a team's
+-- or building's whole market moves day over day.
+--
+-- This migration adds that timeseries, rolling event_listing_snapshot_daily up to:
+--   * performer_metrics_daily — one row per (performer, day, split)
+--       split ∈ {'all','home','away'}. 'all' for every performer; 'home'/'away'
+--       ADDITIONALLY emitted for SPORTS teams only (what_event_type='game').
+--   * venue_metrics_daily — one row per (venue, day). (A venue is a venue — no
+--       home/away concept; the building just hosts.)
+--
+-- HOME/AWAY rule (mirrors app.py:1912 is_home + PROJECT_BIBLE §7 home gate):
+--   home/away is meaningful ONLY for sports performers (what_event_type='game').
+--   A team is HOME for an event when the event's venue is one of the team's home
+--   venues (v_canonical_performer.home_venue_ids), else AWAY. Concert/comedy/
+--   theater performers get an 'all' row only.
+--
+-- Daily collapse: event_listing_snapshot_daily has up to 3 slots/day. We take the
+-- LATEST present slot per (event, day) via DISTINCT ON (evening > midday > morning)
+-- so re-running mid-day upgrades the row as later slots land, and an event with
+-- only a morning slot is still counted. Prices roll up the cross-source blended
+-- amalgam_* fields (best single signal); inventory totals stay per-source so units
+-- never get mixed.
+--
+-- Refresh: refresh_entity_metrics_daily(p_date) — idempotent (delete+insert for the
+-- target date). Cron 'entity-metrics-daily-refresh' runs it for today + yesterday
+-- every 4h (intraday progression + late-data catch). Read via the two SECDEF RPCs
+-- below (email-gated @s4kent.com like the rest of the D0 surface).
+
+-- ============================================================================
+-- 1. Tables
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.performer_metrics_daily (
+  performer_id            bigint      NOT NULL,
+  snapshot_date           date        NOT NULL,
+  split                   text        NOT NULL,            -- 'all' | 'home' | 'away'
+  performer_name          text,
+  what_event_type         text,
+  event_count             integer     NOT NULL DEFAULT 0,
+  evo_tickets_total       integer,
+  evo_owned_tickets_total integer,
+  sg_all_tickets_total    integer,
+  sg_owned_tickets_total  integer,
+  getin_min               numeric,                          -- cheapest get-in across the entity's events that day
+  getin_median            numeric,                          -- median of per-event get-ins
+  price_min               numeric,
+  price_median            numeric,                          -- median of per-event blended medians
+  price_p90               numeric,
+  owned_book_notional     numeric,                          -- Σ owned EVO inventory retail value
+  computed_at             timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT performer_metrics_daily_pk PRIMARY KEY (performer_id, snapshot_date, split),
+  CONSTRAINT performer_metrics_daily_split_chk CHECK (split IN ('all','home','away'))
+);
+CREATE INDEX IF NOT EXISTS performer_metrics_daily_date_idx
+  ON public.performer_metrics_daily (snapshot_date);
+CREATE INDEX IF NOT EXISTS performer_metrics_daily_perf_split_date_idx
+  ON public.performer_metrics_daily (performer_id, split, snapshot_date);
+
+CREATE TABLE IF NOT EXISTS public.venue_metrics_daily (
+  venue_id                bigint      NOT NULL,
+  snapshot_date           date        NOT NULL,
+  venue_name              text,
+  event_count             integer     NOT NULL DEFAULT 0,
+  evo_tickets_total       integer,
+  evo_owned_tickets_total integer,
+  sg_all_tickets_total    integer,
+  sg_owned_tickets_total  integer,
+  getin_min               numeric,
+  getin_median            numeric,
+  price_min               numeric,
+  price_median            numeric,
+  price_p90               numeric,
+  owned_book_notional     numeric,
+  computed_at             timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT venue_metrics_daily_pk PRIMARY KEY (venue_id, snapshot_date)
+);
+CREATE INDEX IF NOT EXISTS venue_metrics_daily_date_idx
+  ON public.venue_metrics_daily (snapshot_date);
+
+-- ============================================================================
+-- 2. Refresh function — roll event_listing_snapshot_daily up to performer + venue
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.refresh_entity_metrics_daily(p_date date DEFAULT current_date)
+RETURNS TABLE(performer_rows integer, venue_rows integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  v_perf integer := 0;
+  v_ven  integer := 0;
+BEGIN
+  -- 2a. canonical daily event row = latest present slot per (event, day)
+  CREATE TEMP TABLE _eld ON COMMIT DROP AS
+  SELECT DISTINCT ON (event_id)
+         event_id,
+         evo_tickets_count, evo_owned_tickets, evo_owned_median, evo_retail_median,
+         sg_all_tickets, sg_owned_tickets,
+         amalgam_getin, amalgam_median
+  FROM public.event_listing_snapshot_daily
+  WHERE snapshot_date = p_date
+  ORDER BY event_id,
+           CASE snapshot_slot WHEN 'evening' THEN 3 WHEN 'midday' THEN 2
+                              WHEN 'morning' THEN 1 ELSE 0 END DESC;
+
+  -- ---- performers (with home/away split for sports) -------------------------
+  DELETE FROM public.performer_metrics_daily WHERE snapshot_date = p_date;
+
+  WITH pe AS (
+    SELECT cp.tevo_performer_id   AS performer_id,
+           cp.tevo_performer_name AS performer_name,
+           cp.what_event_type,
+           CASE WHEN cp.what_event_type = 'game'
+                THEN CASE WHEN e.venue_id = ANY(cp.home_venue_ids) THEN 'home' ELSE 'away' END
+           END AS ha,
+           d.*
+    FROM public.events e
+    CROSS JOIN LATERAL unnest(e.performer_ids) AS u(pid)
+    JOIN public.v_canonical_performer cp ON cp.tevo_performer_id = u.pid
+    JOIN _eld d ON d.event_id = e.id
+  ),
+  rolled AS (
+    -- 'all' split: every performer, every event
+    SELECT performer_id, performer_name, what_event_type, 'all'::text AS split,
+           count(DISTINCT event_id)::int                                              AS event_count,
+           sum(evo_tickets_count)::int                                                AS evo_tickets_total,
+           sum(evo_owned_tickets)::int                                                AS evo_owned_tickets_total,
+           sum(sg_all_tickets)::int                                                   AS sg_all_tickets_total,
+           sum(sg_owned_tickets)::int                                                 AS sg_owned_tickets_total,
+           min(amalgam_getin)                                                         AS getin_min,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY amalgam_getin)                 AS getin_median,
+           min(amalgam_median)                                                        AS price_min,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY amalgam_median)                AS price_median,
+           percentile_cont(0.9) WITHIN GROUP (ORDER BY amalgam_median)                AS price_p90,
+           sum(coalesce(evo_owned_median, evo_retail_median) * evo_owned_tickets)     AS owned_book_notional
+    FROM pe
+    GROUP BY performer_id, performer_name, what_event_type
+    UNION ALL
+    -- 'home'/'away' splits: sports performers only
+    SELECT performer_id, performer_name, what_event_type, ha,
+           count(DISTINCT event_id)::int,
+           sum(evo_tickets_count)::int, sum(evo_owned_tickets)::int,
+           sum(sg_all_tickets)::int,    sum(sg_owned_tickets)::int,
+           min(amalgam_getin),          percentile_cont(0.5) WITHIN GROUP (ORDER BY amalgam_getin),
+           min(amalgam_median),         percentile_cont(0.5) WITHIN GROUP (ORDER BY amalgam_median),
+           percentile_cont(0.9) WITHIN GROUP (ORDER BY amalgam_median),
+           sum(coalesce(evo_owned_median, evo_retail_median) * evo_owned_tickets)
+    FROM pe
+    WHERE ha IS NOT NULL
+    GROUP BY performer_id, performer_name, what_event_type, ha
+  )
+  INSERT INTO public.performer_metrics_daily
+    (performer_id, snapshot_date, split, performer_name, what_event_type, event_count,
+     evo_tickets_total, evo_owned_tickets_total, sg_all_tickets_total, sg_owned_tickets_total,
+     getin_min, getin_median, price_min, price_median, price_p90, owned_book_notional)
+  SELECT performer_id, p_date, split, performer_name, what_event_type, event_count,
+         evo_tickets_total, evo_owned_tickets_total, sg_all_tickets_total, sg_owned_tickets_total,
+         getin_min, getin_median, price_min, price_median, price_p90, owned_book_notional
+  FROM rolled;
+  GET DIAGNOSTICS v_perf = ROW_COUNT;
+
+  -- ---- venues ---------------------------------------------------------------
+  DELETE FROM public.venue_metrics_daily WHERE snapshot_date = p_date;
+
+  INSERT INTO public.venue_metrics_daily
+    (venue_id, snapshot_date, venue_name, event_count,
+     evo_tickets_total, evo_owned_tickets_total, sg_all_tickets_total, sg_owned_tickets_total,
+     getin_min, getin_median, price_min, price_median, price_p90, owned_book_notional)
+  SELECT e.venue_id, p_date, max(v.name), count(DISTINCT d.event_id)::int,
+         sum(d.evo_tickets_count)::int, sum(d.evo_owned_tickets)::int,
+         sum(d.sg_all_tickets)::int,    sum(d.sg_owned_tickets)::int,
+         min(d.amalgam_getin),          percentile_cont(0.5) WITHIN GROUP (ORDER BY d.amalgam_getin),
+         min(d.amalgam_median),         percentile_cont(0.5) WITHIN GROUP (ORDER BY d.amalgam_median),
+         percentile_cont(0.9) WITHIN GROUP (ORDER BY d.amalgam_median),
+         sum(coalesce(d.evo_owned_median, d.evo_retail_median) * d.evo_owned_tickets)
+  FROM public.events e
+  JOIN _eld d ON d.event_id = e.id
+  LEFT JOIN public.venues v ON v.id = e.venue_id
+  WHERE e.venue_id IS NOT NULL
+  GROUP BY e.venue_id;
+  GET DIAGNOSTICS v_ven = ROW_COUNT;
+
+  DROP TABLE IF EXISTS _eld;
+  RETURN QUERY SELECT v_perf, v_ven;
+END;
+$func$;
+
+-- ============================================================================
+-- 3. Read RPCs (email-gated @s4kent.com, like the rest of the D0 surface)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_performer_metrics_daily(
+  p_performer_id bigint,
+  p_days         integer DEFAULT 90,
+  p_split        text    DEFAULT 'all')
+RETURNS SETOF public.performer_metrics_daily
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE='42501';
+  END IF;
+  IF p_split NOT IN ('all','home','away') THEN
+    RAISE EXCEPTION 'invalid split %, expected all|home|away', p_split USING ERRCODE='22023';
+  END IF;
+  RETURN QUERY
+    SELECT * FROM public.performer_metrics_daily
+    WHERE performer_id = p_performer_id
+      AND split = p_split
+      AND snapshot_date >= current_date - make_interval(days => p_days)
+    ORDER BY snapshot_date;
+END;
+$func$;
+
+CREATE OR REPLACE FUNCTION public.get_venue_metrics_daily(
+  p_venue_id bigint,
+  p_days     integer DEFAULT 90)
+RETURNS SETOF public.venue_metrics_daily
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE='42501';
+  END IF;
+  RETURN QUERY
+    SELECT * FROM public.venue_metrics_daily
+    WHERE venue_id = p_venue_id
+      AND snapshot_date >= current_date - make_interval(days => p_days)
+    ORDER BY snapshot_date;
+END;
+$func$;
+
+GRANT EXECUTE ON FUNCTION public.get_performer_metrics_daily(bigint, integer, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_venue_metrics_daily(bigint, integer)           TO authenticated;
+
+-- ============================================================================
+-- 4. Cron — refresh today + yesterday every 4h
+--    (idempotent; later runs upgrade the row as evening slots land, and the
+--    yesterday pass catches any late-arriving snapshot data)
+-- ============================================================================
+DO $$ BEGIN
+  PERFORM cron.unschedule('entity-metrics-daily-refresh');
+EXCEPTION WHEN OTHERS THEN NULL; END $$;
+
+SELECT cron.schedule('entity-metrics-daily-refresh', '20 */4 * * *', $cron$
+  SELECT public.refresh_entity_metrics_daily(current_date);
+  SELECT public.refresh_entity_metrics_daily(current_date - 1);
+$cron$);
+
+-- ============================================================================
+-- 5. Backfill all daily history currently present in the source
+-- ============================================================================
+DO $$
+DECLARE v_d date;
+BEGIN
+  FOR v_d IN SELECT DISTINCT snapshot_date FROM public.event_listing_snapshot_daily ORDER BY 1 LOOP
+    PERFORM public.refresh_entity_metrics_daily(v_d);
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260604160000_world_cup_price_logger.sql
+++ b/supabase/migrations/20260604160000_world_cup_price_logger.sql
@@ -166,6 +166,10 @@ $func$;
 GRANT EXECUTE ON FUNCTION public.get_wc_price_daily(bigint, integer) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.get_wc_price_board()                TO authenticated;
 
+-- refresh fn is a SECDEF writer with no email gate → keep it off PUBLIC/anon
+-- (cron runs as owner, unaffected). Mirrors the D4 write-path revoke pattern.
+REVOKE EXECUTE ON FUNCTION public.refresh_wc_price_daily(date, date) FROM PUBLIC;
+
 -- ============================================================================
 -- 4. Cron — re-roll a trailing 4-day window daily (idempotent; catches the
 --    sparse, late-arriving SG pulls without missing a poll)

--- a/supabase/migrations/20260604160000_world_cup_price_logger.sql
+++ b/supabase/migrations/20260604160000_world_cup_price_logger.sql
@@ -1,0 +1,210 @@
+-- Migration 20260604160000 · lane:D0 (author) → A1 (apply) · writes:wc_price_daily,refresh_wc_price_daily,v_wc_price_latest,get_wc_price_daily,get_wc_price_board,watchlist(seed),cron(wc-price-daily-refresh) · reads:sg_events_canonical,seatgeek_listings_snapshots,cross_source_venue_resolve · pre:20260604120000 · auth:OPERATOR-APPROVED 2026-06-04 (scope: entire World Cup, watchlist=venues, execute=migration/PR). REQUIRES A1 apply (creates table+cron, seeds watchlist, backfills history).
+--
+-- D0 — 2026 WORLD CUP daily price logger + watchlist seed.
+--
+-- Why this is SG-sourced, not the TEvo firehose: the 2026 World Cup is FIFA
+-- PRIMARY inventory. It does NOT flow through TEvo resale, so the broker `events`
+-- table + event_listing_snapshot_daily carry ZERO WC matches (verified 2026-06-04).
+-- SeatGeek DOES list them: all 101 matches are in sg_events_canonical, 100 have
+-- listings, and seatgeek_listings_snapshots already holds ~154k rows of history.
+-- So "pull all sources" = SeatGeek (the only source carrying WC inventory); this
+-- logger rolls that firehose into a per-match daily price series.
+--
+-- WC match identification (the ONE predicate that's correct):
+--   sg_event_name ILIKE '%world cup - match%'
+--   * Group stage  : "Brazil vs Morocco - World Cup - Match 7 (Group C)"   ✓
+--   * Knockouts    : "2026 World Cup - Match 104 (Final)"                  ✓
+--   * EXCLUDES the false positive "... (World Cup Scarf Giveaway)" (an MLB
+--     promo night) which a bare '%world cup%' wrongly catches. → 101 matches.
+--
+-- Daily collapse: SG polls each match ~1-2x/day on a horizon-banded cadence (NOT
+-- every day this far out). For each (event, day) we take the LATEST pull's book
+-- (max(captured_at)) and compute the all-in distribution over it — the end-of-day
+-- order book. Headline price = retail_price_all_in (fees in); broadcast_price kept
+-- alongside. Gaps are expected per event until the cadence tightens near kickoff.
+--
+-- Pieces: wc_price_daily (table) · refresh_wc_price_daily(from,to) (idempotent
+-- delete+insert) · v_wc_price_latest (live board) · get_wc_price_daily /
+-- get_wc_price_board (email-gated RPCs) · daily cron (trailing 4-day re-roll) ·
+-- full backfill · watchlist seed (host venues that resolve to a canonical id).
+
+-- ============================================================================
+-- 1. Table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.wc_price_daily (
+  sg_event_id       bigint      NOT NULL,
+  snapshot_date     date        NOT NULL,
+  sg_event_name     text,
+  venue_name        text,
+  match_date        date,
+  captured_at       timestamptz,            -- the SG pull rolled up for this day
+  listings_count    integer,
+  tickets_count     integer,
+  owned_listings    integer,                -- broker-owned subset (is_broker_owned)
+  owned_tickets     integer,
+  allin_min         numeric,                -- retail_price_all_in (fees in) — headline
+  allin_median      numeric,
+  allin_p90         numeric,
+  broadcast_min     numeric,                -- broadcast/list price
+  broadcast_median  numeric,
+  computed_at       timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT wc_price_daily_pk PRIMARY KEY (sg_event_id, snapshot_date)
+);
+CREATE INDEX IF NOT EXISTS wc_price_daily_date_idx  ON public.wc_price_daily (snapshot_date);
+CREATE INDEX IF NOT EXISTS wc_price_daily_match_idx ON public.wc_price_daily (match_date);
+
+-- ============================================================================
+-- 2. Refresh — roll SeatGeek listings into the daily series for a date range
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.refresh_wc_price_daily(
+  p_from date DEFAULT current_date,
+  p_to   date DEFAULT current_date)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE
+  v_rows integer := 0;
+BEGIN
+  DELETE FROM public.wc_price_daily WHERE snapshot_date BETWEEN p_from AND p_to;
+
+  WITH wc AS (
+    SELECT sg_event_id, sg_event_name, sg_venue_name, sg_event_date
+    FROM public.sg_events_canonical
+    WHERE sg_event_name ILIKE '%world cup - match%'
+  ),
+  day_latest AS (
+    SELECT s.sg_event_id, s.captured_at::date AS dd, max(s.captured_at) AS max_cap
+    FROM public.seatgeek_listings_snapshots s
+    WHERE s.sg_event_id IN (SELECT sg_event_id FROM wc)
+      AND s.captured_at::date BETWEEN p_from AND p_to
+    GROUP BY s.sg_event_id, s.captured_at::date
+  ),
+  book AS (
+    SELECT dl.sg_event_id, dl.dd, dl.max_cap,
+           s.retail_price_all_in, s.broadcast_price, s.quantity, s.is_broker_owned
+    FROM day_latest dl
+    JOIN public.seatgeek_listings_snapshots s
+      ON s.sg_event_id = dl.sg_event_id AND s.captured_at = dl.max_cap
+    WHERE s.retail_price_all_in > 0
+  ),
+  rolled AS (
+    SELECT b.sg_event_id, b.dd AS snapshot_date, max(b.max_cap) AS captured_at,
+           count(*)::int                                              AS listings_count,
+           sum(b.quantity)::int                                       AS tickets_count,
+           count(*) FILTER (WHERE b.is_broker_owned)::int             AS owned_listings,
+           sum(b.quantity) FILTER (WHERE b.is_broker_owned)::int      AS owned_tickets,
+           min(b.retail_price_all_in)                                 AS allin_min,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY b.retail_price_all_in) AS allin_median,
+           percentile_cont(0.9) WITHIN GROUP (ORDER BY b.retail_price_all_in) AS allin_p90,
+           min(b.broadcast_price)                                     AS broadcast_min,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY b.broadcast_price)     AS broadcast_median
+    FROM book b
+    GROUP BY b.sg_event_id, b.dd
+  )
+  INSERT INTO public.wc_price_daily
+    (sg_event_id, snapshot_date, sg_event_name, venue_name, match_date, captured_at,
+     listings_count, tickets_count, owned_listings, owned_tickets,
+     allin_min, allin_median, allin_p90, broadcast_min, broadcast_median)
+  SELECT r.sg_event_id, r.snapshot_date, wc.sg_event_name, wc.sg_venue_name, wc.sg_event_date,
+         r.captured_at, r.listings_count, r.tickets_count, r.owned_listings, r.owned_tickets,
+         r.allin_min, r.allin_median, r.allin_p90, r.broadcast_min, r.broadcast_median
+  FROM rolled r JOIN wc ON wc.sg_event_id = r.sg_event_id;
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RETURN v_rows;
+END;
+$func$;
+
+-- ============================================================================
+-- 3. Live board view (latest snapshot per match) + read RPCs (email-gated)
+-- ============================================================================
+CREATE OR REPLACE VIEW public.v_wc_price_latest AS
+SELECT DISTINCT ON (sg_event_id) *
+FROM public.wc_price_daily
+ORDER BY sg_event_id, snapshot_date DESC;
+
+CREATE OR REPLACE FUNCTION public.get_wc_price_daily(
+  p_sg_event_id bigint,
+  p_days        integer DEFAULT 120)
+RETURNS SETOF public.wc_price_daily
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE='42501';
+  END IF;
+  RETURN QUERY
+    SELECT * FROM public.wc_price_daily
+    WHERE sg_event_id = p_sg_event_id
+      AND snapshot_date >= current_date - make_interval(days => p_days)
+    ORDER BY snapshot_date;
+END;
+$func$;
+
+-- Cheapest-first board across the whole tournament (latest price per match).
+CREATE OR REPLACE FUNCTION public.get_wc_price_board()
+RETURNS SETOF public.wc_price_daily
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+DECLARE v_email text;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE='42501';
+  END IF;
+  RETURN QUERY
+    SELECT * FROM public.v_wc_price_latest ORDER BY allin_min NULLS LAST;
+END;
+$func$;
+
+GRANT EXECUTE ON FUNCTION public.get_wc_price_daily(bigint, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_wc_price_board()                TO authenticated;
+
+-- ============================================================================
+-- 4. Cron — re-roll a trailing 4-day window daily (idempotent; catches the
+--    sparse, late-arriving SG pulls without missing a poll)
+-- ============================================================================
+DO $$ BEGIN
+  PERFORM cron.unschedule('wc-price-daily-refresh');
+EXCEPTION WHEN OTHERS THEN NULL; END $$;
+
+SELECT cron.schedule('wc-price-daily-refresh', '40 7 * * *', $cron$
+  SELECT public.refresh_wc_price_daily(current_date - 3, current_date);
+$cron$);
+
+-- ============================================================================
+-- 5. Backfill all existing SeatGeek WC history
+-- ============================================================================
+SELECT public.refresh_wc_price_daily(DATE '2026-05-01', current_date);
+
+-- ============================================================================
+-- 6. Watchlist seed — host venues that resolve to a canonical venue id
+--    (kind='venue'; label 'World Cup 2026'). Venues that don't resolve
+--    (BC Place, Estadio Azteca/BBVA/Akron, Arrowhead's "GEHA Field at ..."
+--    alias) are skipped — they have no canonical id to key on. NOTE: WC events
+--    are SeatGeek-native (not TEvo-linked), so these venue bookmarks are a
+--    portfolio marker; the live tracking is wc_price_daily above. Idempotent —
+--    as of authoring, all 11 resolvable host venues are ALREADY watched, so this
+--    inserts 0 today; it's kept so any not-yet-watched host venue is picked up.
+-- ============================================================================
+INSERT INTO public.watchlist (kind, ext_id, label)
+SELECT 'venue', r.tevo_venue_id, 'World Cup 2026'
+FROM (
+  SELECT DISTINCT public.cross_source_venue_resolve(v.sg_venue_name, v.sg_venue_city, v.sg_venue_state) AS tevo_venue_id
+  FROM (
+    SELECT DISTINCT sg_venue_name, sg_venue_city, sg_venue_state
+    FROM public.sg_events_canonical
+    WHERE sg_event_name ILIKE '%world cup - match%'
+  ) v
+) r
+WHERE r.tevo_venue_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.watchlist w
+    WHERE w.kind = 'venue' AND w.ext_id = r.tevo_venue_id
+  );


### PR DESCRIPTION
This branch carries **two related D0 migrations** for daily price/metrics tracking.

---

## 1. `20260604120000_entity_metrics_daily.sql` — performer + venue daily rollups

Daily aggregate timeseries at the **performer** and **venue** level, with **home/away** split for sports teams. Fills the gap between per-event daily metrics (`event_listing_snapshot_daily`) and the single-row rolling baselines.

- `performer_metrics_daily` (`split ∈ {all, home, away}`; home/away for `what_event_type='game'` only, home = event venue ∈ `home_venue_ids`, mirrors `app.py` `is_home`).
- `venue_metrics_daily`.
- `refresh_entity_metrics_daily(p_date)` (idempotent), email-gated read RPCs, 4-hourly cron + history backfill.
- Validated read-only vs prod (Yankees: 137 = 68 home + 69 away, exact partition).
- **Fix in `3ddf4bf`:** original venue rollup joined `public.venues`, which **doesn't exist** in this schema — would have failed on apply. Now uses the denormalized `events.venue_name`. Re-validated (Sphere 655 events, MSG 127, Yankee Stadium get-in $3.09).

## 2. `20260604160000_world_cup_price_logger.sql` — 2026 World Cup price tracking

The 2026 World Cup is **FIFA primary inventory** — it does **not** flow through TEvo resale, so the broker firehose has **0** WC matches (which is why there was no trend data). **SeatGeek carries the whole tournament**: all 101 matches in `sg_events_canonical`, ~154k listing-snapshot rows of history. This logs that into a daily per-match series.

- `wc_price_daily` — per (match, day) all-in min/median/p90 + broadcast + inventory, from the latest SG pull that day.
- Match filter `'%world cup - match%'` captures **group + knockout** (Match 1–104) and **excludes** the `World Cup Scarf Giveaway` MLB false positive.
- `refresh_wc_price_daily(from,to)` (idempotent) + daily cron (trailing 4-day re-roll, since SG's WC cadence is sparse this far out) + full backfill (validated: **272 daily rows / 99 matches / 19 days**).
- `v_wc_price_latest` + `get_wc_price_daily` / `get_wc_price_board` (email-gated RPCs — cheapest-first board across the tournament).
- **Watchlist seed:** host venues resolvable to a canonical id (`kind='venue'`, label `World Cup 2026`). All 11 resolvable host venues are **already watched** → inserts 0 today; kept forward-safe. WC events are SeatGeek-native (not TEvo-linked), so `wc_price_daily` is the real tracker.

---

## ⚠️ Apply is operator-gated (both migrations)

Tables, crons, a watchlist seed, and history backfills — none applied here. Per `CLAUDE.md §1`, DDL + cron + prod writes need explicit operator approval, and apply lands via A1. Not yet run against a Supabase preview branch (offered).

## CI
Only red check is the pre-existing, unrelated `test_store_home::test_home_returns_owned_with_enrichment` (D1 storefront) — already failing on `main`; this branch adds only `.sql` files.

https://claude.ai/code/session_011TjaH2PKMBZGaKuzcWohkE