### PR TITLE
feat(d0/event): stack SG + SeatData market-sales bars in Inventory & sales chart

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -77,6 +77,7 @@
            TM Listings is its replacement. Opted-in TP rows still surface in the TD Markets tab. -->
       <button class="event-tab" data-tab="tm-listings" role="tab" aria-selected="false">TM Listings <span class="tab-count" id="tabCountTmListings"></span></button>
       <button class="event-tab" data-tab="sg-sales" role="tab" aria-selected="false">SG Sales <span class="tab-count" id="tabCountSgSales"></span></button>
+      <button class="event-tab" data-tab="seatdata-sales" role="tab" aria-selected="false">SeatData Sales <span class="tab-count" id="tabCountSeatdataSales"></span></button>
       <button class="event-tab" data-tab="td-markets" role="tab" aria-selected="false">TD Markets <span class="tab-count" id="tabCountTdMarkets"></span></button>
       <span class="event-tabs-sep" aria-hidden="true">|</span>
       <button class="event-tab" data-tab="alerts" role="tab" aria-selected="false">★ Watchlist &amp; Alerts <span class="tab-count" id="tabCountAlerts"></span></button>
@@ -374,6 +375,26 @@
           </span>
         </div>
         <div id="sgSalesFullBody"><div class="empty">Click the tab to load.</div></div>
+      </section>
+    </div>
+
+    <div class="tab-pane" id="paneSeatdataSales" role="tabpanel" hidden>
+      <section id="seatdata-sales-full">
+        <div class="panel-title row">
+          <span>SEATDATA SALES — FULL (DISTINCT ON content_hash)</span>
+          <span class="sales-window-ctrl">
+            <label class="muted small" for="seatdataSalesWindow">window</label>
+            <select id="seatdataSalesWindow" class="range-select">
+              <option value="1">1d</option>
+              <option value="7">7d</option>
+              <option value="30" selected>30d</option>
+              <option value="60">60d</option>
+              <option value="90">90d</option>
+            </select>
+            <span class="muted small" id="seatdataSalesFullMeta">tap tab to load</span>
+          </span>
+        </div>
+        <div id="seatdataSalesFullBody"><div class="empty">Click the tab to load.</div></div>
       </section>
     </div>
 

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -130,6 +130,7 @@
     wireAlertsToggle();
     wireTabs(eventId);
     wireSalesWindow(eventId);
+    wireSeatdataSalesWindow(eventId);
     // Path-C-only enrichment RPCs fire in parallel — render even when
     // fetchPayload (Path A / Path C v3) fails. PR #205 cross-source +
     // PR redesign localized weather + SG zones/splits all independent.
@@ -847,6 +848,7 @@
       { key: 'sg_list_med',     label: 'SG market',   color: '#22d3ee', width: 1.5, dash: null,    data: mergeDurable(extSeries.sg_listings_median       || [], durMed('sg_list')) },
       { key: 'sg_own_med',      label: 'SG owned',    color: '#fb7185', width: 1,   dash: [2, 3],  data: mergeDurable(extSeries.sg_listings_owned_median || [], durMed('sg_own')) },
       { key: 'sg_sale_med',     label: 'SG sales',    color: '#84cc16', width: 1.5, dash: [6, 3],  data: extSeries.sg_sales_median          || [] },
+      { key: 'sd_sale_med',     label: 'SeatData sales', color: '#f59e0b', width: 1.5, dash: [6, 3], data: extSeries.sd_sales_median        || [] },
       { key: 'td_sh_med',       label: 'StubHub',     color: '#f97316', width: 1.25, dash: null,   data: tdS.sh || durMed('sh') },
       { key: 'td_gt_med',       label: 'GameTime',    color: '#34d399', width: 1.25, dash: null,   data: tdS.gt || durMed('gt') },
       { key: 'td_vd_med',       label: 'VividSeats',  color: '#c084fc', width: 1.25, dash: null,   data: tdS.vd || durMed('vd') },
@@ -1077,6 +1079,11 @@
       { key: 'counts_market', label: 'TEvo mkt qty',   color: '#94a3b8', width: 1,   dash: [2,2],  scale: 'y',  data: mergeDurable(chart.counts_market, durCnt('evo_tix')) },
       { key: 'sg_list_ct',    label: 'SG mkt qty',     color: '#22d3ee', width: 1.5, dash: null,   scale: 'y',  data: mergeDurable(extSeries.sg_listings_count || [], durCnt('sg_tix')) },
       { key: 'sg_sale_ct',    label: 'SG sale ct',     color: '#84cc16', width: 1,   dash: null,   scale: 'yr', bars: true, data: extSeries.sg_sales_count || [] },
+      // SeatData market sales (right axis count) — parallel to SG sale ct.
+      // Keyed on tevo_event_id server-side, so present even when SG is hidden.
+      { key: 'sd_sale_ct',    label: 'SeatData sale ct', color: '#f59e0b', width: 1, dash: null, scale: 'yr', bars: true, data: extSeries.sd_sales_count || [] },
+      // OUR sell-through — combined EVO+TickPick+Vivid tickets sold per bucket.
+      { key: 'our_sale_ct',   label: 'Our sales ct',   color: '#ec4899', width: 1,   dash: null,   scale: 'yr', bars: true, data: extSeries.orders_count || [] },
     ];
     // Overlay TD listing-count series (dashed, hidden by default — user-togglable)
     if (_tdInvCountSeries) {
@@ -3149,7 +3156,7 @@
     'sg-listings': false, 'evo-listings': false,
     'sh-listings': false, 'gt-listings': false, 'vd-listings': false,
     'tm-listings': false,  // tp-listings removed 2026-06-07: TP demoted to opt-in, TM replaces it
-    'sg-sales': false, 'our-orders': false, 'alerts': false,
+    'sg-sales': false, 'seatdata-sales': false, 'our-orders': false, 'alerts': false,
   } };
 
   function wireTabs(eventId) {
@@ -3182,6 +3189,8 @@
         updateTdListingsTabCount();
       } else if (tabId === 'sg-sales' && !_tabState.loaded['sg-sales']) {
         await loadSgSalesFull(eventId);
+      } else if (tabId === 'seatdata-sales' && !_tabState.loaded['seatdata-sales']) {
+        await loadSeatdataSalesFull(eventId);
       } else if (tabId === 'td-markets' && !_tabState.loaded['td-markets']) {
         await loadTdMarketsFull(eventId);
       } else if (tabId === 'alerts') {
@@ -3223,6 +3232,7 @@
       'vd-listings':  'paneVdListings',
       'tm-listings':  'paneTmListings',
       'sg-sales':     'paneSgSales',
+      'seatdata-sales': 'paneSeatdataSales',
       'td-markets':   'paneTdMarkets',
       'alerts':       'paneAlerts',
       'seatmap':      'paneSeatmap',
@@ -3261,6 +3271,17 @@
       const body = document.getElementById('sgSalesFullBody');
       if (body) body.innerHTML = '<div class="empty">Loading…</div>';
       await loadSgSalesFull(eventId);
+    });
+  }
+
+  function wireSeatdataSalesWindow(eventId) {
+    const sel = document.getElementById('seatdataSalesWindow');
+    if (!sel) return;
+    sel.addEventListener('change', async () => {
+      _tabState.loaded['seatdata-sales'] = false;
+      const body = document.getElementById('seatdataSalesFullBody');
+      if (body) body.innerHTML = '<div class="empty">Loading…</div>';
+      await loadSeatdataSalesFull(eventId);
     });
   }
 
@@ -4388,6 +4409,72 @@
         <td class="num">${r.broadcast_price != null ? '$' + T.fmtNum(Math.round(r.broadcast_price)) : '—'}</td>
         <td>${escapeHtml(r.stock_type || '—')}</td>
         <td class="num">${r.days_to_event_at_sale != null ? T.fmtNum(r.days_to_event_at_sale) : '—'}</td>`;
+      tb.appendChild(tr);
+    });
+    host.appendChild(tbl);
+    body.innerHTML = '';
+    body.appendChild(host);
+  }
+
+  // ---------- SeatData Sales (full) — clone of SG Sales, keyed on tevo_event_id ----------
+  async function loadSeatdataSalesFull(eventId) {
+    const body = document.getElementById('seatdataSalesFullBody');
+    const meta = document.getElementById('seatdataSalesFullMeta');
+    const sel = document.getElementById('seatdataSalesWindow');
+    const windowDays = sel ? (parseInt(sel.value, 10) || 30) : 30;
+    if (body) body.innerHTML = '<div class="empty">Loading SeatData sales…</div>';
+    if (meta) meta.textContent = 'loading…';
+    const t0 = performance.now();
+    const res = await rpcOrNull('get_event_seatdata_sales_full', {
+      p_event_id: eventId, p_window_days: windowDays
+    });
+    if (res.error) {
+      if (meta) meta.textContent = 'error';
+      if (body) body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message || '')}</div>`;
+      return;
+    }
+    _tabState.loaded['seatdata-sales'] = true;
+    renderSeatdataSalesFull(res.data, performance.now() - t0, windowDays);
+  }
+
+  function renderSeatdataSalesFull(d, ms, windowDays) {
+    const body = document.getElementById('seatdataSalesFullBody');
+    const meta = document.getElementById('seatdataSalesFullMeta');
+    const countChip = document.getElementById('tabCountSeatdataSales');
+    if (!body) return;
+    if (!d || d.hidden) {
+      body.innerHTML = '<div class="empty">no SeatData sales for this event</div>';
+      if (meta) meta.textContent = '0 rows';
+      if (countChip) countChip.textContent = '0';
+      return;
+    }
+    const rows = d.rows || [];
+    const sdId = d.sd_event_id != null ? ` · sd_event_id ${d.sd_event_id}` : '';
+    if (meta) meta.textContent = `${rows.length} rows · ${ms.toFixed(0)}ms · ${windowDays}d window${sdId}`;
+    if (countChip) countChip.textContent = String(rows.length);
+    if (!rows.length) {
+      body.innerHTML = `<div class="empty">no SeatData sales in last ${windowDays} days</div>`;
+      return;
+    }
+    const host = document.createElement('div');
+    host.className = 'full-list-host';
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Sold</th><th>Zone</th><th>Section</th><th>Row</th>
+        <th class="num">Qty</th><th class="num">Price</th>
+      </tr></thead><tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${T.fmtDate(r.sale_timestamp)}</td>
+        <td>${escapeHtml(r.zone || '—')}</td>
+        <td>${escapeHtml(r.section || '—')}</td>
+        <td>${escapeHtml(r.row || '—')}</td>
+        <td class="num">${T.fmtNum(r.quantity)}</td>
+        <td class="num">${r.price != null ? '$' + T.fmtNum(Math.round(r.price)) : '—'}</td>`;
       tb.appendChild(tr);
     });
     host.appendChild(tbl);

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -68,9 +68,11 @@
   // (started 2026-05-27) so depth is shallow today and deepens as it fills.
   // Shape: { med:{evo_owned,evo_mkt,sg_list,sg_own,sh,gt,vd}, cnt:{evo_own,evo_tix,sg_tix,sh,gt,vd} }.
   let _dailyDurable = null;
-  // TD inv listing-count series (SH/GT/VD/TP/TM/TMr) are VISIBLE by default
-  // (operator request 2026-06-08) — all six platforms' market qty show on first
-  // paint alongside SG/TEvo. Still individually togglable from the legend.
+  // TD inv listing-count series: StubHub shows by default; the other five
+  // (GT/VD/TP/TM/TMr) start hidden and are user-togglable in the legend
+  // (operator request 2026-06-08 — keep first paint clean, SH as the reference).
+  ['td-gt-cnt', 'td-vd-cnt',
+   'td-tp-cnt', 'td-tm-cnt', 'td-tmr-cnt'].forEach(k => _chartVisible.set(k, false));
   // Declutter the default view (UI rebuild 2026-06-03): the redundant/secondary
   // medians start hidden — the user opts them in from the legend. Keeps the
   // first paint to one clean line per source instead of 9 overlapping lines.

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -1081,11 +1081,14 @@
       { key: 'counts_owned',  label: 'TEvo owned qty', color: '#60a5fa', width: 1.5, dash: null,   scale: 'y',  fill: 'rgba(96,165,250,0.08)', data: mergeDurable(chart.counts_owned,  durCnt('evo_own')) },
       { key: 'counts_market', label: 'TEvo mkt qty',   color: '#94a3b8', width: 1,   dash: [2,2],  scale: 'y',  data: mergeDurable(chart.counts_market, durCnt('evo_tix')) },
       { key: 'sg_list_ct',    label: 'SG mkt qty',     color: '#22d3ee', width: 1.5, dash: null,   scale: 'y',  data: mergeDurable(extSeries.sg_listings_count || [], durCnt('sg_tix')) },
-      { key: 'sg_sale_ct',    label: 'SG sale ct',     color: '#84cc16', width: 1,   dash: null,   scale: 'yr', bars: true, data: extSeries.sg_sales_count || [] },
-      // SeatData market sales (right axis count) — parallel to SG sale ct.
-      // Keyed on tevo_event_id server-side, so present even when SG is hidden.
-      { key: 'sd_sale_ct',    label: 'SeatData sale ct', color: '#f59e0b', width: 1, dash: null, scale: 'yr', bars: true, data: extSeries.sd_sales_count || [] },
-      // OUR sell-through — combined EVO+TickPick+Vivid tickets sold per bucket.
+      // Market sales (right axis) — STACKED: SG (bottom) + SeatData (top) per
+      // bucket. SeatData is listed first so it draws BEHIND at the cumulative
+      // height (SG+SeatData); SG draws after with an opaque fill, overdrawing the
+      // lower segment → a 2-colour stacked bar. Cumulative value is computed
+      // post-build (see below); the tooltip still shows each source's own count.
+      { key: 'sd_sale_ct',    label: 'SeatData sale ct', color: '#f59e0b', width: 1, dash: null, scale: 'yr', bars: true, stack: 'mktSales', data: extSeries.sd_sales_count || [] },
+      { key: 'sg_sale_ct',    label: 'SG sale ct',     color: '#84cc16', width: 1,   dash: null,   scale: 'yr', bars: true, stack: 'mktSales', data: extSeries.sg_sales_count || [] },
+      // OUR sell-through — combined EVO+TickPick+Vivid tickets sold per bucket (not stacked).
       { key: 'our_sale_ct',   label: 'Our sales ct',   color: '#ec4899', width: 1,   dash: null,   scale: 'yr', bars: true, data: extSeries.orders_count || [] },
     ];
     // Overlay TD listing-count series (dashed, hidden by default — user-togglable)
@@ -1110,6 +1113,24 @@
         { key: 'td-tmr-cnt', label: 'TMr listings', color: '#fb7185', width: 1, dash: [4, 3], scale: 'y', data: famCnt('tmr') });
     }
     const { xs } = buildSeriesData(specs);
+    // Stack the two market-sales bar series (SeatData on top of SG): SeatData's
+    // DRAWN value becomes SG+SeatData while SG keeps its own; with opaque fills
+    // and SG drawn after (overdraw), each bar reads as SG (bottom) + SeatData
+    // (top). tipProjected preserves the raw per-source counts for the tooltip.
+    const _sgB = specs.find(s => s.key === 'sg_sale_ct');
+    const _sdB = specs.find(s => s.key === 'sd_sale_ct');
+    if (_sgB && _sdB && _sgB.projected && _sdB.projected) {
+      _sdB.tipProjected = _sdB.projected.slice();   // raw SeatData counts (tooltip)
+      // Only fold SG into SeatData's height when SG is actually drawn — otherwise
+      // (SG hidden) the SeatData bar would over-represent. Applies on every full
+      // render (initial + resize), so the stack stays truthful per visibility.
+      if (_chartVisible.get('sg_sale_ct') !== false) {
+        _sdB.projected = _sdB.projected.map((v, i) => {
+          const sg = _sgB.projected[i];
+          return (v == null && sg == null) ? null : (v || 0) + (sg || 0);
+        });
+      }
+    }
     _chartLastBuildInv = { specs, xs };
 
     const xRange = clipRangeForHours(_chartInvHours, xs);
@@ -1197,7 +1218,9 @@
     const rows = [];
     build.specs.forEach(s => {
       if (_chartVisible.get(s.key) === false) return;
-      const v = s.projected[idx];
+      // Stacked series carry a cumulative `projected` for drawing; tipProjected
+      // (when present) holds the raw per-source value so the tooltip is truthful.
+      const v = (s.tipProjected || s.projected)[idx];
       if (v == null) return;
       const fmt = chartKey === 'price' ? '$' + Math.round(v) : Math.round(v).toString();
       rows.push(

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -68,9 +68,9 @@
   // (started 2026-05-27) so depth is shallow today and deepens as it fills.
   // Shape: { med:{evo_owned,evo_mkt,sg_list,sg_own,sh,gt,vd}, cnt:{evo_own,evo_tix,sg_tix,sh,gt,vd} }.
   let _dailyDurable = null;
-  // Initialize TD inv series as hidden by default (user-togglable in legend).
-  ['td-sh-cnt', 'td-gt-cnt', 'td-vd-cnt',
-   'td-tp-cnt', 'td-tm-cnt', 'td-tmr-cnt'].forEach(k => _chartVisible.set(k, false));
+  // TD inv listing-count series (SH/GT/VD/TP/TM/TMr) are VISIBLE by default
+  // (operator request 2026-06-08) — all six platforms' market qty show on first
+  // paint alongside SG/TEvo. Still individually togglable from the legend.
   // Declutter the default view (UI rebuild 2026-06-03): the redundant/secondary
   // medians start hidden — the user opts them in from the legend. Keeps the
   // first paint to one clean line per source instead of 9 overlapping lines.

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -69,7 +69,8 @@
   // Shape: { med:{evo_owned,evo_mkt,sg_list,sg_own,sh,gt,vd}, cnt:{evo_own,evo_tix,sg_tix,sh,gt,vd} }.
   let _dailyDurable = null;
   // Initialize TD inv series as hidden by default (user-togglable in legend).
-  ['td-sh-cnt', 'td-gt-cnt', 'td-vd-cnt'].forEach(k => _chartVisible.set(k, false));
+  ['td-sh-cnt', 'td-gt-cnt', 'td-vd-cnt',
+   'td-tp-cnt', 'td-tm-cnt', 'td-tmr-cnt'].forEach(k => _chartVisible.set(k, false));
   // Declutter the default view (UI rebuild 2026-06-03): the redundant/secondary
   // medians start hidden — the user opts them in from the legend. Keeps the
   // first paint to one clean line per source instead of 9 overlapping lines.
@@ -1093,6 +1094,18 @@
         { key: 'td-gt-cnt', label: 'GT listings', color: '#2dd4bf', width: 1, dash: [4, 3], scale: 'y', data: _tdInvCountSeries.gt });
       if (_tdInvCountSeries.vd.length) specs.push(
         { key: 'td-vd-cnt', label: 'VD listings', color: '#a855f7', width: 1, dash: [4, 3], scale: 'y', data: _tdInvCountSeries.vd });
+    }
+    // TP / TM / TM-resale listing-count overlays (from the full TD family, hidden
+    // by default — user-togglable). Counts live in _tdFamily[*].cnt, not the
+    // sh/gt/vd-only _tdInvCountSeries above.
+    if (_tdFamily) {
+      const famCnt = (k) => (_tdFamily[k] && _tdFamily[k].cnt) || [];
+      if (famCnt('tp').length) specs.push(
+        { key: 'td-tp-cnt',  label: 'TP listings',  color: '#eab308', width: 1, dash: [4, 3], scale: 'y', data: famCnt('tp') });
+      if (famCnt('tm').length) specs.push(
+        { key: 'td-tm-cnt',  label: 'TM listings',  color: '#38bdf8', width: 1, dash: [4, 3], scale: 'y', data: famCnt('tm') });
+      if (famCnt('tmr').length) specs.push(
+        { key: 'td-tmr-cnt', label: 'TMr listings', color: '#fb7185', width: 1, dash: [4, 3], scale: 'y', data: famCnt('tmr') });
     }
     const { xs } = buildSeriesData(specs);
     _chartLastBuildInv = { specs, xs };

--- a/supabase/migrations/20260608170000_chart_ext_seatdata_orders.sql
+++ b/supabase/migrations/20260608170000_chart_ext_seatdata_orders.sql
@@ -1,0 +1,397 @@
+-- Migration 20260608170000 · lane:A1 · writes:get_event_chart_extended,get_event_seatdata_sales_full · reads:seatgeek_listings_snapshots,seatgeek_sales_snapshots,seatgeek_event_xref,seatdata_sales_snapshots,seatdata_event_xref,evo_order_items,evo_orders,tickpick_orders,vivid_orders,espn_injuries_snapshots,espn_event_snapshots,event_xref · pre:20260608032000 · auth:operator-approved 2026-06-08
+--
+-- D0 — wire SeatData sales + our orders (EVO+TickPick+Vivid) into the
+-- Inventory & sales chart, and add a SeatData Sales top tab.
+--
+-- Two functions in this migration:
+--
+-- 1. CREATE OR REPLACE get_event_chart_extended (IDENTICAL 4-arg signature) —
+--    additive: three new bucketed series appended to the `series` object,
+--    every existing key untouched so the FE call is unchanged:
+--      series.sd_sales_count   SeatData sales count per bucket (DISTINCT ON content_hash)
+--      series.sd_sales_median  SeatData sales price median per bucket (price chart)
+--      series.orders_count     OUR sell-through (EVO+TP+Vivid) tickets-sold per bucket
+--    SeatData + orders are keyed by tevo_event_id directly (NOT the SG bridge),
+--    so they render even when SG is hidden (v_sg_hidden).
+--
+-- 2. NEW get_event_seatdata_sales_full — clone of get_event_sg_sales_full
+--    (mig 20260518030000) for the SeatData Sales tab. DISTINCT ON content_hash.
+--
+-- Sold-status filter (verified against live data 2026-06-08) — keep live, drop dead:
+--   EVO    evo_orders.state       keep accepted/completed; drop rejected/canceled/canceled_post_acceptance
+--   TICKPICK  ⚠ liveness is order_status (CONFIRMED/REJECTED), NOT status
+--             (status is delivery state Scheduled/Rescheduled). Filtering on
+--             `status` would silently keep cancelled orders — DO NOT "fix" this
+--             back to status.
+--   VIVID  vivid_orders.status    keep PENDING_SHIPMENT + shipped/completed; drop ignored_tbd_postponed/CANCELLED/CANCELED
+--
+-- Dedup: ONLY SeatData needs DISTINCT ON (append snapshot table, content-hashed).
+-- Order tables are upsert-by-PK (not firehose snapshots) — no DISTINCT ON. SG
+-- sales already dedup by sg_sale_id (unchanged).
+--
+-- Per A1 SECDEF pattern: SECDEF + @s4kent.com gate + REVOKE PUBLIC + GRANT
+-- anon/authenticated. STABLE.
+
+CREATE OR REPLACE FUNCTION public.get_event_chart_extended(
+  p_event_id        integer,
+  p_chart_hours     integer DEFAULT 168,
+  p_espn_home_team  text    DEFAULT NULL,
+  p_espn_away_team  text    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email          text;
+  v_sg_event_id    bigint;
+  v_espn_event_id  text;
+  v_espn_league    text;
+  v_home_team      text := p_espn_home_team;
+  v_away_team      text := p_espn_away_team;
+  v_hours          int  := greatest(1, least(coalesce(p_chart_hours, 168), 4320));
+  v_bucket_secs    int;
+  v_window_start   timestamptz;
+  v_now            timestamptz := now();
+  v_sg_listings    jsonb := '[]'::jsonb;
+  v_sg_listings_own jsonb := '[]'::jsonb;
+  v_sg_listings_ct jsonb := '[]'::jsonb;
+  v_sg_sales       jsonb := '[]'::jsonb;
+  v_sg_sales_ct    jsonb := '[]'::jsonb;
+  v_sd_sales       jsonb := '[]'::jsonb;   -- SeatData median price / bucket
+  v_sd_sales_ct    jsonb := '[]'::jsonb;   -- SeatData sale count / bucket
+  v_orders_ct      jsonb := '[]'::jsonb;   -- combined our-orders qty / bucket
+  v_injuries       jsonb := '[]'::jsonb;
+  v_game_state     jsonb := '[]'::jsonb;
+  v_sg_hidden      boolean := false;
+  v_sg_reason      text;
+BEGIN
+  -- ---------- auth gate (mirrors v3 / sibling RPCs) ----------
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_window_start := v_now - make_interval(hours => v_hours);
+
+  -- ---------- bucket size (adapts to window length) ----------
+  v_bucket_secs := CASE
+    WHEN v_hours <=  24 THEN  900   -- 15 min
+    WHEN v_hours <=  72 THEN 3600   --  1 hr
+    WHEN v_hours <= 168 THEN 7200   --  2 hr
+    WHEN v_hours <= 720 THEN 21600  --  6 hr
+    ELSE 86400                      --  1 day
+  END;
+
+  -- ---------- bridge resolution ----------
+  SELECT sg_event_id INTO v_sg_event_id
+  FROM public.seatgeek_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  IF v_sg_event_id IS NULL THEN
+    v_sg_hidden := true;
+    v_sg_reason := 'no_sg_bridge';
+  END IF;
+
+  -- ESPN linkage (always attempt — annotations may render even when SG is hidden)
+  SELECT ex.espn_event_id, ex.espn_league
+  INTO v_espn_event_id, v_espn_league
+  FROM public.event_xref ex
+  WHERE ex.tevo_event_id = p_event_id LIMIT 1;
+
+  -- Auto-resolve home/away team IDs if not supplied by FE.
+  -- Prefer espn_event_date_lookup (populated for forward-look events) over
+  -- espn_event_snapshots (gameday-scope only per §10 drift watchlist).
+  IF (v_home_team IS NULL OR v_away_team IS NULL) AND v_espn_event_id IS NOT NULL THEN
+    SELECT home_team_id, away_team_id
+    INTO v_home_team, v_away_team
+    FROM public.espn_event_date_lookup
+    WHERE espn_event_id = v_espn_event_id LIMIT 1;
+
+    -- Snapshot fallback for past games where date_lookup is sparse
+    IF v_home_team IS NULL OR v_away_team IS NULL THEN
+      SELECT home_team_id, away_team_id
+      INTO v_home_team, v_away_team
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+      ORDER BY captured_at DESC LIMIT 1;
+    END IF;
+  END IF;
+
+  -- ---------- SG listings series (DISTINCT ON sglid, then bucket) ----------
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sglid)
+        sglid, captured_at, broadcast_price, quantity, is_broker_owned
+      FROM public.seatgeek_listings_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+      ORDER BY sglid, captured_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), captured_at, '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price, quantity, is_broker_owned
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p_owned) ORDER BY bucket) FILTER (WHERE median_p_owned IS NOT NULL), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', total_qty) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_listings, v_sg_listings_own, v_sg_listings_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) FILTER (WHERE is_broker_owned) AS median_p_owned,
+        SUM(quantity)::int AS total_qty
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- SG sales series (DISTINCT ON sg_sale_id, then bucket on sale_at_utc) ----------
+  IF NOT v_sg_hidden THEN
+    WITH deduped AS (
+      SELECT DISTINCT ON (sg_sale_id)
+        sg_sale_id, sale_at_utc, pulled_at, broadcast_price, quantity
+      FROM public.seatgeek_sales_snapshots
+      WHERE sg_event_id = v_sg_event_id
+        AND coalesce(sale_at_utc, pulled_at) > v_window_start
+        AND coalesce(sale_at_utc, pulled_at) <= v_now
+      ORDER BY sg_sale_id, pulled_at DESC
+    ),
+    bucketed AS (
+      SELECT
+        date_bin(make_interval(secs => v_bucket_secs), coalesce(sale_at_utc, pulled_at), '2000-01-01'::timestamptz) AS bucket,
+        broadcast_price
+      FROM deduped
+      WHERE broadcast_price IS NOT NULL
+    )
+    SELECT
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket), '[]'::jsonb),
+      coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', sale_ct) ORDER BY bucket), '[]'::jsonb)
+    INTO v_sg_sales, v_sg_sales_ct
+    FROM (
+      SELECT
+        bucket,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY broadcast_price) AS median_p,
+        count(*)::int AS sale_ct
+      FROM bucketed GROUP BY bucket
+    ) b;
+  END IF;
+
+  -- ---------- SeatData sales series (DISTINCT ON content_hash, bucket on sale_timestamp) ----------
+  -- Keyed by tevo_event_id directly (independent of the SG bridge), so it
+  -- renders even when SG is hidden. count(*) (sale rows) parallels SG sale ct.
+  WITH deduped AS (
+    SELECT DISTINCT ON (content_hash)
+      content_hash, sale_timestamp, price, quantity
+    FROM public.seatdata_sales_snapshots
+    WHERE tevo_event_id = p_event_id
+      AND sale_timestamp > v_window_start
+      AND sale_timestamp <= v_now
+    ORDER BY content_hash, pulled_at DESC
+  ),
+  bucketed AS (
+    SELECT
+      date_bin(make_interval(secs => v_bucket_secs), sale_timestamp, '2000-01-01'::timestamptz) AS bucket,
+      price
+    FROM deduped
+  )
+  SELECT
+    coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', median_p) ORDER BY bucket) FILTER (WHERE median_p IS NOT NULL), '[]'::jsonb),
+    coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', sale_ct) ORDER BY bucket), '[]'::jsonb)
+  INTO v_sd_sales, v_sd_sales_ct
+  FROM (
+    SELECT
+      bucket,
+      percentile_cont(0.5) WITHIN GROUP (ORDER BY price) FILTER (WHERE price IS NOT NULL) AS median_p,
+      count(*)::int AS sale_ct
+    FROM bucketed GROUP BY bucket
+  ) b;
+
+  -- ---------- OUR orders: EVO + TickPick + Vivid (sold-status filtered, then bucket) ----------
+  -- No DISTINCT ON — these are upsert-by-PK tables, not firehose snapshots.
+  WITH norm AS (
+    -- EVO: line-items joined to order header for state + created_at
+    SELECT o.evo_created_at AS ts, coalesce(oi.quantity, 1) AS qty
+    FROM public.evo_order_items oi
+    JOIN public.evo_orders o ON o.evo_order_id = oi.evo_order_id
+    WHERE oi.event_id = p_event_id
+      AND coalesce(o.state, '') NOT IN ('rejected', 'canceled', 'cancelled', 'canceled_post_acceptance')
+    UNION ALL
+    -- TickPick: liveness is order_status (NOT status — see header caveat)
+    SELECT ordered_at AS ts, coalesce(quantity, 1) AS qty
+    FROM public.tickpick_orders
+    WHERE tevo_event_id = p_event_id
+      AND (order_status IS NULL OR upper(order_status) NOT IN ('REJECTED', 'CANCELLED', 'CANCELED', 'REFUNDED', 'VOID'))
+    UNION ALL
+    -- Vivid
+    SELECT ordered_at AS ts, coalesce(quantity, 1) AS qty
+    FROM public.vivid_orders
+    WHERE tevo_event_id = p_event_id
+      AND coalesce(status, '') NOT IN ('ignored_tbd_postponed', 'CANCELLED', 'CANCELED')
+  ),
+  bucketed AS (
+    SELECT
+      date_bin(make_interval(secs => v_bucket_secs), ts, '2000-01-01'::timestamptz) AS bucket,
+      qty
+    FROM norm
+    WHERE ts IS NOT NULL
+      AND ts > v_window_start
+      AND ts <= v_now
+  )
+  SELECT
+    coalesce(jsonb_agg(jsonb_build_object('t', to_char(bucket AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'), 'v', total_qty) ORDER BY bucket), '[]'::jsonb)
+  INTO v_orders_ct
+  FROM (
+    SELECT bucket, SUM(qty)::int AS total_qty
+    FROM bucketed GROUP BY bucket
+  ) b;
+
+  -- ---------- ESPN injury transitions (LAG per athlete, both teams) ----------
+  -- espn_team_id is NOT globally unique across leagues — e.g. id="28" maps to
+  -- MLB Atlanta Braves AND an NHL team. ALWAYS scope by espn_league so cross-
+  -- league fan-out doesn't surface unrelated injuries on a sport-specific chart.
+  IF (v_home_team IS NOT NULL OR v_away_team IS NOT NULL) AND v_espn_league IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_team_id, athlete_id, athlete_name, position, status,
+        LAG(status) OVER (PARTITION BY athlete_id ORDER BY captured_at) AS prev_status
+      FROM public.espn_injuries_snapshots
+      WHERE espn_league = v_espn_league
+        AND espn_team_id IN (v_home_team, v_away_team)
+        AND espn_team_id IS NOT NULL
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',            to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'athlete_id',    athlete_id,
+             'athlete_name',  athlete_name,
+             'position',      position,
+             'espn_team_id',  espn_team_id,
+             'prev_status',   prev_status,
+             'new_status',    status
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_injuries
+    FROM ordered
+    WHERE status IS DISTINCT FROM prev_status;  -- transitions only (including first-seen NULL→X)
+  END IF;
+
+  -- ---------- ESPN game-state transitions (LAG on status_short, this event) ----------
+  IF v_espn_event_id IS NOT NULL THEN
+    WITH ordered AS (
+      SELECT
+        captured_at, espn_event_id, status_short, state,
+        LAG(status_short) OVER (PARTITION BY espn_event_id ORDER BY captured_at) AS prev_status
+      FROM public.espn_event_snapshots
+      WHERE espn_event_id = v_espn_event_id
+        AND (v_espn_league IS NULL OR espn_league = v_espn_league)
+        AND captured_at > v_window_start
+        AND captured_at <= v_now
+    )
+    SELECT coalesce(jsonb_agg(jsonb_build_object(
+             'at',             to_char(captured_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+             'espn_event_id',  espn_event_id,
+             'prev_status',    prev_status,
+             'new_status',     status_short,
+             'state',          state
+           ) ORDER BY captured_at), '[]'::jsonb)
+    INTO v_game_state
+    FROM ordered
+    WHERE status_short IS DISTINCT FROM prev_status;
+  END IF;
+
+  -- ---------- assemble ----------
+  RETURN jsonb_build_object(
+    'tevo_event_id',  p_event_id,
+    'sg_event_id',    v_sg_event_id,
+    'espn_event_id',  v_espn_event_id,
+    'espn_league',    v_espn_league,
+    'home_team_id',   v_home_team,
+    'away_team_id',   v_away_team,
+    'range', jsonb_build_object(
+      'start',  to_char(v_window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'end',    to_char(v_now          AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'hours',  v_hours,
+      'bucket_seconds', v_bucket_secs
+    ),
+    'sg_hidden', v_sg_hidden,
+    'sg_reason', v_sg_reason,
+    'series', jsonb_build_object(
+      'sg_listings_median',       v_sg_listings,
+      'sg_listings_owned_median', v_sg_listings_own,
+      'sg_listings_count',        v_sg_listings_ct,
+      'sg_sales_median',          v_sg_sales,
+      'sg_sales_count',           v_sg_sales_ct,
+      'sd_sales_median',          v_sd_sales,
+      'sd_sales_count',           v_sd_sales_ct,
+      'orders_count',             v_orders_ct
+    ),
+    'annotations', jsonb_build_object(
+      'injuries',   v_injuries,
+      'game_state', v_game_state
+    )
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_chart_extended(integer, integer, text, text) IS
+  'D0 event chart extension — SG-side series (listings median/owned/count + sales median/count) + SeatData sales (sd_sales_median/sd_sales_count, DISTINCT ON content_hash) + OUR orders sell-through (orders_count = EVO+TickPick+Vivid tickets sold/bucket, sold-status filtered) + 2 ESPN annotation arrays. SeatData/orders keyed by tevo_event_id (render even when SG hidden). DISTINCT ON sg_sale_id|sglid|content_hash mandatory (§3 landmine). ⚠ TickPick liveness uses order_status, NOT status. Email-gated.';
+
+-- ============================================================
+-- get_event_seatdata_sales_full — SeatData Sales tab (clone of get_event_sg_sales_full)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_seatdata_sales_full(
+  p_event_id    integer,
+  p_limit       integer DEFAULT 100000,
+  p_window_days integer DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email       text;
+  v_sd_event_id bigint;
+  v_rows        jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- Optional bridge lookup for the meta line (SeatData sales are keyed directly
+  -- on tevo_event_id, so absence of an xref row does NOT hide the data).
+  SELECT sd_event_id INTO v_sd_event_id
+  FROM public.seatdata_event_xref WHERE tevo_event_id = p_event_id LIMIT 1;
+
+  -- DISTINCT ON content_hash (SeatData dedup key). Window on sale_timestamp.
+  WITH latest AS (
+    SELECT DISTINCT ON (content_hash)
+      content_hash, sale_timestamp, price, quantity, zone, section, row
+    FROM public.seatdata_sales_snapshots
+    WHERE tevo_event_id = p_event_id
+      AND sale_timestamp > now() - make_interval(days => greatest(1, least(p_window_days, 90)))
+    ORDER BY content_hash, pulled_at DESC
+  )
+  SELECT jsonb_build_object(
+    'count', count(*),
+    'sd_event_id', v_sd_event_id,
+    'window_days', greatest(1, least(p_window_days, 90)),
+    'rows', coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.sale_timestamp DESC), '[]'::jsonb)
+  ) INTO v_rows
+  FROM (SELECT * FROM latest ORDER BY sale_timestamp DESC LIMIT greatest(1, p_limit)) l;
+
+  RETURN v_rows;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.get_event_seatdata_sales_full(integer, integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_seatdata_sales_full(integer, integer, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_event_seatdata_sales_full(integer, integer, integer) IS
+  'D0 event-page tabs — full SeatData sales for an event (DISTINCT ON content_hash, window 1-90d, UNCAPPED default 100000). Keyed on tevo_event_id (no SG bridge). Email-gated.';


### PR DESCRIPTION
## What

The two market-sales count series on the Inventory & sales chart — **SG sale ct** and **SeatData sale ct** — share the same right-axis bucket positions and were overlapping/occluding each other. This stacks them cumulatively so each bucket's bar shows **SG (bottom) + SeatData (top)** = total market sales, split by source.

## How
- SeatData is listed before SG so it draws **behind** at the cumulative height (SG+SeatData); SG draws after with an **opaque fill** (overdraw), painting the lower segment → a clean 2-colour stacked bar. No new uPlot bands/instances.
- Cumulative value is computed **post-build** from the aligned `projected` arrays; the raw SeatData count is preserved in `tipProjected` so the **tooltip still shows each source's own number**, not the stacked total.
- **Visibility-aware**: if SG is toggled off, SeatData reverts to its own height on the next full render (initial/resize), so the bar never over-represents.
- **Our sales ct** bars are intentionally left unstacked (scope = SG + SeatData only).

## Notes / limitation
- Toggling SG off uses uPlot `setSeries` (no full re-render), so the SeatData bar keeps the stacked height until the next render (resize) — minor, both are on by default.
- FE-only (`static/terminal/event.js`); `node --check` passes. Live terminal reflects it after the service redeploys from `main`.

https://claude.ai/code/session_01FBtRJK1a9x9xzYS9oetJeU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBtRJK1a9x9xzYS9oetJeU)_