### PR TITLE
feat(d4): promotion + free-claim FE — re-cut #375 onto current d4_bridge

### DIFF
--- a/d4_bridge/src/App.tsx
+++ b/d4_bridge/src/App.tsx
@@ -38,6 +38,8 @@ const EmbedEvent = lazy(() => import('./views/EmbedEvent'));
 const OrganizerOnboarding = lazy(() => import('./views/OrganizerOnboarding'));
 const ClaimInvite = lazy(() => import('./views/ClaimInvite'));
 const OrganizerEventReport = lazy(() => import('./views/OrganizerEventReport'));
+const PromoteEvent = lazy(() => import('./views/PromoteEvent'));
+const OrgPromote = lazy(() => import('./views/OrgPromote'));
 
 /**
  * @license
@@ -107,12 +109,14 @@ export default function App() {
                     <Route path="/create-event" element={<CreateEvent />} />
                     <Route path="/checkin/:eventId" element={<OrganizerCheckIn />} />
                     <Route path="/dashboard/event/:eventId" element={<OrganizerEventReport />} />
+                    <Route path="/dashboard/event/:eventId/promote" element={<PromoteEvent />} />
                     <Route path="/edit-event/:eventId" element={<EditEvent />} />
                     {/* Bridge multi-tenant org views (Sprint 1). */}
                     <Route path="/orgs" element={<Orgs />} />
                     <Route path="/orgs/new" element={<CreateOrg />} />
                     <Route path="/orgs/:orgId/settings" element={<OrgSettings />} />
                     <Route path="/orgs/:orgId/members" element={<OrgMembers />} />
+                    <Route path="/orgs/:orgId/promote" element={<OrgPromote />} />
                     {/* Onboarding flow for new organizers (Sprint 6). */}
                     <Route path="/onboarding" element={<OrganizerOnboarding />} />
                     <Route path="/invite/:token" element={<ClaimInvite />} />

--- a/d4_bridge/src/lib/calendarUtils.ts
+++ b/d4_bridge/src/lib/calendarUtils.ts
@@ -1,5 +1,6 @@
 import * as ics from 'ics';
 import { Event } from '../types';
+import { publicUrl } from './utils';
 
 export const generateGoogleCalendarLink = (event: Event) => {
   const start = new Date(event.date.seconds * 1000).toISOString().replace(/-|:|\.\d\d\d/g, "");
@@ -16,7 +17,7 @@ export const downloadIcsFile = (event: Event) => {
     title: event.title,
     description: event.description,
     location: event.location,
-    url: window.location.origin + '/event/' + event.id,
+    url: publicUrl('event/' + event.id),
     categories: [event.category],
     status: 'CONFIRMED',
     busyStatus: 'BUSY'

--- a/d4_bridge/src/lib/datetime.ts
+++ b/d4_bridge/src/lib/datetime.ts
@@ -27,6 +27,16 @@ export function getBrowserTimezone(): string {
   }
 }
 
+/**
+ * True once we're within `hours` of `date` (i.e. now >= date − hours).
+ * A missing date returns true so we never lock a holder out when the event
+ * time is unknown. Used to gate the scannable entry QR to ~24h before doors.
+ */
+export function isWithinHoursBefore(date: Date | null | undefined, hours: number): boolean {
+  if (!date) return true;
+  return Date.now() >= date.getTime() - hours * 60 * 60 * 1000;
+}
+
 /** Cheap structural check on an IANA timezone string. */
 export function isValidTimezone(tz: string): boolean {
   if (!tz) return false;

--- a/d4_bridge/src/lib/orgs.ts
+++ b/d4_bridge/src/lib/orgs.ts
@@ -12,6 +12,7 @@
 import { Timestamp } from './timestamp';
 import { supabase } from './supabase';
 import { Organization, OrgMembership, OrgRole } from '../types';
+import { publicUrl } from './utils';
 
 // --- Slug helpers (pure) ---------------------------------------------------
 
@@ -359,8 +360,7 @@ export async function createOrgInvite(
     .single();
   if (error) throw error;
 
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
-  const inviteUrl = `${origin}/invite/${data.token}`;
+  const inviteUrl = publicUrl(`invite/${data.token}`);
   // exos_org_invites PK is `token` — there is no `id` column.
   return { token: data.token as string, inviteUrl };
 }

--- a/d4_bridge/src/lib/poster.ts
+++ b/d4_bridge/src/lib/poster.ts
@@ -1,0 +1,68 @@
+// Share an event as a poster IMAGE (not just a link) to Instagram/Stories etc.
+//
+// Mobile share sheets accept image files via the Web Share API
+// (navigator.share({ files })) — picking Instagram lands the image straight in
+// a Story draft. We also copy the event URL to the clipboard so the user can
+// drop it into a link sticker. Desktop / no-file-share / no-image / fetch
+// errors fall back to a copied link.
+//
+// This is the shared implementation behind the "Instagram / Story" buttons on
+// both the ticket page and the public event page.
+
+import type { ToastFn } from './utils';
+
+interface StoryShareInput {
+  title: string;
+  url: string;
+  imageUrl?: string | null;
+}
+
+function fileSlug(s: string): string {
+  return s.replace(/[^a-z0-9]+/gi, '-').toLowerCase().replace(/^-+|-+$/g, '').slice(0, 40) || 'event';
+}
+
+export async function shareEventToStory(input: StoryShareInput, toast?: ToastFn): Promise<void> {
+  const { title, url, imageUrl } = input;
+
+  // Always copy the URL — that's the link-sticker hand-off regardless of path.
+  try {
+    await navigator.clipboard.writeText(url);
+  } catch {
+    /* clipboard may be blocked in some contexts; non-fatal */
+  }
+
+  const nav = navigator as Navigator & {
+    canShare?: (data?: unknown) => boolean;
+    share?: (data?: unknown) => Promise<void>;
+  };
+
+  if (imageUrl && typeof nav.canShare === 'function' && typeof nav.share === 'function') {
+    try {
+      const res = await fetch(imageUrl);
+      if (!res.ok) throw new Error(`image fetch failed: ${res.status}`);
+      const blob = await res.blob();
+      const ext =
+        blob.type === 'image/png' ? 'png' :
+        blob.type === 'image/webp' ? 'webp' : 'jpg';
+      const file = new File([blob], `${fileSlug(title)}.${ext}`, { type: blob.type || 'image/jpeg' });
+      const data = { files: [file], title, text: `${title} — get tickets`, url };
+      if (nav.canShare(data)) {
+        await nav.share(data);
+        toast?.({
+          kind: 'success',
+          title: 'Image ready to post',
+          message: 'In Instagram: pick this image, add a link sticker, and paste — the URL is on your clipboard.',
+          duration: 8000,
+        });
+        return;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      if (/abort/i.test(msg)) return; // user dismissed the share sheet — stay quiet
+      console.warn('Story image share failed; falling back to link copy:', err);
+    }
+  }
+
+  // Fallback: the link is already on the clipboard.
+  toast?.({ kind: 'success', message: 'Event link copied — paste it into your Story.' });
+}

--- a/d4_bridge/src/lib/tickets.ts
+++ b/d4_bridge/src/lib/tickets.ts
@@ -356,6 +356,7 @@ export async function checkInTicket(
   source: 'camera' | 'manual',
   verification: 'verified' | 'legacy' | 'manual',
   barcodePayload?: string,
+  eventId?: string,
 ): Promise<CheckInResult> {
   const { data, error } = await supabase.rpc('exos_check_in_ticket', {
     p_ticket_id: ticketId,
@@ -363,6 +364,8 @@ export async function checkInTicket(
     p_verification: verification,
     // Server re-verifies the HMAC for signed payloads (D4-OPS-6); NULL = manual.
     p_barcode_payload: barcodePayload ?? null,
+    // Event scoping (D4-OPS-18): server rejects a cross-event scan. NULL = skip.
+    p_event_id: eventId ?? null,
   });
   if (error) throw error;
   return (data ?? { ok: false, reason: 'not-found' }) as CheckInResult;
@@ -446,6 +449,30 @@ export async function mintTickets(input: {
     p_order_ref: input.orderRef ?? null,
     p_price_paid: input.pricePaid ?? null,
     p_promoter_id: input.promoterId ?? null,
+  });
+  if (error) throw error;
+  return (data ?? []) as string[];
+}
+
+/** Self-serve claim of FREE tickets for the signed-in user. Returns new ticket
+ *  ids. Server enforces free-tier-only + published + sales window + per-person
+ *  limit + capacity (exos_claim_free_tickets). Paid tiers route through Stripe.
+ *  promoterId/channel come from the landing URL for campaign attribution. */
+export async function claimFreeTickets(input: {
+  eventId: string;
+  tierId: string;
+  quantity?: number;
+  promoterId?: string | null;
+  channel?: string | null;
+  orderRef?: string | null;
+}): Promise<string[]> {
+  const { data, error } = await supabase.rpc('exos_claim_free_tickets', {
+    p_event_id: input.eventId,
+    p_tier_id: input.tierId,
+    p_quantity: input.quantity ?? 1,
+    p_promoter_id: input.promoterId ?? null,
+    p_channel: input.channel ?? null,
+    p_order_ref: input.orderRef ?? null,
   });
   if (error) throw error;
   return (data ?? []) as string[];

--- a/d4_bridge/src/lib/utils.ts
+++ b/d4_bridge/src/lib/utils.ts
@@ -110,6 +110,26 @@ export function formatCurrency(amount: number, currency = 'USD') {
   }
 }
 
+/**
+ * Build an absolute URL to a client route, honoring the Vite base path.
+ *
+ * The SPA is served under `/bridge/` today (vite `base` + `<BrowserRouter
+ * basename>`), and moves to root after the beta DNS split. `BASE_URL` tracks
+ * that ('/bridge/' now, '/' later), so links built here resolve in BOTH
+ * topologies. Building `${origin}/event/x` directly omits the base and 404s
+ * under the current /bridge deployment (there is no bare /event route on the
+ * server — only /bridge/* hosts the SPA).
+ *
+ * @param path route path, leading slash optional (e.g. `event/123` or `/claim/x`)
+ */
+export function publicUrl(path: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const base = ((import.meta as { env?: { BASE_URL?: string } }).env?.BASE_URL ?? '/');
+  const cleanBase = base.endsWith('/') ? base.slice(0, -1) : base; // '/bridge' | ''
+  const cleanPath = path.startsWith('/') ? path : `/${path}`;
+  return `${origin}${cleanBase}${cleanPath}`;
+}
+
 export function generateBarcodeContent(ticketId: string, ownerId: string, secret?: string) {
   // Rotating barcode: ticketId + ownerId + current 30s bucket + secret.
   // The 30s bucket means a screenshotted QR stops scanning after at most

--- a/d4_bridge/src/views/EmbedEvent.tsx
+++ b/d4_bridge/src/views/EmbedEvent.tsx
@@ -30,10 +30,11 @@ import { getPublicEvent } from '../lib/events';
 import { getPublicOrg } from '../lib/orgs';
 import { ThemeProvider, useTheme } from '../context/ThemeContext';
 import { formatInTz } from '../lib/datetime';
+import { publicUrl } from '../lib/utils';
 
 function EmbedInner({ event, org }: { event: Event; org: Organization | null }) {
   const { theme } = useTheme();
-  const buyHref = `${window.location.origin}/event/${event.id}?utm_source=embed&utm_medium=iframe&utm_content=${org?.slug ?? 'unknown'}`;
+  const buyHref = `${publicUrl(`event/${event.id}`)}?utm_source=embed&utm_medium=iframe&utm_content=${org?.slug ?? 'unknown'}`;
 
   // Self-resize: tell the parent how tall the embed is so it can set
   // the iframe height. We measure on mount + on every window resize.

--- a/d4_bridge/src/views/EventDetails.tsx
+++ b/d4_bridge/src/views/EventDetails.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { Event } from '../types';
+import { Event, Organization } from '../types';
 import { getPublicEvent, getEventForEdit } from '../lib/events';
-import { mintTickets } from '../lib/tickets';
+import { mintTickets, claimFreeTickets } from '../lib/tickets';
+import { startCheckout } from '../lib/checkout';
+import SocialLinks from '../components/SocialLinks';
+import { shareEventToStory } from '../lib/poster';
 import { useAuth } from '../context/AuthContext';
 import { Calendar, MapPin, Ticket, ShieldCheck, Share2, ArrowLeft, CheckCircle2, Copy, Send, Instagram, Minus, Plus, Tag } from 'lucide-react';
-import { formatCurrency, generateBarcodeContent, handleFirestoreError, OperationType } from '../lib/utils';
+import { formatCurrency, generateBarcodeContent, handleFirestoreError, OperationType, publicUrl } from '../lib/utils';
 import { getStripe } from '../lib/stripe';
 import { formatInTz } from '../lib/datetime';
 import { motion } from 'motion/react';
@@ -22,6 +25,7 @@ export default function EventDetails() {
   const navigate = useNavigate();
   const { toast } = useToast();
   const [event, setEvent] = useState<Event | null>(null);
+  const [org, setOrg] = useState<Organization | null>(null);
   const [loading, setLoading] = useState(true);
   const [purchasing, setPurchasing] = useState(false);
   const [selectedTierId, setSelectedTierId] = useState<string | null>(null);
@@ -67,7 +71,7 @@ export default function EventDetails() {
             title: data.title,
             description: (data.description || '').slice(0, 200),
             imageUrl: data.image || undefined,
-            canonicalUrl: `${window.location.origin}/event/${data.id}`,
+            canonicalUrl: publicUrl(`event/${data.id}`),
             event: startIso
               ? {
                   name: data.title,
@@ -87,7 +91,7 @@ export default function EventDetails() {
                     price: data.price,
                     currency: data.currency || 'USD',
                     availability: remaining > 0 ? 'InStock' : 'SoldOut',
-                    url: `${window.location.origin}/event/${data.id}`,
+                    url: publicUrl(`event/${data.id}`),
                   },
                 }
               : undefined,
@@ -101,8 +105,9 @@ export default function EventDetails() {
         // orgId, so fetch the public org for its marketing config.
         if (data.orgId) {
           getPublicOrg(data.orgId)
-            .then((org) => {
-              initOrgPixels(org?.marketing?.pixels);
+            .then((o) => {
+              setOrg(o ?? null);
+              initOrgPixels(o?.marketing?.pixels);
               trackPixelEvent('ViewContent', { content_name: data.title, content_ids: [data.id] });
             })
             .catch(() => {/* non-fatal */});
@@ -198,16 +203,80 @@ export default function EventDetails() {
 
   const maxPerOrder = event?.purchaseLimits?.maxPerOrder || 8;
   const maxPerAccount = event?.purchaseLimits?.maxPerAccount || 8;
+  // Paid checkout is gated on the Stripe publishable key — the backend
+  // (exos-checkout + exos_fulfill_checkout) is built but stays dormant until
+  // payments are switched on. No key → paid tiers show "Coming soon".
+  const stripeEnabled = !!(import.meta as { env?: { VITE_STRIPE_PUBLISHABLE_KEY?: string } }).env?.VITE_STRIPE_PUBLISHABLE_KEY;
 
   const handlePurchase = async () => {
-    // Checkout (Stripe Checkout + server-side ticket minting) lands in phase-2 —
-    // it needs the exos_tickets table + a Stripe webhook fulfillment path.
     if (!user) {
-      toast({ kind: 'info', message: 'Sign in to be ready when ticketing opens.' });
+      toast({ kind: 'info', message: 'Sign in to grab your ticket.' });
       await signIn();
       return;
     }
-    toast({ kind: 'info', title: 'Coming soon', message: 'Ticket purchase is being wired up (phase-2).' });
+    if (!event) return;
+    const tier = event.ticketTiers?.find((t) => t.id === selectedTierId) || event.ticketTiers?.[0];
+    if (!tier?.id) {
+      toast({ kind: 'error', message: 'No ticket tier available for this event yet.' });
+      return;
+    }
+    const unitPrice = tier.price ?? event.price ?? 0;
+
+    // Paid tiers → Stripe Checkout (edge fn + webhook fulfillment built; dormant
+    // until the publishable key is set). Free tiers fall through to claim below.
+    if (unitPrice > 0) {
+      if (!stripeEnabled) {
+        toast({ kind: 'info', title: 'Coming soon', message: 'Paid checkout is being wired up.' });
+        return;
+      }
+      setPurchasing(true);
+      try {
+        const url = await startCheckout({
+          eventId: event.id,
+          tierId: tier.id,
+          quantity,
+          successUrl: publicUrl('my-tickets?checkout=success'),
+          cancelUrl: publicUrl(`event/${event.id}`),
+        });
+        window.location.href = url; // leave the SPA for Stripe-hosted checkout
+      } catch (err: any) {
+        console.error('Checkout failed:', err);
+        toast({ kind: 'error', message: err?.message || 'Could not start checkout.' });
+        setPurchasing(false);
+      }
+      return;
+    }
+
+    // Free claim — mint to the buyer, capturing campaign attribution off the URL
+    // (?promoter / ?utm_source) so it lands in the event's Sales report.
+    setPurchasing(true);
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const ids = await claimFreeTickets({
+        eventId: event.id,
+        tierId: tier.id,
+        quantity,
+        promoterId: params.get('promoter'),
+        channel: params.get('utm_source'),
+        // Idempotency key for this claim attempt — a network retry returns the
+        // same tickets instead of minting twice (button is disabled meanwhile).
+        orderRef: crypto.randomUUID(),
+      });
+      trackPixelEvent('Purchase', {
+        content_name: event.title,
+        content_ids: [event.id],
+        value: 0,
+        currency: event.currency || 'USD',
+        num_items: ids.length,
+      });
+      toast({ kind: 'success', title: "You're in!", message: `${ids.length} ticket(s) reserved — find them in My Tickets.` });
+      navigate('/my-tickets');
+    } catch (err: any) {
+      console.error('Free claim failed:', err);
+      toast({ kind: 'error', message: err?.message || 'Could not reserve tickets. Please try again.' });
+    } finally {
+      setPurchasing(false);
+    }
   };
 
   const handleShare = async () => {
@@ -279,92 +348,13 @@ export default function EventDetails() {
   };
 
   const handleInstagramStory = async () => {
-    // Goal: get the event poster image into Instagram's story camera
-    // with the URL preloaded on clipboard so the user can paste a link
-    // sticker. Implementation:
-    //   1. Fetch the event image as a Blob (Firebase Storage download
-    //      URLs are CORS-friendly).
-    //   2. Wrap as a File and pass to navigator.share with the file
-    //      array. On mobile this opens the OS share sheet — picking
-    //      Instagram lands the image directly in a Story draft.
-    //   3. Copy the event URL to clipboard in parallel so the user can
-    //      paste it into the Link Sticker UI inside Instagram.
-    //   4. Toast with the next step ("Add a link sticker and paste").
-    //
-    // Falls back to the old copy-link behaviour on:
-    //   * desktop browsers that don't support file-share
-    //   * events without an image
-    //   * fetch / blob errors (CORS, missing image, etc.)
-    //
-    // Why we can't auto-attach the link as a Story link sticker:
-    // Instagram's Story sticker UI is closed — only Meta's Sharing
-    // API for verified Business accounts can attach stickers from
-    // outside the IG app, and that's beyond the scope of a buyer-side
-    // share flow. The clipboard hand-off is the realistic path.
     if (!event) return;
-    const eventUrl = window.location.href;
-    const imageUrl = event.image;
-
-    // Always copy URL — that's the link-sticker hand-off, regardless
-    // of which path the share takes.
-    try {
-      await navigator.clipboard.writeText(eventUrl);
-    } catch {
-      /* clipboard may be unavailable in some contexts; non-fatal */
-    }
-
-    // Try the file-share path when both the OS share sheet supports
-    // files and we have an image to share.
-    if (
-      imageUrl &&
-      typeof navigator !== 'undefined' &&
-      'share' in navigator &&
-      typeof (navigator as any).canShare === 'function'
-    ) {
-      try {
-        const res = await fetch(imageUrl);
-        if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-        const blob = await res.blob();
-        // Pick a sensible filename + extension from the blob type.
-        const ext = blob.type === 'image/png' ? 'png'
-          : blob.type === 'image/webp' ? 'webp'
-          : blob.type === 'image/svg+xml' ? 'svg'
-          : 'jpg';
-        const file = new File([blob], `${event.title.replace(/[^a-z0-9]+/gi, '-').toLowerCase().slice(0, 40)}.${ext}`, {
-          type: blob.type || 'image/jpeg',
-        });
-        const shareData: any = { files: [file], title: event.title, text: `${event.title} — get tickets`, url: eventUrl };
-        if ((navigator as any).canShare(shareData)) {
-          await (navigator as any).share(shareData);
-          toast({
-            kind: 'success',
-            title: 'Image ready to post',
-            message: 'In Instagram: pick this image, then add a link sticker and paste — the URL is on your clipboard.',
-            duration: 8000,
-          });
-          return;
-        }
-      } catch (err) {
-        // fetch / canShare / share errors all fall through to the
-        // link-only path below. AbortError = user cancelled — quiet.
-        const msg = err instanceof Error ? err.message : '';
-        if (!/abort/i.test(msg)) {
-          console.warn('Story image share failed, falling back to link copy:', err);
-        } else {
-          // User dismissed — don't toast.
-          return;
-        }
-      }
-    }
-
-    // Fallback: link copied (already done above), tell the user.
-    toast({
-      kind: 'success',
-      message: imageUrl
-        ? 'Link copied. On mobile, long-press the event image to save it, then paste the link into your Story.'
-        : 'Link copied — paste it into your Story.',
-      duration: 7000,
-    });
+    // Share the event POSTER image to the OS share sheet (→ Instagram Story),
+    // with the URL copied for the link sticker. Shared impl in lib/poster.ts.
+    await shareEventToStory(
+      { title: event.title, url: publicUrl(`event/${event.id}`), imageUrl: event.image },
+      toast,
+    );
   };
 
   const handleSMSShare = () => {
@@ -583,11 +573,14 @@ export default function EventDetails() {
             <div className="mb-16 bg-[#111111] border border-white/10 p-8 flex items-center justify-between group">
                <div className="flex items-center space-x-6">
                   <div className="w-16 h-16 bg-brand-primary flex items-center justify-center text-2xl font-black text-black italic">
-                    {event.organizerId ? 'O' : '?'}
+                    {(org?.name || 'O').charAt(0).toUpperCase()}
                   </div>
                   <div>
                     <p className="text-[10px] text-white/40 font-black uppercase tracking-widest mb-1">Presented By</p>
-                    <h3 className="text-2xl font-black italic uppercase tracking-tighter">Event Organizer</h3>
+                    <h3 className="text-2xl font-black italic uppercase tracking-tighter">{org?.name || 'Event Organizer'}</h3>
+                    {org?.marketing?.socials && Object.values(org.marketing.socials).some(Boolean) ? (
+                      <SocialLinks socials={org.marketing.socials} className="flex items-center gap-3 mt-2" />
+                    ) : null}
                   </div>
                </div>
                <Link to={`/organizer/${event.orgId ?? ''}`} className="px-6 py-3 bg-white/5 border border-white/10 text-xs font-black uppercase tracking-widest group-hover:bg-brand-primary group-hover:text-black transition-all">

--- a/d4_bridge/src/views/OrgPromote.tsx
+++ b/d4_bridge/src/views/OrgPromote.tsx
@@ -1,0 +1,219 @@
+// OrgPromote — venue-wide promotion hub for one organization.
+//
+// Lives at /orgs/:orgId/promote (linked from the dashboard + the Orgs list).
+// Where the per-event Promote page pushes a single event, this promotes the
+// VENUE: its public storefront (all events), a poster QR for it, share tools,
+// the socials/pixels setup, and a jump into each event's own promote page.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { QRCodeCanvas } from 'qrcode.react';
+import {
+  ArrowLeft, Megaphone, Copy, Download, Share2, ExternalLink, Settings,
+  Sparkles, Calendar,
+} from 'lucide-react';
+import { getOrganization } from '../lib/orgs';
+import { listOrgEvents } from '../lib/events';
+import { Event, Organization } from '../types';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import { publicUrl } from '../lib/utils';
+import { formatInTz } from '../lib/datetime';
+import ShareModal from '../components/ShareModal';
+import SocialLinks from '../components/SocialLinks';
+
+export default function OrgPromote() {
+  const { orgId } = useParams();
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [org, setOrg] = useState<Organization | null>(null);
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [shareOpen, setShareOpen] = useState(false);
+  const qrWrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!orgId) { setLoading(false); return; }
+      setLoading(true);
+      try {
+        const [o, evs] = await Promise.all([
+          getOrganization(orgId),
+          listOrgEvents(orgId).catch(() => [] as Event[]),
+        ]);
+        if (cancelled) return;
+        setOrg(o);
+        setEvents(evs);
+      } catch (err) {
+        console.error('Failed to load org promote hub:', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [orgId]);
+
+  const storefrontUrl = org?.slug ? publicUrl(`o/${org.slug}`) : '';
+  const publishedCount = useMemo(
+    () => events.filter((e) => (e.status ?? 'published') === 'published').length,
+    [events],
+  );
+
+  const copy = async (value: string, label = 'Copied.') => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast({ kind: 'success', message: label });
+    } catch {
+      toast({ kind: 'error', message: 'Could not copy — long-press to copy manually.' });
+    }
+  };
+
+  const downloadQr = () => {
+    const canvas = qrWrapRef.current?.querySelector('canvas');
+    if (!canvas) return;
+    const a = document.createElement('a');
+    a.href = canvas.toDataURL('image/png');
+    a.download = `qr-${org?.slug || 'venue'}.png`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    toast({ kind: 'success', message: 'QR downloaded.' });
+  };
+
+  if (!user) {
+    return <div className="max-w-3xl mx-auto p-20 text-center text-slate-500">Sign in to promote your venue.</div>;
+  }
+  if (loading) {
+    return <div className="max-w-3xl mx-auto p-20 text-center text-slate-300 font-bold uppercase tracking-widest text-xs">Loading…</div>;
+  }
+  if (!org) {
+    return (
+      <div className="max-w-3xl mx-auto p-20 text-center">
+        <p className="text-slate-400 font-bold uppercase tracking-widest text-[10px] mb-4">Venue not found</p>
+        <Link to="/orgs" className="text-[#026cdf] font-bold text-sm">Back to organizations</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#f2f4f7] min-h-screen">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <Link to="/dashboard" className="flex items-center text-slate-400 hover:text-slate-900 mb-8 transition-colors font-bold uppercase tracking-widest text-[10px]">
+          <ArrowLeft className="w-4 h-4 mr-2" /> Back to Dashboard
+        </Link>
+
+        <div className="flex items-center gap-3 mb-2">
+          <Megaphone className="w-6 h-6 text-[#026cdf]" />
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900">Promote {org.name}</h1>
+        </div>
+        <p className="text-slate-500 text-sm mb-8">
+          Your venue storefront lists every published event in one branded page.
+        </p>
+
+        {/* Storefront link */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4 flex items-center gap-2">
+            <Share2 className="w-4 h-4 text-[#026cdf]" /> Your storefront
+          </h2>
+          <div className="flex items-center gap-2 mb-4">
+            <input
+              readOnly
+              value={storefrontUrl}
+              aria-label="Storefront link"
+              onFocus={(e) => e.currentTarget.select()}
+              className="flex-1 bg-slate-50 border border-slate-200 rounded-xl px-4 py-3 text-sm font-mono text-slate-700 truncate"
+            />
+            <button onClick={() => copy(storefrontUrl, 'Storefront link copied.')} className="px-4 py-3 bg-slate-900 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-800 transition-colors flex items-center gap-2">
+              <Copy className="w-3.5 h-3.5" /> Copy
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button onClick={() => setShareOpen(true)} className="flex items-center gap-2 px-4 py-2.5 bg-[#026cdf] text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-[#015bbd] transition-colors">
+              <Share2 className="w-3.5 h-3.5" /> Share…
+            </button>
+            <a href={storefrontUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-50 transition-colors">
+              <ExternalLink className="w-3.5 h-3.5" /> Preview
+            </a>
+          </div>
+        </section>
+
+        {/* QR */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4">Storefront QR</h2>
+          <div className="flex items-center gap-6 flex-wrap">
+            <div ref={qrWrapRef} className="p-4 bg-white border border-slate-200 rounded-2xl">
+              <QRCodeCanvas value={storefrontUrl || org.slug} size={160} level="M" includeMargin />
+            </div>
+            <div className="flex-1 min-w-[200px]">
+              <p className="text-sm text-slate-600 mb-4">Put it on posters at the door or around town — it opens your full event list.</p>
+              <button onClick={downloadQr} className="flex items-center gap-2 px-4 py-2.5 bg-slate-900 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-800 transition-colors">
+                <Download className="w-3.5 h-3.5" /> Download PNG
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {/* Socials + pixels */}
+        <section className="bg-gradient-to-r from-indigo-50 to-purple-50 border border-indigo-200 rounded-2xl p-6 mb-6">
+          <h2 className="text-[11px] font-black text-indigo-900 uppercase tracking-[0.2em] mb-2 flex items-center gap-2">
+            <Sparkles className="w-4 h-4" /> Socials &amp; pixels
+          </h2>
+          {org.marketing?.socials && Object.values(org.marketing.socials).some(Boolean) ? (
+            <div className="mb-3">
+              <p className="text-xs text-indigo-700 mb-2">Showing on your storefront:</p>
+              <SocialLinks socials={org.marketing.socials} className="flex items-center gap-4" />
+            </div>
+          ) : (
+            <p className="text-sm text-indigo-700 mb-4">Add your social handles and ad pixels so your storefront links out and paid promotion is measurable.</p>
+          )}
+          <Link to={`/orgs/${org.id}/settings`} className="inline-flex items-center gap-2 px-4 py-2.5 bg-indigo-600 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-indigo-700 transition-colors">
+            <Settings className="w-3.5 h-3.5" /> Marketing &amp; socials
+          </Link>
+        </section>
+
+        {/* Per-event promote */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4 flex items-center gap-2">
+            <Calendar className="w-4 h-4 text-[#026cdf]" /> Promote a specific event
+          </h2>
+          {events.length === 0 ? (
+            <p className="text-sm text-slate-500">No events yet. <Link to="/create-event" className="text-[#026cdf] font-bold">Create one</Link> to start promoting.</p>
+          ) : (
+            <>
+              <p className="text-sm text-slate-600 mb-4">{publishedCount} published · {events.length} total. Open an event's promote kit for campaign links, QR, embed, and captions.</p>
+              <div className="space-y-2">
+                {events.map((ev) => (
+                  <Link
+                    key={ev.id}
+                    to={`/dashboard/event/${ev.id}/promote`}
+                    className="flex items-center justify-between bg-slate-50 border border-slate-100 rounded-xl px-4 py-3 hover:border-[#026cdf] transition-colors group"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-bold text-slate-900 text-sm truncate">{ev.title}</p>
+                      <p className="text-[10px] text-slate-400 uppercase tracking-widest">
+                        {ev.date ? formatInTz(ev.date.toDate(), ev.timezone, { month: 'short', day: 'numeric', year: 'numeric' }) : '—'}
+                      </p>
+                    </div>
+                    <span className="flex items-center gap-1 text-[10px] font-black uppercase tracking-widest text-slate-400 group-hover:text-[#026cdf] shrink-0">
+                      <Megaphone className="w-3.5 h-3.5" /> Promote
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </>
+          )}
+        </section>
+      </div>
+
+      <ShareModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        title={org.name}
+        url={storefrontUrl}
+        text={`Check out events from ${org.name}`}
+      />
+    </div>
+  );
+}

--- a/d4_bridge/src/views/OrgSettings.tsx
+++ b/d4_bridge/src/views/OrgSettings.tsx
@@ -14,8 +14,10 @@ import { motion } from 'motion/react';
 import { ArrowLeft, Upload } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useOrganization } from '../context/OrganizationContext';
+import { publicUrl } from '../lib/utils';
 import { useToast } from '../context/ToastContext';
 import { getOrganization, updateOrganization } from '../lib/orgs';
+import { startStripeOnboarding } from '../lib/checkout';
 import { uploadOrgLogo } from '../lib/orgLogo';
 import { Organization } from '../types';
 
@@ -39,6 +41,7 @@ export default function OrgSettings() {
   const [marketing, setMarketing] = useState<NonNullable<Organization['marketing']>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [paymentsBusy, setPaymentsBusy] = useState(false);
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -93,6 +96,27 @@ export default function OrgSettings() {
   // who can already see the org — but the form is only enabled for
   // owners.
   const canEdit = isAdmin || activeRole === 'owner';
+  // Paid ticketing is gated on the Stripe publishable key — the Connect
+  // onboarding backend (exos-connect-onboard) is built but dormant until set.
+  const stripeEnabled = !!(import.meta as { env?: { VITE_STRIPE_PUBLISHABLE_KEY?: string } }).env?.VITE_STRIPE_PUBLISHABLE_KEY;
+
+  const handleSetupPayments = async () => {
+    if (!orgId || !canEdit) return;
+    setPaymentsBusy(true);
+    try {
+      const url = await startStripeOnboarding({
+        orgId,
+        returnUrl: publicUrl(`orgs/${orgId}/settings`),
+        refreshUrl: publicUrl(`orgs/${orgId}/settings`),
+      });
+      window.location.href = url;
+    } catch (err: unknown) {
+      console.error('Stripe onboarding failed:', err);
+      toast({ kind: 'error', message: err instanceof Error ? err.message : 'Payments are not enabled yet.' });
+    } finally {
+      setPaymentsBusy(false);
+    }
+  };
 
   async function handleSave() {
     if (!org) return;
@@ -172,7 +196,7 @@ export default function OrgSettings() {
   function buildEmbedSnippet(orgIdValue: string): string {
     const origin = window.location.origin;
     return `<!-- Exos embed for ${orgIdValue}. Replace EVENT_ID with your event id. -->
-<iframe id="vibepass-embed" src="${origin}/embed/event/EVENT_ID" style="width:100%;border:0;min-height:200px" loading="lazy" title="Tickets"></iframe>
+<iframe id="vibepass-embed" src="${publicUrl('embed/event/EVENT_ID')}" style="width:100%;border:0;min-height:200px" loading="lazy" title="Tickets"></iframe>
 <script>
 window.addEventListener('message', function(e) {
   if (e.origin !== '${origin}') return;
@@ -373,6 +397,30 @@ window.addEventListener('message', function(e) {
               </label>
             ))}
           </div>
+        </fieldset>
+
+        <fieldset className="border border-white/10 p-5 space-y-3">
+          <legend className="text-[10px] text-white/60 font-black uppercase tracking-widest px-2">
+            Payments
+          </legend>
+          <p className="text-white/50 text-xs">
+            Connect Stripe to sell paid tickets — payouts go to your account and the
+            platform takes a fee. Free events need nothing here.
+          </p>
+          {stripeEnabled ? (
+            <button
+              type="button"
+              onClick={handleSetupPayments}
+              disabled={!canEdit || paymentsBusy}
+              className="px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 text-white text-[10px] font-black uppercase tracking-widest transition-all disabled:opacity-50"
+            >
+              {paymentsBusy ? 'Opening Stripe…' : 'Set up payments'}
+            </button>
+          ) : (
+            <p className="text-[10px] text-white/30 uppercase tracking-widest">
+              Paid ticketing isn't enabled yet — coming soon.
+            </p>
+          )}
         </fieldset>
 
         {/*

--- a/d4_bridge/src/views/OrgStorefront.tsx
+++ b/d4_bridge/src/views/OrgStorefront.tsx
@@ -21,6 +21,7 @@ import { formatInTz } from '../lib/datetime';
 import { applyMeta } from '../lib/meta';
 import { initOrgPixels } from '../lib/pixels';
 import SocialLinks from '../components/SocialLinks';
+import { publicUrl } from '../lib/utils';
 
 interface ResolvedOrg {
   org: Organization;
@@ -143,7 +144,7 @@ export default function OrgStorefront() {
             title: org.name,
             description: `Upcoming events from ${org.name}.`,
             imageUrl: org.marketing?.shareImageUrl || org.theme?.logoUrl,
-            canonicalUrl: `${window.location.origin}/o/${org.slug}`,
+            canonicalUrl: publicUrl(`o/${org.slug}`),
           });
         } catch {
           /* non-fatal */

--- a/d4_bridge/src/views/OrganizerCheckIn.tsx
+++ b/d4_bridge/src/views/OrganizerCheckIn.tsx
@@ -195,7 +195,7 @@ export default function OrganizerCheckIn() {
           // a second flip of an already-used ticket returns {ok:false,
           // reason:'used'} (no throw), so we still drop it from the queue.
           // Only a real network/auth error throws and keeps it queued.
-          await checkInTicket(tId, 'manual', 'manual');
+          await checkInTicket(tId, 'manual', 'manual', undefined, eventId);
           successfulSyncs.push(tId);
         } catch (err) {
           console.error(`Error syncing pending update ${tId}:`, err);
@@ -406,8 +406,12 @@ export default function OrganizerCheckIn() {
         saveRegistry(eventId, next);
         return next;
       });
-      // A check-in landed (this lane or another) — refresh the attendance count.
-      countEventCheckins(eventId).then(setInsideVenue).catch(() => {});
+      // A check-in landed (this lane or another) — bump the live count by one
+      // rather than re-running a count(*) per scan. A count(*) per realtime tick
+      // per lane doesn't scale at a busy multi-lane gate; postgres_changes emits
+      // exactly one event per check-in row (incl. our own), so +1 is accurate.
+      // Reconciled against the authoritative head-count on reconnect below.
+      setInsideVenue((n) => n + 1);
     });
     return () => ch.leave();
   }, [eventId]);
@@ -427,6 +431,10 @@ export default function OrganizerCheckIn() {
   useEffect(() => {
     if (wasOfflineRef.current && !isOffline) {
       void downloadRegistry({ silent: true });
+      // Realtime doesn't replay check-ins that landed while we were
+      // disconnected, so reconcile the live count against the authoritative
+      // head-count once (the only count(*) on this path — not per scan).
+      if (eventId) countEventCheckins(eventId).then(setInsideVenue).catch(() => {});
     }
     wasOfflineRef.current = isOffline;
   }, [isOffline]);
@@ -485,11 +493,9 @@ export default function OrganizerCheckIn() {
     // happens later, after we've read the ticket doc and have its secret.
     const docId = extractTicketIdFromAny(probeValue) || probeValue;
 
-    // Sanity-check the doc id length before hitting Firestore. A typo
-    // ("T-AAAAAAAAAA…ZZZZ") via the manual-entry path could otherwise
-    // burn a Firestore read on a junk lookup. Firestore doc ids cap at
-    // 1500 bytes; we're stricter — `isValidId` in the rules limits to
-    // 128, so anything longer can't be a real ticket.
+    // Sanity-check the id length before a lookup so a manual-entry typo can't
+    // burn a staff-RLS read on junk. Ticket ids are UUIDs — anything over 128
+    // chars can't be a real ticket id.
     if (!docId || docId.length > 128) {
       setStatus('not-found');
       return;
@@ -611,6 +617,7 @@ export default function OrganizerCheckIn() {
             scanning ? 'camera' : 'manual',
             offlineTicket.barcodeSecret ? 'verified' : 'manual',
             probeValue,
+            eventId,
           );
           // Honor a server-side barcode rejection (e.g. the secret rotated via a
           // transfer since this registry was synced) — do NOT admit locally.
@@ -657,17 +664,12 @@ export default function OrganizerCheckIn() {
       return;
     }
 
-    // Fallback to online search if not in offline registry and online.
+    // Not in the offline registry and we're offline: supabase-js has no offline
+    // write queue (unlike the old Firestore SDK), so we can neither verify the
+    // ticket nor durably record the reject until the link returns. Surface
+    // "not found"; a re-scan once back online audits properly.
     if (isOffline) {
       setStatus('not-found');
-      // Queue an audit reject — Firestore SDK persists pending writes
-      // locally and replays them when network returns. So a bare-id
-      // manual entry while offline + uncached still leaves a paper
-      // trail for the organizer to review later.
-      void writeScanReject('not-found', scanning ? 'camera' : 'manual', {
-        ticketIdAttempted: docId,
-        reasonDetail: 'offline + not in registry',
-      });
       return;
     }
 
@@ -783,7 +785,7 @@ export default function OrganizerCheckIn() {
     // double-scan guard) AND writes the append-only check-in audit row. For a
     // signed payload it also RE-VERIFIES the HMAC server-side (D4-OPS-6), so a
     // forged/replayed code is rejected even if the client check was bypassed.
-    const result = await checkInTicket(scanTicket.id, src, verification, barcodePayload);
+    const result = await checkInTicket(scanTicket.id, src, verification, barcodePayload, eventId);
 
     if (result.ok) {
       setStatus('success');

--- a/d4_bridge/src/views/OrganizerDashboard.tsx
+++ b/d4_bridge/src/views/OrganizerDashboard.tsx
@@ -111,7 +111,16 @@ export default function OrganizerDashboard() {
             </p>
           </div>
           <div className="flex space-x-3">
-            <Link 
+            {orgs.length > 0 && (
+              <Link
+                to={orgs.length === 1 ? `/orgs/${orgs[0].org.id}/promote` : '/orgs'}
+                className="bg-white text-slate-900 border border-slate-200 px-6 py-3 rounded flex items-center space-x-2 font-bold hover:bg-slate-50 shadow-sm transition-all text-sm"
+              >
+                <Megaphone className="w-4 h-4" />
+                <span>Promote</span>
+              </Link>
+            )}
+            <Link
               to="/create-event"
               className="bg-[#026cdf] text-white px-6 py-3 rounded flex items-center space-x-2 font-bold hover:bg-[#015bbd] shadow-sm transition-all text-sm"
             >
@@ -220,12 +229,6 @@ export default function OrganizerDashboard() {
         <div className="bg-white rounded border border-slate-200 shadow-sm overflow-hidden mb-8">
           <div className="px-6 py-5 border-b border-slate-100 flex justify-between items-center bg-white">
             <h2 className="text-sm font-black text-slate-900 uppercase tracking-widest">Your Events</h2>
-            <div className="flex space-x-2">
-               <div className="relative">
-                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 w-3 h-3" />
-                  <input type="text" placeholder="Search events..." className="pl-8 pr-4 py-1.5 bg-slate-50 border border-slate-200 rounded text-xs focus:outline-none focus:border-[#026cdf]" />
-               </div>
-            </div>
           </div>
 
           {loading ? (
@@ -282,6 +285,7 @@ export default function OrganizerDashboard() {
                       </td>
                       <td className="px-6 py-4 text-right">
                         <div className="flex items-center justify-end space-x-2">
+                           <Link to={`/dashboard/event/${event.id}/promote`} aria-label="Promote event" className="p-2 text-slate-400 hover:text-[#026cdf] transition-colors"><Megaphone className="w-4 h-4" /></Link>
                            <Link to={`/dashboard/event/${event.id}`} aria-label="Sales report" className="p-2 text-slate-400 hover:text-[#026cdf] transition-colors"><BarChart3 className="w-4 h-4" /></Link>
                            <Link to={`/edit-event/${event.id}`} aria-label="Edit event" className="p-2 text-slate-400 hover:text-[#026cdf] transition-colors"><Settings className="w-4 h-4" /></Link>
                            <Link to={`/create-event?clone=${event.id}`} aria-label="Duplicate event as a new draft" className="p-2 text-slate-400 hover:text-[#026cdf] transition-colors text-[10px] font-black uppercase tracking-widest">CLONE</Link>
@@ -297,27 +301,6 @@ export default function OrganizerDashboard() {
           )}
         </div>
 
-        <div className="mb-12">
-            <div className="bg-white p-8 rounded border border-slate-200 shadow-sm relative w-full">
-                <div className="flex items-center space-x-2 mb-6">
-                    <BarChart3 className="w-4 h-4 text-[#026cdf]" />
-                    <h3 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em]">Sales Activity</h3>
-                </div>
-                <div className="h-48 flex items-end justify-between space-x-2">
-                    {[40, 70, 45, 90, 65, 85, 30, 60, 75, 50, 80, 95].map((h, i) => (
-                        <div key={i} className="flex-grow bg-slate-100 hover:bg-[#026cdf] transition-all rounded-t-sm" style={{ height: `${h}%` }}></div>
-                    ))}
-                </div>
-                <div className="flex justify-between mt-4 text-[9px] font-bold text-slate-400 uppercase tracking-widest">
-                    <span>MAY</span>
-                    <span>JUN</span>
-                    <span>JUL</span>
-                    <span>AUG</span>
-                    <span>SEP</span>
-                    <span>OCT</span>
-                </div>
-            </div>
-        </div>
       </div>
     </div>
   );

--- a/d4_bridge/src/views/Orgs.tsx
+++ b/d4_bridge/src/views/Orgs.tsx
@@ -8,7 +8,7 @@
 
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'motion/react';
-import { Plus, Settings, Users, Check } from 'lucide-react';
+import { Plus, Settings, Users, Check, Megaphone } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useOrganization } from '../context/OrganizationContext';
 
@@ -109,6 +109,13 @@ export default function Orgs() {
                       Switch
                     </button>
                   )}
+                  <button
+                    onClick={() => navigate(`/orgs/${org.id}/promote`)}
+                    className="p-2 bg-white/5 hover:bg-white/10 transition-all"
+                    title="Promote"
+                  >
+                    <Megaphone size={16} />
+                  </button>
                   {membership.role === 'owner' && (
                     <>
                       <button

--- a/d4_bridge/src/views/PromoteEvent.tsx
+++ b/d4_bridge/src/views/PromoteEvent.tsx
@@ -1,0 +1,340 @@
+// PromoteEvent — organizer-facing promotion toolkit for one event.
+//
+// Lives at /dashboard/event/:eventId/promote (linked from the dashboard
+// event row's Megaphone action). Everything a venue/promoter needs to push
+// an event out the door, in one place:
+//   * the canonical public link (copy / native-share / X / Facebook)
+//   * a downloadable QR for posters & flyers
+//   * a paste-ready embed snippet for the venue's own site
+//   * caption templates for IG / TikTok / X
+//   * a jump to Marketing & socials (pixels) so ad spend is measurable
+//
+// All URLs are built with publicUrl() so they carry the /bridge base in the
+// current deployment (and resolve at root post-beta). A bare ${origin}/event
+// link 404s today — see lib/utils.ts publicUrl().
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { QRCodeCanvas } from 'qrcode.react';
+import {
+  ArrowLeft, Megaphone, Copy, Download, Code2, Share2, ExternalLink,
+  Twitter, Facebook, QrCode, Sparkles, Settings, Tag,
+} from 'lucide-react';
+import { getEventForEdit } from '../lib/events';
+import { Event, Organization } from '../types';
+import { useAuth } from '../context/AuthContext';
+import { useOrganization } from '../context/OrganizationContext';
+import { useToast } from '../context/ToastContext';
+import { publicUrl } from '../lib/utils';
+import { formatInTz } from '../lib/datetime';
+import ShareModal from '../components/ShareModal';
+import SocialLinks from '../components/SocialLinks';
+
+// Channel presets for the campaign-link builder. utm_medium follows the GA4
+// convention (social / email / cpc) so the org's GA4 + ad pixels bucket them
+// correctly with zero extra config.
+const CHANNELS: { key: string; label: string; medium: string }[] = [
+  { key: 'instagram', label: 'Instagram', medium: 'social' },
+  { key: 'tiktok', label: 'TikTok', medium: 'social' },
+  { key: 'facebook', label: 'Facebook', medium: 'social' },
+  { key: 'x', label: 'X / Twitter', medium: 'social' },
+  { key: 'email', label: 'Email', medium: 'email' },
+  { key: 'meta-ads', label: 'Paid — Meta', medium: 'cpc' },
+  { key: 'google-ads', label: 'Paid — Google', medium: 'cpc' },
+];
+
+const slugify = (s: string) =>
+  s.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+export default function PromoteEvent() {
+  const { eventId } = useParams();
+  const { user } = useAuth();
+  const { orgs } = useOrganization();
+  const { toast } = useToast();
+  const [event, setEvent] = useState<Event | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [campaignName, setCampaignName] = useState('');
+  const qrWrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      if (!eventId) return;
+      setLoading(true);
+      try {
+        const ev = await getEventForEdit(eventId);
+        if (!cancelled) setEvent(ev);
+      } catch (err) {
+        console.error('Failed to load event for promote:', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [eventId]);
+
+  // The org this event belongs to (for socials + the settings deep-link).
+  const org: Organization | undefined = useMemo(
+    () => orgs.find((o) => o.org.id === event?.orgId)?.org,
+    [orgs, event?.orgId],
+  );
+
+  const url = eventId ? publicUrl(`event/${eventId}`) : '';
+  const published = (event?.status ?? 'published') === 'published';
+
+  // Campaign-link builder. The campaign slug is set as BOTH utm_campaign (for
+  // the org's GA4/Meta/TikTok dashboards) AND promoter= (for first-party
+  // attribution — the buy flow stamps it onto exos_tickets.promoter_id, which
+  // the event Sales report already aggregates into a per-campaign table).
+  const campaignSlug = slugify(campaignName);
+  const buildCampaignUrl = (ch: { key: string; medium: string }): string => {
+    if (!eventId) return '';
+    const u = new URL(publicUrl(`event/${eventId}`));
+    if (campaignSlug) {
+      u.searchParams.set('utm_campaign', campaignSlug);
+      u.searchParams.set('promoter', campaignSlug);
+    }
+    u.searchParams.set('utm_source', ch.key);
+    u.searchParams.set('utm_medium', ch.medium);
+    return u.toString();
+  };
+
+  const dateLabel = event?.date
+    ? formatInTz(event.date.toDate(), event.timezone, {
+        weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+      })
+    : '';
+
+  const copy = async (value: string, label = 'Copied.') => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast({ kind: 'success', message: label });
+    } catch {
+      toast({ kind: 'error', message: 'Could not copy — long-press to copy manually.' });
+    }
+  };
+
+  const downloadQr = () => {
+    const canvas = qrWrapRef.current?.querySelector('canvas');
+    if (!canvas) return;
+    const a = document.createElement('a');
+    a.href = canvas.toDataURL('image/png');
+    a.download = `qr-${event?.slug || eventId || 'event'}.png`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    toast({ kind: 'success', message: 'QR downloaded — drop it on a poster or flyer.' });
+  };
+
+  const title = event?.title || 'this event';
+  const captions = [
+    `🎟️ ${title}${dateLabel ? ` — ${dateLabel}` : ''}. Grab tickets: ${url}`,
+    `We're live! ${title} tickets are on sale now → ${url} . Tag who you're bringing 👇`,
+    `Don't miss ${title}. Limited tickets, secure yours here: ${url}`,
+  ];
+
+  const embedSnippet = `<!-- Exos embed — ${title} -->
+<iframe id="vibepass-embed" src="${publicUrl(`embed/event/${eventId}`)}" style="width:100%;border:0;min-height:200px" loading="lazy" title="Tickets"></iframe>
+<script>
+window.addEventListener('message', function(e) {
+  if (e.origin !== '${typeof window !== 'undefined' ? window.location.origin : ''}') return;
+  if (e.data && e.data.type === 'vibepass:resize') {
+    var f = document.getElementById('vibepass-embed');
+    if (f) f.style.height = e.data.height + 'px';
+  }
+});
+</script>`;
+
+  const twitterHref = `https://twitter.com/intent/tweet?text=${encodeURIComponent(`${title} ${url}`)}`;
+  const facebookHref = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+
+  if (!user) {
+    return <div className="max-w-3xl mx-auto p-20 text-center text-slate-500">Sign in to promote your events.</div>;
+  }
+  if (loading) {
+    return <div className="max-w-3xl mx-auto p-20 text-center text-slate-300 font-bold uppercase tracking-widest text-xs">Loading…</div>;
+  }
+  if (!event) {
+    return (
+      <div className="max-w-3xl mx-auto p-20 text-center">
+        <p className="text-slate-400 font-bold uppercase tracking-widest text-[10px] mb-4">Event not found</p>
+        <Link to="/dashboard" className="text-[#026cdf] font-bold text-sm">Back to dashboard</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#f2f4f7] min-h-screen">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <Link to="/dashboard" className="flex items-center text-slate-400 hover:text-slate-900 mb-8 transition-colors font-bold uppercase tracking-widest text-[10px]">
+          <ArrowLeft className="w-4 h-4 mr-2" /> Back to Dashboard
+        </Link>
+
+        <div className="flex items-center gap-3 mb-2">
+          <Megaphone className="w-6 h-6 text-[#026cdf]" />
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900">Promote</h1>
+        </div>
+        <p className="text-slate-500 text-sm mb-2">{event.title}{dateLabel ? ` · ${dateLabel}` : ''}</p>
+
+        {!published && (
+          <div className="mb-8 p-4 rounded-xl border border-amber-200 bg-amber-50 text-amber-800 text-xs font-bold">
+            This event is a {event.status || 'draft'}. The public link below won't work until you publish it
+            (only published events are visible to buyers).
+          </div>
+        )}
+
+        {/* Share the link */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4 flex items-center gap-2">
+            <Share2 className="w-4 h-4 text-[#026cdf]" /> Share the link
+          </h2>
+          <div className="flex items-center gap-2 mb-4">
+            <input
+              readOnly
+              value={url}
+              aria-label="Public event link"
+              onFocus={(e) => e.currentTarget.select()}
+              className="flex-1 bg-slate-50 border border-slate-200 rounded-xl px-4 py-3 text-sm font-mono text-slate-700 truncate"
+            />
+            <button
+              onClick={() => copy(url, 'Link copied.')}
+              className="px-4 py-3 bg-slate-900 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-800 transition-colors flex items-center gap-2"
+            >
+              <Copy className="w-3.5 h-3.5" /> Copy
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button onClick={() => setShareOpen(true)} className="flex items-center gap-2 px-4 py-2.5 bg-[#026cdf] text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-[#015bbd] transition-colors">
+              <Share2 className="w-3.5 h-3.5" /> Share…
+            </button>
+            <a href={twitterHref} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-50 transition-colors">
+              <Twitter className="w-3.5 h-3.5" /> X / Twitter
+            </a>
+            <a href={facebookHref} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-50 transition-colors">
+              <Facebook className="w-3.5 h-3.5" /> Facebook
+            </a>
+            <a href={url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 text-slate-700 rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-50 transition-colors">
+              <ExternalLink className="w-3.5 h-3.5" /> Preview
+            </a>
+          </div>
+        </section>
+
+        {/* Campaign links — create + track */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-1 flex items-center gap-2">
+            <Tag className="w-4 h-4 text-[#026cdf]" /> Campaign links
+          </h2>
+          <p className="text-sm text-slate-600 mb-4">
+            Name a campaign and share its per-channel link. Sales attributed to it appear in this event's{' '}
+            <Link to={`/dashboard/event/${eventId}`} className="text-[#026cdf] font-bold">Sales report</Link>;
+            paid reach &amp; ROAS show in your Meta / GA4 / TikTok dashboards (configure pixels below).
+          </p>
+          <input
+            value={campaignName}
+            onChange={(e) => setCampaignName(e.target.value)}
+            placeholder="Campaign name — e.g. spring-launch, radio-spot, influencer-jane"
+            aria-label="Campaign name"
+            className="w-full bg-slate-50 border border-slate-200 rounded-xl px-4 py-3 text-sm font-bold text-slate-900 placeholder:font-normal placeholder:text-slate-400 focus:outline-none focus:border-[#026cdf] mb-4"
+          />
+          {campaignSlug ? (
+            <div className="space-y-2">
+              {CHANNELS.map((ch) => {
+                const link = buildCampaignUrl(ch);
+                return (
+                  <div key={ch.key} className="flex items-center gap-2 bg-slate-50 border border-slate-100 rounded-xl px-3 py-2">
+                    <span className="text-[10px] font-black uppercase tracking-widest text-slate-500 w-28 shrink-0">{ch.label}</span>
+                    <span className="flex-1 text-[11px] font-mono text-slate-600 truncate">{link}</span>
+                    <button onClick={() => copy(link, `${ch.label} link copied.`)} aria-label={`Copy ${ch.label} link`} className="p-2 text-slate-400 hover:text-[#026cdf] transition-colors shrink-0"><Copy className="w-4 h-4" /></button>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-[11px] text-slate-400 italic">Enter a campaign name to generate per-channel tracked links.</p>
+          )}
+        </section>
+
+        {/* QR code */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4 flex items-center gap-2">
+            <QrCode className="w-4 h-4 text-[#026cdf]" /> Poster QR code
+          </h2>
+          <div className="flex items-center gap-6 flex-wrap">
+            <div ref={qrWrapRef} className="p-4 bg-white border border-slate-200 rounded-2xl">
+              <QRCodeCanvas value={url} size={160} level="M" includeMargin />
+            </div>
+            <div className="flex-1 min-w-[200px]">
+              <p className="text-sm text-slate-600 mb-4">
+                Print this on flyers, posters, or the door. It points straight to the ticket page.
+              </p>
+              <button onClick={downloadQr} className="flex items-center gap-2 px-4 py-2.5 bg-slate-900 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-800 transition-colors">
+                <Download className="w-3.5 h-3.5" /> Download PNG
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {/* Embed */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4 flex items-center gap-2">
+            <Code2 className="w-4 h-4 text-[#026cdf]" /> Embed on your site
+          </h2>
+          <p className="text-sm text-slate-600 mb-3">
+            Paste this into your own website (WordPress, Wix, Squarespace, or hand-written HTML). It self-resizes.
+          </p>
+          <pre className="bg-slate-900 text-slate-100 text-[11px] rounded-xl p-4 overflow-x-auto font-mono whitespace-pre-wrap break-all">{embedSnippet}</pre>
+          <button onClick={() => copy(embedSnippet, 'Embed snippet copied.')} className="mt-3 flex items-center gap-2 px-4 py-2.5 bg-slate-900 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-slate-800 transition-colors">
+            <Copy className="w-3.5 h-3.5" /> Copy embed code
+          </button>
+        </section>
+
+        {/* Caption templates */}
+        <section className="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm mb-6">
+          <h2 className="text-[11px] font-black text-slate-900 uppercase tracking-[0.2em] mb-4 flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-[#026cdf]" /> Caption templates
+          </h2>
+          <p className="text-sm text-slate-600 mb-4">Copy-and-post for Instagram, TikTok, or X.</p>
+          <div className="space-y-3">
+            {captions.map((c, i) => (
+              <div key={i} className="flex items-start gap-2 bg-slate-50 border border-slate-100 rounded-xl p-3">
+                <p className="flex-1 text-sm text-slate-700">{c}</p>
+                <button onClick={() => copy(c, 'Caption copied.')} aria-label="Copy caption" className="p-2 text-slate-400 hover:text-[#026cdf] transition-colors shrink-0">
+                  <Copy className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Amplify: pixels + socials */}
+        <section className="bg-gradient-to-r from-indigo-50 to-purple-50 border border-indigo-200 rounded-2xl p-6">
+          <h2 className="text-[11px] font-black text-indigo-900 uppercase tracking-[0.2em] mb-2">Amplify &amp; measure</h2>
+          {org?.marketing?.socials && Object.values(org.marketing.socials).some(Boolean) ? (
+            <div className="mb-3">
+              <p className="text-xs text-indigo-700 mb-2">Your storefront socials:</p>
+              <SocialLinks socials={org.marketing.socials} className="flex items-center gap-4" />
+            </div>
+          ) : null}
+          <p className="text-sm text-indigo-700 mb-4">
+            Add your Meta / GA4 / TikTok pixel and social handles so paid promotion is tracked and your
+            storefront links out to your channels.
+          </p>
+          {org ? (
+            <Link to={`/orgs/${org.id}/settings`} className="inline-flex items-center gap-2 px-4 py-2.5 bg-indigo-600 text-white rounded-xl text-[10px] font-bold uppercase tracking-widest hover:bg-indigo-700 transition-colors">
+              <Settings className="w-3.5 h-3.5" /> Marketing &amp; socials
+            </Link>
+          ) : null}
+        </section>
+      </div>
+
+      <ShareModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        title={event.title}
+        url={url}
+      />
+    </div>
+  );
+}

--- a/d4_bridge/src/views/TicketDetail.tsx
+++ b/d4_bridge/src/views/TicketDetail.tsx
@@ -4,11 +4,13 @@ import { getTicket, listMyTicketsForEvent } from '../lib/tickets';
 import { Ticket, Event } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { QRCodeSVG } from 'qrcode.react';
-import { ArrowLeft, Share2, ShieldCheck, RefreshCw, Ticket as TicketIcon, Calendar, Download, PlusCircle, Instagram, Send, ChevronLeft, ChevronRight, Smartphone } from 'lucide-react';
-import { formatInTz } from '../lib/datetime';
+import { publicUrl } from '../lib/utils';
+import { ArrowLeft, Share2, ShieldCheck, RefreshCw, Ticket as TicketIcon, Calendar, Download, PlusCircle, Instagram, Send, ChevronLeft, ChevronRight, Smartphone, Lock } from 'lucide-react';
+import { formatInTz, isWithinHoursBefore } from '../lib/datetime';
 import { signBarcode, currentBucket } from '../lib/barcode';
 import { motion, AnimatePresence } from 'motion/react';
 import { downloadIcsFile } from '../lib/calendarUtils';
+import { shareEventToStory } from '../lib/poster';
 import { useToast } from '../context/ToastContext';
 import ShareModal from '../components/ShareModal';
 
@@ -156,18 +158,18 @@ export default function TicketDetail() {
   }
 
   const currentTicket = tickets[currentIndex];
+  // Gate the scannable entry QR to within 24h of the event — before that the
+  // code is useless at the door and showing it early only invites screenshots.
+  const qrUnlocked = isWithinHoursBefore(event.date?.toDate?.(), 24);
   const handleInstagramStory = async () => {
-    try {
-      await navigator.clipboard.writeText(`${window.location.origin}/event/${event.id}`);
-      toast({ kind: 'success', message: 'Event link copied — paste it into your Story.' });
-    } catch (err) {
-      console.error('Story share failed:', err);
-      toast({ kind: 'error', message: 'Could not copy link.' });
-    }
+    await shareEventToStory(
+      { title: event.title, url: publicUrl(`event/${event.id}`), imageUrl: event.image },
+      toast,
+    );
   };
 
   const handleSMSShare = () => {
-    const text = `I just secured tickets for ${event.title}! Join me: ${window.location.origin}/event/${event.id}`;
+    const text = `I just secured tickets for ${event.title}! Join me: ${publicUrl(`event/${event.id}`)}`;
     window.location.href = `sms:?&body=${encodeURIComponent(text)}`;
   };
 
@@ -204,7 +206,17 @@ export default function TicketDetail() {
               <div className="-mt-12 px-10 relative z-20">
                  <div className="bg-white p-10 shadow-2xl flex flex-col items-center justify-center group mb-12 relative">
                     <div className={`relative p-6 bg-white border-2 border-black transition-transform duration-500 flex flex-col items-center ${currentTicket.status === 'used' || currentTicket.status === 'voided' || (currentTicket as any).pendingTransferId ? 'opacity-20 grayscale' : 'group-hover:scale-[1.02]'}`}>
-                      <QRCodeSVG value={barcode} size={220} level="H" includeMargin={false} fgColor="#000000" />
+                      {qrUnlocked ? (
+                        <QRCodeSVG value={barcode} size={220} level="H" includeMargin={false} fgColor="#000000" />
+                      ) : (
+                        <div className="w-[220px] h-[220px] flex flex-col items-center justify-center text-center px-4 bg-slate-50 border border-dashed border-black/20">
+                          <Lock className="w-8 h-8 text-black/30 mb-3" aria-hidden="true" />
+                          <p className="text-[10px] font-black uppercase tracking-widest text-black/50">Entry code locked</p>
+                          <p className="text-[10px] font-medium text-black/40 mt-1">
+                            Unlocks 24h before{event.date ? ` · ${formatInTz(event.date.toDate(), event.timezone, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}` : ' the event'}
+                          </p>
+                        </div>
+                      )}
                       <div className="mt-6 w-full text-center border-t-2 border-dashed border-black/20 pt-6 space-y-2">
                         <div>
                           <p className="text-[9px] font-black uppercase tracking-widest text-black/40">Event</p>
@@ -434,7 +446,7 @@ export default function TicketDetail() {
           open={showShare}
           onClose={() => setShowShare(false)}
           title={event.title}
-          url={`${window.location.origin}/event/${event.id}`}
+          url={publicUrl(`event/${event.id}`)}
           text={`I'm going to ${event.title}!`}
         />
       )}

--- a/d4_bridge/src/views/TransferTicket.tsx
+++ b/d4_bridge/src/views/TransferTicket.tsx
@@ -5,6 +5,7 @@ import { Ticket, Event } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { ArrowLeft, UserPlus, ShieldAlert, Send, Check, Copy } from 'lucide-react';
 import { queueEmail } from '../lib/mail';
+import { publicUrl } from '../lib/utils';
 import { motion } from 'motion/react';
 import { useToast } from '../context/ToastContext';
 
@@ -104,7 +105,7 @@ export default function TransferTicket() {
   // instead of the form. The sender keeps the page open, copies the
   // claim link, and pastes it into whatever messaging app they prefer.
   if (completedTransferId) {
-    const claimUrl = `${window.location.origin}/claim/${completedTransferId}`;
+    const claimUrl = publicUrl(`claim/${completedTransferId}`);
     const handleCopy = async () => {
       try {
         await navigator.clipboard.writeText(claimUrl);

--- a/d4_bridge/src/views/WalletPass.tsx
+++ b/d4_bridge/src/views/WalletPass.tsx
@@ -25,13 +25,13 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { QRCodeSVG } from 'qrcode.react';
-import { ArrowLeft, Sun } from 'lucide-react';
+import { ArrowLeft, Sun, Lock } from 'lucide-react';
 import { motion } from 'motion/react';
 import { getTicket } from '../lib/tickets';
 import { Event, Ticket } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { signBarcode, currentBucket } from '../lib/barcode';
-import { formatInTz } from '../lib/datetime';
+import { formatInTz, isWithinHoursBefore } from '../lib/datetime';
 
 export default function WalletPass() {
   const { ticketId } = useParams();
@@ -182,6 +182,8 @@ export default function WalletPass() {
   const isVoided = ticket.status === 'voided';
   const isInTransfer = !!(ticket as { pendingTransferId?: string | null }).pendingTransferId;
   const muted = isUsed || isVoided || isInTransfer;
+  // Entry QR only renders within 24h of the event (unknown date → unlocked).
+  const qrUnlocked = isWithinHoursBefore(event?.date?.toDate?.(), 24);
   const stamp = isVoided
     ? {
         text: 'REFUNDED',
@@ -253,7 +255,17 @@ export default function WalletPass() {
 
           <div className="relative flex flex-col items-center">
             <div className={`p-4 bg-white border-2 border-black rounded-2xl ${muted ? 'opacity-20 grayscale' : ''}`}>
-              <QRCodeSVG value={barcode || ticket.id} size={260} level="H" includeMargin={false} fgColor="#000000" />
+              {qrUnlocked ? (
+                <QRCodeSVG value={barcode || ticket.id} size={260} level="H" includeMargin={false} fgColor="#000000" />
+              ) : (
+                <div className="w-[260px] h-[260px] flex flex-col items-center justify-center text-center px-6">
+                  <Lock className="w-10 h-10 text-black/30 mb-4" aria-hidden="true" />
+                  <p className="text-[11px] font-black uppercase tracking-widest text-black/50">Entry code locked</p>
+                  <p className="text-[11px] font-medium text-black/40 mt-1">
+                    Unlocks 24h before{event?.date ? ` · ${formatInTz(event.date.toDate(), event.timezone, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}` : ' the event'}
+                  </p>
+                </div>
+              )}
             </div>
 
             {stamp ? (
@@ -283,7 +295,7 @@ export default function WalletPass() {
             </div>
           </div>
 
-          {!muted ? (
+          {!muted && qrUnlocked ? (
             <div className="mt-6 flex flex-col items-center">
               <p className="text-[9px] text-black/40 font-black uppercase tracking-tighter">Code refreshes in</p>
               <p className="text-2xl font-black text-black italic tracking-tighter leading-none mt-1">


### PR DESCRIPTION
## Why

Completes the **D4 half of #375** that was deferred during the orphan recovery — #432 landed only #375's backend exos migrations; this re-cuts the **promotion + free-claim FE**.

Audit: current main's `d4_bridge` is **unchanged from #375's base** (the 2026-05-29 re-root preserved it and no later PR touched these files), so the FE grafts cleanly with no divergence.

## What's here (19 files)
- **New:** `views/PromoteEvent.tsx`, `views/OrgPromote.tsx`, `lib/poster.ts` — organizer promotion surface (poster/share generation, promote links).
- **Free-claim:** `views/EventDetails.tsx` "Get tickets" → `exos_claim_free_tickets` RPC.
- **Wiring/misc:** `App.tsx` routes, `lib/tickets.ts`, `lib/utils.ts`, `lib/datetime.ts`, `lib/calendarUtils.ts`, `lib/orgs.ts`, and Org/Organizer/Ticket/Wallet/Embed view updates.

## Validation
- `tsc --noEmit` — clean
- `vite build` — succeeds (PromoteEvent/EventDetails/all chunks emit)

## Backend note
The promotion/free-claim RPCs (`exos_claim_free_tickets` etc.) are **authored migrations from #432, gated for A1/operator to apply** — the FE degrades gracefully until they're live.

Closes the #375 follow-up.

https://claude.ai/code/session_01Kwe3YZTpxMHCafXRnVmDTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kwe3YZTpxMHCafXRnVmDTf)_