### PR TITLE
feat(d0/home): replace BLIND SPOTS panel with Top-50 SG market chart

### DIFF
--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -14,7 +14,7 @@
 // Source toggle lets operator pin to a single platform or use the merged
 // composite. Owned/market deltas + SG sales / owned median / value cols
 // from the legacy panel are NOT in v2 — they render as "—" honest empty.
-// Blind spots fires its own RPC (get_blind_spots_sg_selling) — independent.
+// Top-50 chart fires its own RPC (get_sg_market_chart) — independent.
 
 (function () {
   'use strict';
@@ -28,6 +28,7 @@
     sortKey: 'delta_market_pct',
     sortDir: 'desc',
     gapMap: new Map(),        // event_id → [{ gap_type, detail, signal_score }]
+    chartTab: 'top',          // 'top' (rank 1-50) | 'rest' (rank 51+)
   };
 
   async function init() {
@@ -36,8 +37,9 @@
     // Watchlist is the first table — the user's own tracked events. Independent
     // RPC, runs in parallel with movers/blind-spots.
     loadWatchlist().catch(e => console.error('[watchlist]', e));
-    // Blind spots fires its own RPC, independent of movers — runs in parallel.
-    renderBlindSpots().catch(e => console.error('[blindSpots]', e));
+    // Top-50 chart fires its own RPC, independent of movers — runs in parallel.
+    wireChartTabs();
+    renderMarketChart().catch(e => console.error('[sgChart]', e));
     load();
   }
 
@@ -301,31 +303,49 @@
     setText('cvToday', T.fmtNum(today));
   }
 
-  // ---------- Blind spots panel — SG selling, we're not ----------
+  // ---------- TOP 50 — SG SELLING, WE'RE NOT IN ----------
   //
-  // Calls get_blind_spots_sg_selling(p_min_score) RPC (mig 20260520370000).
-  // Composite 0-4 score across:
-  //   1. listings shrinking >= 5% over 48h
-  //   2. price rising       >= 10% over 48h
-  //   3. sales accelerating >= 30% (last 24h vs prior 24h)
-  //   4. sales clearing at/above current ask
-  // Surfaces events scoring >= 2/4 (two independent signals agreeing). Pool:
-  // ~2,930 unmatched US SG events polled at 12h cadence (TRACK_BLINDSPOT tier).
-  // RPC perf-fixed via matview mig 20260524120000 (was timing out >11s).
+  // Billboard-style daily chart of SG market events we hold ZERO owned
+  // inventory in, ranked by sales ACTIVITY. Calls get_sg_market_chart(offset,
+  // limit) RPC (mig 20260606120000), which reads the daily-rebuilt
+  // sg_market_chart table.
   //
-  // Replaces the prior heuristic (sg_sales_window >= 5 AND cur_owned_tix == 0
-  // pulled from /api/broker/movers) — that surfaced matched events with SG
-  // activity but doesn't cover the unmatched-US cohort the new tracker targets.
+  //   chart_score = percent_rank(7d-MA daily volume)
+  //               + percent_rank(7d-MA sales median)        (0..2)
+  //
+  // High on EITHER axis charts; high on BOTH tops it. Eligibility:
+  // owned_count_last_7d = 0, future event, >= 2 days of sales in trailing 7d.
+  // Each row carries prev_rank / peak_rank / days_on_chart for movement.
+  // Two tabs: "Top 50" (rank 1-50) and "The Rest" (rank 51+, capped server-side).
 
-  const BLIND_SPOT_MIN_SCORE = 2;  // was 3; audit 2026-05-24 found score>=3 ~never reached
-  const BLIND_SPOT_MAX_ROWS  = 20;
-  // BLIND_SPOT_MIN_SG_SALES removed: the movers panel is now v2 RPC-backed and
-  // no longer uses sg_sales_window to highlight rows. The sg_selling blind-spot
-  // RPC (renderBlindSpots) provides a dedicated panel for that signal.
+  const CHART_PAGE = 50;        // tab 1 size = top 50
+  const CHART_REST_LIMIT = 200; // tab 2: ranks 51..250
 
-  async function renderBlindSpots() {
-    const body = document.getElementById('blindSpotsBody');
-    const countEl = document.getElementById('blindSpotsCount');
+  function wireChartTabs() {
+    document.querySelectorAll('[data-chart-tab]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (btn.classList.contains('is-active')) return;
+        document.querySelectorAll('[data-chart-tab]').forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        state.chartTab = btn.dataset.chartTab;
+        renderMarketChart().catch(e => console.error('[sgChart]', e));
+      });
+    });
+  }
+
+  // Movement glyph from rank_delta (prev_rank - rank): + = climbed.
+  function movementCell(r) {
+    if (r.is_new) return '<span class="chart-move new" title="new entry">NEW</span>';
+    const d = r.rank_delta;
+    if (d == null) return '<span class="chart-move flat">—</span>';
+    if (d > 0)  return `<span class="chart-move up"   title="up ${d} from #${r.prev_rank}">▲ ${d}</span>`;
+    if (d < 0)  return `<span class="chart-move down" title="down ${-d} from #${r.prev_rank}">▼ ${-d}</span>`;
+    return '<span class="chart-move flat" title="no change">=</span>';
+  }
+
+  async function renderMarketChart() {
+    const body = document.getElementById('sgChartBody');
+    const metaEl = document.getElementById('sgChartMeta');
     if (!body) return;
 
     const Auth = window.TerminalAuth;
@@ -336,82 +356,79 @@
 
     body.innerHTML = '<div class="empty">loading…</div>';
 
-    let rows;
+    const isRest = state.chartTab === 'rest';
+    const args = isRest
+      ? { p_offset: CHART_PAGE, p_limit: CHART_REST_LIMIT }
+      : { p_offset: 0,          p_limit: CHART_PAGE };
+
+    let payload;
     try {
-      const res = await Auth.client.rpc('get_blind_spots_sg_selling',
-        { p_min_score: BLIND_SPOT_MIN_SCORE });
+      const res = await Auth.client.rpc('get_sg_market_chart', args);
       if (res.error) throw new Error(res.error.message || 'RPC error');
-      rows = res.data || [];
+      payload = res.data || {};
     } catch (e) {
       body.innerHTML = '<div class="empty">error: ' + escapeHtml(e.message) + '</div>';
-      if (countEl) countEl.textContent = '';
+      if (metaEl) metaEl.textContent = '';
       return;
     }
 
-    const n = rows.length;
-    if (countEl) countEl.textContent = n
-      ? `${n} event${n === 1 ? '' : 's'} (showing top ${Math.min(n, BLIND_SPOT_MAX_ROWS)})`
-      : '';
+    const rows = payload.rows || [];
+    const total = payload.total || 0;
+    const charted = payload.chart_date ? ` · ${escapeHtml(payload.chart_date)}` : '';
+    if (metaEl) {
+      metaEl.textContent = total
+        ? (isRest ? `ranks 51–${Math.min(total, CHART_PAGE + rows.length)} of ${total}${charted}`
+                  : `${total} non-owned events charting${charted}`)
+        : '';
+    }
 
-    if (!n) {
-      body.innerHTML =
-        '<div class="empty">no SG-selling signals at score &ge; ' + BLIND_SPOT_MIN_SCORE +
-        '/4 (48h baseline accumulating)</div>';
+    if (!rows.length) {
+      body.innerHTML = isRest
+        ? '<div class="empty">no events beyond the top 50</div>'
+        : '<div class="empty">chart not built yet (rebuilds daily @ 11:05 UTC)</div>';
       return;
     }
 
     const tbl = document.createElement('table');
-    tbl.className = 'blind-spots-tbl';
+    tbl.className = 'blind-spots-tbl chart-tbl';
     tbl.innerHTML = `
       <thead><tr>
+        <th class="num">#</th>
+        <th title="Movement vs yesterday's chart">+/-</th>
         <th>Event</th><th>Venue</th>
         <th class="num">T-days</th>
-        <th class="num" title="Composite 0-4 across listings drop + price rise + sales accel + sales above ask">Score</th>
-        <th class="num" title="DISTINCT sg_sale_id in last 24h">Sales 24h</th>
-        <th class="num" title="Sales velocity: last 24h vs prior 24h">Vel %</th>
-        <th class="num">Listings</th>
-        <th class="num" title="48h delta on distinct sglid count">L Δ%</th>
-        <th class="num">Med px</th>
-        <th class="num" title="48h delta on median listing price">P Δ%</th>
-        <th class="num" title="Median sale 24h vs current median ask">Sale/Ask</th>
-        <th class="num" title="Sales 24h / Listings now">Clear</th>
+        <th class="num" title="7-day moving average of daily sales (distinct sg_sale_id / day)">Vol/day</th>
+        <th class="num" title="7-day moving average of daily sales median price">Med px</th>
+        <th class="num" title="7-day MA daily gross (volume × median, approx)">GMV/day</th>
+        <th class="num" title="Chart score = percentile(volume) + percentile(median), 0–2">Score</th>
+        <th class="num" title="Best rank achieved · days on chart">Peak·On</th>
       </tr></thead>
       <tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
 
-    rows.slice(0, BLIND_SPOT_MAX_ROWS).forEach(r => {
+    rows.forEach(r => {
       const d = T.daysUntil(r.sg_datetime_utc);
       const tr = document.createElement('tr');
 
-      // Event cell links to event.html if we have a TEvo bridge, else plain text.
       const eventLabel = r.tevo_event_id
         ? `<a href="event.html?event=${r.tevo_event_id}">${escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id))}</a>`
         : escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id));
 
-      // Score cell — hover reveals which signals are lit.
-      const signalsTitle = [
-        (r.signal_listings_drop  ? '✓' : '✗') + ' listings shrinking ≥ 5%',
-        (r.signal_price_rise     ? '✓' : '✗') + ' price rising ≥ 10%',
-        (r.signal_sales_accel    ? '✓' : '✗') + ' sales accelerating ≥ 30%',
-        (r.signal_sales_above_ask? '✓' : '✗') + ' sales clearing at/above ask'
-      ].join(' · ');
-
-      const pct = v => (v == null ? '—' : T.fmtPct(v));
-      const cls = (cond, on, off) => cond ? on : (off || '');
+      const money = v => (v == null ? '—' : '$' + T.fmtNum(Math.round(+v)));
+      const score = (r.chart_score == null) ? '—' : (+r.chart_score).toFixed(2);
+      const peakOn = `${r.peak_rank ?? '—'}·${r.days_on_chart ?? '—'}`;
 
       tr.innerHTML = `
+        <td class="num chart-rank">${r.rank}</td>
+        <td>${movementCell(r)}</td>
         <td>${eventLabel}</td>
         <td>${escapeHtml(r.sg_venue_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
-        <td class="num" title="${signalsTitle}"><strong>${r.selling_score}/4</strong></td>
-        <td class="num">${r.sales_24h_count || 0}</td>
-        <td class="num ${cls(r.sales_velocity_pct > 0, 'pos', r.sales_velocity_pct < 0 ? 'neg' : '')}">${pct(r.sales_velocity_pct)}</td>
-        <td class="num">${r.listings_now}</td>
-        <td class="num ${cls(r.listings_pct_delta < 0, 'neg', r.listings_pct_delta > 0 ? 'pos' : '')}">${pct(r.listings_pct_delta)}</td>
-        <td class="num">${r.median_now ? '$' + T.fmtNum(Math.round(+r.median_now)) : '—'}</td>
-        <td class="num ${cls(r.price_pct_delta > 0, 'pos', r.price_pct_delta < 0 ? 'neg' : '')}">${pct(r.price_pct_delta)}</td>
-        <td class="num ${cls(r.sale_vs_listing_pct > 0, 'pos', r.sale_vs_listing_pct < 0 ? 'neg' : '')}">${pct(r.sale_vs_listing_pct)}</td>
-        <td class="num">${r.clearing_ratio != null ? T.fmtNum(Math.round(r.clearing_ratio * 100)) + '%' : '—'}</td>`;
+        <td class="num">${r.ma7_volume == null ? '—' : T.fmtNum(Math.round(+r.ma7_volume))}</td>
+        <td class="num">${money(r.ma7_median)}</td>
+        <td class="num">${money(r.ma7_gross)}</td>
+        <td class="num" title="vol pct ${r.pct_volume} · med pct ${r.pct_median}"><strong>${score}</strong></td>
+        <td class="num" title="peak rank · consecutive days on chart">${peakOn}</td>`;
       tb.appendChild(tr);
     });
 

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -44,12 +44,16 @@
       </div>
     </section>
 
-    <section id="blind-spots">
+    <section id="sg-chart">
       <div class="panel-title row">
-        <span>BLIND SPOTS — SG SELLING, WE'RE NOT</span>
-        <span class="muted small" id="blindSpotsCount"></span>
+        <span>TOP 50 — SG SELLING, WE'RE NOT IN</span>
+        <span class="muted small" id="sgChartMeta"></span>
       </div>
-      <div id="blindSpotsBody"><div class="empty">loading…</div></div>
+      <div class="ctrl-group sg-chart-tabs">
+        <button class="ctrl-btn is-active" data-chart-tab="top">Top 50</button>
+        <button class="ctrl-btn" data-chart-tab="rest">The Rest</button>
+      </div>
+      <div id="sgChartBody"><div class="empty">loading…</div></div>
     </section>
 
     <section id="movers-panel">

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -480,6 +480,15 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 .blind-spots-tbl .num.warn { color: var(--warn); font-weight: 600; }
 .blind-spots-tbl tbody tr:hover td { background: var(--shade); }
 
+/* TOP 50 — SG SELLING, WE'RE NOT IN (Billboard-style chart) */
+.sg-chart-tabs { margin-bottom: 8px; }
+.chart-tbl .chart-rank { font-weight: 700; color: var(--text); width: 32px; }
+.chart-move { font-family: var(--mono); font-size: 10px; font-weight: 600; white-space: nowrap; }
+.chart-move.up   { color: var(--pos); }
+.chart-move.down { color: var(--neg); }
+.chart-move.new  { color: var(--accent); }
+.chart-move.flat { color: var(--dim); }
+
 /* Amber-cued SG sales cell on movers table when blind-spot conditions met
    (sg > threshold AND owned_tix = 0) */
 .movers-tbl .warn-cell {

--- a/supabase/migrations/20260606120000_sg_market_chart_top50.sql
+++ b/supabase/migrations/20260606120000_sg_market_chart_top50.sql
@@ -1,0 +1,262 @@
+-- Migration 20260606120000 · level:2 · lane:D0 (operator-directed)
+-- writes: CREATE TABLE sg_market_chart; CREATE fn rebuild_sg_market_chart();
+--         CREATE RPC get_sg_market_chart(int,int); cron_policy row +
+--         cron.schedule('sg_market_chart_rebuild_daily'); one initial rebuild.
+-- reads:  seatgeek_event_metrics (sold_*), sg_event_priority_state (owned/horizon).
+--
+-- ============================================================
+-- "TOP 50 — SG SELLING, WE'RE NOT IN" — a Billboard-style daily chart of the
+-- SeatGeek market events we hold ZERO owned inventory in, ranked by sales
+-- ACTIVITY (7-day moving average of daily sales VOLUME and/or MEDIAN price).
+--
+-- Operator directive 2026-06-06: replace the home "BLIND SPOTS — SG SELLING,
+-- WE'RE NOT" pressure panel with a top-50 charting leaderboard ("think
+-- Billboard top 50"), a second tab for the rest, refreshed daily.
+--
+-- SCORING — the "either high volume OR high median price OR both" blend:
+--   chart_score = percent_rank(ma7_volume) + percent_rank(ma7_median)   (0..2)
+-- An event that is high on EITHER axis charts well; high on BOTH tops it.
+-- (Pure GMV = vol*price was rejected: it buries the high-price/low-volume
+-- names — Ariana Grande, F1 — that are genuine opportunities.)
+--
+-- ELIGIBILITY: owned_count_last_7d = 0 (we are not exposed), event in the
+-- future, and >= 2 days of sales in the trailing 7d (a real MA, not a spike).
+--
+-- CHARTING: sg_market_chart retains one ranked row set per UTC day, carrying
+-- prev_rank / peak_rank / days_on_chart so the UI can show Billboard-style
+-- movement (▲/▼/NEW). 90-day history retained.
+--
+-- SOURCE NOTE: seatgeek_event_metrics.sold_quantity is a trailing-24h count of
+-- distinct sales (sg_sale_id), inserted hourly by refresh_sg_broker_sales_event_
+-- metrics (@ :17). Taking the latest row per UTC day => that day's daily volume;
+-- avg over the 7d window => the 7-day moving average. Sales tracking is NOT
+-- ownership-gated (PROJECT_BIBLE §SG sales), so every non-owned event is covered.
+--
+-- PENDING OPERATOR APPLY: prod application is gated (CLAUDE.md §1). The final
+-- SELECT rebuild_sg_market_chart() populates the table on apply so the panel has
+-- data immediately. ROLLBACK: cron.unschedule('sg_market_chart_rebuild_daily');
+-- DROP FUNCTION get_sg_market_chart(int,int), rebuild_sg_market_chart();
+-- DROP TABLE sg_market_chart; DELETE cron_policy row.
+-- ============================================================
+
+-- ---------- 1. Chart history table (one ranked set per UTC day) ----------
+CREATE TABLE IF NOT EXISTS public.sg_market_chart (
+  chart_date       date        NOT NULL,
+  sg_event_id      bigint      NOT NULL,
+  rank             integer     NOT NULL,
+  chart_score      numeric     NOT NULL,
+  pct_volume       numeric,
+  pct_median       numeric,
+  ma7_volume       numeric,
+  ma7_median       numeric,
+  ma7_gross        numeric,
+  days_with_sales  integer,
+  prev_rank        integer,        -- rank on the most recent prior chart_date (NULL = new entry)
+  peak_rank        integer,        -- best (lowest) rank ever achieved by this event
+  days_on_chart    integer,        -- consecutive daily appearances (resets on a gap)
+  tevo_event_id    bigint,
+  sg_event_name    text,
+  sg_venue_name    text,
+  sg_datetime_utc  timestamptz,
+  PRIMARY KEY (chart_date, sg_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS sg_market_chart_date_rank_idx
+  ON public.sg_market_chart (chart_date, rank);
+CREATE INDEX IF NOT EXISTS sg_market_chart_event_idx
+  ON public.sg_market_chart (sg_event_id);
+
+-- secure-by-default: only the SECDEF RPC (owner) reads it; no anon/auth surface
+REVOKE ALL ON public.sg_market_chart FROM anon, authenticated;
+
+-- ---------- 2. Daily rebuild function ----------
+CREATE OR REPLACE FUNCTION public.rebuild_sg_market_chart()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_today date := (now() AT TIME ZONE 'UTC')::date;
+  v_prev  date;
+  v_count int := 0;
+BEGIN
+  SELECT max(chart_date) INTO v_prev
+  FROM public.sg_market_chart WHERE chart_date < v_today;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date = v_today;  -- idempotent re-run
+
+  WITH daily AS (
+    -- one row per (event, UTC day): latest hourly rollup; sold_* is trailing-24h
+    SELECT DISTINCT ON (sg_event_id, (captured_at AT TIME ZONE 'UTC')::date)
+      sg_event_id,
+      (captured_at AT TIME ZONE 'UTC')::date AS d,
+      sold_quantity, sold_price_median, sold_gross
+    FROM public.seatgeek_event_metrics
+    WHERE captured_at > now() - interval '7 days'
+      AND coalesce(sold_quantity, 0) > 0
+    ORDER BY sg_event_id, (captured_at AT TIME ZONE 'UTC')::date, captured_at DESC
+  ),
+  ma AS (
+    SELECT sg_event_id,
+      count(*)                        AS days_with_sales,
+      avg(sold_quantity)::numeric     AS ma7_volume,
+      avg(sold_price_median)::numeric AS ma7_median,
+      avg(sold_gross)::numeric        AS ma7_gross
+    FROM daily
+    GROUP BY sg_event_id
+  ),
+  elig AS (
+    SELECT m.sg_event_id, m.days_with_sales, m.ma7_volume, m.ma7_median, m.ma7_gross,
+           p.tevo_event_id, p.sg_event_name, p.sg_venue_name, p.sg_datetime_utc
+    FROM ma m
+    JOIN public.sg_event_priority_state p ON p.sg_event_id = m.sg_event_id
+    WHERE coalesce(p.owned_count_last_7d, 0) = 0   -- we hold no inventory
+      AND p.sg_datetime_utc > now()                -- future events only
+      AND m.days_with_sales >= 2                   -- real MA, not a one-off spike
+  ),
+  scored AS (
+    SELECT e.*,
+      -- percent_rank() is double precision; cast to numeric so round() resolves
+      (percent_rank() OVER (ORDER BY ma7_volume))::numeric AS pct_volume,
+      (percent_rank() OVER (ORDER BY ma7_median))::numeric AS pct_median
+    FROM elig e
+  ),
+  ranked AS (
+    SELECT s.*,
+      (pct_volume + pct_median) AS chart_score,
+      row_number() OVER (
+        ORDER BY (pct_volume + pct_median) DESC, ma7_gross DESC NULLS LAST, ma7_volume DESC
+      ) AS rnk
+    FROM scored s
+  )
+  INSERT INTO public.sg_market_chart (
+    chart_date, sg_event_id, rank, chart_score, pct_volume, pct_median,
+    ma7_volume, ma7_median, ma7_gross, days_with_sales,
+    prev_rank, peak_rank, days_on_chart,
+    tevo_event_id, sg_event_name, sg_venue_name, sg_datetime_utc)
+  SELECT
+    v_today, r.sg_event_id, r.rnk::int, round(r.chart_score, 4),
+    round(r.pct_volume, 4), round(r.pct_median, 4),
+    round(r.ma7_volume, 1), round(r.ma7_median, 2), round(r.ma7_gross, 2), r.days_with_sales,
+    prev.rank,
+    -- peak = best of (today's rank, lowest rank ever before today)
+    LEAST(r.rnk::int,
+          coalesce((SELECT min(h.rank) FROM public.sg_market_chart h
+                    WHERE h.sg_event_id = r.sg_event_id), r.rnk::int)),
+    CASE WHEN prev.rank IS NOT NULL THEN coalesce(prev.days_on_chart, 0) + 1 ELSE 1 END,
+    r.tevo_event_id, r.sg_event_name, r.sg_venue_name, r.sg_datetime_utc
+  FROM ranked r
+  LEFT JOIN public.sg_market_chart prev
+    ON prev.sg_event_id = r.sg_event_id AND prev.chart_date = v_prev;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  -- retention: keep 90 days of chart history
+  DELETE FROM public.sg_market_chart WHERE chart_date < v_today - 90;
+
+  RETURN v_count;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.rebuild_sg_market_chart() FROM anon, PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rebuild_sg_market_chart() TO service_role;
+
+COMMENT ON FUNCTION public.rebuild_sg_market_chart() IS
+  'Rebuilds today''s sg_market_chart: top non-owned future SG events ranked by '
+  'percent_rank(7d-MA sales volume) + percent_rank(7d-MA sales median). Carries '
+  'prev_rank/peak_rank/days_on_chart for Billboard-style movement. Daily cron @ 11:05 UTC.';
+
+-- ---------- 3. Read RPC (email-gated, paged: top 50 + the rest) ----------
+CREATE OR REPLACE FUNCTION public.get_sg_market_chart(
+  p_offset integer DEFAULT 0,
+  p_limit  integer DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_email text;
+  v_date  date;
+  v_total int;
+  v_rows  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT max(chart_date) INTO v_date FROM public.sg_market_chart;
+  IF v_date IS NULL THEN
+    RETURN jsonb_build_object('chart_date', NULL, 'total', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  SELECT count(*) INTO v_total FROM public.sg_market_chart WHERE chart_date = v_date;
+
+  SELECT coalesce(jsonb_agg(r.obj ORDER BY (r.obj->>'rank')::int), '[]'::jsonb)
+  INTO v_rows
+  FROM (
+    SELECT jsonb_build_object(
+      'rank',            m.rank,
+      'prev_rank',       m.prev_rank,
+      'rank_delta',      CASE WHEN m.prev_rank IS NULL THEN NULL ELSE m.prev_rank - m.rank END,
+      'is_new',          (m.prev_rank IS NULL),
+      'peak_rank',       m.peak_rank,
+      'days_on_chart',   m.days_on_chart,
+      'sg_event_id',     m.sg_event_id,
+      'tevo_event_id',   m.tevo_event_id,
+      'sg_event_name',   m.sg_event_name,
+      'sg_venue_name',   m.sg_venue_name,
+      'sg_datetime_utc', to_char(m.sg_datetime_utc AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'ma7_volume',      m.ma7_volume,
+      'ma7_median',      m.ma7_median,
+      'ma7_gross',       m.ma7_gross,
+      'pct_volume',      m.pct_volume,
+      'pct_median',      m.pct_median,
+      'chart_score',     m.chart_score,
+      'days_with_sales', m.days_with_sales
+    ) AS obj
+    FROM public.sg_market_chart m
+    WHERE m.chart_date = v_date
+    ORDER BY m.rank
+    OFFSET greatest(coalesce(p_offset, 0), 0)
+    LIMIT  least(coalesce(p_limit, 50), 500)
+  ) r;
+
+  RETURN jsonb_build_object('chart_date', v_date, 'total', v_total, 'rows', v_rows);
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_sg_market_chart(integer, integer) FROM anon, PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_sg_market_chart(integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.get_sg_market_chart(integer, integer) IS
+  'Returns {chart_date,total,rows[]} for the latest sg_market_chart day, paged by '
+  'rank (offset/limit). Powers the terminal home "TOP 50 — SG SELLING, WE''RE NOT IN" '
+  'panel: tab 1 = offset 0/limit 50, tab 2 = offset 50. Email-gated @s4kent.com.';
+
+-- ---------- 4. Daily rebuild cron (gated) ----------
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min, daily_max_fires, enabled, notes)
+VALUES
+  ('sg_market_chart_rebuild_daily',
+   ARRAY[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],
+   720, 720, 2, true,
+   'Daily rebuild of sg_market_chart (Top-50 non-owned SG sales chart, home panel). Fires once @ 11:05 UTC; 720-min gate guards against double-fire.')
+ON CONFLICT (jobname) DO UPDATE
+  SET peak_hours_et = EXCLUDED.peak_hours_et,
+      peak_min_interval_min = EXCLUDED.peak_min_interval_min,
+      offpeak_min_interval_min = EXCLUDED.offpeak_min_interval_min,
+      daily_max_fires = EXCLUDED.daily_max_fires,
+      enabled = true,
+      notes = EXCLUDED.notes,
+      updated_at = now();
+
+SELECT cron.schedule('sg_market_chart_rebuild_daily', '5 11 * * *', $cron$
+  DO $body$ BEGIN
+    IF NOT public.cron_should_fire('sg_market_chart_rebuild_daily') THEN RETURN; END IF;
+    SET LOCAL statement_timeout = '120s';
+    PERFORM public.rebuild_sg_market_chart();
+  END $body$;
+$cron$);
+
+-- ---------- 5. Seed today's chart so the panel renders immediately on apply ----------
+SELECT public.rebuild_sg_market_chart();


### PR DESCRIPTION
## What

Replaces the home page **BLIND SPOTS — SG SELLING, WE'RE NOT** pressure panel with a **Billboard-style "TOP 50 — SG SELLING, WE'RE NOT IN"** chart: a daily-refreshed leaderboard of SeatGeek market events we hold **zero owned inventory** in, ranked by sales activity.

## Scoring — "high volume and/or high median price"

```
chart_score = percent_rank(7d-MA daily sales volume)
            + percent_rank(7d-MA sales median price)        (0..2)
```

High on **either** axis charts well; high on **both** tops it. Pure GMV (vol×price) was rejected because it buries the high-price/low-volume opportunities (Ariana Grande, F1).

**Eligibility:** `owned_count_last_7d = 0`, future event, ≥2 days of sales in the trailing 7d (a real MA, not a one-off spike).

## Changes

- **Migration `20260606120000_sg_market_chart_top50.sql`**
  - `sg_market_chart` table — one ranked row set per UTC day, carrying `prev_rank` / `peak_rank` / `days_on_chart` for Billboard-style movement (▲/▼/NEW). 90-day retention.
  - `rebuild_sg_market_chart()` — daily rebuild (SECDEF).
  - `get_sg_market_chart(offset, limit)` — paged read RPC, email-gated `@s4kent.com`. Returns `{chart_date, total, rows[]}`.
  - Daily gated cron `sg_market_chart_rebuild_daily` @ 11:05 UTC + seed rebuild on apply.
- **Home FE** (`home.js`, `index.html`, `style.css`)
  - Two tabs: **Top 50** (rank 1–50) and **The Rest** (rank 51+, capped server-side).
  - Columns: rank · movement · event · venue · T-days · 7d-MA vol/day · median · GMV/day · score · peak·days-on-chart.
  - Old `get_blind_spots_sg_selling` RPC left **intact** — `movers.html` still uses it.

## Validation

Dry-ran the ranking logic read-only against prod: **1,006 events qualify** (so "The Rest" is well-populated). Top entries: Alan Jackson (high on both, 1.994), BTS / Morgan Wallen (high volume), Olivia Dean / Foo Fighters (balanced). The read-only dry-run also caught a `round(double precision, int)` bug pre-apply (`percent_rank()` is double precision) — fixed by casting the percentiles to `numeric`.

## ⚠️ Operator action required

Prod migration apply is gated (CLAUDE.md §1). The new RPC must be applied to prod before the home panel will load. The migration seeds today's chart on apply so it renders immediately.

https://claude.ai/code/session_01SMFjU8azdQih4PsjPpipw1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMFjU8azdQih4PsjPpipw1)_