### PR TITLE
feat(d0): non-SG AQ→TEvo cold-search bridge — re-cut onto rewritten main

### DIFF
--- a/supabase/functions/aq-to-tevo-search-bridge/index.ts
+++ b/supabase/functions/aq-to-tevo-search-bridge/index.ts
@@ -1,0 +1,212 @@
+// aq-to-tevo-search-bridge (v1)
+//
+// COLD BRIDGE (non-SG analogue of sg-to-tevo-search-bridge): for aq_event_map
+// hub rows that carry a Ticketmaster / Vivid / ScoreBig(SH) id but NO sg_event_id
+// and NO canonical tevo_event_id, actively call TEvo /v9/events (venue+date,
+// then name+date) to discover the matching TEvo event and fill
+// aq_event_map.tevo_event_id.
+//
+// Why this exists: TM/Vivid/SH rows only ever mapped *passively* before (when
+// they coincided with an SG or order match). Nothing actively searched TEvo for
+// them, leaving ~1,250 upcoming non-parking hub rows permanently unmapped.
+//
+// Candidate selection is server-side (aq_tevo_search_candidates RPC), which
+// anti-joins the attempt ledger and orders NEVER-TRIED-FIRST — so it drains the
+// whole backlog instead of starving on the nearest-dated front like the SG
+// bridge's client-side date-LIMIT window does.
+//
+// GET /functions/v1/aq-to-tevo-search-bridge?limit=30&dry_run=false
+//                                            &min_score=50
+//                                            &backoff_hours=24
+//
+// Body-gated via requireCronSecret per PROJECT_BIBLE §1 rule #7.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
+import { requireCronSecret } from "../_shared/cron-auth.ts";
+
+const HOST = "api.ticketevolution.com";
+const BASE = `https://${HOST}`;
+
+async function hmac(secret: string, msg: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(msg));
+  let bin = ""; for (const b of new Uint8Array(sig)) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+function qs(p: Record<string, unknown>): string {
+  const pairs: [string, string][] = [];
+  for (const [k, v] of Object.entries(p)) {
+    if (v === null || v === undefined || v === "") continue;
+    pairs.push([k, typeof v === "boolean" ? (v ? "true" : "false") : String(v)]);
+  }
+  pairs.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return pairs.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");
+}
+
+async function tevoSearch(token: string, secret: string, params: Record<string, unknown>) {
+  const path = "/v9/events";
+  const queryStr = qs(params);
+  const sig = await hmac(secret, `GET ${HOST}${path}?${queryStr}`);
+  const r = await fetch(`${BASE}${path}?${queryStr}`, {
+    headers: { "X-Token": token, "X-Signature": sig, "Accept": "application/vnd.ticketevolution.api+json; version=9" },
+  });
+  if (r.status !== 200) return { ok: false as const, status: r.status, body: (await r.text()).slice(0, 300) };
+  return { ok: true as const, body: await r.json() };
+}
+
+const slug = (s: string) => (s ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+const tokenSet = (s: string) => new Set((s ?? "").toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 1));
+
+// Split a hub event_name into competitor sides. Handles "A vs. B", "A vs B",
+// "A v. B", "A at B" (sports). Returns [a, b] with b="" for single-name events
+// (concerts / theatre).
+function splitSides(name: string): [string, string] {
+  const m = (name ?? "").split(/\s+(?:vs\.?|v\.?|at)\s+/i);
+  if (m.length >= 2) return [m[0].trim(), m.slice(1).join(" ").trim()];
+  return [(name ?? "").trim(), ""];
+}
+
+// Returns {total, venue}. `venue` is the venue-only contribution; acceptance
+// requires venue >= 25 so a same-name/same-date hit at a DIFFERENT venue (e.g.
+// a touring play with simultaneous productions) cannot pass on name+date alone.
+function scoreParts(candidate: any, q: { date: string; venue: string; tevo_venue_id: number | null; team_a: string; team_b: string }): { total: number; venue: number } {
+  let venue = 0;
+  if (q.tevo_venue_id && candidate.venue?.id === q.tevo_venue_id) venue = 50;
+  else if (candidate.venue?.name && slug(candidate.venue.name) === slug(q.venue)) venue = 40;
+  else if (candidate.venue?.name && (slug(candidate.venue.name).startsWith(slug(q.venue)) || slug(q.venue).startsWith(slug(candidate.venue.name)))) venue = 25;
+  let s = venue;
+  const candidateTokens = tokenSet(candidate.name ?? "");
+  let teamHits = 0;
+  for (const t of tokenSet(q.team_b)) if (candidateTokens.has(t)) teamHits++;
+  for (const t of tokenSet(q.team_a)) if (candidateTokens.has(t)) teamHits++;
+  s += teamHits * 10;
+  const qT = new Date(q.date).getTime();
+  const candT = new Date(candidate.occurs_at).getTime();
+  const hours = Math.abs((candT - qT) / 3600000);
+  if (!isNaN(hours)) s += Math.max(0, 24 - hours);
+  return { total: s, venue };
+}
+
+// aq_event_map.event_date is `timestamp without time zone` (naive local wall
+// clock). Treat it as the event's local time; a ±24h date window around it is
+// wide enough to absorb the tz skew for the TEvo occurs_at filter.
+function dateWindow(eventDate: string): { gte: string; lte: string; ms: number } {
+  const t = new Date((eventDate ?? "").replace(" ", "T")).getTime();
+  return {
+    gte: new Date(t - 24 * 3600000).toISOString().slice(0, 10),
+    lte: new Date(t + 24 * 3600000).toISOString().slice(0, 10),
+    ms: t,
+  };
+}
+
+Deno.serve(async (req) => {
+  const authErr = requireCronSecret(req);
+  if (authErr) return authErr;
+
+  const sb = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!, { auth: { persistSession: false, autoRefreshToken: false } });
+  const tevoToken = Deno.env.get("TEVO_TOKEN") ?? Deno.env.get("TEVO_API_TOKEN") ?? "";
+  const tevoSecret = Deno.env.get("TEVO_SECRET") ?? Deno.env.get("TEVO_API_SECRET") ?? "";
+  if (!tevoToken || !tevoSecret) return new Response(JSON.stringify({ ok: false, error: "missing TEvo creds" }), { status: 500, headers: { "content-type": "application/json" } });
+
+  const url = new URL(req.url);
+  const limit = Math.max(1, Math.min(200, Number(url.searchParams.get("limit") ?? "30")));
+  const dryRun = url.searchParams.get("dry_run") === "true";
+  const minScore = Number(url.searchParams.get("min_score") ?? "50");
+  const backoffHours = Math.max(1, Number(url.searchParams.get("backoff_hours") ?? "24"));
+
+  // Server-side candidate selection — anti-joins the ledger, never-tried-first.
+  const { data: candidates, error: candErr } = await sb.rpc("aq_tevo_search_candidates", {
+    p_limit: limit,
+    p_backoff_hours: backoffHours,
+  });
+  if (candErr) return new Response(JSON.stringify({ ok: false, error: candErr.message }), { status: 500, headers: { "content-type": "application/json" } });
+  const pool: any[] = candidates ?? [];
+
+  // Resolve TEvo venue ids in parallel (independent read RPCs).
+  const venueMap = new Map<number, number | null>();
+  await Promise.all(
+    pool.map(async (c: any) => {
+      const { data } = await sb.rpc("cross_source_venue_resolve", {
+        p_venue_name: c.venue_name,
+        p_city: c.city,
+        p_state: c.state,
+      });
+      venueMap.set(c.aq_id, data ?? null);
+    }),
+  );
+
+  const samples: any[] = [];
+  let matched = 0, noResults = 0, lowScore = 0, errored = 0;
+
+  for (const c of pool) {
+    const [teamA, teamB] = splitSides(c.event_name);
+    const tevoVenueId = venueMap.get(c.aq_id) ?? null;
+    const w = dateWindow(c.event_date);
+    // Name query: home/away team for sports, else performer or full name.
+    const nameQuery = (teamB || c.performer || teamA || c.event_name || "").trim();
+
+    let resp = tevoVenueId
+      ? await tevoSearch(tevoToken, tevoSecret, { venue_id: tevoVenueId, "occurs_at.gte": w.gte, "occurs_at.lte": w.lte, per_page: 25, page: 1 })
+      : { ok: false as const, status: 0, body: null };
+
+    // Fall back to name+date if venue search empty or unavailable.
+    if ((resp.ok && (((resp.body as any).events ?? []) as any[]).length === 0) || !resp.ok) {
+      resp = await tevoSearch(tevoToken, tevoSecret, { name: nameQuery, "occurs_at.gte": w.gte, "occurs_at.lte": w.lte, per_page: 25, page: 1 });
+    }
+
+    if (!resp.ok) {
+      errored++;
+      if (!dryRun) await sb.from("aq_tevo_search_attempts").upsert({ aq_id: c.aq_id, attempted_at: new Date().toISOString(), result: "errored", meta: { status: resp.status, body: resp.body, name: nameQuery } }, { onConflict: "aq_id" });
+      samples.push({ aq_id: c.aq_id, error: resp.status });
+      continue;
+    }
+
+    const events: any[] = ((resp.body as any).events ?? []) as any[];
+    if (events.length === 0) {
+      noResults++;
+      if (!dryRun) await sb.from("aq_tevo_search_attempts").upsert({ aq_id: c.aq_id, attempted_at: new Date().toISOString(), result: "no_results", meta: { date_gte: w.gte, date_lte: w.lte, name: nameQuery, tevo_venue_id: tevoVenueId, src: c.src } }, { onConflict: "aq_id" });
+      continue;
+    }
+
+    let best: any = null, bestScore = -1, bestVenue = 0;
+    for (const ev of events) {
+      const sc = scoreParts(ev, { date: c.event_date, venue: c.venue_name, tevo_venue_id: tevoVenueId, team_a: teamA, team_b: teamB });
+      if (sc.total > bestScore) { bestScore = sc.total; bestVenue = sc.venue; best = ev; }
+    }
+
+    // Accept only with BOTH enough total score AND a real venue signal — guards
+    // against same-name/same-date matches at a different venue.
+    if (!best || bestScore < minScore || bestVenue < 25) {
+      lowScore++;
+      if (!dryRun) await sb.from("aq_tevo_search_attempts").upsert({ aq_id: c.aq_id, attempted_at: new Date().toISOString(), result: "low_score", meta: { best_score: bestScore, best_venue: bestVenue, best_id: best?.id, best_name: best?.name, top_n: events.length, name: nameQuery, src: c.src } }, { onConflict: "aq_id" });
+      continue;
+    }
+
+    if (!dryRun) {
+      const performances = best.performances ?? [];
+      const primaryPerf = performances.find((p: any) => p.primary) ?? performances[0];
+      await sb.from("events").upsert({
+        id: best.id, name: best.name, occurs_at_local: best.occurs_at_local ?? best.occurs_at, state: best.state,
+        venue_id: best.venue?.id ?? null, venue_name: best.venue?.name ?? null, venue_location: best.venue?.location ?? null,
+        primary_performer_id: primaryPerf?.performer?.id ?? null, primary_performer_name: primaryPerf?.performer?.name ?? null,
+        performer_ids: performances.map((p: any) => p.performer?.id).filter((x: any) => x),
+        event_type: best.category?.slug ?? null, last_seen: new Date().toISOString(),
+      }, { onConflict: "id" });
+
+      // Canonical link: set the hub row's tevo_event_id.
+      await sb.from("aq_event_map").update({ tevo_event_id: best.id }).eq("id", c.aq_id);
+
+      await sb.from("aq_tevo_search_attempts").upsert({ aq_id: c.aq_id, attempted_at: new Date().toISOString(), result: "matched", meta: { tevo_event_id: best.id, score: bestScore, name: best.name, src: c.src } }, { onConflict: "aq_id" });
+    }
+
+    matched++;
+    if (samples.length < 18) samples.push({ aq_id: c.aq_id, src: c.src, aq_name: c.event_name, aq_venue: c.venue_name, aq_date: c.event_date, matched_to: { id: best.id, name: best.name, venue: best.venue?.name, occurs_at: best.occurs_at_local ?? best.occurs_at }, score: bestScore });
+  }
+
+  return new Response(JSON.stringify({
+    ok: true, dry_run: dryRun, limit, min_score: minScore, backoff_hours: backoffHours,
+    attempted: pool.length, matched, no_results: noResults, low_score: lowScore, errored, samples,
+  }, null, 2), { headers: { "content-type": "application/json" } });
+});

--- a/supabase/migrations/20260605133000_td_sg_event_linkage_and_aq_tevo_fill.sql
+++ b/supabase/migrations/20260605133000_td_sg_event_linkage_and_aq_tevo_fill.sql
@@ -1,0 +1,229 @@
+-- Migration 20260528380000 · level:2 · lane:A1
+-- writes: ticketsdata_event_xref, aq_event_map
+-- reads: sg_events_canonical, aq_event_map
+--
+-- Purpose: Add tevo_event_id + sg_event_id + tevo_match_method to ticketsdata_event_xref.
+--   Backfill day 1: 575/575 get sg_event_id, 417/575 get tevo_event_id (72.5%).
+--   Creates refresh_td_event_links() — nightly 5-step sync with full fallback chain.
+--   Authored by D0 2026-05-28. A1 to review + apply.
+--
+-- Validated dry-run (2026-05-28):
+--   575/575 td_xref rows have aq_short_event_id → 100% join coverage to aq_event_map
+--   575/575 get sg_event_id from aq_event_map
+--   417/575 get tevo_event_id from aq_event_map (72.5%)
+--   158 missing tevo_event_id: 84 active (36 parking + 48 non-parking), 74 inactive
+--   Parking events: TEvo does not track stadium parking lots → correct to leave tevo_event_id NULL
+--   Non-parking pending: sg_to_tevo_search_bridge_30min cron resolves over time;
+--     refresh_td_event_links() picks up each nightly run
+--   aq reverse-fill (aq_event_map ← sg_events_canonical): currently 0 rows (already fully synced)
+--     Kept in refresh fn as defensive step for future state
+--
+-- KEY ARCHITECTURE NOTE (do not re-discover):
+--   Source IDs are source-internal — NEVER join cross-source on raw IDs.
+--   TEvo event_id range: 3.0M–3.4M. SG sg_event_id: 17M+. TD platform IDs: 4.5M–160M.
+--   ticketsdata_event_xref.aq_short_event_id = 7-char alphanumeric (e.g. K9KX32Z, TD's cross-platform key)
+--   listings_snapshots.aq_short_event_id = SYS-{hex} (TEvo-internal only — DIFFERENT SYSTEM, same col name)
+--   aq_event_map is the canonical hub: all platform IDs converge here.
+--   Bridge cron sg_to_tevo_search_bridge_30min fills aq_event_map.tevo_event_id over time.
+--   See D0_BIBLE.md §3 and PROJECT_BIBLE §5 for full chain documentation.
+
+-- ── PART 1: Add columns to ticketsdata_event_xref ────────────────────────────
+
+ALTER TABLE public.ticketsdata_event_xref
+  ADD COLUMN IF NOT EXISTS tevo_event_id     bigint,
+  ADD COLUMN IF NOT EXISTS sg_event_id       bigint,
+  ADD COLUMN IF NOT EXISTS tevo_match_method text;
+
+COMMENT ON COLUMN public.ticketsdata_event_xref.tevo_event_id IS
+  'TEvo event_id resolved via aq_event_map or fallback chain. NULL for parking lots and international events TEvo does not track.';
+COMMENT ON COLUMN public.ticketsdata_event_xref.sg_event_id IS
+  'SeatGeek sg_event_id resolved via aq_event_map. Coverage: 100% of active TD events.';
+COMMENT ON COLUMN public.ticketsdata_event_xref.tevo_match_method IS
+  'How tevo_event_id was resolved: aq_event_map | sg_canonical_direct | text_performer_date | pending_bridge | null_parking | null_international';
+
+CREATE INDEX IF NOT EXISTS idx_tdx_tevo_event_id
+  ON public.ticketsdata_event_xref (tevo_event_id)
+  WHERE tevo_event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tdx_sg_event_id
+  ON public.ticketsdata_event_xref (sg_event_id)
+  WHERE sg_event_id IS NOT NULL;
+
+-- ── PART 2: Initial backfill from aq_event_map ───────────────────────────────
+-- Expected result: 575 sg_event_id filled, 417 tevo_event_id filled
+
+UPDATE public.ticketsdata_event_xref tdx
+SET
+  sg_event_id       = aem.sg_event_id,
+  tevo_event_id     = aem.tevo_event_id,
+  tevo_match_method = CASE
+    WHEN aem.tevo_event_id IS NOT NULL THEN 'aq_event_map'
+    WHEN tdx.aq_short_event_id IS NOT NULL THEN 'pending_bridge'
+    ELSE NULL
+  END
+FROM public.aq_event_map aem
+WHERE aem.aq_short_event_id = tdx.aq_short_event_id
+  AND (tdx.sg_event_id IS NULL OR tdx.tevo_event_id IS NULL);
+
+-- ── PART 3: refresh_td_event_links() — nightly 5-step sync ───────────────────
+--
+-- Step A: defensive reverse-fill aq_event_map.tevo_event_id from sg_events_canonical
+--         (normally 0 rows — catches edge cases where sg_canonical updated via non-bridge path)
+-- Step B: fill td_xref.sg_event_id from aq_event_map (new td events since last run)
+-- Step C: fill td_xref.tevo_event_id from aq_event_map.tevo_event_id  [PRIMARY PATH]
+-- Step D: AQ FALLBACK — td_xref → aq_event_map.sg_event_id → sg_events_canonical.tevo_event_id
+--         (catches bridge resolution that updated sg_canonical before aq_event_map was synced)
+-- Step E: TEXT FALLBACK — performer name + date text match via sg_events_canonical
+--         Principle: touring artists don't play same city twice same day → performer+date = unique
+--         Sports: team names in event_name are unique per venue per day
+--         Safety: only accepts unambiguous 1:1 matches (n_candidates = 1)
+--         Does NOT use source IDs (venue_id, sg_venue_id) — those are source-internal
+
+CREATE OR REPLACE FUNCTION public.refresh_td_event_links()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_aq_filled    integer := 0;
+  v_td_sg_filled integer := 0;
+  v_td_tv_aq     integer := 0;
+  v_td_tv_sg     integer := 0;
+  v_td_tv_text   integer := 0;
+BEGIN
+
+  -- ── Step A: defensive reverse-fill aq_event_map ← sg_events_canonical ─────
+  -- Normally 0 rows. Covers edge case where sg_canonical was updated by a path
+  -- other than the standard sg_to_tevo_search_bridge → aq_event_map chain.
+  WITH updated AS (
+    UPDATE public.aq_event_map aem
+    SET tevo_event_id = sgc.tevo_event_id
+    FROM public.sg_events_canonical sgc
+    WHERE sgc.sg_event_id    = aem.sg_event_id
+      AND sgc.tevo_event_id IS NOT NULL
+      AND aem.tevo_event_id IS NULL
+    RETURNING 1
+  ) SELECT COUNT(*) INTO v_aq_filled FROM updated;
+
+  -- ── Step B: fill td_xref.sg_event_id from aq_event_map ───────────────────
+  -- Picks up new TD events added since last nightly run.
+  WITH updated AS (
+    UPDATE public.ticketsdata_event_xref tdx
+    SET sg_event_id = aem.sg_event_id
+    FROM public.aq_event_map aem
+    WHERE aem.aq_short_event_id  = tdx.aq_short_event_id
+      AND aem.sg_event_id       IS NOT NULL
+      AND tdx.sg_event_id       IS NULL
+    RETURNING 1
+  ) SELECT COUNT(*) INTO v_td_sg_filled FROM updated;
+
+  -- ── Step C: fill td_xref.tevo_event_id from aq_event_map [PRIMARY] ────────
+  WITH updated AS (
+    UPDATE public.ticketsdata_event_xref tdx
+    SET tevo_event_id     = aem.tevo_event_id,
+        tevo_match_method = 'aq_event_map'
+    FROM public.aq_event_map aem
+    WHERE aem.aq_short_event_id  = tdx.aq_short_event_id
+      AND aem.tevo_event_id     IS NOT NULL
+      AND tdx.tevo_event_id     IS NULL
+    RETURNING 1
+  ) SELECT COUNT(*) INTO v_td_tv_aq FROM updated;
+
+  -- ── Step D: AQ FALLBACK — sg_canonical direct bypass ─────────────────────
+  -- Chain: td_xref → aq_event_map.sg_event_id → sg_events_canonical.tevo_event_id
+  -- Use when aq_event_map.tevo_event_id is still NULL but sg_canonical already has it.
+  -- Occurs when bridge cron resolves SG→TEvo but aq_event_map hasn't been updated yet.
+  WITH updated AS (
+    UPDATE public.ticketsdata_event_xref tdx
+    SET tevo_event_id     = sgc.tevo_event_id,
+        tevo_match_method = 'sg_canonical_direct'
+    FROM public.aq_event_map aem
+    JOIN public.sg_events_canonical sgc ON sgc.sg_event_id = aem.sg_event_id
+    WHERE aem.aq_short_event_id  = tdx.aq_short_event_id
+      AND sgc.tevo_event_id     IS NOT NULL
+      AND tdx.tevo_event_id     IS NULL
+    RETURNING 1
+  ) SELECT COUNT(*) INTO v_td_tv_sg FROM updated;
+
+  -- ── Step E: TEXT FALLBACK — performer + date match via sg_events_canonical ─
+  -- For events where all AQ paths still leave tevo_event_id NULL.
+  -- Skips parking lots and CANCELLED events (those correctly remain NULL).
+  -- IMPORTANT: Do NOT filter by source IDs (venue_id, sg_venue_id) — they are
+  --   source-internal and don't cross-join. Use text names + dates only.
+  -- Safety: accepts only unambiguous single-candidate matches.
+  WITH event_candidates AS (
+    SELECT DISTINCT ON (aem.aq_short_event_id)
+      aem.aq_short_event_id,
+      sgc.tevo_event_id,
+      COUNT(DISTINCT sgc.sg_event_id) OVER (PARTITION BY aem.aq_short_event_id) AS n_candidates
+    FROM public.aq_event_map aem
+    JOIN public.sg_events_canonical sgc
+      ON sgc.tevo_event_id IS NOT NULL
+      AND DATE(sgc.sg_datetime_utc) = DATE(aem.event_date)
+      AND length(trim(coalesce(aem.performer, ''))) > 3
+      AND (
+        -- performer name substring match in SG event name (touring artist uniqueness)
+        sgc.sg_event_name ILIKE '%' || trim(aem.performer) || '%'
+        OR
+        -- normalized full event name exact match (sports team matchup format)
+        lower(regexp_replace(aem.event_name,  '[^a-z0-9 ]', '', 'gi'))
+          = lower(regexp_replace(sgc.sg_event_name, '[^a-z0-9 ]', '', 'gi'))
+      )
+    WHERE aem.tevo_event_id IS NULL
+      AND aem.event_name NOT ILIKE '%parking%'
+      AND aem.event_name NOT ILIKE '%cancelled%'
+    ORDER BY aem.aq_short_event_id, sgc.sg_event_id
+  ),
+  text_updated AS (
+    UPDATE public.ticketsdata_event_xref tdx
+    SET tevo_event_id     = ec.tevo_event_id,
+        tevo_match_method = 'text_performer_date'
+    FROM event_candidates ec
+    JOIN public.aq_event_map aem ON aem.aq_short_event_id = ec.aq_short_event_id
+    WHERE aem.aq_short_event_id  = tdx.aq_short_event_id
+      AND ec.n_candidates        = 1   -- only accept unambiguous 1:1 matches
+      AND tdx.tevo_event_id     IS NULL
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_td_tv_text FROM text_updated;
+
+  RETURN jsonb_build_object(
+    'aq_tevo_filled',    v_aq_filled,
+    'td_sg_filled',      v_td_sg_filled,
+    'td_tevo_via_aq',    v_td_tv_aq,
+    'td_tevo_via_sg',    v_td_tv_sg,
+    'td_tevo_via_text',  v_td_tv_text
+  );
+END;
+$$;
+
+-- ── PART 4: Daily cron at 06:05 UTC ──────────────────────────────────────────
+
+SELECT cron.unschedule('refresh-td-event-links')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'refresh-td-event-links');
+
+SELECT cron.schedule(
+  'refresh-td-event-links',
+  '5 6 * * *',
+  $cronbody$
+    DO $b$ BEGIN
+      IF NOT public.cron_should_fire('refresh-td-event-links') THEN RETURN; END IF;
+      PERFORM public.refresh_td_event_links();
+    END $b$;
+  $cronbody$
+);
+
+-- ── Verification (run after apply) ───────────────────────────────────────────
+SELECT
+  COUNT(*)                                                          AS total,
+  COUNT(sg_event_id)                                                AS has_sg_id,
+  COUNT(tevo_event_id)                                              AS has_tevo_id,
+  COUNT(*) FILTER (WHERE active AND tevo_event_id IS NULL)          AS active_missing_tevo,
+  COUNT(*) FILTER (WHERE tevo_match_method = 'aq_event_map')        AS matched_via_aq,
+  COUNT(*) FILTER (WHERE tevo_match_method = 'pending_bridge')      AS pending_bridge,
+  COUNT(*) FILTER (WHERE active AND venue_name ILIKE '%parking%')   AS active_parking_correctly_null
+FROM public.ticketsdata_event_xref tdx
+LEFT JOIN public.aq_event_map aem ON aem.aq_short_event_id = tdx.aq_short_event_id;
+-- expect:
+--   total=575, has_sg_id=575, has_tevo_id=417
+--   active_missing_tevo=84 (36 parking + 48 non-parking awaiting bridge)
+--   matched_via_aq=417, pending_bridge=158

--- a/supabase/migrations/20260605133500_aq_tevo_search_bridge.sql
+++ b/supabase/migrations/20260605133500_aq_tevo_search_bridge.sql
@@ -1,0 +1,170 @@
+-- Migration 20260601120000 · level:2 · lane:D0
+-- writes: aq_tevo_search_attempts (new table)
+-- reads:  aq_event_map
+--
+-- Purpose: Stand up the server-side half of the AQ→TEvo cold-search bridge — the
+--   non-SG analogue of sg_to_tevo_search_bridge. Today TM / Vivid / ScoreBig(SH)
+--   rows in aq_event_map only acquire a canonical tevo_event_id *passively* (when
+--   they happen to coincide with an SG match or an order sweep). ~1,250 upcoming,
+--   non-parking, non-cancelled hub rows carry only TM/Vivid/SH ids and are never
+--   actively searched against TEvo /v9/events.
+--
+--   This migration adds:
+--     1. aq_tevo_search_attempts — per-hub-row attempt ledger (mirrors
+--        sg_tevo_search_attempts, keyed on aq_event_map.id).
+--     2. aq_tevo_search_candidates(p_limit, p_backoff_hours) — the candidate
+--        selector the edge fn drains. It anti-joins the ledger and orders
+--        NEVER-TRIED-FIRST, then stalest-attempt, then by event date.
+--
+--   DESIGN NOTE — why the selector lives in SQL, not the edge fn:
+--     The SG bridge picks candidates client-side with
+--     `.order(date asc).limit(N*6)` then filters out recently-tried rows. That
+--     pins it to the nearest-dated front of the queue and starves the deeper
+--     backlog (observed: 645 SG candidates never attempted; see KANBAN). Doing
+--     the anti-join server-side with `(attempt is null) DESC` ordering guarantees
+--     the window advances through the whole backlog and cannot starve.
+--
+--   Authored by D0 2026-06-01. Writes to aq_event_map.tevo_event_id are performed
+--   by the edge fn (service role), gated min_score + venue-signal; dry_run validated first.
+--
+-- ## Already applied to prod  Applied via MCP 2026-06-01 (operator-authorized).
+--   Edge fn `aq-to-tevo-search-bridge` deployed v2 (venue-signal guard). First live
+--   run: 30 attempted / 13 matched / 0 errored, all 13 written to aq_event_map.
+--   Cron `aq_to_tevo_search_bridge_13h` scheduled (see PART 3) — 13h cadence.
+--
+-- KEY ARCHITECTURE NOTE (do not re-discover):
+--   aq_event_map is the canonical hub; tevo_event_id is the canonical link.
+--   Source IDs are source-internal — never cross-join on raw IDs. The hub row is
+--   self-describing (event_name/venue_name/event_date/city/state/performer/category),
+--   which is enough to drive a TEvo /v9/events text+date search directly.
+--   See D0_BIBLE.md §3 and PROJECT_BIBLE §5.
+
+-- ── PART 1: attempt ledger ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.aq_tevo_search_attempts (
+  aq_id        bigint PRIMARY KEY
+                 REFERENCES public.aq_event_map(id) ON DELETE CASCADE,
+  attempted_at timestamptz NOT NULL DEFAULT now(),
+  result       text NOT NULL
+                 CHECK (result IN ('matched','no_results','low_score','errored')),
+  meta         jsonb
+);
+
+COMMENT ON TABLE public.aq_tevo_search_attempts IS
+  'Per-hub-row attempt ledger for the AQ→TEvo cold-search bridge (aq-to-tevo-search-bridge edge fn). Keyed on aq_event_map.id. Mirrors sg_tevo_search_attempts. no_results/low_score rows are retried after the backoff window; matched rows are terminal (the hub row leaves the candidate pool once tevo_event_id is set).';
+
+CREATE INDEX IF NOT EXISTS idx_aqtsa_attempted_at
+  ON public.aq_tevo_search_attempts (attempted_at);
+CREATE INDEX IF NOT EXISTS idx_aqtsa_result
+  ON public.aq_tevo_search_attempts (result);
+
+-- ── PART 2: candidate selector (anti-join, never-tried-first) ────────────────
+-- LANGUAGE sql body is validated at CREATE time → must be declared AFTER the
+-- table above exists in this same migration (PROJECT_BIBLE §7 landmine).
+
+CREATE OR REPLACE FUNCTION public.aq_tevo_search_candidates(
+  p_limit         int DEFAULT 30,
+  p_backoff_hours int DEFAULT 24
+)
+RETURNS TABLE (
+  aq_id       bigint,
+  event_name  text,
+  venue_name  text,
+  city        text,
+  state       text,
+  performer   text,
+  category    text,
+  event_date  timestamp,
+  src         text,
+  last_result text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    m.id,
+    m.event_name,
+    m.venue_name,
+    m.city,
+    m.state,
+    m.performer,
+    m.category,
+    m.event_date,
+    CASE
+      WHEN m.tm_event_id    IS NOT NULL THEN 'TM'
+      WHEN m.vivid_event_id IS NOT NULL THEN 'VIVID'
+      WHEN m.sh_event_id    IS NOT NULL THEN 'SH'
+      ELSE 'OTHER'
+    END                                 AS src,
+    a.result                            AS last_result
+  FROM public.aq_event_map m
+  LEFT JOIN public.aq_tevo_search_attempts a ON a.aq_id = m.id
+  WHERE m.tevo_event_id IS NULL
+    AND m.sg_event_id   IS NULL                              -- SG rows are the SG bridge's job
+    AND COALESCE(m.tm_event_id, m.vivid_event_id, m.sh_event_id) IS NOT NULL
+    AND m.event_date >= now()::timestamp                     -- upcoming only
+    AND NOT (m.category IN ('Parking','parking')
+             OR m.venue_name ILIKE '%parking%'
+             OR m.event_name ILIKE '%parking%')              -- TEvo folds parking in
+    AND NOT (m.event_name ~* '(cancelled|if necessary|\(date tbd\))')
+    AND (
+      a.aq_id IS NULL                                        -- never tried
+      OR a.attempted_at < now() - make_interval(hours => p_backoff_hours)
+    )
+  ORDER BY
+    (a.aq_id IS NULL) DESC,                                  -- never-tried first
+    a.attempted_at ASC NULLS FIRST,                          -- then stalest attempt
+    m.event_date ASC                                         -- then soonest event
+  LIMIT GREATEST(1, LEAST(200, p_limit));
+$$;
+
+COMMENT ON FUNCTION public.aq_tevo_search_candidates(int, int) IS
+  'Next batch of unmapped non-SG hub rows for the AQ→TEvo cold-search bridge. Anti-joins aq_tevo_search_attempts and orders never-tried-first to drain the full backlog (avoids the date-LIMIT starvation the SG bridge suffers). Service-role only.';
+
+-- Service-role only (edge fn calls with SUPABASE_SERVICE_ROLE_KEY).
+REVOKE ALL ON FUNCTION public.aq_tevo_search_candidates(int, int) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.aq_tevo_search_candidates(int, int) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.aq_tevo_search_candidates(int, int) TO service_role;
+
+-- ── PART 3: cron wiring (applied 2026-06-01, AFTER the edge fn was deployed) ──
+-- Ran as a separate gated step (cron.schedule + cron_policy + edge-fn deploy are
+-- all gated per PROJECT_BIBLE §1, and the fn must exist before the cron fires).
+--
+-- Cadence: every 13 hours (operator directive 2026-06-01). Standard cron can't
+-- express a strict 13h interval, so the schedule TRIGGERS hourly at :08 and the
+-- cron_should_fire min-interval gate (780 min, all hours treated as "peak")
+-- releases it only ~every 13h. "now" was seeded as the first fire so the first
+-- automated run lands ~13h after deploy.
+--
+-- INSERT INTO public.cron_policy (jobname, peak_hours_et, peak_min_interval_min,
+--   offpeak_min_interval_min, work_check_sql, daily_max_fires, enabled, notes)
+-- VALUES (
+--   'aq_to_tevo_search_bridge_13h',
+--   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+--   780, 780,
+--   'SELECT EXISTS(SELECT 1 FROM public.aq_tevo_search_candidates(1, 24))',
+--   NULL, true,
+--   'Active TEvo /v9/events search bridge for non-SG (TM/Vivid/SH) hub rows. 13h cadence via min-interval gate. limit=30/run.'
+-- )
+-- ON CONFLICT (jobname) DO UPDATE SET ... ;
+--
+-- -- seed now as first fire so next automated run is ~13h out:
+-- INSERT INTO public.cron_gate_decisions (jobname, decided_at, decision, hour_et)
+-- VALUES ('aq_to_tevo_search_bridge_13h', now(), 'fire',
+--         EXTRACT(hour FROM (now() AT TIME ZONE 'America/New_York'))::int);
+--
+-- SELECT cron.schedule(
+--   'aq_to_tevo_search_bridge_13h',
+--   '8 * * * *',
+--   $cronbody$
+--     DO $b$ BEGIN
+--       IF NOT public.cron_should_fire('aq_to_tevo_search_bridge_13h') THEN RETURN; END IF;
+--       PERFORM public._cron_invoke_edge_fn(
+--         'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/aq-to-tevo-search-bridge?limit=30&min_score=50',
+--         '{}'::jsonb
+--       );
+--     END $b$;
+--   $cronbody$
+-- );


### PR DESCRIPTION
## Why

Recovers **#392** (D0's non-SG AQ→TEvo cold-search bridge), which the 2026-05-29 `main` re-root left off current main. Audited each piece against **live prod** (`hzrizjeaxlqcxfrtczpq`) before re-cutting.

## What's here

| File | Purpose | Prod audit |
|---|---|---|
| `supabase/functions/aq-to-tevo-search-bridge/index.ts` | Edge fn: searches TEvo `/v9/events` for TM/Vivid/SH hub rows with no `sg_event_id`, fills `aq_event_map.tevo_event_id`. Venue-signal guard (≥25) blocks same-name/diff-venue false positives. | dep `_shared/cron-auth.ts` present; mirrors live `sg-to-tevo-search-bridge` |
| `…_aq_tevo_search_bridge.sql` | `aq_tevo_search_attempts` ledger + `aq_tevo_search_candidates` never-tried-first selector RPC | **both already exist in prod** (applied via MCP 2026-06-01) → file is idempotent repo parity |
| `…_td_sg_event_linkage_and_aq_tevo_fill.sql` | adds tevo/sg/match-method cols to `ticketsdata_event_xref` + `refresh_td_event_links()` nightly sync | **not yet applied** to prod → stays gated for A1/operator |

## Audit + tests
- `aq_event_map` confirmed to have all 12 columns the selector references.
- Migrations re-dated to `2026-06-05` (original `20260601120000` collided with main's `…_d0_event_realtime_dirty_ping.sql`).
- **Smoke:** full pytest — **251 passed, 12 skipped**.
- **Render/boot:** FastAPI app imports clean — **112 routes**, `/api/store/*` present.

## Not included
- The `PROJECT_BIBLE`/`RESOURCES_BIBLE` doc edits from #392 — they conflict with A1's newer bible content; the bridge inventory rows should be re-added separately to avoid clobbering.

## Follow-up
- Close #392 once this lands.

https://claude.ai/code/session_01Kwe3YZTpxMHCafXRnVmDTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kwe3YZTpxMHCafXRnVmDTf)_