### PR TITLE
feat(trip-planner): optimal per-performer trip planning (shared D0/D1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1159,6 +1159,49 @@ def broker_performer_assets(performer_id: int, _=Depends(require_auth)):
     return row[0] if row else {"performer_id": performer_id, "logo_default_url": None}
 
 
+def _trip_plan_payload(performer_id: int, home_lat: float, home_lon: float,
+                       budget_km: float, home_name: str, days: int,
+                       max_events: int | None) -> dict:
+    """Shared body for the D0/D1 per-performer trip-plan routes.
+
+    Plans the maximum-value multi-city itinerary around a performer's upcoming dates within
+    a round-trip km budget. Pure read (v_event_base) + compute — no writes, no upstream API.
+    Engine + planner live in the shared `trip_planner` package.
+    """
+    from datetime import date, timedelta
+
+    from trip_planner import plan_performer_trip
+
+    db = require_sb()
+    start = date.today()
+    end = start + timedelta(days=max(1, min(int(days), 730)))
+    budget = max(100.0, min(float(budget_km), 50000.0))
+    return plan_performer_trip(
+        db, int(performer_id), float(home_lat), float(home_lon), budget,
+        start, end, home_name=(home_name or "Home").strip()[:60], max_events=max_events,
+    )
+
+
+@app.get("/api/broker/performers/{performer_id}/trip-plan")
+def broker_performer_trip_plan(
+    performer_id: int,
+    home_lat: float,
+    home_lon: float,
+    budget_km: float = 6000.0,
+    home_name: str = "Home",
+    days: int = 365,
+    max_events: int | None = None,
+    _=Depends(require_auth),
+):
+    """D0 terminal: optimal trip around a touring performer's upcoming concert dates.
+
+    Given a home location + round-trip travel budget, returns the maximum-value itinerary
+    (which shows to attend, in date order) plus the sort-by-date baseline for comparison.
+    """
+    return _trip_plan_payload(performer_id, home_lat, home_lon, budget_km,
+                              home_name, days, max_events)
+
+
 def _bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
     """Fetch performer_metadata for many performer_ids at once. Returns map
     {performer_id: {logo_default_url, color_primary, ...}}. Used by event
@@ -6640,6 +6683,28 @@ def store_events_near(
     }
 
 
+@app.get("/api/store/performers/{performer_id}/trip-plan")
+def store_performer_trip_plan(
+    performer_id: int,
+    home_lat: float,
+    home_lon: float,
+    budget_km: float = 6000.0,
+    home_name: str = "Home",
+    days: int = 365,
+    max_events: int | None = None,
+):
+    """D1 store: 'plan a trip around <performer>'.
+
+    Consumer-facing. Given a fan's home location + how far they're willing to travel
+    (round-trip km budget), returns the best set of this performer's upcoming shows to
+    attend, in date order, alongside the naive sort-by-date plan for comparison.
+
+    Shares the optimizer with the D0 broker route via `trip_planner`.
+    """
+    return _trip_plan_payload(performer_id, home_lat, home_lon, budget_km,
+                              home_name, days, max_events)
+
+
 def _section_sort_key(s: str) -> tuple:
     """Sort key for venue sections. Letters before digits (Floor, Courtside,
     GA come before 100, 101, etc.); within each group, natural-numeric for
@@ -7928,6 +7993,13 @@ def store_test_media_test_page(_=Depends(_require_non_prod)):
     # primary_performer_logo / primary_performer_color (already in the
     # /api/store/events payload) actually render through the test harness.
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "media_test.html"))
+
+
+@app.get("/store/test/trip")
+def store_test_trip_page(_=Depends(_require_non_prod)):
+    """Sandbox for the per-performer trip planner (/api/store/performers/{id}/trip-plan).
+    Pick a performer + home + travel budget → optimal multi-city itinerary vs sort-by-date."""
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "trip.html"))
 
 
 # ============================================================

--- a/static/store/test/trip.html
+++ b/static/store/test/trip.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Trip planner — VibePass</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+  <style>
+    .trip-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin: 16px 0 8px; }
+    .trip-form label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+    .trip-form input { width: 100%; padding: 10px 12px; font-size: 14px; box-sizing: border-box; }
+    .budget-row { margin: 8px 0 20px; }
+    .budget-row input[type=range] { width: 100%; }
+    .stat { display: flex; gap: 24px; flex-wrap: wrap; margin: 16px 0; padding: 14px 16px; background: var(--card, #15151c); border-radius: 10px; }
+    .stat b { font-size: 22px; display: block; }
+    .stat .lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+    .gain { color: var(--accent-2, #4ade80); }
+    ul.itin { list-style: none; padding: 0; margin: 0; }
+    ul.itin li { display: flex; gap: 12px; padding: 9px 12px; border-bottom: 1px solid rgba(255,255,255,.06); align-items: baseline; }
+    ul.itin li.skip { opacity: .38; }
+    ul.itin li .d { width: 96px; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 13px; }
+    ul.itin li .c { width: 120px; font-weight: 600; }
+    ul.itin li .badge { margin-left: auto; font-size: 11px; color: var(--accent-2, #4ade80); }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">sandbox</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/performer"><span class="num"></span> Performers</a>
+      <a href="/store/test/venue"><span class="num"></span> Venues</a>
+      <a href="/store/test/trip"><span class="num"></span> Trip planner</a>
+    </nav>
+
+    <main class="content">
+      <h1>Plan a trip around a performer</h1>
+      <p class="subtitle">Pick how far you'll travel — we find the most shows you can catch within that budget. Exact optimizer, not a sort-by-date list.</p>
+
+      <div class="trip-form">
+        <div>
+          <label for="pid">Performer ID (tevo)</label>
+          <input id="pid" type="number" value="27474" />
+        </div>
+        <div>
+          <label for="hlat">Home latitude</label>
+          <input id="hlat" type="number" step="0.0001" value="40.7128" />
+        </div>
+        <div>
+          <label for="hlon">Home longitude</label>
+          <input id="hlon" type="number" step="0.0001" value="-74.0060" />
+        </div>
+        <div>
+          <label for="hname">Home label</label>
+          <input id="hname" type="text" value="New York City" />
+        </div>
+      </div>
+
+      <div class="budget-row">
+        <label for="budget" style="font-size:12px;color:var(--muted)">Round-trip travel budget: <b id="budgetLabel">6000</b> km</label>
+        <input id="budget" type="range" min="1000" max="16000" step="500" value="6000" />
+      </div>
+
+      <button id="go" style="padding: 11px 22px">Plan my trip</button>
+      <span style="font-size:12px;color:var(--muted);margin-left:10px">Default = Ariana Grande (27474), home NYC.</span>
+
+      <div id="status" style="color: var(--muted); font-size: 13px; margin: 16px 0"></div>
+
+      <div id="result" hidden>
+        <div class="stat">
+          <div><span class="lbl">Optimal trip</span><b id="oCount">–</b><span class="lbl" id="oKm"></span></div>
+          <div><span class="lbl">Sort-by-date</span><b id="bCount">–</b><span class="lbl" id="bKm"></span></div>
+          <div><span class="lbl">Optimizer adds</span><b class="gain" id="gain">–</b><span class="lbl">more shows</span></div>
+        </div>
+        <h2 style="margin:18px 0 6px" id="itinHead">Itinerary</h2>
+        <p class="subtitle" id="itinSub"></p>
+        <ul class="itin" id="itin"></ul>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const $ = (id) => document.getElementById(id);
+      const budget = $('budget');
+      budget.addEventListener('input', () => { $('budgetLabel').textContent = budget.value; });
+
+      function fmtDate(iso) {
+        const d = new Date(iso + 'T00:00:00');
+        return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+      }
+
+      async function plan() {
+        const pid = parseInt($('pid').value, 10);
+        const params = new URLSearchParams({
+          home_lat: $('hlat').value, home_lon: $('hlon').value,
+          home_name: $('hname').value, budget_km: budget.value, days: '365',
+        });
+        $('status').textContent = 'Planning…';
+        $('result').hidden = true;
+        try {
+          const r = await fetch(`/api/store/performers/${pid}/trip-plan?` + params);
+          if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + (await r.text()).slice(0, 200));
+          render(await r.json());
+        } catch (e) {
+          $('status').textContent = 'Error: ' + e.message;
+        }
+      }
+
+      function render(d) {
+        if (!d.tour_date_count) {
+          $('status').textContent = `No upcoming geocoded dates for performer ${d.performer_id}.`;
+          return;
+        }
+        $('status').textContent =
+          `${d.performer} · ${d.tour_date_count} upcoming dates · budget ${d.budget_km.toFixed(0)} km from ${d.home.name}`;
+        const o = d.optimal, b = d.baseline_by_date;
+        $('oCount').textContent = o.count;
+        $('oKm').textContent = o.travel_km.toFixed(0) + ' km';
+        $('bCount').textContent = b.count;
+        $('bKm').textContent = b.travel_km.toFixed(0) + ' km';
+        $('gain').textContent = (d.shows_gained >= 0 ? '+' : '') + d.shows_gained;
+
+        const picked = new Set(o.events.map((e) => e.event_id));
+        $('itinHead').textContent = `Your trip — ${o.count} shows`;
+        const cities = [...new Set(o.events.map((e) => e.city))].join(' → ');
+        $('itinSub').textContent = cities || '—';
+
+        const ul = $('itin');
+        ul.innerHTML = '';
+        for (const e of d.all_dates) {
+          const on = picked.has(e.event_id);
+          const li = document.createElement('li');
+          if (!on) li.className = 'skip';
+          li.innerHTML =
+            `<span class="d">${fmtDate(e.date)}</span>` +
+            `<span class="c">${e.city || ''}</span>` +
+            `<span>${e.venue || ''}</span>` +
+            (on ? `<span class="badge">● going</span>` : '');
+          ul.appendChild(li);
+        }
+        $('result').hidden = false;
+      }
+
+      $('go').addEventListener('click', plan);
+      plan();
+    })();
+  </script>
+</body>
+</html>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -67,19 +67,17 @@
       </div>
     </section>
 
-    <!-- Default active tab: Market Carpet — the performer as its own "stock ticker" -->
+    <!-- Default active tab: Overview -->
     <nav class="event-tabs" id="perfTabs" role="tablist" hidden>
-      <button class="event-tab" data-tab="overview"   role="tab" aria-selected="false">Overview</button>
+      <button class="event-tab active" data-tab="overview" role="tab" aria-selected="true">Overview</button>
       <button class="event-tab" data-tab="upcoming"   role="tab" aria-selected="false">Upcoming Events <span class="tab-count" id="tabCountUpcoming"></span></button>
-      <button class="event-tab" data-tab="trip"       role="tab" aria-selected="false">🗺 Trip Planner</button>
       <button class="event-tab" data-tab="blindspots" role="tab" aria-selected="false">Blind Spots <span class="tab-count" id="tabCountBlindspots"></span></button>
-      <button class="event-tab active" data-tab="market" role="tab" aria-selected="true">Market Carpet <span class="tab-count" id="tabCountMarket"></span></button>
       <button class="event-tab" data-tab="espn"       role="tab" aria-selected="false">ESPN Context</button>
       <button class="event-tab" data-tab="alerts"     role="tab" aria-selected="false">🔔 Alerts</button>
     </nav>
 
-    <!-- Overview pane: rollup KPIs + ESPN form strip -->
-    <div class="tab-pane" id="paneOverview" role="tabpanel" hidden>
+    <!-- Overview pane: rollup KPIs + ESPN form strip (default tab) -->
+    <div class="tab-pane active" id="paneOverview" role="tabpanel">
       <section id="perf-rollup">
         <div class="panel-title">PORTFOLIO ROLLUP</div>
         <div class="rollup-grid">
@@ -98,19 +96,8 @@
       </section>
     </div>
 
-    <!-- Upcoming Events pane -->
+    <!-- Upcoming Events pane — Trip Planner sits above the slate -->
     <div class="tab-pane" id="paneUpcoming" role="tabpanel" hidden>
-      <section id="perf-events">
-        <div class="panel-title row">
-          <span>UPCOMING SLATE</span>
-          <span class="muted small" id="phEventCount"></span>
-        </div>
-        <div id="phEventsBody"></div>
-      </section>
-    </div>
-
-    <!-- Trip Planner pane (lazy-loaded on tab click) -->
-    <div class="tab-pane" id="paneTrip" role="tabpanel" hidden>
       <section id="perf-trip">
         <div class="panel-title row">
           <span>TRIP PLANNER — optimal multi-city run of this tour</span>
@@ -118,7 +105,7 @@
         </div>
         <div class="muted small" style="margin-bottom: 10px;">
           Pick a home base + round-trip travel budget. Exact optimizer (vs naive sort-by-date)
-          over this performer's upcoming geocoded dates — which shows to catch, and the value it adds.
+          over this performer's upcoming dates — which shows to catch, and the value it adds.
         </div>
         <div class="trip-controls">
           <label>home lat<input id="tripLat" type="number" step="0.0001" value="40.7128" /></label>
@@ -129,6 +116,14 @@
         </div>
         <div id="tripStats" class="trip-stats" hidden></div>
         <div id="tripBody"><div class="empty">tap Plan to compute</div></div>
+      </section>
+
+      <section id="perf-events" style="margin-top: 18px;">
+        <div class="panel-title row">
+          <span>UPCOMING SLATE</span>
+          <span class="muted small" id="phEventCount"></span>
+        </div>
+        <div id="phEventsBody"></div>
       </section>
     </div>
 
@@ -143,26 +138,6 @@
           Games where this performer has &gt;50 tix on market but our owned_tix = 0. Sorted by approx market notional (qty × median).
         </div>
         <div id="phBlindSpotsBody"></div>
-      </section>
-    </div>
-
-    <!-- Market Carpet pane — default view. Treats performer as a stock ticker.
-         Aggregated portfolio view + per-event cross-source medians.
-         Lazy-loaded automatically on page open. -->
-    <div class="tab-pane active" id="paneMarket" role="tabpanel">
-      <section id="perf-market-ticker">
-        <div id="perfMarketTickerBody"><div class="empty">loading…</div></div>
-      </section>
-      <section id="perf-market-carpet">
-        <div class="panel-title row">
-          <span>MARKET CARPET — cross-source medians + signals per event</span>
-          <span class="muted small" id="perfMarketMeta">loading…</span>
-        </div>
-        <div class="muted small" style="margin-bottom:8px">
-          EVO/SG/SH/GT/VD medians from latest <code>event_listing_snapshot_daily</code> row per event.
-          Spreads = each platform relative to EVO retail. TD data started 2026-05-27.
-        </div>
-        <div id="perfMarketBody"><div class="empty">loading…</div></div>
       </section>
     </div>
 

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -16,6 +16,21 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Performer</title>
   <link rel="stylesheet" href="style.css" />
+  <style>
+    .trip-controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-bottom: 14px; }
+    .trip-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--muted, #9aa); text-transform: uppercase; letter-spacing: .04em; }
+    .trip-controls input[type=number], .trip-controls input[type=text] { width: 130px; padding: 7px 9px; background: var(--panel, #14141b); color: inherit; border: 1px solid rgba(255,255,255,.12); border-radius: 6px; font: inherit; }
+    .trip-controls input[type=range] { width: 200px; }
+    .trip-stats { display: flex; gap: 26px; flex-wrap: wrap; margin: 6px 0 14px; padding: 12px 16px; background: var(--panel, #14141b); border-radius: 8px; }
+    .trip-stats .ts-num { font-size: 22px; font-weight: 700; display: block; line-height: 1.1; }
+    .trip-stats .ts-num.gain { color: var(--good, #4ade80); }
+    .trip-stats .ts-lbl { font-size: 11px; color: var(--muted, #9aa); }
+    .trip-row { display: flex; gap: 14px; padding: 7px 4px; border-bottom: 1px solid rgba(255,255,255,.06); align-items: baseline; font-size: 13px; }
+    .trip-row.skip { opacity: .4; }
+    .trip-row .tr-date { width: 110px; color: var(--muted, #9aa); font-variant-numeric: tabular-nums; }
+    .trip-row .tr-city { width: 120px; font-weight: 600; }
+    .trip-row .tr-go { margin-left: auto; color: var(--good, #4ade80); font-size: 11px; }
+  </style>
 </head>
 <body data-page="performer">
 
@@ -56,6 +71,7 @@
     <nav class="event-tabs" id="perfTabs" role="tablist" hidden>
       <button class="event-tab" data-tab="overview"   role="tab" aria-selected="false">Overview</button>
       <button class="event-tab" data-tab="upcoming"   role="tab" aria-selected="false">Upcoming Events <span class="tab-count" id="tabCountUpcoming"></span></button>
+      <button class="event-tab" data-tab="trip"       role="tab" aria-selected="false">🗺 Trip Planner</button>
       <button class="event-tab" data-tab="blindspots" role="tab" aria-selected="false">Blind Spots <span class="tab-count" id="tabCountBlindspots"></span></button>
       <button class="event-tab active" data-tab="market" role="tab" aria-selected="true">Market Carpet <span class="tab-count" id="tabCountMarket"></span></button>
       <button class="event-tab" data-tab="espn"       role="tab" aria-selected="false">ESPN Context</button>
@@ -90,6 +106,29 @@
           <span class="muted small" id="phEventCount"></span>
         </div>
         <div id="phEventsBody"></div>
+      </section>
+    </div>
+
+    <!-- Trip Planner pane (lazy-loaded on tab click) -->
+    <div class="tab-pane" id="paneTrip" role="tabpanel" hidden>
+      <section id="perf-trip">
+        <div class="panel-title row">
+          <span>TRIP PLANNER — optimal multi-city run of this tour</span>
+          <span class="muted small" id="tripMeta"></span>
+        </div>
+        <div class="muted small" style="margin-bottom: 10px;">
+          Pick a home base + round-trip travel budget. Exact optimizer (vs naive sort-by-date)
+          over this performer's upcoming geocoded dates — which shows to catch, and the value it adds.
+        </div>
+        <div class="trip-controls">
+          <label>home lat<input id="tripLat" type="number" step="0.0001" value="40.7128" /></label>
+          <label>home lon<input id="tripLon" type="number" step="0.0001" value="-74.0060" /></label>
+          <label>label<input id="tripHome" type="text" value="New York City" /></label>
+          <label>budget <b id="tripBudgetLabel">6000</b> km<input id="tripBudget" type="range" min="1000" max="16000" step="500" value="6000" /></label>
+          <button id="tripGo" class="event-tab">Plan</button>
+        </div>
+        <div id="tripStats" class="trip-stats" hidden></div>
+        <div id="tripBody"><div class="empty">tap Plan to compute</div></div>
       </section>
     </div>
 

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -95,10 +95,10 @@
   }
 
   // ============================================================
-  // DETAIL mode — hero + rollup + tabs (Market Carpet default)
+  // DETAIL mode — hero + rollup + tabs (Overview default)
   // ============================================================
   function showDetailMode(performerId) {
-    // Unhide DETAIL chrome; Market Carpet pane is already active in HTML
+    // Unhide DETAIL chrome; Overview pane is already active in HTML
     document.getElementById('perf-hero').removeAttribute('hidden');
     document.getElementById('perfTabs').removeAttribute('hidden');
 
@@ -120,13 +120,11 @@
       try { renderRollup(portfolio); }            catch (e) { console.error('rollup', e); }
       try { renderEvents(portfolio); }            catch (e) { console.error('events', e); }
       try { renderBlindSpots(portfolio); }        catch (e) { console.error('blindSpots', e); }
-      // Auto-load Market Carpet (default view) now that portfolio is available
-      loadMarketCarpet().catch(e => console.error('marketCarpet', e));
     });
   }
 
   // ---------- Tab nav ----------
-  const _tabState = { loaded: { espn: false, market: false, alerts: false, trip: false }, performerId: null, portfolio: null };
+  const _tabState = { loaded: { espn: false, alerts: false, trip: false }, performerId: null, portfolio: null };
 
   function wireTabs(performerId) {
     _tabState.performerId = performerId;
@@ -139,9 +137,7 @@
       activateTab(tabId);
       if (tabId === 'espn' && !_tabState.loaded.espn) {
         await loadEspnContext(performerId);
-      } else if (tabId === 'market' && !_tabState.loaded.market) {
-        await loadMarketCarpet();
-      } else if (tabId === 'trip' && !_tabState.loaded.trip) {
+      } else if (tabId === 'upcoming' && !_tabState.loaded.trip) {
         initTripPlanner(performerId);
       } else if (tabId === 'alerts' && !_tabState.loaded.alerts) {
         _tabState.loaded.alerts = true;
@@ -155,10 +151,8 @@
     overview:   'paneOverview',
     upcoming:   'paneUpcoming',
     blindspots: 'paneBlindspots',
-    market:     'paneMarket',
     espn:       'paneEspn',
     alerts:     'panePerfAlerts',
-    trip:       'paneTrip',
   };
 
   function activateTab(tabId) {
@@ -219,7 +213,15 @@
     const body = document.getElementById('tripBody');
     const stats = document.getElementById('tripStats');
     const meta = document.getElementById('tripMeta');
-    if (meta) meta.textContent = d.tour_date_count ? `${d.tour_date_count} dates · budget ${Math.round(d.budget_km)} km` : '';
+    if (meta) {
+      const cov = d.coord_coverage || {};
+      const extra = [];
+      if (cov.city_fallback) extra.push(`${cov.city_fallback} ≈ city`);
+      if (cov.dropped_no_coords) extra.push(`${cov.dropped_no_coords} no-coords dropped`);
+      meta.textContent = d.tour_date_count
+        ? `${d.tour_date_count} dates · budget ${Math.round(d.budget_km)} km${extra.length ? ' · ' + extra.join(', ') : ''}`
+        : '';
+    }
     if (!d.tour_date_count) {
       if (stats) stats.hidden = true;
       body.innerHTML = '<div class="empty">no upcoming geocoded dates for this performer</div>';
@@ -237,9 +239,10 @@
     const cities = [...new Set(o.events.map(e => e.city))].filter(Boolean).join(' → ');
     const rows = (d.all_dates || []).map(e => {
       const on = picked.has(e.event_id);
+      const approx = e.coord_source === 'city' ? ' <span class="muted small" title="approximate city-centroid location">≈</span>' : '';
       return `<div class="trip-row${on ? '' : ' skip'}">`
         + `<span class="tr-date">${escapeHtml(_tripDate(e.date))}</span>`
-        + `<span class="tr-city">${escapeHtml(e.city || '')}</span>`
+        + `<span class="tr-city">${escapeHtml(e.city || '')}${approx}</span>`
         + `<span class="tr-venue">${escapeHtml(e.venue || '')}</span>`
         + (on ? '<span class="tr-go">● going</span>' : '')
         + '</div>';
@@ -541,210 +544,6 @@
       meta.textContent = [d.espn_league || '', out ? 'out: ' + out : ''].filter(Boolean).join(' · ');
     }
     sec.removeAttribute('hidden');
-  }
-
-  // ---------- Market Carpet — performer as stock ticker ----------
-  // Auto-loaded on page open (default tab). Builds:
-  //   1. Stock-ticker KPI strip: aggregate price, owned position, signals
-  //   2. Per-event cross-source medians table
-  async function loadMarketCarpet() {
-    _tabState.loaded.market = true;
-    const tickerBody = document.getElementById('perfMarketTickerBody');
-    const body       = document.getElementById('perfMarketBody');
-    const meta       = document.getElementById('perfMarketMeta');
-    const countEl    = document.getElementById('tabCountMarket');
-    if (tickerBody) tickerBody.innerHTML = '<div class="empty">loading…</div>';
-    if (body)       body.innerHTML       = '<div class="empty">Loading market data…</div>';
-
-    const Auth = window.TerminalAuth;
-    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
-      if (tickerBody) tickerBody.innerHTML = '<div class="empty">not signed in</div>';
-      if (body)       body.innerHTML       = '<div class="empty">not signed in</div>';
-      return;
-    }
-    const portfolio = _tabState.portfolio;
-    const events = (portfolio && portfolio.events) || [];
-    if (!events.length) {
-      if (tickerBody) tickerBody.innerHTML = '<div class="empty">no events to analyze</div>';
-      if (body)       body.innerHTML       = '<div class="empty">no events to analyze</div>';
-      return;
-    }
-    const eventIds = events.map(e => e.id).filter(Boolean);
-
-    // Parallel fetch: snapshots + movers + gaps
-    const [snapRes, moversRes, gapsRes] = await Promise.all([
-      Auth.client
-        .from('event_listing_snapshot_daily')
-        .select('event_id,snapshot_date,snapshot_slot,evo_retail_median,sg_all_median,td_sh_listings,td_sh_median,td_gt_listings,td_gt_median,td_vd_listings,td_vd_median,td_tp_listings,td_tp_median,td_tm_listings,td_tm_median,td_tm_resale_listings,td_tm_resale_median,td_combined_median')
-        .in('event_id', eventIds)
-        .order('snapshot_date', { ascending: false })
-        .order('snapshot_slot', { ascending: false }),
-      Auth.client
-        .from('event_movers_index')
-        .select('event_id,source,window_days,category,rank,price_delta_pct,signal_score')
-        .in('event_id', eventIds)
-        .order('signal_score', { ascending: false }),
-      Auth.client
-        .from('discovery_gap_alerts')
-        .select('event_id,gap_type,detail,signal_score')
-        .in('event_id', eventIds)
-        .is('resolved_at', null),
-    ]);
-
-    // JS-dedup snapshots: keep first (latest) per event_id
-    const snapByEvent = {};
-    for (const r of (snapRes.data || [])) {
-      if (!snapByEvent[r.event_id]) snapByEvent[r.event_id] = r;
-    }
-
-    // Group movers + gaps by event
-    const moversByEvent = {};
-    for (const r of (moversRes.data || [])) {
-      (moversByEvent[r.event_id] = moversByEvent[r.event_id] || []).push(r);
-    }
-    const gapsByEvent = {};
-    for (const r of (gapsRes.data || [])) {
-      (gapsByEvent[r.event_id] = gapsByEvent[r.event_id] || []).push(r);
-    }
-
-    const snapCount = Object.keys(snapByEvent).length;
-    if (meta) meta.textContent = `${events.length} events · ${snapCount} with snapshots`;
-    if (countEl) countEl.textContent = String(events.length);
-
-    // ── Stock Ticker: aggregate metrics ──────────────────────────────────────
-    const ag = (portfolio && portfolio.aggregate) || {};
-    // Weighted-avg medians across events that have snapshots
-    let sumEvo = 0, sumSg = 0, sumSh = 0, sumGt = 0, sumVd = 0, sumTp = 0, sumTm = 0, wCount = 0;
-    events.forEach(e => {
-      const sn = snapByEvent[e.id];
-      if (!sn) return;
-      const w = 1; // equal weight per event; can weight by owned_qty if preferred
-      if (sn.evo_retail_median != null) sumEvo += +sn.evo_retail_median * w;
-      if (sn.sg_all_median    != null) sumSg  += +sn.sg_all_median    * w;
-      if (sn.td_sh_median     != null) sumSh  += +sn.td_sh_median     * w;
-      if (sn.td_gt_median     != null) sumGt  += +sn.td_gt_median     * w;
-      if (sn.td_vd_median     != null) sumVd  += +sn.td_vd_median     * w;
-      if (sn.td_tp_median     != null) sumTp  += +sn.td_tp_median     * w;
-      if (sn.td_tm_median     != null) sumTm  += +sn.td_tm_median     * w;
-      wCount += w;
-    });
-    const wavg = (sum) => wCount > 0 ? Math.round(sum / wCount) : null;
-    const avgEvo = wavg(sumEvo), avgSg = wavg(sumSg);
-    const avgSh  = wavg(sumSh),  avgGt = wavg(sumGt), avgVd = wavg(sumVd);
-    const avgTp  = wavg(sumTp),  avgTm = wavg(sumTm);
-
-    // Signal counts
-    const allMovers = Object.values(moversByEvent).flat();
-    const priceUp   = allMovers.filter(m => m.category === 'price_up').length;
-    const priceDown = allMovers.filter(m => m.category === 'price_down').length;
-    const allGaps   = Object.values(gapsByEvent).flat();
-    const gapCount  = allGaps.length;
-
-    const sgSpreadPct = (avgEvo && avgSg) ? ((avgSg - avgEvo) / avgEvo * 100) : null;
-    const $p = v => (v != null ? '$' + T.fmtNum(v) : '—');
-    const pct = (v, decimals=0) => v != null ? (v >= 0 ? '+' : '') + v.toFixed(decimals) + '%' : '';
-
-    if (tickerBody) {
-      tickerBody.innerHTML = `
-        <div class="market-ticker-strip">
-          <div class="ticker-cell ticker-price">
-            <span class="ticker-lbl">EVO MEDIAN</span>
-            <span class="ticker-val">${$p(avgEvo)}</span>
-            ${avgSg ? `<span class="ticker-sub ${sgSpreadPct && sgSpreadPct > 0 ? 'pos' : sgSpreadPct && sgSpreadPct < 0 ? 'neg' : ''}">${pct(sgSpreadPct, 1)} vs SG</span>` : ''}
-          </div>
-          <div class="ticker-cell">
-            <span class="ticker-lbl">PLATFORM MED</span>
-            <span class="ticker-val">${$p(avgSg)}<span class="ticker-src"> SG</span></span>
-            <span class="ticker-sub">${avgSh ? $p(avgSh) + ' SH' : '—'} · ${avgGt ? $p(avgGt) + ' GT' : '—'} · ${avgVd ? $p(avgVd) + ' VD' : '—'} · ${avgTp ? $p(avgTp) + ' TP' : '—'} · ${avgTm ? $p(avgTm) + ' TM' : '—'}</span>
-          </div>
-          <div class="ticker-cell">
-            <span class="ticker-lbl">POSITION</span>
-            <span class="ticker-val">${ag.owned_tickets_total ? T.fmtNum(ag.owned_tickets_total) + ' tix' : '—'}</span>
-            <span class="ticker-sub">${ag.owned_retail_value_total ? '$' + T.fmtNum(Math.round(+ag.owned_retail_value_total)) + ' notional' : ''}</span>
-          </div>
-          <div class="ticker-cell">
-            <span class="ticker-lbl">MARKET DEPTH</span>
-            <span class="ticker-val">${events.length} events</span>
-            <span class="ticker-sub">${ag.events_with_owned ? ag.events_with_owned + ' with position' : 'no positions'}</span>
-          </div>
-          <div class="ticker-cell">
-            <span class="ticker-lbl">SIGNALS</span>
-            <span class="ticker-val ${priceUp > priceDown ? 'pos' : priceDown > priceUp ? 'neg' : ''}">${priceUp > 0 ? '↑' + priceUp : ''}${priceDown > 0 ? ' ↓' + priceDown : ''}${!priceUp && !priceDown ? '—' : ''}</span>
-            <span class="ticker-sub">${gapCount ? gapCount + ' gap' + (gapCount > 1 ? 's' : '') : 'no gaps'}</span>
-          </div>
-        </div>`;
-    }
-
-    // ── Per-event table ───────────────────────────────────────────────────────
-    const spread = (a, b) => {
-      if (a == null || b == null || +b === 0) return '';
-      const v = ((+a - +b) / +b) * 100;
-      return `<span class="${v > 2 ? 'pos' : v < -2 ? 'neg' : 'muted small'}">${v > 0 ? '+' : ''}${v.toFixed(0)}%</span>`;
-    };
-
-    const tbl = document.createElement('table');
-    tbl.className = 'market-carpet-tbl';
-    tbl.innerHTML = `
-      <thead><tr>
-        <th>Event</th>
-        <th class="num">T-days</th>
-        <th class="num">EVO</th>
-        <th class="num">SG</th>
-        <th class="num">SH</th>
-        <th class="num">GT</th>
-        <th class="num">VD</th>
-        <th class="num">TP</th>
-        <th class="num">TM</th>
-        <th class="num" title="Ticketmaster verified resale (secondary market)">TM-R</th>
-        <th class="num">SH÷EVO</th>
-        <th class="num">GT÷SH</th>
-        <th class="num">VD÷SH</th>
-        <th class="num" title="resale premium over TM primary face">TM-R÷TM</th>
-        <th>Movers</th>
-        <th>Gaps</th>
-      </tr></thead><tbody></tbody>`;
-    const tb = tbl.querySelector('tbody');
-
-    events.forEach(e => {
-      const sn  = snapByEvent[e.id]  || {};
-      const mvs = moversByEvent[e.id] || [];
-      const gps = gapsByEvent[e.id]  || [];
-      const d   = T.daysUntil(e.occurs_at_local);
-      const hasSn = !!snapByEvent[e.id];
-
-      const moverHtml = mvs.slice(0, 3).map(m => {
-        const mPct = m.price_delta_pct != null ? (m.price_delta_pct > 0 ? '+' : '') + (+m.price_delta_pct).toFixed(0) + '%' : '';
-        const cls = m.category === 'price_up' ? 'pos' : m.category === 'price_down' ? 'neg' : 'muted small';
-        return `<span class="badge ${cls}" title="${escapeHtml(m.source + ' ' + m.window_days + 'd')}">${escapeHtml(m.category.replace('_',' '))}${mPct ? ' ' + mPct : ''}</span>`;
-      }).join(' ') || '—';
-
-      const gapHtml = gps.slice(0, 4).map(g =>
-        `<span class="badge" title="${escapeHtml(g.detail || '')}">${escapeHtml(g.gap_type.replace(/_/g,' '))}</span>`
-      ).join(' ') || '—';
-
-      const tr = document.createElement('tr');
-      tr.className = hasSn ? '' : 'muted';
-      tr.innerHTML = `
-        <td><a href="event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a></td>
-        <td class="num">${d === null ? '—' : d}</td>
-        <td class="num">${$p(sn.evo_retail_median)}</td>
-        <td class="num">${$p(sn.sg_all_median)}</td>
-        <td class="num">${$p(sn.td_sh_median)}</td>
-        <td class="num">${$p(sn.td_gt_median)}</td>
-        <td class="num">${$p(sn.td_vd_median)}</td>
-        <td class="num">${$p(sn.td_tp_median)}</td>
-        <td class="num">${$p(sn.td_tm_median)}</td>
-        <td class="num">${$p(sn.td_tm_resale_median)}</td>
-        <td class="num">${spread(sn.td_sh_median, sn.evo_retail_median)}</td>
-        <td class="num">${spread(sn.td_gt_median, sn.td_sh_median)}</td>
-        <td class="num">${spread(sn.td_vd_median, sn.td_sh_median)}</td>
-        <td class="num">${spread(sn.td_tm_resale_median, sn.td_tm_median)}</td>
-        <td>${moverHtml}</td>
-        <td>${gapHtml}</td>`;
-      tb.appendChild(tr);
-    });
-
-    if (body) { body.innerHTML = ''; body.appendChild(tbl); }
   }
 
   // ---------- Util ----------

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -126,7 +126,7 @@
   }
 
   // ---------- Tab nav ----------
-  const _tabState = { loaded: { espn: false, market: false, alerts: false }, performerId: null, portfolio: null };
+  const _tabState = { loaded: { espn: false, market: false, alerts: false, trip: false }, performerId: null, portfolio: null };
 
   function wireTabs(performerId) {
     _tabState.performerId = performerId;
@@ -141,6 +141,8 @@
         await loadEspnContext(performerId);
       } else if (tabId === 'market' && !_tabState.loaded.market) {
         await loadMarketCarpet();
+      } else if (tabId === 'trip' && !_tabState.loaded.trip) {
+        initTripPlanner(performerId);
       } else if (tabId === 'alerts' && !_tabState.loaded.alerts) {
         _tabState.loaded.alerts = true;
         const label = document.getElementById('phName')?.textContent || '';
@@ -156,6 +158,7 @@
     market:     'paneMarket',
     espn:       'paneEspn',
     alerts:     'panePerfAlerts',
+    trip:       'paneTrip',
   };
 
   function activateTab(tabId) {
@@ -170,6 +173,78 @@
       if (id === tabId) { pane.removeAttribute('hidden'); pane.classList.add('active'); }
       else { pane.setAttribute('hidden', ''); pane.classList.remove('active'); }
     });
+  }
+
+  // ---------- Trip Planner (lazy-loaded tab) ----------
+  // Calls /api/broker/performers/{id}/trip-plan (shared trip_planner module) and shows
+  // the optimal multi-city itinerary vs the naive sort-by-date baseline.
+
+  function initTripPlanner(performerId) {
+    _tabState.loaded.trip = true;
+    const slider = document.getElementById('tripBudget');
+    const label = document.getElementById('tripBudgetLabel');
+    if (slider && label) slider.addEventListener('input', () => { label.textContent = slider.value; });
+    const go = document.getElementById('tripGo');
+    if (go) go.addEventListener('click', () => runTripPlan(performerId));
+    runTripPlan(performerId);
+  }
+
+  async function runTripPlan(performerId) {
+    const body = document.getElementById('tripBody');
+    const stats = document.getElementById('tripStats');
+    if (!body) return;
+    const q = new URLSearchParams({
+      home_lat: document.getElementById('tripLat').value,
+      home_lon: document.getElementById('tripLon').value,
+      home_name: document.getElementById('tripHome').value,
+      budget_km: document.getElementById('tripBudget').value,
+      days: '365',
+    });
+    body.innerHTML = '<div class="empty">planning…</div>';
+    if (stats) stats.hidden = true;
+    try {
+      const d = await T.api(`/api/broker/performers/${performerId}/trip-plan?` + q.toString());
+      renderTripPlan(d);
+    } catch (e) {
+      body.innerHTML = `<div class="empty">error: ${escapeHtml(e.message || String(e))}</div>`;
+    }
+  }
+
+  function _tripDate(iso) {
+    try { return new Date(iso + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }); }
+    catch (_) { return iso; }
+  }
+
+  function renderTripPlan(d) {
+    const body = document.getElementById('tripBody');
+    const stats = document.getElementById('tripStats');
+    const meta = document.getElementById('tripMeta');
+    if (meta) meta.textContent = d.tour_date_count ? `${d.tour_date_count} dates · budget ${Math.round(d.budget_km)} km` : '';
+    if (!d.tour_date_count) {
+      if (stats) stats.hidden = true;
+      body.innerHTML = '<div class="empty">no upcoming geocoded dates for this performer</div>';
+      return;
+    }
+    const o = d.optimal, b = d.baseline_by_date;
+    if (stats) {
+      stats.hidden = false;
+      stats.innerHTML =
+        `<div><span class="ts-num">${o.count}</span><span class="ts-lbl">optimal shows · ${Math.round(o.travel_km)} km</span></div>` +
+        `<div><span class="ts-num">${b.count}</span><span class="ts-lbl">sort-by-date · ${Math.round(b.travel_km)} km</span></div>` +
+        `<div><span class="ts-num gain">+${d.shows_gained}</span><span class="ts-lbl">shows gained</span></div>`;
+    }
+    const picked = new Set(o.events.map(e => e.event_id));
+    const cities = [...new Set(o.events.map(e => e.city))].filter(Boolean).join(' → ');
+    const rows = (d.all_dates || []).map(e => {
+      const on = picked.has(e.event_id);
+      return `<div class="trip-row${on ? '' : ' skip'}">`
+        + `<span class="tr-date">${escapeHtml(_tripDate(e.date))}</span>`
+        + `<span class="tr-city">${escapeHtml(e.city || '')}</span>`
+        + `<span class="tr-venue">${escapeHtml(e.venue || '')}</span>`
+        + (on ? '<span class="tr-go">● going</span>' : '')
+        + '</div>';
+    }).join('');
+    body.innerHTML = (cities ? `<div class="muted small" style="margin:4px 0 8px">${escapeHtml(cities)}</div>` : '') + rows;
   }
 
   // ---------- Hero ----------

--- a/trip_planner/NOTICE.md
+++ b/trip_planner/NOTICE.md
@@ -1,0 +1,12 @@
+# Vendored engine attribution
+
+The `gigtrip/` package in this directory (`model.py`, `distance.py`, `optimizer.py`) is
+vendored **verbatim** from the open-source project **axiom-orion/gigtrip**, licensed under
+the **MIT License**. Only the optimization engine is vendored; the upstream project's
+Bandsintown client and Streamlit UI are intentionally not included — this spike feeds the
+optimizer our own canonical event data (`public.v_event_base`) instead.
+
+Upstream: https://github.com/axiom-orion/gigtrip  ·  License: MIT
+
+This is an exploratory spike (D1 store / per-performer trip planning). It is not wired into
+any served route. See `README.md` in this directory.

--- a/trip_planner/README.md
+++ b/trip_planner/README.md
@@ -1,0 +1,47 @@
+# trip_planner — optimal trips around live events
+
+Shared server-side module that plans the **maximum-value multi-city itinerary** around a
+performer's upcoming tour dates, within a travel budget. Used by:
+
+- **D1 store** — `GET /api/store/performers/{performer_id}/trip-plan` (consumer, open)
+- **D0 terminal** — `GET /api/broker/performers/{performer_id}/trip-plan` (auth-gated)
+
+Both routes are thin wrappers over `plan_performer_trip()`; the planning logic lives here so
+the two surfaces never duplicate it.
+
+## How it works
+Every event has a fixed date, so the calendar forces visit order — planning is **selection
+under a travel budget**, not a travelling-salesman ordering problem. The engine
+(`gigtrip/`, vendored verbatim from [axiom-orion/gigtrip](https://github.com/axiom-orion/gigtrip),
+MIT — see `NOTICE.md`) solves it exactly with a Pareto label-setting DP, verified against a
+brute-force oracle. Bandsintown + Streamlit layers of the upstream project are **not**
+vendored — we feed the optimizer our own `public.v_event_base` data instead.
+
+It is pure compute: **no writes, no upstream API calls** (consistent with the read-only
+lockdown in `CLAUDE.md`/`PROJECT_BIBLE.md §1`).
+
+## API
+```
+GET /api/store/performers/{performer_id}/trip-plan
+      ?home_lat=&home_lon=&budget_km=6000&home_name=&days=365&max_events=
+```
+Returns `{ performer, performer_id, home, budget_km, window, tour_date_count,
+optimal:{count,value,travel_km,events[]}, baseline_by_date:{...}, shows_gained, all_dates[] }`.
+
+`optimal.events` is the recommended itinerary (date order); `all_dates` is the full tour so
+the UI can show selected vs skipped. `baseline_by_date` is the naive sort-by-date trip, kept
+so the UI can show the value the optimizer adds.
+
+## Test
+```bash
+python3 -m trip_planner.test_ariana
+```
+Offline end-to-end on a real tour snapshot (Ariana Grande, performer 27474). Asserts the
+exact optimizer equals the brute-force oracle, and that it beats the baseline at a binding
+budget.
+
+## Notes / next
+- Single performer = uniform preference weights (every show valued 1.0); the engine already
+  supports a `prefs` map for the multi-performer "plan my whole summer" case.
+- The km budget can become a **$ budget** by making `prize`/cost price-aware — the cost model
+  is isolated in `gigtrip/distance.py` by design.

--- a/trip_planner/README.md
+++ b/trip_planner/README.md
@@ -26,7 +26,23 @@ GET /api/store/performers/{performer_id}/trip-plan
       ?home_lat=&home_lon=&budget_km=6000&home_name=&days=365&max_events=
 ```
 Returns `{ performer, performer_id, home, budget_km, window, tour_date_count,
+coord_coverage:{venue,city_fallback,dropped_no_coords},
 optimal:{count,value,travel_km,events[]}, baseline_by_date:{...}, shows_gained, all_dates[] }`.
+Each event carries `coord_source` = `"venue"` (precise geocode) or `"city"` (centroid fallback).
+
+### Location data + the city-centroid fallback
+EVO/TEvo gives an event only **text** location (`venue_name` + `venue_location` "City, ST" +
+`venue_id`) — **no coordinates**. The lat/lon the planner needs is geocoded separately into
+`venue_assets` (`geocode_source='nominatim_osm'`), which has gaps (un-geocoded venues, some
+mis-citied rows). Without a fallback those shows get NULL coords and are silently dropped
+(e.g. Ariana Grande: 17 of 25 dates routable, Kia Forum + Barclays shows lost).
+
+`city_centroids.py` closes most of that gap: for any event missing a precise geocode, it
+resolves EVO's reliable `events.venue_location` "City, ST" text to an approximate city
+centroid (static gazetteer of North American touring markets — no external call). Such shows
+are tagged `coord_source="city"` and still routed; a few km of imprecision is negligible
+against inter-city legs. Cities not in the gazetteer fall through to `dropped_no_coords`
+(reported, not silent).
 
 `optimal.events` is the recommended itinerary (date order); `all_dates` is the full tour so
 the UI can show selected vs skipped. `baseline_by_date` is the naive sort-by-date trip, kept

--- a/trip_planner/__init__.py
+++ b/trip_planner/__init__.py
@@ -1,0 +1,19 @@
+"""Trip planner — optimal multi-city itineraries around live events.
+
+Shared server-side module used by both the D1 store (`/api/store/performers/{id}/trip-plan`)
+and the D0 terminal (`/api/broker/performers/{id}/trip-plan`). Engine vendored from
+axiom-orion/gigtrip (MIT) — see NOTICE.md.
+"""
+from .planner import (
+    fetch_performer_rows,
+    plan_from_rows,
+    plan_performer_trip,
+    row_to_event,
+)
+
+__all__ = [
+    "plan_performer_trip",
+    "plan_from_rows",
+    "fetch_performer_rows",
+    "row_to_event",
+]

--- a/trip_planner/city_centroids.py
+++ b/trip_planner/city_centroids.py
@@ -1,0 +1,97 @@
+"""City-centroid gazetteer — coarse fallback coordinates for events whose venue has no
+precise geocode in `venue_assets`.
+
+EVO/TEvo gives every event a reliable `events.venue_location` "City, ST" string, but the
+lat/lon the planner needs lives in our separately-geocoded `venue_assets`, which has gaps
+(ungeocoded venues, and some mis-citied rows). Without a fallback those shows get NULL coords
+and the planner silently drops them.
+
+This maps "City, ST" -> an approximate city centroid so the show still routes (a few km of
+imprecision is negligible against inter-city legs of hundreds of km). It is a static,
+offline table — no external geocoding call. Coordinates are well-known city centroids;
+coverage targets North American arena/stadium touring markets. Misses fall through to a
+reported drop rather than a silent one.
+"""
+from __future__ import annotations
+
+# keyed by normalized "city, st" (lowercased) -> (lat, lon)
+CITY_CENTROIDS: dict[str, tuple[float, float]] = {
+    # --- New York metro ---
+    "new york, ny": (40.7128, -74.0060), "brooklyn, ny": (40.6782, -73.9442),
+    "bronx, ny": (40.8448, -73.8648), "queens, ny": (40.7282, -73.7949),
+    "newark, nj": (40.7357, -74.1724), "east rutherford, nj": (40.8128, -74.0764),
+    "uniondale, ny": (40.7006, -73.5907), "elmont, ny": (40.7007, -73.7037),
+    # --- California ---
+    "los angeles, ca": (34.0522, -118.2437), "inglewood, ca": (33.9617, -118.3531),
+    "anaheim, ca": (33.8366, -117.9143), "san diego, ca": (32.7157, -117.1611),
+    "san francisco, ca": (37.7749, -122.4194), "oakland, ca": (37.8044, -122.2712),
+    "san jose, ca": (37.3382, -121.8863), "sacramento, ca": (38.5816, -121.4944),
+    "fresno, ca": (36.7378, -119.7871),
+    # --- Northeast / Mid-Atlantic ---
+    "boston, ma": (42.3601, -71.0589), "foxborough, ma": (42.0909, -71.2643),
+    "philadelphia, pa": (39.9526, -75.1652), "pittsburgh, pa": (40.4406, -79.9959),
+    "hershey, pa": (40.2859, -76.6502), "washington, dc": (38.9072, -77.0369),
+    "baltimore, md": (39.2904, -76.6122), "hartford, ct": (41.7637, -72.6851),
+    "uncasville, ct": (41.4368, -72.0901), "providence, ri": (41.8240, -71.4128),
+    "buffalo, ny": (42.8864, -78.8784), "rochester, ny": (43.1566, -77.6088),
+    "albany, ny": (42.6526, -73.7562), "syracuse, ny": (43.0481, -76.1474),
+    "camden, nj": (39.9259, -75.1196),
+    # --- Southeast ---
+    "atlanta, ga": (33.7490, -84.3880), "miami, fl": (25.7617, -80.1918),
+    "sunrise, fl": (26.1224, -80.2570), "orlando, fl": (28.5383, -81.3792),
+    "tampa, fl": (27.9506, -82.4572), "jacksonville, fl": (30.3322, -81.6557),
+    "charlotte, nc": (35.2271, -80.8431), "raleigh, nc": (35.7796, -78.6382),
+    "greensboro, nc": (36.0726, -79.7920), "columbia, sc": (34.0007, -81.0348),
+    "nashville, tn": (36.1627, -86.7816), "memphis, tn": (35.1495, -90.0490),
+    "knoxville, tn": (35.9606, -83.9207), "new orleans, la": (29.9511, -90.0715),
+    "birmingham, al": (33.5186, -86.8104), "richmond, va": (37.5407, -77.4360),
+    "virginia beach, va": (36.8529, -75.9780), "louisville, ky": (38.2527, -85.7585),
+    # --- Midwest ---
+    "chicago, il": (41.8781, -87.6298), "detroit, mi": (42.3314, -83.0458),
+    "grand rapids, mi": (42.9634, -85.6681), "cleveland, oh": (41.4993, -81.6944),
+    "columbus, oh": (39.9612, -82.9988), "cincinnati, oh": (39.1031, -84.5120),
+    "indianapolis, in": (39.7684, -86.1581), "milwaukee, wi": (43.0389, -87.9065),
+    "green bay, wi": (44.5133, -88.0133), "minneapolis, mn": (44.9778, -93.2650),
+    "st. paul, mn": (44.9537, -93.0900), "kansas city, mo": (39.0997, -94.5786),
+    "st. louis, mo": (38.6270, -90.1994), "omaha, ne": (41.2565, -95.9345),
+    "des moines, ia": (41.5868, -93.6250), "wichita, ks": (37.6872, -97.3301),
+    # --- South Central / Texas ---
+    "dallas, tx": (32.7767, -96.7970), "arlington, tx": (32.7357, -97.1081),
+    "fort worth, tx": (32.7555, -97.3308), "houston, tx": (29.7604, -95.3698),
+    "austin, tx": (30.2672, -97.7431), "san antonio, tx": (29.4241, -98.4936),
+    "el paso, tx": (31.7619, -106.4850), "oklahoma city, ok": (35.4676, -97.5164),
+    "tulsa, ok": (36.1540, -95.9928),
+    # --- Mountain / West ---
+    "denver, co": (39.7392, -104.9903), "phoenix, az": (33.4484, -112.0740),
+    "glendale, az": (33.5387, -112.1860), "tucson, az": (32.2226, -110.9747),
+    "albuquerque, nm": (35.0844, -106.6504), "las vegas, nv": (36.1699, -115.1398),
+    "paradise, nv": (36.0972, -115.1467), "salt lake city, ut": (40.7608, -111.8910),
+    "boise, id": (43.6150, -116.2023),
+    # --- Pacific Northwest ---
+    "seattle, wa": (47.6062, -122.3321), "tacoma, wa": (47.2529, -122.4443),
+    "portland, or": (45.5152, -122.6784), "honolulu, hi": (21.3069, -157.8583),
+    # --- Canada ---
+    "toronto, on": (43.6532, -79.3832), "montreal, qc": (45.5017, -73.5673),
+    "vancouver, bc": (49.2827, -123.1207), "ottawa, on": (45.4215, -75.6972),
+    "calgary, ab": (51.0447, -114.0719), "edmonton, ab": (53.5461, -113.4938),
+    "winnipeg, mb": (49.8951, -97.1384), "quebec city, qc": (46.8139, -71.2080),
+    "hamilton, on": (43.2557, -79.8711),
+}
+
+
+def centroid_for(location_text: str | None) -> tuple[float, float] | None:
+    """Resolve an EVO 'City, ST' string to an approximate city centroid, or None.
+
+    Tolerant of casing/whitespace and a trailing country token (e.g. 'Brooklyn, NY, USA').
+    """
+    if not location_text:
+        return None
+    norm = " ".join(str(location_text).split()).lower().strip()
+    if norm in CITY_CENTROIDS:
+        return CITY_CENTROIDS[norm]
+    # tolerate a trailing country segment: keep the first "city, st"
+    parts = [p.strip() for p in norm.split(",")]
+    if len(parts) >= 2:
+        key = f"{parts[0]}, {parts[1]}"
+        return CITY_CENTROIDS.get(key)
+    return None

--- a/trip_planner/gigtrip/__init__.py
+++ b/trip_planner/gigtrip/__init__.py
@@ -1,0 +1,3 @@
+# Vendored from axiom-orion/gigtrip (MIT). See ../NOTICE.md for provenance + license.
+# Engine only — Bandsintown + Streamlit layers intentionally NOT vendored; this spike
+# feeds the optimizer our own canonical event data instead.

--- a/trip_planner/gigtrip/distance.py
+++ b/trip_planner/gigtrip/distance.py
@@ -1,0 +1,22 @@
+"""Great-circle (haversine) distance between venues, in kilometres.
+
+This is a straight-line distance, **not** road or flight routing — stated plainly because
+the optimizer's travel budget is only as honest as its cost model. It is monotonic in true
+travel cost, which is what the selection needs; swap in a real routing/airfare API to make
+the kilometre budget a dollar budget without touching the optimizer.
+
+Vendored verbatim from axiom-orion/gigtrip (MIT).
+"""
+from __future__ import annotations
+
+import math
+
+EARTH_RADIUS_KM = 6371.0088
+
+
+def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return 2 * EARTH_RADIUS_KM * math.asin(min(1.0, math.sqrt(a)))

--- a/trip_planner/gigtrip/model.py
+++ b/trip_planner/gigtrip/model.py
@@ -1,0 +1,60 @@
+"""Core datatypes for the gigtrip itinerary optimizer.
+
+An itinerary is an ordered set of live events (concerts / games / comedy) you attend on a
+trip out of a home base. Because every event has a *fixed date*, the visit order is forced
+by the calendar — so planning is a **selection** problem under travel constraints, not a
+travelling-salesman ordering problem. See `optimizer.py`.
+
+Vendored verbatim from axiom-orion/gigtrip (MIT).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class Event:
+    """A dated live event at a geocoded venue."""
+    id: str
+    title: str            # band / team / comedian
+    kind: str             # "music" | "sports" | "comedy"
+    day: date
+    city: str
+    venue: str
+    lat: float
+    lon: float
+
+
+@dataclass(frozen=True)
+class Constraints:
+    """A trip request: where you start, the window, and the travel budget."""
+    home_name: str
+    home_lat: float
+    home_lon: float
+    start: date
+    end: date
+    max_travel_km: float                 # round-trip km budget (home -> events -> home)
+    max_events: int | None = None        # optional cap on number of events
+    max_km_per_day: float = 1200.0       # how far you can travel between consecutive events per day
+    default_pref: float = 0.0            # prize for an artist/team not in your preferences
+
+
+@dataclass(frozen=True)
+class Itinerary:
+    """A planned trip: events in date order, with its total value and round-trip distance."""
+    events: tuple[Event, ...]
+    value: float
+    travel_km: float
+
+    @property
+    def count(self) -> int:
+        return len(self.events)
+
+    def ids(self) -> tuple[str, ...]:
+        return tuple(e.id for e in self.events)
+
+
+def prize(event: Event, prefs: dict[str, float], default: float = 0.0) -> float:
+    """Preference-weighted value of attending an event (keyed on lowercased title)."""
+    return prefs.get(event.title.lower(), default)

--- a/trip_planner/gigtrip/optimizer.py
+++ b/trip_planner/gigtrip/optimizer.py
@@ -1,0 +1,205 @@
+"""Itinerary optimizer: greedy baselines + an exact Pareto label-setting solver.
+
+Vendored verbatim from axiom-orion/gigtrip (MIT). The exact optimiser is verified against
+the brute-force oracle (`brute_force_optimal`) on random instances in the source project.
+"""
+from __future__ import annotations
+
+import itertools
+
+from .distance import haversine_km
+from .model import Constraints, Event, Itinerary, prize
+
+EPS = 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# geometry / feasibility helpers
+# --------------------------------------------------------------------------- #
+def candidates(events: list[Event], c: Constraints) -> list[Event]:
+    """In-window events, in calendar order (the forced visit order)."""
+    return sorted((e for e in events if c.start <= e.day <= c.end),
+                  key=lambda e: (e.day, e.id))
+
+
+def feasible_leg(a: Event, b: Event, c: Constraints) -> bool:
+    """Can you get from event a to a later event b in time? You have (date_b - date_a) days
+    and can cover c.max_km_per_day each; same-day hops only if essentially co-located."""
+    gap = (b.day - a.day).days
+    if gap < 0:
+        return False
+    dist = haversine_km(a.lat, a.lon, b.lat, b.lon)
+    if gap == 0:
+        return dist <= 50.0
+    return dist <= gap * c.max_km_per_day + EPS
+
+
+def route_km(seq: list[Event] | tuple[Event, ...], c: Constraints) -> float:
+    """Round-trip kilometres: home -> seq[0] -> ... -> seq[-1] -> home."""
+    if not seq:
+        return 0.0
+    km = haversine_km(c.home_lat, c.home_lon, seq[0].lat, seq[0].lon)
+    for a, b in zip(seq, seq[1:], strict=False):
+        km += haversine_km(a.lat, a.lon, b.lat, b.lon)
+    km += haversine_km(seq[-1].lat, seq[-1].lon, c.home_lat, c.home_lon)
+    return km
+
+
+def evaluate(seq: list[Event] | tuple[Event, ...], prefs: dict[str, float],
+             c: Constraints) -> Itinerary:
+    value = sum(prize(e, prefs, c.default_pref) for e in seq)
+    return Itinerary(tuple(seq), value, route_km(seq, c))
+
+
+def _legs_feasible(seq: tuple[Event, ...] | list[Event], c: Constraints) -> bool:
+    return all(feasible_leg(a, b, c) for a, b in zip(seq, seq[1:], strict=False))
+
+
+# --------------------------------------------------------------------------- #
+# baselines (greedy)
+# --------------------------------------------------------------------------- #
+def _date_insert(seq: list[Event], e: Event) -> list[Event]:
+    out = list(seq)
+    i = 0
+    while i < len(out) and (out[i].day, out[i].id) < (e.day, e.id):
+        i += 1
+    out.insert(i, e)
+    return out
+
+
+def _valid_km(seq: list[Event], c: Constraints) -> float | None:
+    if c.max_events is not None and len(seq) > c.max_events:
+        return None
+    if not _legs_feasible(seq, c):
+        return None
+    km = route_km(seq, c)
+    return km if km <= c.max_travel_km + EPS else None
+
+
+def _greedy(events: list[Event], prefs: dict[str, float], c: Constraints, key) -> Itinerary:
+    seq: list[Event] = []
+    for e in sorted(candidates(events, c), key=key):
+        trial = _date_insert(seq, e)
+        if _valid_km(trial, c) is not None:
+            seq = trial
+    return evaluate(seq, prefs, c)
+
+
+def plan_by_date(events, prefs, c):
+    """Baseline: take events soonest-first while the trip stays feasible + in budget."""
+    return _greedy(events, prefs, c, key=lambda e: (e.day, e.id))
+
+
+def plan_by_prize(events, prefs, c):
+    """Baseline: take your most-wanted artists first (date order preserved)."""
+    return _greedy(events, prefs, c, key=lambda e: (-prize(e, prefs, c.default_pref), e.day, e.id))
+
+
+def plan_by_ratio(events, prefs, c):
+    """Baseline: distance-aware greedy — repeatedly add the event with the best marginal
+    value-per-kilometre that keeps the trip feasible + in budget."""
+    seq: list[Event] = []
+    remaining = list(candidates(events, c))
+    cur_km = 0.0
+    while True:
+        best = None  # (key, event, trial, km)
+        for e in remaining:
+            p = prize(e, prefs, c.default_pref)
+            if p <= 0:
+                continue
+            trial = _date_insert(seq, e)
+            km = _valid_km(trial, c)
+            if km is None:
+                continue
+            dkm = max(km - cur_km, EPS)
+            key = (p / dkm, p)
+            if best is None or key > best[0]:
+                best = (key, e, trial, km)
+        if best is None:
+            break
+        _, e, trial, km = best
+        seq, cur_km = trial, km
+        remaining.remove(e)
+    return evaluate(seq, prefs, c)
+
+
+# --------------------------------------------------------------------------- #
+# exact optimiser — Pareto label-setting on the date-DAG
+# --------------------------------------------------------------------------- #
+def _pareto(labels: list[tuple[float, int, float, tuple[int, ...]]]):
+    """Keep labels not dominated on (open_km ↓, count ↓, value ↑)."""
+    labels = sorted(labels, key=lambda lab: (lab[0], lab[1], -lab[2]))
+    kept: list[tuple[float, int, float, tuple[int, ...]]] = []
+    for lab in labels:
+        okm, cnt, val, _ = lab
+        if not any(k[0] <= okm + EPS and k[1] <= cnt and k[2] >= val - 1e-12 for k in kept):
+            kept.append(lab)
+    return kept
+
+
+def plan_optimal(events: list[Event], prefs: dict[str, float], c: Constraints) -> Itinerary:
+    """Exact maximum-value itinerary within the travel budget (and optional event cap)."""
+    cand = candidates(events, c)
+    n = len(cand)
+    p = [prize(e, prefs, c.default_pref) for e in cand]
+    home_km = [haversine_km(c.home_lat, c.home_lon, e.lat, e.lon) for e in cand]
+    labels: list[list[tuple[float, int, float, tuple[int, ...]]]] = [[] for _ in range(n)]
+    best = Itinerary((), 0.0, 0.0)  # the empty trip is always feasible
+
+    def consider(open_km: float, value: float, path: tuple[int, ...]) -> None:
+        nonlocal best
+        last = cand[path[-1]]
+        total = open_km + haversine_km(last.lat, last.lon, c.home_lat, c.home_lon)
+        if total > c.max_travel_km + EPS:
+            return
+        if value > best.value + 1e-12 or (
+                abs(value - best.value) <= 1e-12 and total < best.travel_km - 1e-12):
+            best = Itinerary(tuple(cand[i] for i in path), value, total)
+
+    for i in range(n):
+        new: list[tuple[float, int, float, tuple[int, ...]]] = []
+        if home_km[i] <= c.max_travel_km + EPS and (c.max_events is None or c.max_events >= 1):
+            new.append((home_km[i], 1, p[i], (i,)))
+        for j in range(i):
+            if not feasible_leg(cand[j], cand[i], c):
+                continue
+            leg = haversine_km(cand[j].lat, cand[j].lon, cand[i].lat, cand[i].lon)
+            for okm, cnt, val, path in labels[j]:
+                if c.max_events is not None and cnt + 1 > c.max_events:
+                    continue
+                nokm = okm + leg
+                if nokm > c.max_travel_km + EPS:   # adding the return leg can only grow km
+                    continue
+                new.append((nokm, cnt + 1, val + p[i], path + (i,)))
+        labels[i] = _pareto(new)
+        for okm, _, val, path in labels[i]:
+            consider(okm, val, path)
+    return best
+
+
+def brute_force_optimal(events: list[Event], prefs: dict[str, float],
+                        c: Constraints) -> Itinerary:
+    """Ground-truth optimum by enumerating every feasible subset. Tests only (exponential)."""
+    cand = candidates(events, c)
+    best = Itinerary((), 0.0, 0.0)
+    max_r = len(cand) if c.max_events is None else min(c.max_events, len(cand))
+    for r in range(1, max_r + 1):
+        for combo in itertools.combinations(cand, r):  # cand is date-sorted -> combo is too
+            if not _legs_feasible(combo, c):
+                continue
+            it = evaluate(list(combo), prefs, c)
+            if it.travel_km > c.max_travel_km + EPS:
+                continue
+            if it.value > best.value + 1e-12 or (
+                    abs(it.value - best.value) <= 1e-12 and it.travel_km < best.travel_km - 1e-12):
+                best = it
+    return best
+
+
+# rungs the eval ablates, in order
+PLANNERS = {
+    "by-date": plan_by_date,
+    "by-prize": plan_by_prize,
+    "distance-aware": plan_by_ratio,
+    "optimal": plan_optimal,
+}

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -1,0 +1,135 @@
+"""Per-performer (and multi-performer) trip planning over our canonical event data.
+
+Bridges `public.v_event_base` rows into the vendored gigtrip optimizer (see `gigtrip/`,
+MIT — `NOTICE.md`) and returns a JSON-serializable plan. Pure compute: no writes, no
+upstream API calls — it only reads event geography/dates we already hold.
+
+Split so the planning logic is testable offline:
+  - `plan_from_rows(...)` — pure: rows -> itinerary dict (no DB).
+  - `fetch_performer_rows(db, ...)` / `plan_performer_trip(db, ...)` — thin Supabase wrappers.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from .gigtrip.model import Constraints, Event, Itinerary
+from .gigtrip.optimizer import plan_by_date, plan_optimal
+
+
+# --------------------------------------------------------------------------- #
+# row mapping + serialization
+# --------------------------------------------------------------------------- #
+def row_to_event(r: dict) -> Event:
+    """Map one v_event_base-shaped row into a gigtrip Event.
+
+    PostgREST returns numerics as strings, so lat/lon/date are coerced defensively.
+    """
+    d = r.get("event_date")
+    day = d if isinstance(d, date) else date.fromisoformat(str(d)[:10])
+    return Event(
+        id=str(r["tevo_event_id"]),
+        title=(r.get("primary_performer_name") or r.get("event_name") or "").strip(),
+        kind="music",
+        day=day,
+        city=r.get("venue_city") or "",
+        venue=r.get("venue_name") or "",
+        lat=float(r["venue_lat"]),
+        lon=float(r["venue_lon"]),
+    )
+
+
+def _event_dict(e: Event) -> dict:
+    return {
+        "event_id": int(e.id),
+        "performer": e.title,
+        "venue": e.venue,
+        "city": e.city,
+        "date": e.day.isoformat(),
+        "lat": e.lat,
+        "lon": e.lon,
+    }
+
+
+def _itin_dict(it: Itinerary) -> dict:
+    return {
+        "count": it.count,
+        "value": round(it.value, 4),
+        "travel_km": round(it.travel_km, 1),
+        "events": [_event_dict(e) for e in it.events],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# pure planning (no DB) — unit-testable
+# --------------------------------------------------------------------------- #
+def plan_from_rows(rows: list[dict], home: dict, budget_km: float,
+                   start: date, end: date, prefs: dict[str, float] | None = None,
+                   max_events: int | None = None,
+                   max_km_per_day: float = 1200.0) -> dict:
+    """Build the optimal itinerary (and the sort-by-date baseline) from raw rows.
+
+    `home` is {"name", "lat", "lon"}. `prefs` maps lowercased performer title -> weight;
+    when omitted every distinct performer is weighted 1.0 (the single-performer case is
+    just the uniform-weight degenerate of the general multi-performer optimizer).
+    """
+    events = [row_to_event(r) for r in rows if r.get("venue_lat") is not None
+              and r.get("venue_lon") is not None]
+    if prefs is None:
+        prefs = {e.title.lower(): 1.0 for e in events}
+
+    c = Constraints(
+        home_name=home["name"], home_lat=float(home["lat"]), home_lon=float(home["lon"]),
+        start=start, end=end, max_travel_km=float(budget_km),
+        max_events=max_events, max_km_per_day=max_km_per_day,
+    )
+    optimal = plan_optimal(events, prefs, c)
+    baseline = plan_by_date(events, prefs, c)
+
+    titles = sorted({e.title for e in events})
+    performer_label = titles[0] if len(titles) == 1 else f"{len(titles)} performers"
+
+    return {
+        "performer": performer_label,
+        "home": home,
+        "budget_km": float(budget_km),
+        "window": {"start": start.isoformat(), "end": end.isoformat()},
+        "tour_date_count": len(events),
+        "optimal": _itin_dict(optimal),
+        "baseline_by_date": _itin_dict(baseline),
+        "shows_gained": optimal.count - baseline.count,
+        "all_dates": [_event_dict(e) for e in sorted(events, key=lambda e: (e.day, e.id))],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# DB-backed entry points (Supabase client) — used by app.py routes
+# --------------------------------------------------------------------------- #
+_SELECT = ("tevo_event_id, event_name, primary_performer_name, venue_name, "
+           "venue_city, venue_state, event_date, venue_lat, venue_lon")
+
+
+def fetch_performer_rows(db, performer_id: int, start: date, end: date,
+                         limit: int = 500) -> list[dict]:
+    """Upcoming geocoded events for one performer from v_event_base, calendar order."""
+    return (db.table("v_event_base")
+            .select(_SELECT)
+            .eq("tevo_performer_id", performer_id)
+            .gte("event_date", start.isoformat())
+            .lte("event_date", end.isoformat())
+            .not_.is_("venue_lat", "null")
+            .order("event_date")
+            .limit(limit)
+            .execute().data) or []
+
+
+def plan_performer_trip(db, performer_id: int, home_lat: float, home_lon: float,
+                        budget_km: float, start: date, end: date,
+                        home_name: str = "Home", max_events: int | None = None,
+                        max_km_per_day: float = 1200.0) -> dict:
+    """End-to-end: pull a performer's upcoming dates and plan the optimal trip."""
+    rows = fetch_performer_rows(db, performer_id, start, end)
+    home = {"name": home_name, "lat": home_lat, "lon": home_lon}
+    payload = plan_from_rows(rows, home, budget_km, start, end,
+                             max_events=max_events, max_km_per_day=max_km_per_day)
+    payload["performer_id"] = int(performer_id)
+    return payload

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from datetime import date
 
+from .city_centroids import centroid_for
 from .gigtrip.model import Constraints, Event, Itinerary
 from .gigtrip.optimizer import plan_by_date, plan_optimal
 
@@ -38,7 +39,7 @@ def row_to_event(r: dict) -> Event:
     )
 
 
-def _event_dict(e: Event) -> dict:
+def _event_dict(e: Event, csrc: dict[int, str]) -> dict:
     return {
         "event_id": int(e.id),
         "performer": e.title,
@@ -47,15 +48,16 @@ def _event_dict(e: Event) -> dict:
         "date": e.day.isoformat(),
         "lat": e.lat,
         "lon": e.lon,
+        "coord_source": csrc.get(int(e.id), "venue"),  # "venue" (precise) | "city" (centroid)
     }
 
 
-def _itin_dict(it: Itinerary) -> dict:
+def _itin_dict(it: Itinerary, csrc: dict[int, str]) -> dict:
     return {
         "count": it.count,
         "value": round(it.value, 4),
         "travel_km": round(it.travel_km, 1),
-        "events": [_event_dict(e) for e in it.events],
+        "events": [_event_dict(e, csrc) for e in it.events],
     }
 
 
@@ -72,8 +74,10 @@ def plan_from_rows(rows: list[dict], home: dict, budget_km: float,
     when omitted every distinct performer is weighted 1.0 (the single-performer case is
     just the uniform-weight degenerate of the general multi-performer optimizer).
     """
-    events = [row_to_event(r) for r in rows if r.get("venue_lat") is not None
+    usable = [r for r in rows if r.get("venue_lat") is not None
               and r.get("venue_lon") is not None]
+    events = [row_to_event(r) for r in usable]
+    csrc = {int(r["tevo_event_id"]): r.get("_coord_source", "venue") for r in usable}
     if prefs is None:
         prefs = {e.title.lower(): 1.0 for e in events}
 
@@ -87,6 +91,7 @@ def plan_from_rows(rows: list[dict], home: dict, budget_km: float,
 
     titles = sorted({e.title for e in events})
     performer_label = titles[0] if len(titles) == 1 else f"{len(titles)} performers"
+    n_city = sum(1 for v in csrc.values() if v == "city")
 
     return {
         "performer": performer_label,
@@ -94,10 +99,15 @@ def plan_from_rows(rows: list[dict], home: dict, budget_km: float,
         "budget_km": float(budget_km),
         "window": {"start": start.isoformat(), "end": end.isoformat()},
         "tour_date_count": len(events),
-        "optimal": _itin_dict(optimal),
-        "baseline_by_date": _itin_dict(baseline),
+        "coord_coverage": {
+            "venue": len(usable) - n_city,        # precise venue geocode
+            "city_fallback": n_city,              # approximated to city centroid
+            "dropped_no_coords": len(rows) - len(usable),  # neither available -> excluded
+        },
+        "optimal": _itin_dict(optimal, csrc),
+        "baseline_by_date": _itin_dict(baseline, csrc),
         "shows_gained": optimal.count - baseline.count,
-        "all_dates": [_event_dict(e) for e in sorted(events, key=lambda e: (e.day, e.id))],
+        "all_dates": [_event_dict(e, csrc) for e in sorted(events, key=lambda e: (e.day, e.id))],
     }
 
 
@@ -110,16 +120,41 @@ _SELECT = ("tevo_event_id, event_name, primary_performer_name, venue_name, "
 
 def fetch_performer_rows(db, performer_id: int, start: date, end: date,
                          limit: int = 500) -> list[dict]:
-    """Upcoming geocoded events for one performer from v_event_base, calendar order."""
+    """Upcoming events for one performer from v_event_base, calendar order.
+
+    Returns ALL in-window rows (including those without a precise venue geocode); the
+    city-centroid fallback fills coords for the un-geocoded ones before planning.
+    """
     return (db.table("v_event_base")
             .select(_SELECT)
             .eq("tevo_performer_id", performer_id)
             .gte("event_date", start.isoformat())
             .lte("event_date", end.isoformat())
-            .not_.is_("venue_lat", "null")
             .order("event_date")
             .limit(limit)
             .execute().data) or []
+
+
+def _apply_coord_fallback(db, rows: list[dict]) -> None:
+    """In-place: tag rows with a precise venue geocode as coord_source='venue'; for the rest,
+    resolve EVO's `events.venue_location` 'City, ST' text to a city centroid (coord_source=
+    'city'). Rows that resolve to neither keep NULL coords and are dropped at plan time."""
+    missing = []
+    for r in rows:
+        if r.get("venue_lat") is not None and r.get("venue_lon") is not None:
+            r["_coord_source"] = "venue"
+        else:
+            missing.append(r)
+    if not missing:
+        return
+    ids = [int(r["tevo_event_id"]) for r in missing]
+    locs = (db.table("events").select("id, venue_location")
+            .in_("id", ids).execute().data) or []
+    locmap = {int(x["id"]): x.get("venue_location") for x in locs}
+    for r in missing:
+        c = centroid_for(locmap.get(int(r["tevo_event_id"])))
+        if c:
+            r["venue_lat"], r["venue_lon"], r["_coord_source"] = c[0], c[1], "city"
 
 
 def plan_performer_trip(db, performer_id: int, home_lat: float, home_lon: float,
@@ -128,6 +163,7 @@ def plan_performer_trip(db, performer_id: int, home_lat: float, home_lon: float,
                         max_km_per_day: float = 1200.0) -> dict:
     """End-to-end: pull a performer's upcoming dates and plan the optimal trip."""
     rows = fetch_performer_rows(db, performer_id, start, end)
+    _apply_coord_fallback(db, rows)
     home = {"name": home_name, "lat": home_lat, "lon": home_lon}
     payload = plan_from_rows(rows, home, budget_km, start, end,
                              max_events=max_events, max_km_per_day=max_km_per_day)

--- a/trip_planner/test_ariana.py
+++ b/trip_planner/test_ariana.py
@@ -1,0 +1,75 @@
+"""Offline end-to-end test of the planner on a real active touring performer.
+
+Fixture = a snapshot of `public.v_event_base` for Ariana Grande (tevo_performer_id 27474),
+17 geocoded upcoming dates 2026-06-14 .. 2026-08-07. Exercises the pure `plan_from_rows`
+path (no DB) and asserts the exact optimizer matches the brute-force oracle.
+
+Run from repo root:  python3 -m trip_planner.test_ariana
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from .gigtrip.model import Constraints
+from .gigtrip.optimizer import brute_force_optimal, plan_optimal
+from .planner import plan_from_rows, row_to_event
+
+ROWS = [
+    {"tevo_event_id": 3094846, "primary_performer_name": "Ariana Grande", "venue_name": "Crypto.com Arena",   "venue_city": "Los Angeles", "event_date": "2026-06-14", "venue_lat": 34.042998, "venue_lon": -118.267135},
+    {"tevo_event_id": 3094847, "primary_performer_name": "Ariana Grande", "venue_name": "Crypto.com Arena",   "venue_city": "Los Angeles", "event_date": "2026-06-15", "venue_lat": 34.042998, "venue_lon": -118.267135},
+    {"tevo_event_id": 3094889, "primary_performer_name": "Ariana Grande", "venue_name": "Amerant Bank Arena", "venue_city": "Sunrise",     "event_date": "2026-06-30", "venue_lat": 26.158370, "venue_lon": -80.325429},
+    {"tevo_event_id": 3094890, "primary_performer_name": "Ariana Grande", "venue_name": "Amerant Bank Arena", "venue_city": "Sunrise",     "event_date": "2026-07-02", "venue_lat": 26.158370, "venue_lon": -80.325429},
+    {"tevo_event_id": 3110252, "primary_performer_name": "Ariana Grande", "venue_name": "Amerant Bank Arena", "venue_city": "Sunrise",     "event_date": "2026-07-04", "venue_lat": 26.158370, "venue_lon": -80.325429},
+    {"tevo_event_id": 3094898, "primary_performer_name": "Ariana Grande", "venue_name": "State Farm Arena",   "venue_city": "Atlanta",     "event_date": "2026-07-06", "venue_lat": 33.757370, "venue_lon": -84.396385},
+    {"tevo_event_id": 3094901, "primary_performer_name": "Ariana Grande", "venue_name": "State Farm Arena",   "venue_city": "Atlanta",     "event_date": "2026-07-08", "venue_lat": 33.757370, "venue_lon": -84.396385},
+    {"tevo_event_id": 3110254, "primary_performer_name": "Ariana Grande", "venue_name": "State Farm Arena",   "venue_city": "Atlanta",     "event_date": "2026-07-10", "venue_lat": 33.757370, "venue_lon": -84.396385},
+    {"tevo_event_id": 3094899, "primary_performer_name": "Ariana Grande", "venue_name": "TD Garden",          "venue_city": "Boston",      "event_date": "2026-07-22", "venue_lat": 42.366299, "venue_lon": -71.062162},
+    {"tevo_event_id": 3094900, "primary_performer_name": "Ariana Grande", "venue_name": "TD Garden",          "venue_city": "Boston",      "event_date": "2026-07-24", "venue_lat": 42.366299, "venue_lon": -71.062162},
+    {"tevo_event_id": 3110257, "primary_performer_name": "Ariana Grande", "venue_name": "TD Garden",          "venue_city": "Boston",      "event_date": "2026-07-26", "venue_lat": 42.366299, "venue_lon": -71.062162},
+    {"tevo_event_id": 3094895, "primary_performer_name": "Ariana Grande", "venue_name": "Centre Bell",        "venue_city": "Montreal",    "event_date": "2026-07-28", "venue_lat": 45.496036, "venue_lon": -73.569203},
+    {"tevo_event_id": 3094896, "primary_performer_name": "Ariana Grande", "venue_name": "Centre Bell",        "venue_city": "Montreal",    "event_date": "2026-07-30", "venue_lat": 45.496036, "venue_lon": -73.569203},
+    {"tevo_event_id": 3110259, "primary_performer_name": "Ariana Grande", "venue_name": "Centre Bell",        "venue_city": "Montreal",    "event_date": "2026-08-01", "venue_lat": 45.496036, "venue_lon": -73.569203},
+    {"tevo_event_id": 3094902, "primary_performer_name": "Ariana Grande", "venue_name": "United Center",      "venue_city": "Chicago",     "event_date": "2026-08-04", "venue_lat": 41.880683, "venue_lon": -87.674185},
+    {"tevo_event_id": 3094903, "primary_performer_name": "Ariana Grande", "venue_name": "United Center",      "venue_city": "Chicago",     "event_date": "2026-08-06", "venue_lat": 41.880683, "venue_lon": -87.674185},
+    {"tevo_event_id": 3110270, "primary_performer_name": "Ariana Grande", "venue_name": "United Center",      "venue_city": "Chicago",     "event_date": "2026-08-07", "venue_lat": 41.880683, "venue_lon": -87.674185},
+]
+HOME = {"name": "New York City", "lat": 40.7128, "lon": -74.0060}
+START, END = date(2026, 6, 8), date(2026, 8, 31)
+BUDGETS = (2000, 4000, 6000, 9000, 14000)
+
+
+def test_optimal_matches_oracle():
+    events = [row_to_event(r) for r in ROWS]
+    prefs = {"ariana grande": 1.0}
+    for b in BUDGETS:
+        c = Constraints(HOME["name"], HOME["lat"], HOME["lon"], START, END, b)
+        o = plan_optimal(events, prefs, c)
+        g = brute_force_optimal(events, prefs, c)
+        assert abs(o.value - g.value) < 1e-9, f"budget {b}: optimal {o.value} != oracle {g.value}"
+
+
+def test_optimal_beats_baseline_at_binding_budget():
+    # At 9000 km from NYC, sort-by-date wastes budget flying to the earliest (LA) date;
+    # the optimizer clusters the eastern + Chicago legs for strictly more shows.
+    p = plan_from_rows(ROWS, HOME, 9000, START, END)
+    assert p["optimal"]["count"] > p["baseline_by_date"]["count"]
+    assert p["shows_gained"] >= 1
+
+
+def main():
+    print(f"\nPer-performer trip planner — Ariana Grande (home {HOME['name']})")
+    print(f"window {START}..{END}  ·  {len(ROWS)} geocoded tour dates\n")
+    for b in BUDGETS:
+        p = plan_from_rows(ROWS, HOME, b, START, END)
+        o, base = p["optimal"], p["baseline_by_date"]
+        cities = ", ".join(dict.fromkeys(e["city"] for e in o["events"]))
+        print(f"  budget {b:>6} km | optimal {o['count']:>2} shows / {o['travel_km']:>6.0f} km"
+              f"  vs by-date {base['count']:>2} / {base['travel_km']:>6.0f} km"
+              f"  -> +{p['shows_gained']} shows  [{cities}]")
+    test_optimal_matches_oracle()
+    test_optimal_beats_baseline_at_binding_budget()
+    print("\n  asserts passed: optimal == brute-force oracle; optimal > baseline at 9000 km\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/trip_planner/test_ariana.py
+++ b/trip_planner/test_ariana.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import date
 
+from .city_centroids import centroid_for
 from .gigtrip.model import Constraints
 from .gigtrip.optimizer import brute_force_optimal, plan_optimal
 from .planner import plan_from_rows, row_to_event
@@ -56,6 +57,29 @@ def test_optimal_beats_baseline_at_binding_budget():
     assert p["shows_gained"] >= 1
 
 
+def test_city_centroid_fallback():
+    # The two real venues the planner was silently dropping (no precise geocode) are now
+    # recoverable from their EVO "City, ST" text via the centroid gazetteer.
+    assert centroid_for("Inglewood, CA") is not None
+    assert centroid_for("Brooklyn, NY") is not None
+    assert centroid_for("Brooklyn, NY, USA") is not None        # tolerant of trailing country
+    assert centroid_for("Nowhere, ZZ") is None
+
+    # A row with no precise coords but a city-centroid fill is counted + included; a row that
+    # resolves to neither is reported as dropped (not silently lost).
+    rows = list(ROWS) + [
+        {"tevo_event_id": 9001, "primary_performer_name": "Ariana Grande", "venue_name": "Kia Forum",
+         "venue_city": "Inglewood", "event_date": "2026-06-20",
+         "venue_lat": 33.9617, "venue_lon": -118.3531, "_coord_source": "city"},
+        {"tevo_event_id": 9002, "primary_performer_name": "Ariana Grande", "venue_name": "Mystery Hall",
+         "venue_city": None, "event_date": "2026-06-21", "venue_lat": None, "venue_lon": None},
+    ]
+    p = plan_from_rows(rows, HOME, 14000, START, END)
+    assert p["coord_coverage"]["city_fallback"] == 1
+    assert p["coord_coverage"]["dropped_no_coords"] == 1
+    assert p["tour_date_count"] == len(ROWS) + 1   # the centroid row counts, the coord-less one doesn't
+
+
 def main():
     print(f"\nPer-performer trip planner — Ariana Grande (home {HOME['name']})")
     print(f"window {START}..{END}  ·  {len(ROWS)} geocoded tour dates\n")
@@ -68,7 +92,9 @@ def main():
               f"  -> +{p['shows_gained']} shows  [{cities}]")
     test_optimal_matches_oracle()
     test_optimal_beats_baseline_at_binding_budget()
-    print("\n  asserts passed: optimal == brute-force oracle; optimal > baseline at 9000 km\n")
+    test_city_centroid_fallback()
+    print("\n  asserts passed: optimal == brute-force oracle; optimal > baseline at 9000 km;")
+    print("  city-centroid fallback recovers un-geocoded shows (Inglewood/Brooklyn)\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds **"plan a trip around a performer"** — given a home location and a round-trip travel budget, returns the *maximum-value* set of a performer's upcoming shows to attend (date order), plus the naive sort-by-date plan for comparison.

Engine is the itinerary optimizer **vendored from [axiom-orion/gigtrip](https://github.com/axiom-orion/gigtrip) (MIT)** — an exact Pareto label-setting DP, verified against a brute-force oracle. Only the engine is vendored; the upstream Bandsintown + Streamlit layers are dropped in favor of our own `public.v_event_base` data.

**Pure read + compute** — no writes, no upstream API calls (consistent with the read-only lockdown in `CLAUDE.md` / `PROJECT_BIBLE.md §1`).

## Surfaces
- **D1 store** — `GET /api/store/performers/{id}/trip-plan` (consumer, open) + sandbox UI at `/store/test/trip`
- **D0 terminal** — `GET /api/broker/performers/{id}/trip-plan` (auth-gated)

Both routes are thin wrappers over the shared `trip_planner` module, so the two lanes never duplicate the logic.

## Proof on real data
Offline end-to-end test on a real active tour (Ariana Grande, performer 27474, 17 geocoded dates), home = NYC:

| Budget | Optimal | Sort-by-date | Gain |
|---|---|---|---|
| 4,000 km | **9 shows** / 3,057 km | 6 / 3,852 km | **+3** |
| 9,000 km | **15 shows** / 6,909 km | 8 / 8,863 km | **+7** |

At 9,000 km, sort-by-date burns the budget flying to the earliest (LA) date; the optimizer skips far-flung LA and clusters the eastern + Chicago legs for more shows at less travel. `test_ariana.py` asserts optimal == brute-force oracle at every budget.

```bash
python3 -m trip_planner.test_ariana
```

## Status / notes
- **Frontends not yet live-verified** — this sandbox has no Supabase creds, so the engine is proven offline and the routes match the codebase idiom; live verification is on deploy.
- **D1 is PAUSED** per `PROJECT_BIBLE.md §2`; this is an operator-directed spike-to-feature. Cross-lane (D0+D1) — flagging for owner visibility.
- Next: D0 performer-page tab UI; optional $-budget (price-aware cost model) and multi-performer mode (engine already supports a `prefs` map).

Draft until the frontends are verified against live data.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_