### PR TITLE
chore(recovery): re-cut orphaned 05-26/27 work onto rewritten main

### DIFF
--- a/app.py
+++ b/app.py
@@ -3782,16 +3782,18 @@ def broker_event_cadences(event_id: int, _=Depends(require_auth)):
 # migration 20260509060000. Going over those caps requires bumping BOTH the
 # DB defaults AND the seatdata_client.py constants.
 #
-# Auth: requires SEATDATA_API_KEY env var. Set it in Railway:
-#   railway variables --set SEATDATA_API_KEY=<key>
-# Routes return 503 if the key is missing rather than crashing the app.
+# Auth: SEATDATA_API_KEY resolved via SeatDataClient's chain:
+#   1. SEATDATA_API_KEY env var (Railway / Render)
+#   2. Supabase Vault via get_app_secret('SEATDATA_API_KEY')
+# Routes return 503 if the key is missing from both env and vault.
 
 def _get_seatdata_client():
-    """Lazy import + instantiation. Returns None if SEATDATA_API_KEY is missing."""
-    if not os.environ.get("SEATDATA_API_KEY"):
+    """Lazy import + instantiation. Returns None if SEATDATA_API_KEY not found anywhere."""
+    from seatdata_client import SeatDataClient, SeatDataError
+    try:
+        return SeatDataClient(db=require_sb())
+    except SeatDataError:
         return None
-    from seatdata_client import SeatDataClient
-    return SeatDataClient(db=require_sb())
 
 
 @app.get("/api/seatdata/account")
@@ -5623,10 +5625,13 @@ def _section_featured(candidates: list,
         except (TypeError, ValueError):
             continue
         owned = c.get("owned_tickets_count") or 0
-        if owned <= 100:
-            # Global gate — every Featured event needs depth
-            continue
         playoff = _classify_playoff(c.get("name") or "")
+        if owned <= 100 and not playoff:
+            # Global depth gate for non-playoff events. Playoff games are
+            # exempt (operator directive 2026-05-26) — they're the highest-
+            # value NYC inventory even at thin owned counts (e.g. Knicks
+            # Game 7 sits at owned ~60, well under the regular-season bar).
+            continue
         rivalry = rivalry_by_eid.get(eid_int)
         holiday = holiday_by_eid.get(eid_int)
         marquee = _classify_marquee_competition(c.get("name") or "")
@@ -5717,12 +5722,19 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
 
     if not events_rows:
         return {"city": city, "days": day_cap, "count": 0, "events": []}
-    # Drop speculative names (CANCELLED / (If Necessary) / (Date TBD)) —
-    # playoff "may not happen" placeholders shouldn't surface to consumers
-    # via the movers strip. event_lifecycle.is_active stays true for these
-    # because the game *could* happen, so the name-string filter is the
-    # right layer. Mirrors search + home behavior.
-    events_rows = [e for e in events_rows if not _is_speculative_event_name(e.get("name"))]
+    # Drop speculative names (CANCELLED / (If Necessary)) — playoff "may not
+    # happen" placeholders normally shouldn't surface to consumers. EXCEPTION
+    # (operator directive 2026-05-26): playoff games keep their "(If Necessary)"
+    # slot in the movers strip — they're the highest-value NYC inventory (e.g.
+    # Knicks Game 7, $5,880 median) and are exactly what the Featured rail is
+    # for. Genuine CANCELLED games still drop, even playoff ones. This relaxes
+    # the filter ONLY for the movers strip; search + home still hide these.
+    events_rows = [
+        e for e in events_rows
+        if not _is_speculative_event_name(e.get("name"))
+        or (_classify_playoff(e.get("name"))
+            and "CANCELLED" not in (e.get("name") or "").upper())
+    ]
     if not events_rows:
         return {"city": city, "days": day_cap, "count": 0, "events": []}
     events_by_id = {int(e["id"]): e for e in events_rows if e.get("id")}
@@ -5913,7 +5925,11 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     # Every owned (>=1) event lands in `candidates` with its full signal
     # payload. Each section helper below filters this pool independently;
     # an event can qualify for 0, 1, or multiple sections.
+    # `all_owned_cards` collects EVERY owned event (incl. owned<=50) so the
+    # empty-rail fallback below has a pool to draw from when nothing clears
+    # the curation gates (operator directive 2026-05-26).
     candidates: list[dict] = []
+    all_owned_cards: list[dict] = []
     for eid, m in metrics_by_id.items():
         if eid in inactive:
             continue
@@ -5975,11 +5991,7 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             break
         b = perf_assets.get(away_pid) if away_pid else None
         owned_tickets = m.get("owned_tickets_count") or 0
-        if owned_tickets <= 50:
-            # Sections (except holidays) require owned > 50 for inventory depth;
-            # holidays is even tighter at > 100, applied in the section helper.
-            continue
-        candidates.append({
+        card = {
             "id": ev.get("id"),
             "name": ev.get("name"),
             "occurs_at_local": ev.get("occurs_at_local"),
@@ -6006,7 +6018,14 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
             "owned_tickets_count": owned_tickets,
             "owned_median_retail": m.get("owned_median_retail"),
             "owned_share": m.get("owned_share"),
-        })
+        }
+        all_owned_cards.append(card)
+        if owned_tickets > 50:
+            # Sections (except holidays) require owned > 50 for inventory depth;
+            # holidays/specials are tighter at > 100, applied in the section
+            # helpers. Playoff games additionally bypass the owned>100 Featured
+            # gate (see _section_featured).
+            candidates.append(card)
 
     # ----- Specials enrichment: pull holiday-window matches + rivalry
     # tags. Both wrapped in try/except so a view-side failure degrades
@@ -6191,6 +6210,20 @@ def _compute_movers(db, city: str, day_cap: int, cap: int) -> dict:
     # other lists we have"). Holiday/rivalry events with owned > 100 that
     # don't qualify for Featured land here.
     specials = _consume(_section_specials(candidates, holiday_by_eid, rivalry_by_eid))
+
+    # Empty-rail fallback (operator directive 2026-05-26): never render a blank
+    # homepage. When nothing clears the curation gates — common in thin-
+    # inventory windows (offseason, between playoff rounds) — surface the
+    # soonest upcoming owned NYC events in the Featured rail so it always has
+    # something bookable. These qualify on recency + owned inventory alone, so
+    # they carry no curation chip (_featured_tag = "").
+    if not (featured or moving_fast or price_drops or climbing or specials):
+        fallback = sorted(all_owned_cards,
+                          key=lambda c: c.get("occurs_at_local") or "9999")[:cap]
+        for fc in fallback:
+            fc.setdefault("_featured_tag", "")
+            fc["_featured_kind"] = "fallback"
+        featured = fallback
 
     return {
         "city": city,

--- a/d2_dashboard/main.py
+++ b/d2_dashboard/main.py
@@ -199,6 +199,24 @@ def require_auth(authorization: str | None = Header(None)):
 
 # ---------- Client factories (lazy — only init when called) ----------
 
+def _vault_secret(name: str) -> str | None:
+    """Fetch a secret from Supabase Vault via get_app_secret RPC.
+    Returns None when Supabase is unavailable or the secret is unset."""
+    sb = _sb()
+    if sb is None:
+        return None
+    try:
+        res = sb.rpc("get_app_secret", {"p_name": name}).execute()
+        data = res.data
+        if isinstance(data, str):
+            return data or None
+        if isinstance(data, dict):
+            return data.get("get_app_secret") or data.get("value") or None
+    except Exception:
+        pass
+    return None
+
+
 def _env_first(*names: str) -> str | None:
     """Return the first set env var from `names`. Lets us accept either the
     vault-canonical key (TEVO_API_TOKEN) or the legacy storefront key
@@ -284,24 +302,24 @@ def _tickpick_client():
 
 def _vivid_client():
     from vivid_client import VividClient
-    token = os.environ.get("VIVID_API_TOKEN")
+    token = os.environ.get("VIVID_API_TOKEN") or _vault_secret("VIVID_API_TOKEN")
     if not token:
         return None
     return VividClient(token)
 
 
 def _seatdata_client():
-    from seatdata_client import SeatDataClient
-    api_key = os.environ.get("SEATDATA_API_KEY")
-    if not api_key:
+    from seatdata_client import SeatDataClient, SeatDataError
+    try:
+        return SeatDataClient(db=_sb())
+    except SeatDataError:
         return None
-    return SeatDataClient(api_key=api_key)
 
 
 def _gotickets_client():
     from gotickets_client import GoTicketsClient
-    access_id = os.environ.get("GOTICKETS_ACCESS_ID")
-    api_secret = os.environ.get("GOTICKETS_API_SECRET")
+    access_id = os.environ.get("GOTICKETS_ACCESS_ID") or _vault_secret("GOTICKETS_ACCESS_ID")
+    api_secret = os.environ.get("GOTICKETS_API_SECRET") or _vault_secret("GOTICKETS_API_SECRET")
     if not (access_id and api_secret):
         return None
     return GoTicketsClient(access_id, api_secret)

--- a/scripts/ticketsdata_mvp.py
+++ b/scripts/ticketsdata_mvp.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""TicketsData MVP smoke test — budget-guarded.
+
+Exercises the TicketsData client against a tiny, explicit set of calls so we
+can confirm auth + connectivity + parsing WITHOUT burning through the plan.
+
+Plan context (Starter): 10,000 API credits/mo + 250 Market-Intelligence
+reports/mo. Cost: /fetch = 1 credit, /events = 1 credit, /match = 12 credits
+AND 1 report.
+
+The guard: this script projects the WORST-CASE credit cost of the requested
+actions up front and refuses to make any call if that exceeds --max-credits.
+After every call it reads `quota_remaining` (and `reports_remaining` for
+/match) from the response and aborts the rest of the plan if either drops
+below its floor. /match is OFF unless you pass --allow-match.
+
+Credentials come from TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD env vars.
+
+Note: seatgeek is excluded (sourced natively) — fetch/events reject it.
+
+Examples:
+  # dry run — print the plan + projected cost, make zero calls
+  python scripts/ticketsdata_mvp.py --platform stubhub \\
+      --event-url https://www.stubhub.com/x/event/159756853/ --dry-run
+
+  # one /fetch (1 credit)
+  python scripts/ticketsdata_mvp.py --platform stubhub \\
+      --event-url https://www.stubhub.com/x/event/159756853/
+
+  # one /events discovery + one /fetch on the first result (<= 2 credits)
+  python scripts/ticketsdata_mvp.py --platform stubhub \\
+      --performer-url https://www.stubhub.com/morgan-wallen-tickets/performer/123/ --then-fetch
+
+  # cross-market report (12 credits + 1 report) — must opt in AND raise cap
+  python scripts/ticketsdata_mvp.py --allow-match --max-credits 12 \\
+      --match-url https://www.stubhub.com/x/event/159756853/
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Allow running as `python scripts/ticketsdata_mvp.py` from repo root.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ticketsdata_client import (  # noqa: E402
+    CREDIT_COST,
+    TicketsDataClient,
+    TicketsDataError,
+)
+
+
+class BudgetExceeded(RuntimeError):
+    pass
+
+
+class Budget:
+    """Hard credit ceiling for one MVP run. Refuses spend over the cap and
+    tracks the live `quota_remaining` floor reported by the API."""
+
+    def __init__(self, max_credits: int, min_quota_floor: int):
+        self.max_credits = max_credits
+        self.min_quota_floor = min_quota_floor
+        self.spent = 0
+        self.last_quota_remaining: int | None = None
+
+    def check(self, cost: int) -> None:
+        if self.spent + cost > self.max_credits:
+            raise BudgetExceeded(
+                f"would spend {self.spent + cost} credits > cap {self.max_credits}"
+            )
+        if (
+            self.last_quota_remaining is not None
+            and self.last_quota_remaining - cost < self.min_quota_floor
+        ):
+            raise BudgetExceeded(
+                f"quota_remaining {self.last_quota_remaining} would drop below "
+                f"floor {self.min_quota_floor}"
+            )
+
+    def record(self, cost: int, quota_remaining: int | None) -> None:
+        self.spent += cost
+        if isinstance(quota_remaining, int):
+            self.last_quota_remaining = quota_remaining
+
+
+def _maybe_supabase():
+    """Best-effort service-role Supabase client for the Vault credential
+    fallback. Returns None if env/lib unavailable (then env creds are used)."""
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not (url and key):
+        return None
+    try:
+        from supabase import create_client
+        return create_client(url, key)
+    except Exception as e:
+        print(f"(supabase client unavailable, using env creds: {e})", file=sys.stderr)
+        return None
+
+
+def _q(env: dict) -> int | None:
+    v = env.get("quota_remaining")
+    return v if isinstance(v, int) else None
+
+
+def _summarize_fetch(env: dict) -> str:
+    # Real /fetch envelope (confirmed live 2026-05-26): top-level status_code +
+    # event_id, listings under items.{totalListings,offers}. The docs' nested
+    # body._embedded/listings shape is kept as a fallback.
+    status = env.get("status_code", env.get("status"))
+    n = None
+    items = env.get("items")
+    if isinstance(items, dict):
+        if isinstance(items.get("totalListings"), int):
+            n = items["totalListings"]
+        elif isinstance(items.get("offers"), list):
+            n = len(items["offers"])
+    if n is None:
+        body = env.get("body")
+        if isinstance(body, list):
+            n = len(body)
+        elif isinstance(body, dict):
+            emb = body.get("_embedded")
+            if isinstance(emb, dict) and isinstance(emb.get("offer"), list):
+                n = len(emb["offer"])
+            elif isinstance(body.get("listings"), list):
+                n = len(body["listings"])
+            elif isinstance(body.get("offers"), list):
+                n = len(body["offers"])
+    listings = f"{n} listings" if n is not None else "listings (shape varies)"
+    return (f"  /fetch: status={status} event={env.get('event_id', '?')} "
+            f"{listings} in {env.get('response_s')}s")
+
+
+def _summarize_match(env: dict) -> str:
+    intel = (env.get("fetch_results") or {}).get("intelligence") or {}
+    snap = intel.get("cross_market_snapshot") or {}
+    best = snap.get("best_entry_total") or {}
+    deep = snap.get("deepest_market") or {}
+    arb = intel.get("section_arbitrage") or []
+    top = arb[0] if arb else {}
+    lines = [
+        f"  /match: confidence={env.get('match_confidence')} "
+        f"markets={snap.get('marketplaces_compared')}",
+        f"    best entry: {best.get('marketplace')} ${best.get('price')} "
+        f"({best.get('section')})",
+        f"    deepest:    {deep.get('marketplace')} {deep.get('listing_count')} listings",
+    ]
+    if top:
+        lines.append(
+            f"    top spread: {top.get('section')} ${top.get('spread')} "
+            f"({top.get('spread_pct_vs_best')}% vs best)"
+        )
+    lines.append(f"    reports_remaining={env.get('reports_remaining')}")
+    return "\n".join(lines)
+
+
+def _first_event_url(env: dict) -> str | None:
+    """Best-effort extraction of the first event URL from an /events body."""
+    body = env.get("body")
+    items = body if isinstance(body, list) else (
+        body.get("events") if isinstance(body, dict) else None
+    )
+    if not isinstance(items, list):
+        return None
+    for it in items:
+        if isinstance(it, dict):
+            for key in ("event_url", "url", "link"):
+                if it.get(key):
+                    return it[key]
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="TicketsData MVP smoke test (budget-guarded)")
+    ap.add_argument("--platform", help="marketplace for --event-url / --performer-url")
+    ap.add_argument("--event-url", help="event URL for a single /fetch")
+    ap.add_argument("--performer-url", help="performer/venue page for a single /events")
+    ap.add_argument("--then-fetch", action="store_true",
+                    help="after /events, run one /fetch on the first discovered event")
+    ap.add_argument("--match-url", help="event URL for /match (cross-market report)")
+    ap.add_argument("--allow-match", action="store_true",
+                    help="permit the 12-credit + 1-report /match call (off by default)")
+    ap.add_argument("--max-credits", type=int, default=5,
+                    help="hard ceiling on credits this run may spend (default 5)")
+    ap.add_argument("--min-quota-floor", type=int, default=50,
+                    help="abort if quota_remaining would drop below this (default 50)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the plan + projected worst-case cost, make NO calls")
+    args = ap.parse_args()
+
+    # Build the plan.
+    plan: list[tuple[str, int]] = []
+    if args.event_url:
+        plan.append(("fetch", CREDIT_COST["fetch"]))
+    if args.performer_url:
+        plan.append(("events", CREDIT_COST["events"]))
+        if args.then_fetch:
+            plan.append(("fetch-discovered", CREDIT_COST["fetch"]))
+    if args.match_url:
+        if not args.allow_match:
+            print("ERROR: --match-url requires --allow-match "
+                  "(12 credits + 1 report).", file=sys.stderr)
+            return 2
+        plan.append(("match", CREDIT_COST["match"]))
+
+    if not plan:
+        print("Nothing to do. Provide --event-url, --performer-url, and/or "
+              "--match-url. See --help.", file=sys.stderr)
+        return 2
+
+    worst_case = sum(cost for _, cost in plan)
+    print(f"Plan: {[name for name, _ in plan]}")
+    print(f"Projected worst-case cost: {worst_case} credits "
+          f"(cap --max-credits={args.max_credits})")
+    if args.match_url:
+        print("  note: /match also consumes 1 Market-Intelligence report")
+
+    if worst_case > args.max_credits:
+        print(f"REFUSING: projected {worst_case} credits exceeds cap "
+              f"{args.max_credits}. Raise --max-credits to proceed.", file=sys.stderr)
+        return 3
+
+    if args.dry_run:
+        print("Dry run — no calls made.")
+        return 0
+
+    try:
+        # Pass a service-role db (if Supabase env is set) so creds can resolve
+        # from Vault; otherwise TICKETSDATA_* env vars are used directly.
+        client = TicketsDataClient(db=_maybe_supabase())
+    except TicketsDataError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    budget = Budget(args.max_credits, args.min_quota_floor)
+
+    try:
+        if args.event_url:
+            if not args.platform:
+                print("ERROR: --event-url needs --platform", file=sys.stderr)
+                return 2
+            budget.check(CREDIT_COST["fetch"])
+            env = client.fetch(args.platform, args.event_url)
+            budget.record(CREDIT_COST["fetch"], _q(env))
+            print(_summarize_fetch(env))
+            print(f"  quota_remaining={_q(env)}  (spent {budget.spent})")
+
+        if args.performer_url:
+            if not args.platform:
+                print("ERROR: --performer-url needs --platform", file=sys.stderr)
+                return 2
+            budget.check(CREDIT_COST["events"])
+            env = client.events(args.platform, performer_url=args.performer_url)
+            budget.record(CREDIT_COST["events"], _q(env))
+            first = _first_event_url(env)
+            print(f"  /events {args.platform}: discovered first event = {first}")
+            print(f"  quota_remaining={_q(env)}  (spent {budget.spent})")
+            if args.then_fetch and first:
+                budget.check(CREDIT_COST["fetch"])
+                env2 = client.fetch(args.platform, first)
+                budget.record(CREDIT_COST["fetch"], _q(env2))
+                print(_summarize_fetch(env2))
+                print(f"  quota_remaining={_q(env2)}  (spent {budget.spent})")
+
+        if args.match_url:
+            budget.check(CREDIT_COST["match"])
+            env = client.match(args.match_url)
+            budget.record(CREDIT_COST["match"], _q(env))
+            print(_summarize_match(env))
+            print(f"  quota_remaining={_q(env)}  (spent {budget.spent})")
+
+    except BudgetExceeded as e:
+        print(f"ABORTED mid-plan (budget guard): {e}", file=sys.stderr)
+        return 3
+    except TicketsDataError as e:
+        print(f"API error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Done. Total credits spent this run: {budget.spent}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supabase/migrations/20260605130000_optimize_zone_section_metrics_dedup.sql
+++ b/supabase/migrations/20260605130000_optimize_zone_section_metrics_dedup.sql
@@ -1,0 +1,400 @@
+-- 20260526080000_optimize_zone_section_metrics_dedup.sql
+--
+-- A1 / Task #17: Optimize compute_event_zone_metrics + compute_event_section_metrics
+-- for heavy events (500-1000+ listing rows, e.g. Yankees Stadium).
+--
+-- ROOT CAUSES:
+--   1. Both functions call match_performer_zone() via LATERAL once per listing row
+--      even when the performer/venue has zero curated zone rules (the common case).
+--   2. Both functions call derive_zone_fallback() 2-3× per row due to expression
+--      duplication in the SELECT list (can't reference a column alias in the same
+--      clause in PostgreSQL, so the call was repeated inline in COALESCE and CASE).
+--   3. Neither function deduplicates zone lookups by unique (section, row) pair —
+--      multiple brokers listing in the same section trigger redundant lookups.
+--
+-- FIXES:
+--   1. v_has_zones pre-check: single EXISTS query against performer_zones.
+--      If false (no curated zones for this performer+venue), the CASE WHEN v_has_zones
+--      guard skips all match_performer_zone() calls entirely.
+--   2. unique_sec + sec_zones CTEs: compute both curated_name and fb_zone exactly
+--      once per distinct (section, row) pair, then JOIN back to the full listing set.
+--   3. zone / zone_source derived from the pre-computed sec_zones columns — zero
+--      repeated function calls.
+--
+-- PERF IMPACT (measured against heaviest event: 836 rows, 682 unique section/row pairs):
+--   - match_performer_zone:  836 calls → 0 (no curated zones) or 682 (has zones)
+--   - derive_zone_fallback:  836×2 / 836×3 calls → 682×1 calls
+--   - Expected wall-clock improvement: 1-3s per heavy event → <0.3s
+--
+-- ROLLBACK: revert both functions to prior definitions (see git history).
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. compute_event_zone_metrics
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.compute_event_zone_metrics(
+  p_event_id    bigint,
+  p_captured_at timestamptz
+)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_performer_id bigint;
+  v_venue_id     bigint;
+  v_has_zones    boolean := false;
+  v_count        integer;
+BEGIN
+  SELECT primary_performer_id, venue_id
+    INTO v_performer_id, v_venue_id
+  FROM events WHERE id = p_event_id;
+
+  -- Fast pre-check: skip all match_performer_zone() calls when this
+  -- performer+venue has no curated zone rules (the common case for long-tail events).
+  IF v_performer_id IS NOT NULL AND v_venue_id IS NOT NULL THEN
+    SELECT EXISTS(
+      SELECT 1 FROM performer_zones
+      WHERE performer_id = v_performer_id AND venue_id = v_venue_id
+    ) INTO v_has_zones;
+  END IF;
+
+  WITH
+  -- Distinct (section, row) pairs for this snapshot — avoids redundant lookups
+  -- when multiple brokers list in the same section (common for popular seats).
+  unique_sec AS (
+    SELECT DISTINCT section, row
+    FROM listings_snapshots
+    WHERE event_id = p_event_id
+      AND captured_at = p_captured_at
+  ),
+  -- Resolve both curated_name and fb_zone exactly once per unique pair.
+  -- v_has_zones guard skips match_performer_zone() entirely when no rules exist.
+  sec_zones AS (
+    SELECT
+      u.section,
+      u.row,
+      CASE WHEN v_has_zones
+           THEN match_performer_zone(v_performer_id, v_venue_id, u.section, u.row)
+      END                                       AS curated_name,
+      derive_zone_fallback(u.section, u.row)    AS fb_zone
+    FROM unique_sec u
+  ),
+  -- Annotate each listing row from the pre-computed zone map (no repeated calls).
+  zoned AS (
+    SELECT
+      l.event_id,
+      l.captured_at,
+      l.section,
+      l.row,
+      l.quantity,
+      l.retail_price,
+      l.wholesale_price,
+      l.is_owned,
+      sz.curated_name,
+      CASE WHEN sz.curated_name IS NOT NULL THEN sz.curated_name
+           ELSE COALESCE(sz.fb_zone, 'unmapped')
+      END AS zone,
+      CASE WHEN sz.curated_name IS NOT NULL THEN 'curated'
+           WHEN sz.fb_zone IS NOT NULL       THEN 'fallback'
+           ELSE                                   'unmapped'
+      END AS zone_source
+    FROM listings_snapshots l
+    LEFT JOIN sec_zones sz
+           ON sz.section IS NOT DISTINCT FROM l.section
+          AND sz.row     IS NOT DISTINCT FROM l.row
+    WHERE l.event_id     = p_event_id
+      AND l.captured_at  = p_captured_at
+      AND l.is_ancillary = false
+  ),
+  -- Expand rows by quantity for per-ticket percentile calculations.
+  expanded AS (
+    SELECT z.zone, z.zone_source, gs.n,
+           z.retail_price, z.wholesale_price, z.is_owned
+    FROM zoned z
+    JOIN LATERAL generate_series(1, GREATEST(z.quantity, 0)) AS gs(n) ON true
+  ),
+  agg AS (
+    SELECT
+      z.zone,
+      MAX(CASE WHEN z.zone_source = 'curated'  THEN 3
+               WHEN z.zone_source = 'fallback' THEN 2
+               ELSE 1 END)                      AS src_rank,
+      SUM(z.quantity)::int                      AS tickets_count,
+      COUNT(*)::int                             AS groups_count,
+      COUNT(DISTINCT z.section)::int            AS sections_count,
+      MIN(z.retail_price) FILTER (WHERE z.quantity >= 2 AND z.retail_price IS NOT NULL)
+                                                AS getin_price,
+      COUNT(*) FILTER (WHERE z.is_owned)::int   AS owned_groups_count,
+      COALESCE(SUM(z.quantity) FILTER (WHERE z.is_owned), 0)::int
+                                                AS owned_tickets_count
+    FROM zoned z
+    GROUP BY z.zone
+  ),
+  pct AS (
+    SELECT
+      e.zone,
+      MIN(e.retail_price)                                             AS retail_min,
+      percentile_cont(0.25) WITHIN GROUP (ORDER BY e.retail_price)   AS retail_p25,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)   AS retail_median,
+      AVG(e.retail_price)                                             AS retail_mean,
+      percentile_cont(0.75) WITHIN GROUP (ORDER BY e.retail_price)   AS retail_p75,
+      percentile_cont(0.9)  WITHIN GROUP (ORDER BY e.retail_price)   AS retail_p90,
+      MAX(e.retail_price)                                             AS retail_max,
+      SUM(e.retail_price)                                             AS retail_sum,
+      MIN(e.wholesale_price)                                          AS wholesale_min,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.wholesale_price) AS wholesale_median,
+      AVG(e.wholesale_price)                                          AS wholesale_mean,
+      MAX(e.wholesale_price)                                          AS wholesale_max,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)
+        FILTER (WHERE e.is_owned)                                     AS owned_median_retail
+    FROM expanded e
+    GROUP BY e.zone
+  )
+  INSERT INTO zone_metrics (
+    event_id, captured_at, zone, zone_source,
+    tickets_count, groups_count, sections_count,
+    retail_min, retail_p25, retail_median, retail_mean, retail_p75, retail_p90, retail_max, retail_sum,
+    wholesale_min, wholesale_median, wholesale_mean, wholesale_max,
+    getin_price,
+    owned_groups_count, owned_tickets_count, owned_share, owned_median_retail
+  )
+  SELECT
+    p_event_id, p_captured_at, a.zone,
+    CASE a.src_rank WHEN 3 THEN 'curated' WHEN 2 THEN 'fallback' ELSE 'unmapped' END,
+    a.tickets_count, a.groups_count, a.sections_count,
+    round(p.retail_min::numeric,      2),
+    round(p.retail_p25::numeric,      2),
+    round(p.retail_median::numeric,   2),
+    round(p.retail_mean::numeric,     2),
+    round(p.retail_p75::numeric,      2),
+    round(p.retail_p90::numeric,      2),
+    round(p.retail_max::numeric,      2),
+    round(p.retail_sum::numeric,      2),
+    round(p.wholesale_min::numeric,   2),
+    round(p.wholesale_median::numeric,2),
+    round(p.wholesale_mean::numeric,  2),
+    round(p.wholesale_max::numeric,   2),
+    round(a.getin_price::numeric,     2),
+    a.owned_groups_count, a.owned_tickets_count,
+    CASE WHEN a.tickets_count > 0
+         THEN round((a.owned_tickets_count::numeric / a.tickets_count)::numeric, 4)
+         ELSE NULL END,
+    round(p.owned_median_retail::numeric, 2)
+  FROM agg a
+  JOIN pct p ON p.zone = a.zone
+  ON CONFLICT (event_id, captured_at, zone) DO UPDATE SET
+    zone_source         = EXCLUDED.zone_source,
+    tickets_count       = EXCLUDED.tickets_count,
+    groups_count        = EXCLUDED.groups_count,
+    sections_count      = EXCLUDED.sections_count,
+    retail_min          = EXCLUDED.retail_min,
+    retail_p25          = EXCLUDED.retail_p25,
+    retail_median       = EXCLUDED.retail_median,
+    retail_mean         = EXCLUDED.retail_mean,
+    retail_p75          = EXCLUDED.retail_p75,
+    retail_p90          = EXCLUDED.retail_p90,
+    retail_max          = EXCLUDED.retail_max,
+    retail_sum          = EXCLUDED.retail_sum,
+    wholesale_min       = EXCLUDED.wholesale_min,
+    wholesale_median    = EXCLUDED.wholesale_median,
+    wholesale_mean      = EXCLUDED.wholesale_mean,
+    wholesale_max       = EXCLUDED.wholesale_max,
+    getin_price         = EXCLUDED.getin_price,
+    owned_groups_count  = EXCLUDED.owned_groups_count,
+    owned_tickets_count = EXCLUDED.owned_tickets_count,
+    owned_share         = EXCLUDED.owned_share,
+    owned_median_retail = EXCLUDED.owned_median_retail;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$function$;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. compute_event_section_metrics
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.compute_event_section_metrics(
+  p_event_id    bigint,
+  p_captured_at timestamptz
+)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_performer_id bigint;
+  v_venue_id     bigint;
+  v_has_zones    boolean := false;
+  v_count        integer;
+BEGIN
+  SELECT primary_performer_id, venue_id
+    INTO v_performer_id, v_venue_id
+  FROM events WHERE id = p_event_id;
+
+  IF v_performer_id IS NOT NULL AND v_venue_id IS NOT NULL THEN
+    SELECT EXISTS(
+      SELECT 1 FROM performer_zones
+      WHERE performer_id = v_performer_id AND venue_id = v_venue_id
+    ) INTO v_has_zones;
+  END IF;
+
+  WITH
+  unique_sec AS (
+    SELECT DISTINCT section, row
+    FROM listings_snapshots
+    WHERE event_id    = p_event_id
+      AND captured_at = p_captured_at
+      AND section IS NOT NULL
+  ),
+  sec_zones AS (
+    SELECT
+      u.section,
+      u.row,
+      CASE WHEN v_has_zones
+           THEN match_performer_zone(v_performer_id, v_venue_id, u.section, u.row)
+      END                                       AS curated_name,
+      derive_zone_fallback(u.section, u.row)    AS fb_zone
+    FROM unique_sec u
+  ),
+  -- per_row: each listing row annotated with zone/zone_source from pre-computed map.
+  -- derive_zone_fallback called once per unique (section,row) above, not 3× per row.
+  per_row AS (
+    SELECT
+      l.section,
+      l.row,
+      l.quantity,
+      l.retail_price,
+      l.wholesale_price,
+      l.is_owned,
+      l.is_ancillary,
+      sz.curated_name,
+      sz.fb_zone,
+      COALESCE(sz.curated_name, sz.fb_zone, 'unmapped')  AS zone,
+      CASE WHEN sz.curated_name IS NOT NULL THEN 'curated'
+           WHEN sz.fb_zone IS NOT NULL       THEN 'fallback'
+           ELSE                                   'unmapped'
+      END AS zone_source
+    FROM listings_snapshots l
+    LEFT JOIN sec_zones sz
+           ON sz.section = l.section
+          AND sz.row IS NOT DISTINCT FROM l.row
+    WHERE l.event_id     = p_event_id
+      AND l.captured_at  = p_captured_at
+      AND l.section IS NOT NULL
+  ),
+  expanded AS (
+    SELECT pr.section, pr.retail_price, pr.wholesale_price, pr.is_owned
+    FROM per_row pr
+    JOIN LATERAL generate_series(1, GREATEST(pr.quantity, 0)) AS gs(n) ON true
+  ),
+  per_section_zone_counts AS (
+    SELECT section, zone, zone_source, COUNT(*) AS row_cnt
+    FROM per_row
+    GROUP BY section, zone, zone_source
+  ),
+  per_section_zone AS (
+    SELECT section, zone, zone_source,
+           ROW_NUMBER() OVER (
+             PARTITION BY section
+             ORDER BY CASE zone_source WHEN 'curated' THEN 0 WHEN 'fallback' THEN 1 ELSE 2 END,
+                      row_cnt DESC
+           ) AS rn
+    FROM per_section_zone_counts
+  ),
+  agg AS (
+    SELECT
+      pr.section,
+      bool_and(pr.is_ancillary)                                            AS all_ancillary,
+      SUM(pr.quantity)::int                                                AS tickets_count,
+      COUNT(*)::int                                                        AS groups_count,
+      MIN(pr.retail_price) FILTER (WHERE pr.quantity >= 2 AND pr.retail_price IS NOT NULL)
+                                                                           AS getin_price,
+      COUNT(*) FILTER (WHERE pr.is_owned)::int                             AS owned_groups_count,
+      COALESCE(SUM(pr.quantity) FILTER (WHERE pr.is_owned), 0)::int        AS owned_tickets_count
+    FROM per_row pr
+    GROUP BY pr.section
+  ),
+  pct AS (
+    SELECT
+      e.section,
+      MIN(e.retail_price)                                                       AS retail_min,
+      percentile_cont(0.25) WITHIN GROUP (ORDER BY e.retail_price)              AS retail_p25,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)              AS retail_median,
+      AVG(e.retail_price)                                                       AS retail_mean,
+      percentile_cont(0.75) WITHIN GROUP (ORDER BY e.retail_price)              AS retail_p75,
+      percentile_cont(0.9)  WITHIN GROUP (ORDER BY e.retail_price)              AS retail_p90,
+      MAX(e.retail_price)                                                       AS retail_max,
+      SUM(e.retail_price)                                                       AS retail_sum,
+      MIN(e.wholesale_price)                                                    AS wholesale_min,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.wholesale_price)           AS wholesale_median,
+      AVG(e.wholesale_price)                                                    AS wholesale_mean,
+      MAX(e.wholesale_price)                                                    AS wholesale_max,
+      percentile_cont(0.5)  WITHIN GROUP (ORDER BY e.retail_price)
+        FILTER (WHERE e.is_owned)                                               AS owned_median_retail
+    FROM expanded e
+    GROUP BY e.section
+  )
+  INSERT INTO section_metrics (
+    event_id, captured_at, section, is_ancillary,
+    tickets_count, groups_count, sections_count,
+    retail_min, retail_p25, retail_median, retail_mean, retail_p75, retail_p90, retail_max, retail_sum,
+    wholesale_min, wholesale_median, wholesale_mean, wholesale_max,
+    getin_price,
+    owned_groups_count, owned_tickets_count, owned_share, owned_median_retail,
+    zone, zone_source
+  )
+  SELECT
+    p_event_id, p_captured_at, a.section, a.all_ancillary,
+    a.tickets_count, a.groups_count, 1,
+    round(p.retail_min::numeric,      2),
+    round(p.retail_p25::numeric,      2),
+    round(p.retail_median::numeric,   2),
+    round(p.retail_mean::numeric,     2),
+    round(p.retail_p75::numeric,      2),
+    round(p.retail_p90::numeric,      2),
+    round(p.retail_max::numeric,      2),
+    round(p.retail_sum::numeric,      2),
+    round(p.wholesale_min::numeric,   2),
+    round(p.wholesale_median::numeric,2),
+    round(p.wholesale_mean::numeric,  2),
+    round(p.wholesale_max::numeric,   2),
+    round(a.getin_price::numeric,     2),
+    a.owned_groups_count, a.owned_tickets_count,
+    CASE WHEN a.tickets_count > 0
+         THEN round((a.owned_tickets_count::numeric / a.tickets_count)::numeric, 4)
+         ELSE NULL END,
+    round(p.owned_median_retail::numeric, 2),
+    z.zone, z.zone_source
+  FROM agg a
+  JOIN pct p ON p.section = a.section
+  LEFT JOIN per_section_zone z ON z.section = a.section AND z.rn = 1
+  ON CONFLICT (event_id, captured_at, section) DO UPDATE SET
+    is_ancillary        = EXCLUDED.is_ancillary,
+    tickets_count       = EXCLUDED.tickets_count,
+    groups_count        = EXCLUDED.groups_count,
+    sections_count      = EXCLUDED.sections_count,
+    retail_min          = EXCLUDED.retail_min,
+    retail_p25          = EXCLUDED.retail_p25,
+    retail_median       = EXCLUDED.retail_median,
+    retail_mean         = EXCLUDED.retail_mean,
+    retail_p75          = EXCLUDED.retail_p75,
+    retail_p90          = EXCLUDED.retail_p90,
+    retail_max          = EXCLUDED.retail_max,
+    retail_sum          = EXCLUDED.retail_sum,
+    wholesale_min       = EXCLUDED.wholesale_min,
+    wholesale_median    = EXCLUDED.wholesale_median,
+    wholesale_mean      = EXCLUDED.wholesale_mean,
+    wholesale_max       = EXCLUDED.wholesale_max,
+    getin_price         = EXCLUDED.getin_price,
+    owned_groups_count  = EXCLUDED.owned_groups_count,
+    owned_tickets_count = EXCLUDED.owned_tickets_count,
+    owned_share         = EXCLUDED.owned_share,
+    owned_median_retail = EXCLUDED.owned_median_retail,
+    zone                = EXCLUDED.zone,
+    zone_source         = EXCLUDED.zone_source;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$function$;

--- a/supabase/migrations/20260605130500_drop_td_enqueue_peak_old_overload.sql
+++ b/supabase/migrations/20260605130500_drop_td_enqueue_peak_old_overload.sql
@@ -1,0 +1,8 @@
+-- Drop the dead single-arg overload of td_enqueue_peak.
+-- The two-arg version (p_platform text, p_interval_tag text) is the active one used by
+-- td_enqueue_peak_sh/gt/vd crons. The old single-arg version (LIMIT 80, no platform scope)
+-- is unreachable by any cron and is a credit-burn risk if called manually.
+
+DROP FUNCTION IF EXISTS public.td_enqueue_peak(text);
+
+-- ## Already applied to prod  Applied via MCP 2026-05-27

--- a/supabase/migrations/20260605131000_exos_media_restrict_anon_listing.sql
+++ b/supabase/migrations/20260605131000_exos_media_restrict_anon_listing.sql
@@ -1,0 +1,26 @@
+-- 20260526060000_exos_media_restrict_anon_listing.sql
+--
+-- Close anon enumeration of the exos-media bucket (bot_chat #539 SEC-MED;
+-- Supabase advisor `public_bucket_allows_listing`). The bucket is public AND
+-- its SELECT policy applied to ALL roles, so an anon caller could LIST every
+-- object (enumerate org logos / event images / draft uploads).
+--
+-- Public-by-URL rendering is UNAFFECTED: public=true serves the
+-- /storage/v1/object/public/... endpoint without consulting RLS, and
+-- d4_bridge/src/lib/storage.ts renders only via getPublicUrl() (it never calls
+-- .list() or createSignedUrl() for cross-user objects). So scoping the SELECT
+-- policy to the object owner removes the anon LIST capability with no UX loss.
+--
+-- D4 authors; A1/operator applies (storage.* DDL is prod-gated). Keep public=true.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS exos_media_read ON storage.objects;
+
+CREATE POLICY exos_media_read ON storage.objects
+  FOR SELECT TO authenticated
+  USING (bucket_id = 'exos-media' AND owner = auth.uid());
+
+-- ROLLBACK (restores the prior world-readable policy):
+--   DROP POLICY exos_media_read ON storage.objects;
+--   CREATE POLICY exos_media_read ON storage.objects
+--     FOR SELECT USING (bucket_id = 'exos-media');

--- a/supabase/migrations/20260605131500_exos_checkins_scanned_by_email.sql
+++ b/supabase/migrations/20260605131500_exos_checkins_scanned_by_email.sql
@@ -1,0 +1,15 @@
+-- 20260526070000_exos_checkins_scanned_by_email.sql
+--
+-- B1-NEXT-62: durable door audit. exos_event_checkins.scanned_by is a uuid that
+-- points at the scanning staff account; if that account is later removed the
+-- audit trail loses the "who". Add a denormalized scanned_by_email captured at
+-- scan time (populated by exos_check_in_ticket as of mig 20260526080000).
+-- Nullable; existing rows stay NULL (no backfill — historical scans predate it).
+--
+-- D4 authors; A1 applies.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.exos_event_checkins
+  ADD COLUMN IF NOT EXISTS scanned_by_email text;
+
+-- ROLLBACK: ALTER TABLE public.exos_event_checkins DROP COLUMN IF EXISTS scanned_by_email;

--- a/supabase/migrations/20260605132000_exos_check_in_event_scope.sql
+++ b/supabase/migrations/20260605132000_exos_check_in_event_scope.sql
@@ -1,0 +1,133 @@
+-- 20260526080000_exos_check_in_event_scope.sql
+--
+-- D4-OPS-18: server-side event scoping for check-in + populate scanned_by_email.
+--
+-- Today exos_check_in_ticket is org-scoped (any owner/manager/scanner of the
+-- ticket's org can flip it); the "is this ticket for THIS door's event?" check
+-- lives only in the FE (OrganizerCheckIn compares scanTicket.eventId). At a
+-- multi-event org, a valid ticket for event A could be flipped at event B's
+-- door if the client check were bypassed. Add an optional p_event_id and, when
+-- supplied, reject a cross-event scan server-side (reason 'wrong-event').
+--
+-- Also denormalizes the scanner's email onto the audit row (mig 20260526070000).
+--
+-- Backward compatible: p_event_id defaults NULL → behaviour unchanged. The FE
+-- passes the door's eventId, so they must ship together (apply this migration
+-- with the keyed static/bridge rebuild). The old 4-arg overload is dropped to
+-- avoid `function is not unique` ambiguity (§7 signature-change landmine).
+--
+-- D4 authors; A1 applies (B1 review: door-security surface).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Drop the prior 4-arg signature before adding the p_event_id overload.
+DROP FUNCTION IF EXISTS public.exos_check_in_ticket(uuid, text, text, text);
+
+CREATE OR REPLACE FUNCTION public.exos_check_in_ticket(
+  p_ticket_id       uuid,
+  p_source          text DEFAULT 'manual',
+  p_verification    text DEFAULT 'manual',
+  p_barcode_payload text DEFAULT NULL,
+  p_event_id        uuid DEFAULT NULL
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid     uuid := auth.uid();
+  v_org     uuid;
+  v_event   uuid;
+  v_prev    text;
+  v_pending uuid;
+  v_owner   uuid;
+  v_secret  text;
+  v_updated int;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'exos_check_in_ticket: not authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT org_id, event_id, status, pending_transfer_id, owner_id, barcode_secret
+    INTO v_org, v_event, v_prev, v_pending, v_owner, v_secret
+    FROM public.exos_tickets WHERE id = p_ticket_id;
+  IF v_org IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'not-found');
+  END IF;
+
+  IF NOT (exos_is_admin() OR exos_has_org_role(v_org, ARRAY['owner','manager','scanner'])) THEN
+    RAISE EXCEPTION 'exos_check_in_ticket: not authorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Event scoping (D4-OPS-18). When the caller passes the door's event id,
+  -- reject a ticket that belongs to a different event of the same org.
+  IF p_event_id IS NOT NULL AND v_event <> p_event_id THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'wrong-event');
+  END IF;
+
+  -- Server-side barcode verification (only for signed payloads).
+  IF p_barcode_payload IS NOT NULL AND left(p_barcode_payload, 2) = 'T-' THEN
+    DECLARE
+      v_parts text[] := string_to_array(substring(p_barcode_payload FROM 3), ':');
+      v_cur   bigint := floor(extract(epoch FROM now()) * 1000 / 30000);
+      v_bkt   bigint;
+      v_exp   text;
+    BEGIN
+      IF array_length(v_parts, 1) = 4 THEN     -- signed; 3 = legacy (skip)
+        IF v_parts[1] <> p_ticket_id::text OR v_parts[2] <> v_owner::text THEN
+          RETURN jsonb_build_object('ok', false, 'reason', 'barcode-rejected');
+        END IF;
+        v_bkt := v_parts[3]::bigint;
+        IF abs(v_cur - v_bkt) > 2 THEN
+          RETURN jsonb_build_object('ok', false, 'reason', 'barcode-expired');
+        END IF;
+        v_exp := rtrim(translate(encode(
+                   extensions.hmac(v_parts[1] || ':' || v_parts[2] || ':' || v_parts[3],
+                                   coalesce(v_secret, ''), 'sha256'), 'base64'),
+                   '+/', '-_'), '=');
+        IF v_exp <> v_parts[4] THEN
+          RETURN jsonb_build_object('ok', false, 'reason', 'barcode-rejected');
+        END IF;
+      ELSIF array_length(v_parts, 1) <> 3 THEN
+        RETURN jsonb_build_object('ok', false, 'reason', 'barcode-rejected');
+      END IF;
+    EXCEPTION WHEN others THEN
+      RETURN jsonb_build_object('ok', false, 'reason', 'barcode-rejected');
+    END;
+  END IF;
+
+  IF v_pending IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'in-transfer');
+  END IF;
+  IF v_prev = 'voided' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'voided');
+  END IF;
+  IF v_prev = 'used' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'used');
+  END IF;
+
+  UPDATE public.exos_tickets
+     SET status = 'used', check_in_at = now()
+   WHERE id = p_ticket_id AND status = 'active';
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated = 0 THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'used');  -- lost the race
+  END IF;
+
+  INSERT INTO public.exos_event_checkins
+    (event_id, ticket_id, org_id, scanned_by, scanned_by_email, source, verification)
+  VALUES (
+    v_event, p_ticket_id, v_org, v_uid,
+    lower(coalesce(auth.jwt() ->> 'email', '')),
+    CASE WHEN p_source IN ('camera','manual') THEN p_source ELSE 'manual' END,
+    CASE WHEN p_verification IN ('verified','legacy','manual') THEN p_verification ELSE 'manual' END
+  );
+
+  RETURN jsonb_build_object('ok', true, 'reason', 'checked-in');
+END $function$;
+
+REVOKE ALL ON FUNCTION public.exos_check_in_ticket(uuid, text, text, text, uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.exos_check_in_ticket(uuid, text, text, text, uuid) TO authenticated;
+
+-- ROLLBACK: drop the 5-arg fn and recreate the 4-arg version from
+-- mig 20260523160000 (and DROP COLUMN scanned_by_email if rolling back 070000).

--- a/supabase/migrations/20260605132500_exos_claim_free_tickets.sql
+++ b/supabase/migrations/20260605132500_exos_claim_free_tickets.sql
@@ -1,0 +1,147 @@
+-- 20260526090000_exos_claim_free_tickets.sql
+--
+-- D4 free-first acquisition: a self-serve claim path so a signed-in attendee can
+-- actually GET a ticket for a FREE tier. Until now the only mint path was
+-- exos_mint_tickets (org-staff/admin comp only) — there was no buyer flow at all
+-- (EventDetails showed "Coming soon"). Paid tiers still route through Stripe
+-- checkout (dormant); this RPC hard-refuses any tier with a non-zero price.
+--
+-- Guards (all server-side, no admin bypass on this self-serve surface):
+--   * authenticated caller; mints to themselves (buyer = owner = auth.uid())
+--   * event must be 'published'
+--   * tier must belong to the event, be price = 0, visibility public, and
+--     within its sales window (sales_start/sales_end when set)
+--   * per-person purchase limit enforced via exos_assert_purchase_limit
+--   * atomic tier-capacity + event house-cap claim (same pattern as
+--     exos_mint_tickets); sold-out → RAISE (rolls back the whole claim)
+--   * captures promoter_id + channel_source from the landing URL (campaign
+--     attribution → event Sales report); queues the ticket-issued mail
+--     best-effort (a mail hiccup must not unwind a successful claim)
+--
+-- D4 authors; A1 applies. ⚠️ B1 review requested — this is a NEW self-serve
+-- minting surface (authenticated → real exos_tickets rows).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.exos_claim_free_tickets(
+  p_event_id    uuid,
+  p_tier_id     uuid,
+  p_quantity    int  DEFAULT 1,
+  p_promoter_id text DEFAULT NULL,
+  p_channel     text DEFAULT NULL,
+  p_order_ref   text DEFAULT NULL
+) RETURNS uuid[]
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_uid        uuid := auth.uid();
+  v_org        uuid;
+  v_status     text;
+  v_tier_name  text;
+  v_price      numeric;
+  v_vis        text;
+  v_sstart     timestamptz;
+  v_send       timestamptz;
+  v_tier_event uuid;
+  v_ids        uuid[] := '{}';
+  v_id         uuid;
+  v_updated    int;
+  i            int;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: not authenticated' USING ERRCODE = '42501';
+  END IF;
+  IF p_quantity < 1 OR p_quantity > 10 THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: quantity must be 1-10';
+  END IF;
+
+  SELECT org_id, status INTO v_org, v_status
+    FROM public.exos_events WHERE id = p_event_id;
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: event not found';
+  END IF;
+  IF v_status <> 'published' THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: event not on sale' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT name, price, visibility, sales_start, sales_end, event_id
+    INTO v_tier_name, v_price, v_vis, v_sstart, v_send, v_tier_event
+    FROM public.exos_ticket_tiers WHERE id = p_tier_id;
+  IF v_tier_event IS NULL OR v_tier_event <> p_event_id THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: tier not found for this event';
+  END IF;
+  IF coalesce(v_price, 0) <> 0 THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: tier is not free — use checkout' USING ERRCODE = '42501';
+  END IF;
+  IF v_vis IS NOT NULL AND v_vis <> 'public' THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: tier not available' USING ERRCODE = '42501';
+  END IF;
+  IF v_sstart IS NOT NULL AND now() < v_sstart THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: sales have not started' USING ERRCODE = '42501';
+  END IF;
+  IF v_send IS NOT NULL AND now() > v_send THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: sales have ended' USING ERRCODE = '42501';
+  END IF;
+
+  -- Idempotency: a retry carrying the same order_ref returns the tickets already
+  -- minted for it instead of minting again (guards double-submit / network retry;
+  -- the maxPerAccount limit + the client's disabled button cover the concurrent case).
+  IF nullif(p_order_ref, '') IS NOT NULL THEN
+    SELECT array_agg(id) INTO v_ids
+      FROM public.exos_tickets
+     WHERE event_id = p_event_id AND owner_id = v_uid AND order_ref = p_order_ref;
+    IF v_ids IS NOT NULL AND array_length(v_ids, 1) > 0 THEN
+      RETURN v_ids;
+    END IF;
+    v_ids := '{}';
+  END IF;
+
+  -- Per-person limit (cumulative; no admin bypass on the self-serve path).
+  PERFORM public.exos_assert_purchase_limit(p_event_id, v_uid, p_quantity);
+
+  -- Atomic capacity claim — tier first, then the event house cap.
+  UPDATE public.exos_ticket_tiers
+     SET sold = sold + p_quantity
+   WHERE id = p_tier_id AND event_id = p_event_id
+     AND (capacity = 0 OR sold + p_quantity <= capacity);
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated = 0 THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: tier sold out' USING ERRCODE = '23514';
+  END IF;
+
+  UPDATE public.exos_events
+     SET tickets_sold = tickets_sold + p_quantity
+   WHERE id = p_event_id
+     AND (total_tickets = 0 OR tickets_sold + p_quantity <= total_tickets);
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated = 0 THEN
+    RAISE EXCEPTION 'exos_claim_free_tickets: event sold out' USING ERRCODE = '23514';
+  END IF;
+
+  FOR i IN 1..p_quantity LOOP
+    INSERT INTO public.exos_tickets (
+      event_id, org_id, tier_id, tier_name, buyer_id, owner_id, buyer_email,
+      status, barcode_secret, price_paid, order_ref, channel_source, promoter_id
+    ) VALUES (
+      p_event_id, v_org, p_tier_id, v_tier_name, v_uid, v_uid,
+      lower(coalesce(auth.jwt() ->> 'email', '')),
+      'active', gen_random_uuid()::text, 0,
+      coalesce(nullif(p_order_ref, ''), 'free_' || gen_random_uuid()::text),
+      coalesce(nullif(p_channel, ''), 'vibepass'), nullif(p_promoter_id, '')
+    ) RETURNING id INTO v_id;
+    v_ids := array_append(v_ids, v_id);
+    -- Confirmation mail (best-effort — never unwind the claim on a mail error).
+    BEGIN
+      PERFORM public.exos_queue_ticket_issued(v_id);
+    EXCEPTION WHEN OTHERS THEN
+      NULL;
+    END;
+  END LOOP;
+
+  RETURN v_ids;
+END $$;
+
+REVOKE ALL ON FUNCTION public.exos_claim_free_tickets(uuid, uuid, int, text, text, text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.exos_claim_free_tickets(uuid, uuid, int, text, text, text) TO authenticated;
+
+-- ROLLBACK: DROP FUNCTION IF EXISTS public.exos_claim_free_tickets(uuid, uuid, int, text, text, text);

--- a/tests/test_store_home.py
+++ b/tests/test_store_home.py
@@ -403,6 +403,139 @@ def test_is_tbd_helper_unit():
     assert app_module._is_tbd(None) is False
 
 
+# ---------- Featured rail: playoff exemption + empty-rail fallback ----------
+#
+# Operator directive 2026-05-26: the "Featured in NYC" rail (/api/store/movers)
+# was rendering empty because all current NYC owned inventory was either an
+# "(If Necessary)" playoff game (dropped as speculative) or below the owned-
+# count gates. Two behavior changes:
+#   1. Playoff games surface in the movers strip despite "(If Necessary)" and
+#      bypass the owned>100 Featured depth gate (highest-value NYC inventory).
+#   2. When NO rail qualifies, Featured falls back to the soonest upcoming
+#      owned NYC events so the homepage is never blank.
+# NOTE: this relaxation is scoped to the movers strip only — /api/store/home
+# and search still drop "(If Necessary)" games (see tests above).
+#
+# _compute_movers filters events to occurs_at_local >= today, so the end-to-end
+# tests below use dates RELATIVE to today (not hardcoded) — otherwise they'd
+# become a CI time-bomb the moment the fixed dates fall into the past (the same
+# class of bug fixed for the store_home fixture).
+
+def _fut(days_ahead: int) -> str:
+    """An occurs_at_local timestamp `days_ahead` days from today (Eastern-ish
+    offset), kept inside the movers day_cap window."""
+    from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+    d = (_dt.now(_tz.utc).date() + _td(days=days_ahead)).isoformat()
+    return f"{d}T19:00:00-04:00"
+
+
+def test_section_featured_includes_playoff_under_owned_gate():
+    """Playoff game with owned <= 100 must still be Featured — playoff games
+    are exempt from the owned>100 depth gate."""
+    playoff = {
+        "id": 1,
+        "name": "Cleveland Cavaliers at New York Knicks (Game 7) (If Necessary)",
+        "owned_tickets_count": 61,           # < 100, would fail the gate
+        "owned_median_retail": 5880,
+        "occurs_at_local": "2026-05-31T20:00:00-04:00",
+    }
+    out = app_module._section_featured([playoff], {}, {})
+    assert [c["id"] for c in out] == [1]
+    assert out[0]["_featured_kind"] == "playoff"
+
+
+def test_section_featured_excludes_nonplayoff_under_owned_gate():
+    """Non-playoff event under owned 100 with sub-$50 median stays out — the
+    depth gate still applies to everything that isn't a playoff/holiday/
+    rivalry/marquee signal."""
+    ev = {
+        "id": 2, "name": "Some Concert",
+        "owned_tickets_count": 61, "owned_median_retail": 20,
+        "occurs_at_local": "2026-06-01T19:00:00-04:00",
+    }
+    assert app_module._section_featured([ev], {}, {}) == []
+
+
+def test_section_featured_premium_nonplayoff_still_included():
+    """Regression guard: a non-playoff event with owned>100 AND median>$50
+    is still Featured as 'premium' (existing behavior unchanged)."""
+    ev = {
+        "id": 3, "name": "Big Headliner",
+        "owned_tickets_count": 150, "owned_median_retail": 120,
+        "occurs_at_local": "2026-06-02T19:00:00-04:00",
+    }
+    out = app_module._section_featured([ev], {}, {})
+    assert [c["id"] for c in out] == [3]
+    assert out[0]["_featured_kind"] == "premium"
+
+
+def test_compute_movers_features_playoff_if_necessary():
+    """End-to-end: a playoff '(If Necessary)' game with owned 61 survives the
+    speculative-name filter AND the owned>100 gate, landing in Featured."""
+    db = _FakeDB({
+        "events": [_event(
+            1, name="Cleveland Cavaliers at New York Knicks (Game 7) (If Necessary)",
+            occurs=_fut(5))],
+        "latest_event_metrics": [_lem(1, owned=61, retail_min=5880.0)],
+        "event_lifecycle": [_lc(1)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    assert 1 in [c["id"] for c in out["featured"]]
+    assert out["featured"][0]["_featured_kind"] == "playoff"
+
+
+def test_compute_movers_drops_cancelled_playoff():
+    """A CANCELLED playoff game must NOT surface — cancellation is terminal,
+    unlike '(If Necessary)' which merely may-not-be-played."""
+    db = _FakeDB({
+        "events": [_event(
+            1, name="Knicks at Pacers (Game 6) - CANCELLED",
+            occurs=_fut(6))],
+        "latest_event_metrics": [_lem(1, owned=200, retail_min=900.0)],
+        "event_lifecycle": [_lc(1)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    all_ids = [c["id"] for rail in
+               ("featured", "moving_fast", "price_drops", "climbing", "specials")
+               for c in out.get(rail, [])]
+    assert 1 not in all_ids
+
+
+def test_compute_movers_fallback_to_soonest_when_all_rails_empty():
+    """Two thin-inventory non-playoff events (owned 49 + 9) clear no rail.
+    Featured falls back to the soonest upcoming owned events, soonest first,
+    tagged _featured_kind='fallback' with no curation chip."""
+    db = _FakeDB({
+        "events": [
+            _event(10, name="Don Toliver Concert", occurs=_fut(10)),
+            _event(11, name="Cincinnati Reds at New York Mets", occurs=_fut(3)),
+        ],
+        "latest_event_metrics": [_lem(10, owned=49), _lem(11, owned=9)],
+        "event_lifecycle": [_lc(10), _lc(11)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    assert out["moving_fast"] == [] and out["price_drops"] == [] and out["climbing"] == []
+    assert [c["id"] for c in out["featured"]] == [11, 10]  # sooner event first
+    assert all(c.get("_featured_kind") == "fallback" for c in out["featured"])
+    assert all(c.get("_featured_tag") == "" for c in out["featured"])
+
+
+def test_compute_movers_no_fallback_when_a_rail_populated():
+    """When a rail already has events, the fallback does NOT fire — Featured
+    holds the curated playoff pick, not the thin-inventory long tail."""
+    db = _FakeDB({
+        "events": [
+            _event(1, name="Cavaliers at Knicks (Game 7) (If Necessary)", occurs=_fut(5)),
+            _event(10, name="Low Inventory Concert", occurs=_fut(10)),
+        ],
+        "latest_event_metrics": [_lem(1, owned=61, retail_min=5880.0), _lem(10, owned=9)],
+        "event_lifecycle": [_lc(1), _lc(10)],
+    })
+    out = app_module._compute_movers(db, "NYC", 21, 8)
+    assert [c["id"] for c in out["featured"]] == [1]
+    assert out["featured"][0]["_featured_kind"] == "playoff"
+
+
 def test_home_city_nyc_filters_correctly(store_home_client):
     """city=NYC restricts to NYC-area venues. Bronx + Flushing + Manhattan
     all pass; LA + Chicago must not."""

--- a/tests/test_ticketsdata_client.py
+++ b/tests/test_ticketsdata_client.py
@@ -1,0 +1,171 @@
+"""TicketsData client + MVP budget-guard tests. No real HTTP calls."""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+import ticketsdata_client as td
+
+
+# ---------- read-only guard ----------
+
+def test_assert_readonly_allows_get():
+    td._assert_readonly_method("GET")  # no raise
+
+
+def test_assert_readonly_raises_on_writes():
+    for method in ("POST", "PUT", "PATCH", "DELETE"):
+        with pytest.raises(td.TicketsDataReadOnlyError):
+            td._assert_readonly_method(method)
+
+
+# ---------- construction / validation ----------
+
+def test_requires_credentials(monkeypatch):
+    monkeypatch.delenv("TICKETSDATA_USERNAME", raising=False)
+    monkeypatch.delenv("TICKETSDATA_PASSWORD", raising=False)
+    with pytest.raises(td.TicketsDataError):
+        td.TicketsDataClient()
+
+
+class _FakeRpcResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeDB:
+    """Stands in for a service-role Supabase client: rpc(get_app_secret)."""
+    def __init__(self, secrets):
+        self._secrets = secrets
+
+    def rpc(self, name, params):
+        assert name == "get_app_secret"
+        self._pending = self._secrets.get(params["p_name"])
+        return self
+
+    def execute(self):
+        return _FakeRpcResult(self._pending)
+
+
+def test_credentials_resolve_from_vault(monkeypatch):
+    monkeypatch.delenv("TICKETSDATA_USERNAME", raising=False)
+    monkeypatch.delenv("TICKETSDATA_PASSWORD", raising=False)
+    db = _FakeDB({
+        "TICKETSDATA_USERNAME": "vault-user@example.com",
+        "TICKETSDATA_PASSWORD": "vault-pw",
+    })
+    c = td.TicketsDataClient(db=db)
+    assert c._username == "vault-user@example.com"
+    assert c._password == "vault-pw"
+
+
+def test_env_takes_precedence_over_vault(monkeypatch):
+    monkeypatch.setenv("TICKETSDATA_USERNAME", "env-user@example.com")
+    monkeypatch.setenv("TICKETSDATA_PASSWORD", "env-pw")
+    db = _FakeDB({"TICKETSDATA_USERNAME": "vault-user", "TICKETSDATA_PASSWORD": "vault-pw"})
+    c = td.TicketsDataClient(db=db)
+    assert c._username == "env-user@example.com"
+
+
+def test_fetch_rejects_unsupported_platform():
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataError):
+        c.fetch("nope", "https://x")
+
+
+def test_fetch_rejects_seatgeek_sourced_natively():
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataError) as exc:
+        c.fetch("seatgeek", "https://seatgeek.com/concert/1")
+    assert "natively" in str(exc.value)
+    with pytest.raises(td.TicketsDataError):
+        c.events("seatgeek", performer_url="https://seatgeek.com/x")
+
+
+def test_events_requires_a_page_url():
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataError):
+        c.events("stubhub")
+
+
+def test_credit_costs():
+    assert td.CREDIT_COST == {"fetch": 1, "events": 1, "match": 12}
+
+
+# ---------- transport (mocked) ----------
+
+class _FakeResp:
+    def __init__(self, status, payload=None, headers=None):
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.headers = headers or {}
+        self.ok = 200 <= status < 300
+        self.text = "x"
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_parses_and_passes_creds(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResp(200, {"status_code": 200, "event_id": "159756853",
+                               "items": {"totalListings": 3, "offers": [1, 2, 3]},
+                               "quota_remaining": 9999})
+
+    monkeypatch.setattr(td.requests, "get", fake_get)
+    c = td.TicketsDataClient("u@example.com", "secret-pw")
+    env = c.fetch("stubhub", "https://www.stubhub.com/x/event/159756853/")
+    assert env["quota_remaining"] == 9999
+    # creds travel in params, never baked into the URL string
+    assert "secret-pw" not in captured["url"]
+    assert captured["params"]["username"] == "u@example.com"
+    assert captured["params"]["password"] == "secret-pw"
+
+
+def test_auth_error_does_not_leak_credentials(monkeypatch):
+    monkeypatch.setattr(td.requests, "get", lambda *a, **k: _FakeResp(401))
+    c = td.TicketsDataClient("u@example.com", "secret-pw")
+    with pytest.raises(td.TicketsDataAuthError) as exc:
+        c.fetch("stubhub", "https://www.stubhub.com/x/event/1/")
+    assert "secret-pw" not in str(exc.value)
+
+
+def test_quota_exhausted_maps_to_402(monkeypatch):
+    monkeypatch.setattr(td.requests, "get", lambda *a, **k: _FakeResp(402))
+    c = td.TicketsDataClient("u@example.com", "pw")
+    with pytest.raises(td.TicketsDataQuotaError):
+        c.events("stubhub", performer_url="https://www.stubhub.com/x")
+
+
+# ---------- MVP budget guard ----------
+
+def _load_mvp():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "ticketsdata_mvp.py"
+    spec = importlib.util.spec_from_file_location("ticketsdata_mvp", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_budget_refuses_over_cap():
+    mvp = _load_mvp()
+    b = mvp.Budget(max_credits=5, min_quota_floor=10)
+    b.check(1)
+    b.record(1, quota_remaining=9000)
+    with pytest.raises(mvp.BudgetExceeded):
+        b.check(12)  # a /match would blow the 5-credit cap
+
+
+def test_budget_refuses_below_quota_floor():
+    mvp = _load_mvp()
+    b = mvp.Budget(max_credits=100, min_quota_floor=50)
+    b.record(1, quota_remaining=51)
+    with pytest.raises(mvp.BudgetExceeded):
+        b.check(2)  # 51 - 2 = 49 < floor 50

--- a/ticketsdata_client.py
+++ b/ticketsdata_client.py
@@ -1,0 +1,213 @@
+"""TicketsData unified ticket-inventory API client (read-only).
+
+Host: https://ticketsdata.com
+Aggregates live inventory + pricing across 9 marketplaces (Ticketmaster,
+StubHub, SeatGeek, VividSeats, Gametime, TickPick, Viagogo, Dice, Eventbrite)
+behind a single GET API. There is NO write surface — every endpoint is a
+read — so this honors the read-only-upstream contract (CLAUDE.md §2).
+
+Auth: account email + password are passed as query params (their scheme).
+Credentials are sourced from env (TICKETSDATA_USERNAME / TICKETSDATA_PASSWORD),
+never hardcoded, and never written to logs or exception messages — the URL is
+built only at request time and never rendered with its params.
+
+Credit cost (watch the budget — see scripts/ticketsdata_mvp.py):
+  GET /fetch    1 credit    one event's inventory on one platform
+  GET /events   1 credit    performer / venue -> upcoming event list
+  GET /match    12 credits + 1 Market-Intelligence report   (Pro plan+)
+
+/fetch and /events responses carry `quota_remaining`; /match also carries
+`reports_remaining`. Callers should watch both to avoid exhausting the plan.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+
+
+# Read-only by design. Mirrors the RULE 2 guard pattern used by the orders/
+# sales clients (evo/seatgeek/tickpick/vivid). TicketsData has no write
+# endpoint at all, but we enforce GET-only at the transport layer anyway.
+ALLOWED_HTTP_METHODS = frozenset({"GET"})
+
+SUPPORTED_PLATFORMS = frozenset({
+    "ticketmaster", "stubhub", "seatgeek", "vividseats", "gametime",
+    "tickpick", "viagogo", "dice", "eventbrite",
+})
+
+# Marketplaces we already source natively (SeatGeek via seatgeek_client + the SG
+# broker crons), so we must NOT pay TicketsData to re-fetch them. fetch()/events()
+# reject these — use the native pipeline instead. (/match is unaffected: its value
+# is the cross-market comparison, which legitimately includes SeatGeek.)
+EXCLUDED_PLATFORMS = frozenset({"seatgeek"})
+
+# Credit cost per endpoint, per the TicketsData docs. Used by callers and the
+# MVP budget guard to project spend BEFORE making a call.
+CREDIT_COST = {"fetch": 1, "events": 1, "match": 12}
+
+
+class TicketsDataError(RuntimeError):
+    pass
+
+
+class TicketsDataReadOnlyError(TicketsDataError):
+    """Raised when a non-GET method is attempted against TicketsData."""
+
+
+class TicketsDataAuthError(TicketsDataError):
+    """401 — bad credentials."""
+
+
+class TicketsDataQuotaError(TicketsDataError):
+    """402 — plan quota exhausted."""
+
+
+def _assert_readonly_method(method: str) -> None:
+    if method.upper() not in ALLOWED_HTTP_METHODS:
+        raise TicketsDataReadOnlyError(
+            f"READ-ONLY violation: method {method} is not allowed. "
+            "TicketsData client is read-only by design (CLAUDE.md §2). "
+            "Pulling data only — never write back to ticketsdata.com."
+        )
+
+
+def _validate_platform(platform: str) -> str:
+    plat = (platform or "").strip().lower()
+    if plat not in SUPPORTED_PLATFORMS:
+        raise TicketsDataError(
+            f"unsupported platform {platform!r}; one of {sorted(SUPPORTED_PLATFORMS)}"
+        )
+    if plat in EXCLUDED_PLATFORMS:
+        raise TicketsDataError(
+            f"{plat} is sourced natively, not via TicketsData — excluded to avoid "
+            "duplicate paid fetches. Use the native pipeline (seatgeek_client)."
+        )
+    return plat
+
+
+def _vault_secret(db: Any, name: str) -> str | None:
+    """Read a secret from Supabase Vault via the get_app_secret RPC (the same
+    bridge seatgeek_client uses). Requires a service-role db client."""
+    if db is None:
+        return None
+    try:
+        res = db.rpc("get_app_secret", {"p_name": name}).execute()
+        return getattr(res, "data", None) or None
+    except Exception as e:  # never surface the value; only the failure
+        print(f"ticketsdata: vault lookup for {name} failed: {e}")
+        return None
+
+
+class TicketsDataClient:
+    BASE_URL = "https://ticketsdata.com"
+
+    def __init__(
+        self,
+        username: str | None = None,
+        password: str | None = None,
+        *,
+        db: Any = None,
+        timeout: int = 30,
+    ):
+        # Resolution order mirrors seatgeek_client: explicit arg -> env var ->
+        # Supabase Vault (get_app_secret). Pass db (a service-role client) to
+        # enable the Vault fallback.
+        u = username or os.environ.get("TICKETSDATA_USERNAME") or _vault_secret(db, "TICKETSDATA_USERNAME")
+        p = password or os.environ.get("TICKETSDATA_PASSWORD") or _vault_secret(db, "TICKETSDATA_PASSWORD")
+        if not u or not p:
+            raise TicketsDataError(
+                "TicketsData credentials required. Set TICKETSDATA_USERNAME / "
+                "TICKETSDATA_PASSWORD env, or store them in Vault: "
+                "SELECT public.upsert_app_secret('TICKETSDATA_USERNAME', '<email>'); "
+                "SELECT public.upsert_app_secret('TICKETSDATA_PASSWORD', '<password>');"
+            )
+        self._username = u.strip()
+        self._password = p  # never stripped/logged; sent verbatim
+        self.timeout = timeout
+
+    @classmethod
+    def from_env(cls, *, timeout: int = 30) -> "TicketsDataClient":
+        return cls(timeout=timeout)
+
+    @classmethod
+    def from_vault(cls, db: Any, *, timeout: int = 30) -> "TicketsDataClient":
+        """Build a client resolving creds from Supabase Vault (db = service-role
+        client). Falls back to env vars if those are set too."""
+        return cls(db=db, timeout=timeout)
+
+    # ---------- transport ----------
+
+    def _get(self, path: str, params: dict | None = None) -> dict[str, Any]:
+        _assert_readonly_method("GET")
+        url = f"{self.BASE_URL}{path}"
+        # Credentials live in params, never in the logged/raised URL string.
+        clean = {k: v for k, v in (params or {}).items() if v is not None}
+        clean["username"] = self._username
+        clean["password"] = self._password
+
+        # Per docs: retry 429 (back off), 503 (service_unavailable) and 504
+        # (timeout); do NOT retry 400/401/402/404 (deterministic).
+        r = None
+        delays = [1.5, 3.0]
+        for attempt in range(len(delays) + 1):
+            r = requests.get(url, params=clean, timeout=self.timeout)
+            if r.status_code in (429, 503, 504) and attempt < len(delays):
+                retry_after = r.headers.get("Retry-After")
+                try:
+                    delay = float(retry_after) if retry_after else delays[attempt]
+                except (TypeError, ValueError):
+                    delay = delays[attempt]
+                time.sleep(min(delay, 30.0))
+                continue
+            break
+
+        if r.status_code == 401:
+            raise TicketsDataAuthError("HTTP 401 — invalid TicketsData credentials")
+        if r.status_code == 402:
+            raise TicketsDataQuotaError("HTTP 402 — plan quota exhausted")
+        if not r.ok:
+            # Surface the path + status only — never the credential-bearing URL.
+            raise TicketsDataError(f"HTTP {r.status_code} on GET {path}")
+        try:
+            body = r.json()
+        except ValueError:
+            return {"raw_text": r.text}
+        return body if isinstance(body, dict) else {"body": body}
+
+    # ---------- endpoints ----------
+
+    def fetch(self, platform: str, event_url: str, *, mode: str | None = None) -> dict[str, Any]:
+        """GET /fetch — full live inventory for one event on one platform.
+        Cost: 1 credit. `mode` is platform-specific (see docs mode matrix)."""
+        plat = _validate_platform(platform)
+        if not event_url:
+            raise TicketsDataError("event_url is required for /fetch")
+        return self._get("/fetch", {"platform": plat, "event_url": event_url, "mode": mode})
+
+    def events(
+        self,
+        platform: str,
+        *,
+        performer_url: str | None = None,
+        venue_url: str | None = None,
+    ) -> dict[str, Any]:
+        """GET /events — upcoming events for a performer/venue/organizer page.
+        Cost: 1 credit. Dice.fm venue/promoter pages use venue_url."""
+        plat = _validate_platform(platform)
+        if not performer_url and not venue_url:
+            raise TicketsDataError("one of performer_url / venue_url is required for /events")
+        return self._get(
+            "/events",
+            {"platform": plat, "performer_url": performer_url, "venue_url": venue_url},
+        )
+
+    def match(self, event_url: str) -> dict[str, Any]:
+        """GET /match — cross-market arbitrage report (Pro plan+).
+        Cost: 12 credits + 1 Market-Intelligence report. The engine
+        auto-detects the source platform from the URL, so no platform arg."""
+        if not event_url:
+            raise TicketsDataError("event_url is required for /match")
+        return self._get("/match", {"event_url": event_url})


### PR DESCRIPTION
## Why

The 2026-05-29 `main` re-root (#388) orphaned 8 branches onto **dead history with no common ancestor** — git can't merge them. This branch recovers the work that is **genuinely still missing** from current main, audited branch-by-branch (the rest was already shipped or superseded).

## Re-cut (verified still missing on main)

| Origin PR | What | Form |
|---|---|---|
| **#377** | `compute_event_zone/section_metrics` dedup — `v_has_zones` pre-check skips `match_performer_zone()` for no-curated-zone events; `derive_zone_fallback()` once per unique (section,row) | migration *(A1 applies)* |
| **#382** | SeatData / Vivid / GoTickets resolve creds via **Vault**, not env-only (`app.py` + `d2_dashboard` factories use the `SeatDataClient(db=…)` 3-step chain) | code |
| **#379** | Playoff games exempt from the owned>100 Featured gate + survive the speculative-name filter (unless CANCELLED); **empty-rail fallback** so the NYC rail is never blank | code + tests |
| **#378** | TicketsData **read-only** client (GET-only, vault creds) + budget-guarded MVP smoke-test + tests | code + tests |
| **#381** | Drop dead single-arg `td_enqueue_peak(text)` overload (credit-burn risk) | migration *(A1 applies)* |
| **#375** | exos door/check-in hardening + free-claim RPC | migrations *(A1 applies)* |

## Deliberately NOT re-cut (superseded / already shipped)

- **#380** — TicketsData Phase 1 SQL is **already on main** (`20260526090000`→`20260527200000`). Close as shipped; only its Python client was missing (recovered via #378).
- **#378 FE wiring** — `home.js`/`movers.js` were rewritten by the #388 redesign to use `get_event_movers_v2`; re-cutting the old `/api/broker/movers` wiring would regress it.
- **#375 bridge FE** (promotion/free-claim UI) — `d4_bridge` diverged; must be re-cut against current bridge by the **D4 owner**.

## Notes

- All re-cut migrations re-dated to `2026-06-05` so they apply cleanly atop main's existing migration timeline. Migrations are authored-only — application stays gated to A1/operator per `CLAUDE.md` lockdown.
- **#379 tests use relative dates** — the originals hardcoded `2026-05-31` etc. and would have re-introduced the exact CI time-bomb #426 just fixed.
- Test suite: **244 passed, 12 skipped** locally.

## Suggested follow-ups

- Close orphan PRs #380 (shipped), and #377/#378/#379/#381/#382 once this lands.
- D4 to re-cut #375's promotion/free-claim **FE** against current `d4_bridge`.

https://claude.ai/code/session_01Kwe3YZTpxMHCafXRnVmDTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kwe3YZTpxMHCafXRnVmDTf)_