### PR TITLE
feat(d0): watchlist at-a-glance metrics + fix TickPick rollup price basis

### DIFF
--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -45,6 +45,7 @@
   const WL_PAGE_SIZE = 50;
   let _wlItems = [];
   let _wlPage = 0;
+  let _wlBasis = null;   // 'bell' (since today's 12:00 ET open) | '24h' — drives the Δ caption
 
   async function loadWatchlist() {
     const body = document.getElementById('watchlistBody');
@@ -65,6 +66,7 @@
       return;
     }
     _wlItems = (res.data && res.data.items) || [];
+    _wlBasis = (res.data && res.data.basis) || null;
     _wlPage = 0;
     renderWatchlistPage();
   }
@@ -75,7 +77,11 @@
     const pager = document.getElementById('watchlistPager');
     if (!body) return;
 
-    if (countEl) countEl.textContent = _wlItems.length ? `${_wlItems.length} events` : '';
+    if (countEl) {
+      const dLbl = _wlBasis === 'bell' ? ' · Δ since opening bell (12:00 ET)'
+                 : _wlBasis === '24h'  ? ' · Δ vs 24h ago' : '';
+      countEl.textContent = _wlItems.length ? `${_wlItems.length} events${dLbl}` : '';
+    }
     if (!_wlItems.length) {
       body.innerHTML = '<div class="empty">No tracked events yet — open an event and tap ★ Track to add it.</div>';
       if (pager) pager.hidden = true;
@@ -86,25 +92,45 @@
     _wlPage = Math.max(0, Math.min(_wlPage, pages - 1));
     const slice = _wlItems.slice(_wlPage * WL_PAGE_SIZE, (_wlPage + 1) * WL_PAGE_SIZE);
 
+    const dHint = _wlBasis === 'bell' ? 'since today’s 12:00 ET open' : 'vs 24h ago';
     const tbl = document.createElement('table');
     tbl.innerHTML = `
       <thead><tr>
         <th>Event</th>
         <th class="num">T-days</th>
-        <th>Venue</th>
+        <th class="num" title="Cheapest listing — TEvo market">Get-in</th>
+        <th class="num" title="Change in get-in ${dHint}">Δ Get-in</th>
+        <th class="num" title="Median listing price — TEvo market">Median</th>
+        <th class="num" title="90th-percentile price — TEvo market">P90</th>
+        <th class="num" title="Tickets available — TEvo market">Tickets</th>
         <th class="num">Alerts</th>
         <th class="num"></th>
       </tr></thead>
       <tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
+    const money = v => (v == null ? '—' : '$' + T.fmtNum(Math.round(+v)));
     slice.forEach(it => {
       const d = T.daysUntil(it.occurs_at_local);
+      const m = it.metrics || null;
+      const venueLine = [it.venue_name || it.venue_location, it.performer].filter(Boolean).join(' · ');
+      // Headline Δ on the get-in (resale floor). pos/neg class on the <td> (matches
+      // the table td.pos/.neg rule); abs $ + %; flat/no-baseline → muted dash.
+      let dCls = '', dInner = '<span class="muted">—</span>';
+      if (m && m.d_getin != null) {
+        dCls = pctCls(+m.d_getin);
+        const pct = (m.d_getin_pct != null) ? ` <span class="small">(${T.fmtPct(+m.d_getin_pct, 1)})</span>` : '';
+        dInner = `${fmtDelta(+m.d_getin)}${pct}`;
+      }
       const tr = document.createElement('tr');
       tr.innerHTML = `
         <td><a href="event.html?event=${it.tevo_event_id}">${escapeHtml(it.event_name || ('Event ' + it.tevo_event_id))}</a>
-            ${it.performer ? `<div class="muted small">${escapeHtml(it.performer)}</div>` : ''}</td>
+            ${venueLine ? `<div class="muted small">${escapeHtml(venueLine)}</div>` : ''}</td>
         <td class="num">${d === null ? '—' : d}</td>
-        <td class="muted small">${escapeHtml(it.venue_name || it.venue_location || '—')}</td>
+        <td class="num">${money(m && m.getin)}</td>
+        <td class="num ${dCls}" title="${escapeHtml(dHint)}">${dInner}</td>
+        <td class="num">${money(m && m.median)}</td>
+        <td class="num">${money(m && m.p90)}</td>
+        <td class="num">${m && m.tickets != null ? T.fmtNum(m.tickets) : '—'}</td>
         <td class="num">
           <button class="wl-alert-btn ${it.alert_enabled ? 'on' : 'off'}" data-id="${it.tevo_event_id}"
                   title="${it.alert_enabled ? 'Alerts on — click to mute' : 'Alerts muted — click to enable'}">

--- a/supabase/migrations/20260606160000_fix_td_tp_median_price_with_fees.sql
+++ b/supabase/migrations/20260606160000_fix_td_tp_median_price_with_fees.sql
@@ -1,0 +1,135 @@
+-- Migration 20260606160000 · lane:D0 (author) → A1 (apply) · writes:compute_event_listing_snapshot · reads:event_metrics,seatgeek_event_metrics,ticketsdata_listings_snapshots,ticketsdata_event_xref,aq_event_map,sg_events_canonical · pre:20260529174007 · auth:operator-approved 2026-06-06
+--
+-- D0 — FIX: TickPick (TP) median/get-in in the daily rollup were computed from
+-- `list_price`, which for TickPick is a seller/base value, NOT the displayed
+-- buyer price. TickPick is an all-in marketplace (no checkout fees), so the
+-- market price IS `price_with_fees`. Symptom: td_tp_median rendered far below
+-- reality — e.g. Detroit Tigers @ NY Yankees 6/30 (tevo 3091433) showed
+-- td_tp_median = $60 while the true all-in median was $342, and $60 sits BELOW
+-- the cheapest actual TP listing ($142.50). The bad value also poisoned
+-- td_combined_median via LEAST(... NULLIF(td.tp_median,0) ...).
+--
+-- Per-platform median(list_price) vs median(price_with_fees) on that event:
+--   SH 138/138 (1.00x) · GT 59/69 (1.18x) · TM 105/128 (1.21x) · VD 78/109 (1.39x)
+--   TP 60/342 (5.60x, per-row ratio swings 9–15x)  ← only TP is incoherent
+--
+-- Surgical fix: TP uses `price_with_fees`; SH/GT/VD/TM stay on `list_price` so
+-- their continuous historical daily series keeps one consistent basis. This also
+-- aligns TP with get_event_all_source_listing_metrics (the live cross-source
+-- panel), which already uses price_with_fees for every TD source.
+--
+-- NOTE: historical TP daily rows remain on the old (list_price) basis — the raw
+-- firehose is trimmed (~25h retention) so past slots cannot be recomputed. Fix is
+-- forward-only; the chart's TP history self-heals as old points age out.
+
+CREATE OR REPLACE FUNCTION public.compute_event_listing_snapshot(p_slot text DEFAULT 'midday'::text)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE v_count int := 0;
+BEGIN
+  INSERT INTO public.event_listing_snapshot_daily (
+    event_id, snapshot_slot, snapshot_date,
+    evo_tickets_count, evo_owned_tickets, evo_owned_median,
+    evo_retail_getin, evo_retail_median, evo_retail_mean, evo_retail_min, evo_retail_max,
+    sg_all_listings, sg_all_tickets, sg_owned_tickets, sg_owned_median, sg_all_median, sg_all_getin, sg_all_mean,
+    td_sh_listings, td_sh_median, td_gt_listings, td_gt_median, td_vd_listings, td_vd_median,
+    td_tp_listings, td_tp_median, td_tm_listings, td_tm_median,
+    td_tm_resale_listings, td_tm_resale_median,
+    td_sh_getin, td_gt_getin, td_vd_getin, td_tp_getin, td_tm_getin,
+    td_combined_median, captured_at
+  )
+  SELECT
+    em.event_id, p_slot, CURRENT_DATE,
+    em.tickets_count, em.owned_tickets_count, em.owned_median_retail,
+    em.getin_price, em.retail_median, em.retail_mean, em.retail_min, em.retail_max,
+    sgm.listings_all_count, sgm.listings_all_tickets, sgm.listings_owned_tickets,
+    sgm.listings_owned_median, sgm.listings_all_median, sgm.listings_all_min, sgm.listings_all_mean,
+    td.sh_listings, td.sh_median, td.gt_listings, td.gt_median, td.vd_listings, td.vd_median,
+    td.tp_listings, td.tp_median, td.tm_listings, td.tm_median,
+    td.tm_resale_listings, td.tm_resale_median,
+    td.sh_getin, td.gt_getin, td.vd_getin, td.tp_getin, td.tm_getin,
+    LEAST(NULLIF(td.sh_median,0), NULLIF(td.gt_median,0), NULLIF(td.vd_median,0),
+          NULLIF(td.tp_median,0), NULLIF(td.tm_median,0)),
+    now()
+  FROM (
+    SELECT DISTINCT ON (event_id)
+      event_id, tickets_count, owned_tickets_count, owned_median_retail,
+      getin_price, retail_median, retail_mean, retail_min, retail_max
+    FROM public.event_metrics ORDER BY event_id, captured_at DESC
+  ) em
+  LEFT JOIN (
+    SELECT DISTINCT ON (tevo_event_id)
+      tevo_event_id, listings_all_count, listings_all_tickets, listings_owned_tickets,
+      listings_owned_median, listings_all_median, listings_all_min, listings_all_mean
+    FROM public.seatgeek_event_metrics ORDER BY tevo_event_id, captured_at DESC
+  ) sgm ON sgm.tevo_event_id = em.event_id
+  LEFT JOIN (
+    WITH latest_capture AS (
+      SELECT event_id, platform, MAX(captured_at) AS max_at
+      FROM public.ticketsdata_listings_snapshots
+      WHERE captured_at > now() - interval '25 hours' AND is_parking = false AND list_price > 0
+      GROUP BY event_id, platform
+    ),
+    latest_td AS (
+      -- eff_price: TickPick (TP) is an all-in marketplace — its `list_price` is a
+      -- seller/base value, not the displayed price — so use `price_with_fees`.
+      -- Every other TD platform keeps `list_price` (coherent pre-fee basis).
+      SELECT tds.event_id, tds.platform,
+             CASE WHEN tds.platform = 'TP' THEN tds.price_with_fees ELSE tds.list_price END AS eff_price,
+             tds.raw->'offer'->>'inventoryType' AS inv_type
+      FROM public.ticketsdata_listings_snapshots tds
+      JOIN latest_capture lc ON lc.event_id = tds.event_id AND lc.platform = tds.platform
+        AND tds.captured_at >= lc.max_at - interval '15 minutes'
+      WHERE tds.is_parking = false AND tds.list_price > 0
+    )
+    SELECT
+      sgc.tevo_event_id,
+      COUNT(*) FILTER (WHERE lt.platform='SH') AS sh_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.eff_price) FILTER (WHERE lt.platform='SH') AS sh_median,
+      COUNT(*) FILTER (WHERE lt.platform='GT') AS gt_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.eff_price) FILTER (WHERE lt.platform='GT') AS gt_median,
+      COUNT(*) FILTER (WHERE lt.platform='VD') AS vd_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.eff_price) FILTER (WHERE lt.platform='VD') AS vd_median,
+      COUNT(*) FILTER (WHERE lt.platform='TP') AS tp_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.eff_price) FILTER (WHERE lt.platform='TP') AS tp_median,
+      COUNT(*) FILTER (WHERE lt.platform='TM' AND COALESCE(lt.inv_type,'primary') <> 'resale') AS tm_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.eff_price)
+        FILTER (WHERE lt.platform='TM' AND COALESCE(lt.inv_type,'primary') <> 'resale') AS tm_median,
+      COUNT(*) FILTER (WHERE lt.platform='TM' AND lt.inv_type = 'resale') AS tm_resale_listings,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lt.eff_price)
+        FILTER (WHERE lt.platform='TM' AND lt.inv_type = 'resale') AS tm_resale_median,
+      MIN(lt.eff_price) FILTER (WHERE lt.platform='SH') AS sh_getin,
+      MIN(lt.eff_price) FILTER (WHERE lt.platform='GT') AS gt_getin,
+      MIN(lt.eff_price) FILTER (WHERE lt.platform='VD') AS vd_getin,
+      MIN(lt.eff_price) FILTER (WHERE lt.platform='TP') AS tp_getin,
+      MIN(lt.eff_price) FILTER (WHERE lt.platform='TM' AND COALESCE(lt.inv_type,'primary') <> 'resale') AS tm_getin
+    FROM latest_td lt
+    JOIN public.ticketsdata_event_xref tdx ON tdx.event_id = lt.event_id AND tdx.active = true
+    JOIN public.aq_event_map aem ON aem.aq_short_event_id = tdx.aq_short_event_id
+    JOIN public.sg_events_canonical sgc ON sgc.sg_event_id = aem.sg_event_id
+    GROUP BY sgc.tevo_event_id
+  ) td ON td.tevo_event_id = em.event_id
+  ON CONFLICT (event_id, snapshot_date, snapshot_slot) DO UPDATE SET
+    evo_tickets_count=EXCLUDED.evo_tickets_count, evo_owned_tickets=EXCLUDED.evo_owned_tickets,
+    evo_owned_median=EXCLUDED.evo_owned_median, evo_retail_getin=EXCLUDED.evo_retail_getin,
+    evo_retail_median=EXCLUDED.evo_retail_median, evo_retail_mean=EXCLUDED.evo_retail_mean,
+    evo_retail_min=EXCLUDED.evo_retail_min, evo_retail_max=EXCLUDED.evo_retail_max,
+    sg_all_listings=EXCLUDED.sg_all_listings, sg_all_tickets=EXCLUDED.sg_all_tickets,
+    sg_owned_tickets=EXCLUDED.sg_owned_tickets, sg_owned_median=EXCLUDED.sg_owned_median,
+    sg_all_median=EXCLUDED.sg_all_median, sg_all_getin=EXCLUDED.sg_all_getin, sg_all_mean=EXCLUDED.sg_all_mean,
+    td_sh_listings=EXCLUDED.td_sh_listings, td_sh_median=EXCLUDED.td_sh_median,
+    td_gt_listings=EXCLUDED.td_gt_listings, td_gt_median=EXCLUDED.td_gt_median,
+    td_vd_listings=EXCLUDED.td_vd_listings, td_vd_median=EXCLUDED.td_vd_median,
+    td_tp_listings=EXCLUDED.td_tp_listings, td_tp_median=EXCLUDED.td_tp_median,
+    td_tm_listings=EXCLUDED.td_tm_listings, td_tm_median=EXCLUDED.td_tm_median,
+    td_tm_resale_listings=EXCLUDED.td_tm_resale_listings, td_tm_resale_median=EXCLUDED.td_tm_resale_median,
+    td_sh_getin=EXCLUDED.td_sh_getin, td_gt_getin=EXCLUDED.td_gt_getin, td_vd_getin=EXCLUDED.td_vd_getin,
+    td_tp_getin=EXCLUDED.td_tp_getin, td_tm_getin=EXCLUDED.td_tm_getin,
+    td_combined_median=EXCLUDED.td_combined_median, captured_at=EXCLUDED.captured_at;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$function$;

--- a/supabase/migrations/20260606170000_watchlist_list_metrics.sql
+++ b/supabase/migrations/20260606170000_watchlist_list_metrics.sql
@@ -1,0 +1,104 @@
+-- Migration 20260606170000 · lane:D0 (author) → A1 (apply) · writes:event_watchlist_list · reads:event_watchlist,events,event_metrics · pre:20260603190000 · auth:operator-requested 2026-06-06
+--
+-- D0 — enrich the home "MY WATCHLIST — TRACKED EVENTS" table with at-a-glance
+-- metrics + a change figure per tracked event. Backward-compatible: the payload
+-- shape (user_email/count/items) is unchanged; each item gains a `metrics` object
+-- (NULL when the event has no event_metrics row yet, e.g. far-future / TEvo-only).
+--
+-- Metrics are TEvo (public.event_metrics — our canonical, frequently-captured
+-- per-event source): get-in, retail median, retail p90, tickets count.
+--
+-- Change basis ("opening bell" = start of the first peak period, ET 12:00 per
+-- collector_cadence / collector_band peak hours 12-23):
+--   • if now() is at/after today's 12:00 ET bell → compare vs the snapshot as of
+--     the bell (intraday "since open"), basis='bell'
+--   • otherwise (pre-bell / overnight) → compare vs ~24h ago, basis='24h'
+-- The baseline row is the latest event_metrics capture at/before the baseline
+-- instant (the value "as of" that moment); NULL delta if none exists that far back.
+
+CREATE OR REPLACE FUNCTION public.event_watchlist_list()
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_email    text        := public._wl_require_email();
+  v_bell     timestamptz := (date_trunc('day', now() AT TIME ZONE 'America/New_York')
+                              + interval '12 hours') AT TIME ZONE 'America/New_York';
+  v_basis    text;
+  v_baseline timestamptz;
+  v_rows     jsonb;
+BEGIN
+  IF now() >= v_bell THEN
+    v_baseline := v_bell;                 v_basis := 'bell';
+  ELSE
+    v_baseline := now() - interval '24 hours'; v_basis := '24h';
+  END IF;
+
+  WITH wl AS (
+    SELECT w.tevo_event_id AS eid, w.alert_enabled, w.added_at,
+           w.event_name AS snap_name, w.occurs_at_local AS snap_occ, w.venue_name AS snap_venue
+    FROM public.event_watchlist w
+    WHERE w.user_email = v_email
+  ),
+  cur AS (
+    SELECT DISTINCT ON (m.event_id)
+      m.event_id, m.captured_at, m.getin_price, m.retail_median, m.retail_p90, m.tickets_count
+    FROM public.event_metrics m JOIN wl ON wl.eid = m.event_id
+    ORDER BY m.event_id, m.captured_at DESC
+  ),
+  base AS (
+    SELECT DISTINCT ON (m.event_id)
+      m.event_id, m.captured_at AS base_at, m.getin_price AS base_getin, m.retail_median AS base_median
+    FROM public.event_metrics m JOIN wl ON wl.eid = m.event_id
+    WHERE m.captured_at <= v_baseline
+    ORDER BY m.event_id, m.captured_at DESC
+  )
+  SELECT coalesce(
+           jsonb_agg(r ORDER BY (r->>'occurs_at_local') ASC NULLS LAST, (r->>'added_at') DESC),
+           '[]'::jsonb)
+    INTO v_rows
+  FROM (
+    SELECT jsonb_build_object(
+      'tevo_event_id',   wl.eid,
+      'event_name',      coalesce(e.name, wl.snap_name),
+      'occurs_at_local', coalesce(e.occurs_at_local, wl.snap_occ),
+      'venue_name',      coalesce(e.venue_name, wl.snap_venue),
+      'venue_location',  e.venue_location,
+      'performer',       e.primary_performer_name,
+      'alert_enabled',   wl.alert_enabled,
+      'added_at',        wl.added_at,
+      'metrics', CASE WHEN c.event_id IS NULL THEN NULL ELSE jsonb_build_object(
+        'getin',        round(c.getin_price),
+        'median',       round(c.retail_median),
+        'p90',          round(c.retail_p90),
+        'tickets',      c.tickets_count,
+        'd_getin',      CASE WHEN b.base_getin IS NOT NULL THEN round(c.getin_price - b.base_getin) END,
+        'd_getin_pct',  CASE WHEN b.base_getin IS NOT NULL AND b.base_getin <> 0
+                             THEN round((c.getin_price - b.base_getin) / b.base_getin * 100, 1) END,
+        'd_median',     CASE WHEN b.base_median IS NOT NULL THEN round(c.retail_median - b.base_median) END,
+        'd_median_pct', CASE WHEN b.base_median IS NOT NULL AND b.base_median <> 0
+                             THEN round((c.retail_median - b.base_median) / b.base_median * 100, 1) END,
+        'basis',        v_basis,
+        'cur_at',       c.captured_at,
+        'base_at',      b.base_at
+      ) END
+    ) AS r
+    FROM wl
+    LEFT JOIN public.events e        ON e.id = wl.eid
+    LEFT JOIN cur c                  ON c.event_id = wl.eid
+    LEFT JOIN base b                 ON b.event_id = wl.eid
+  ) q;
+
+  RETURN jsonb_build_object(
+    'user_email',  v_email,
+    'count',       jsonb_array_length(v_rows),
+    'basis',       v_basis,
+    'baseline_at', v_baseline,
+    'items',       v_rows
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.event_watchlist_list() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.event_watchlist_list() TO authenticated;

--- a/tests/test_watchlist_metrics.py
+++ b/tests/test_watchlist_metrics.py
@@ -1,0 +1,163 @@
+"""Wiring tests for the home watchlist at-a-glance metrics (PR: watchlist metrics).
+
+Two layers:
+  • Static contract checks (always run) — pin the RPC↔frontend wiring so a field
+    renamed on one side but not the other fails CI. The home watchlist is a direct
+    Supabase RPC (event_watchlist_list) consumed by static/terminal/home.js, so the
+    contract is "the metric keys the RPC emits == the keys home.js reads."
+  • Live-DB checks (skipped unless SUPABASE_DB_URL is set) — exercise the deployed
+    function: SECURITY DEFINER, payload shape, and the opening-bell vs 24h basis
+    branch against the live clock.
+
+Mirrors tests/test_views_and_helpers.py for the live-DB harness + skip gate.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MIGRATION = REPO_ROOT / "supabase" / "migrations" / "20260606170000_watchlist_list_metrics.sql"
+HOME_JS = REPO_ROOT / "static" / "terminal" / "home.js"
+
+DB_URL = os.environ.get("SUPABASE_DB_URL")
+skip_no_db = pytest.mark.skipif(not DB_URL, reason="SUPABASE_DB_URL not set; skipping live-DB tests")
+
+# The contract. Each metric the RPC emits inside the per-item `metrics` object must
+# be consumed by home.js as `m.<key>` (and vice-versa for the displayed/delta set).
+DISPLAY_KEYS = ["getin", "median", "p90", "tickets"]   # rendered as table columns
+DELTA_KEYS = ["d_getin", "d_getin_pct"]                # headline Δ on the get-in
+
+
+@pytest.fixture(scope="module")
+def migration_sql() -> str:
+    assert MIGRATION.exists(), f"migration file missing: {MIGRATION}"
+    return MIGRATION.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def home_js() -> str:
+    assert HOME_JS.exists(), f"home.js missing: {HOME_JS}"
+    return HOME_JS.read_text(encoding="utf-8")
+
+
+# ---------- Static contract checks (no DB) ----------
+
+def test_rpc_emits_all_metric_keys(migration_sql: str):
+    """Every display + delta key is a jsonb key in the RPC's metrics object."""
+    for key in DISPLAY_KEYS + DELTA_KEYS + ["basis", "cur_at", "base_at"]:
+        assert f"'{key}'" in migration_sql, f"RPC migration missing metrics key '{key}'"
+
+
+def test_frontend_consumes_all_metric_keys(home_js: str):
+    """home.js reads each metric/delta key off the per-item `metrics` object."""
+    for key in DISPLAY_KEYS + DELTA_KEYS:
+        assert f"m.{key}" in home_js, f"home.js does not consume m.{key}"
+
+
+def test_rpc_and_fe_key_sets_agree(migration_sql: str, home_js: str):
+    """Guard against drift: any m.<key> the FE reads must be emitted by the RPC."""
+    fe_keys = set(re.findall(r"\bm\.([a-z_][a-z0-9_]*)\b", home_js))
+    # Keys the FE reads off the metrics object (exclude unrelated locals if any).
+    metric_like = {k for k in fe_keys if k in set(DISPLAY_KEYS + DELTA_KEYS)
+                   or k.startswith("d_")}
+    for key in metric_like:
+        assert f"'{key}'" in migration_sql, \
+            f"home.js reads m.{key} but the RPC never emits '{key}'"
+
+
+def test_frontend_calls_the_rpc_and_reads_envelope(home_js: str):
+    """FE calls event_watchlist_list and reads items + basis off the envelope."""
+    assert "event_watchlist_list" in home_js
+    assert "res.data" in home_js and ".items" in home_js
+    assert ".basis" in home_js and "_wlBasis" in home_js
+
+
+def test_basis_labels_present_both_sides(migration_sql: str, home_js: str):
+    """'bell' / '24h' basis values exist in the RPC and are labeled in the UI."""
+    assert "'bell'" in migration_sql and "'24h'" in migration_sql
+    assert "'bell'" in home_js and "'24h'" in home_js
+    assert "opening bell" in home_js.lower()
+
+
+def test_opening_bell_is_noon_et_with_24h_fallback(migration_sql: str):
+    """Bell = today 12:00 America/New_York; fallback = trailing 24h."""
+    assert "America/New_York" in migration_sql
+    assert "interval '12 hours'" in migration_sql
+    assert "interval '24 hours'" in migration_sql
+
+
+def test_rpc_payload_backward_compatible(migration_sql: str):
+    """The existing envelope keys are preserved and metrics is NULL-guarded."""
+    for key in ["'user_email'", "'count'", "'items'"]:
+        assert key in migration_sql, f"RPC dropped backward-compat envelope key {key}"
+    assert "CASE WHEN c.event_id IS NULL THEN NULL" in migration_sql, \
+        "metrics must be NULL when the event has no event_metrics row"
+
+
+# ---------- Live-DB checks (require SUPABASE_DB_URL) ----------
+
+def _run_query(sql: str) -> list[dict]:
+    psycopg2 = pytest.importorskip("psycopg2")
+    import psycopg2.extras
+    with psycopg2.connect(DB_URL) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(sql)
+            return [dict(r) for r in cur.fetchall()]
+
+
+def _run_as_email(email: str, sql: str) -> list[dict]:
+    """Run sql in a transaction with the JWT email GUC set (SECDEF reads auth.jwt())."""
+    psycopg2 = pytest.importorskip("psycopg2")
+    import psycopg2.extras
+    with psycopg2.connect(DB_URL) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT set_config('request.jwt.claims', %s, true)",
+                        (json.dumps({"email": email}),))
+            cur.execute(sql)
+            return [dict(r) for r in cur.fetchall()]
+
+
+@skip_no_db
+def test_function_exists_and_is_secdef():
+    rows = _run_query(
+        "SELECT prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace "
+        "WHERE n.nspname='public' AND p.proname='event_watchlist_list'"
+    )
+    assert rows, "event_watchlist_list not found"
+    assert rows[0]["prosecdef"] is True, "event_watchlist_list must be SECURITY DEFINER"
+
+
+@skip_no_db
+def test_payload_shape_for_empty_user():
+    """A user with no rows still gets a well-formed envelope (no crash, basis set)."""
+    rows = _run_as_email("smoketest@s4kent.com",
+        "SELECT (public.event_watchlist_list()->>'basis') AS basis, "
+        "(public.event_watchlist_list()->>'count')::int AS count, "
+        "jsonb_typeof(public.event_watchlist_list()->'items') AS items_type")
+    assert rows[0]["basis"] in ("bell", "24h")
+    assert rows[0]["items_type"] == "array"
+    assert rows[0]["count"] >= 0
+
+
+@skip_no_db
+def test_basis_branch_matches_live_clock():
+    """The chosen basis equals the independently-computed bell-vs-now decision."""
+    rows = _run_as_email("smoketest@s4kent.com",
+        "SELECT (public.event_watchlist_list()->>'basis') AS got, "
+        "(CASE WHEN now() >= ((date_trunc('day', now() AT TIME ZONE 'America/New_York') "
+        "  + interval '12 hours') AT TIME ZONE 'America/New_York') "
+        "  THEN 'bell' ELSE '24h' END) AS expected")
+    assert rows[0]["got"] == rows[0]["expected"]
+
+
+@skip_no_db
+def test_email_gate_rejects_non_s4kent():
+    """The SECDEF email gate must reject a non-@s4kent.com caller."""
+    psycopg2 = pytest.importorskip("psycopg2")
+    with pytest.raises(psycopg2.Error):
+        _run_as_email("intruder@example.com", "SELECT public.event_watchlist_list()")


### PR DESCRIPTION
Two D0 changes on this branch.

---

## 1. feat: at-a-glance metrics + Δ on the home watchlist

The home **MY WATCHLIST — TRACKED EVENTS** table now shows per-event metrics so the user can scan their watchlist without opening each event:

- **Get-in · Median · P90 · Tickets available** (TEvo `event_metrics` — our canonical, frequently-captured per-event source).
- **Headline Δ on the get-in** (the resale floor — the most-watched number), shown as `±$ (±%)`, colored pos/neg.

**Change basis** ("opening bell" = start of the first peak period, ET 12:00 per `collector_cadence`/`collector_band`):
- past today's 12:00 ET bell → compare vs the snapshot *as of the bell* (intraday "since open"), labeled "Δ since opening bell (12:00 ET)"
- pre-bell / overnight → compare vs ~24h ago, labeled "Δ vs 24h ago"

Chosen server-side; the baseline row is the latest capture at/before that instant. NULL delta if no capture exists that far back.

**Backend:** `event_watchlist_list()` gains a backward-compatible per-item `metrics` object (NULL for events with no `event_metrics` yet, e.g. far-future / TEvo-only). Payload shape (`user_email`/`count`/`items`) is unchanged; adds `basis` + `baseline_at`. **Frontend:** new columns, venue folded into the event subline, Δ colored via the existing `table td.pos/.neg` rule.

Verified live against the operator's 4 tracked events, e.g. Knicks Finals G4 get-in **$13,514 (+$6,122 / +82.8%)** over 24h, Red Sox @ Yankees **$62 (−$14 / −18.7%)**.

## 2. fix: TickPick daily-rollup median/get-in use `price_with_fees`

`compute_event_listing_snapshot` computed every TD platform's median + get-in from `list_price`. For **TickPick** that's wrong — TickPick is an all-in marketplace, so the TicketsData `list_price` is a seller/base value, not the displayed price. Symptom on **Detroit Tigers at NY Yankees 6/30** (tevo `3091433`): `td_tp_median = $60` vs true all-in **$342**, *below* the cheapest actual listing ($142.50); it also poisoned `td_combined_median`.

Per-platform `median(list_price)` vs `median(price_with_fees)`: SH 1.00× · GT 1.18× · TM 1.21× · VD 1.39× · **TP 5.60×** (incoherent, per-row 9–15×). Only TP is broken.

Fix: an `eff_price` CASE → TP uses `price_with_fees`; SH/GT/VD/TM stay on `list_price` (continuous historical basis). Aligns TP with `get_event_all_source_listing_metrics`. Verified: TP median **$60 → $342**, get-in **$13 → $143**; others unchanged. Forward-only (raw firehose ~25h retention).

---

Both migrations applied to prod (`hzrizjeaxlqcxfrtczpq`) as `watchlist_list_metrics` and `fix_td_tp_median_price_with_fees`. Draft pending review/promotion to `main` (A1).

https://claude.ai/code/session_01C7V8j6qy4s2dDhSWHAg7ia