### PR TITLE
feat(d0/performer): add SVG route map to Trip Planner

### DIFF
--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -30,6 +30,14 @@
     .trip-row .tr-date { width: 110px; color: var(--muted, #9aa); font-variant-numeric: tabular-nums; }
     .trip-row .tr-city { width: 120px; font-weight: 600; }
     .trip-row .tr-go { margin-left: auto; color: var(--good, #4ade80); font-size: 11px; }
+    .trip-map { margin: 6px 0 14px; background: var(--panel, #14141b); border: 1px solid rgba(255,255,255,.08); border-radius: 8px; padding: 6px; }
+    .trip-map-svg { width: 100%; height: auto; display: block; }
+    .tm-route { fill: none; stroke: var(--good, #4ade80); stroke-width: 1.6; stroke-opacity: .75; stroke-linejoin: round; stroke-dasharray: 5 3; }
+    .tm-go { fill: var(--good, #4ade80); stroke: #0a0a0a; stroke-width: 1; }
+    .tm-skip { fill: none; stroke: var(--muted, #9aa); stroke-width: 1.3; opacity: .55; }
+    .tm-home circle { fill: #fff; stroke: var(--good, #4ade80); stroke-width: 2; }
+    .tm-lbl { fill: var(--muted, #cbd5e1); font-size: 10px; }
+    .tm-home-lbl { fill: #fff; font-weight: 600; }
   </style>
 </head>
 <body data-page="performer">
@@ -115,6 +123,7 @@
           <button id="tripGo" class="event-tab">Plan</button>
         </div>
         <div id="tripStats" class="trip-stats" hidden></div>
+        <div id="tripMap" class="trip-map" hidden></div>
         <div id="tripBody"><div class="empty">tap Plan to compute</div></div>
       </section>
 

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -209,9 +209,62 @@
     catch (_) { return iso; }
   }
 
+  // Build a self-contained SVG route map (no tiles / external libs — CSP-safe).
+  // Equirectangular projection with a cos(lat) longitude correction so the spread
+  // looks geographically sane; plots home, every stop, and the optimizer's route.
+  function _tripProjector(points, W, H, pad) {
+    const lats = points.map(p => p.lat), lons = points.map(p => p.lon);
+    const minLat = Math.min(...lats), maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons), maxLon = Math.max(...lons);
+    const k = Math.cos(((minLat + maxLat) / 2) * Math.PI / 180) || 1;
+    const minX = minLon * k, maxX = maxLon * k;
+    const xr = (maxX - minX) || 1e-6, yr = (maxLat - minLat) || 1e-6;
+    return (lat, lon) => [
+      pad + (lon * k - minX) / xr * (W - 2 * pad),
+      pad + (maxLat - lat) / yr * (H - 2 * pad),
+    ];
+  }
+
+  function buildTripMap(d) {
+    const W = 600, H = 340, pad = 42;
+    const pts = [{ lat: +d.home.lat, lon: +d.home.lon }];
+    (d.all_dates || []).forEach(e => pts.push({ lat: +e.lat, lon: +e.lon }));
+    if (pts.length < 2) return '';
+    const proj = _tripProjector(pts, W, H, pad);
+    const [hx, hy] = proj(+d.home.lat, +d.home.lon);
+    const going = d.optimal.events || [];
+    const picked = new Set(going.map(e => e.event_id));
+
+    const route = [[hx, hy], ...going.map(e => proj(+e.lat, +e.lon)), [hx, hy]];
+    const routeD = route.map((p, i) => (i ? 'L' : 'M') + p[0].toFixed(1) + ' ' + p[1].toFixed(1)).join(' ');
+
+    let dots = '';
+    (d.all_dates || []).forEach(e => {
+      const [x, y] = proj(+e.lat, +e.lon);
+      const on = picked.has(e.event_id);
+      dots += `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="${on ? 5 : 3.5}" class="${on ? 'tm-go' : 'tm-skip'}">`
+        + `<title>${escapeHtml((e.city || '') + ' · ' + (e.venue || '') + ' · ' + e.date)}</title></circle>`;
+    });
+
+    let labels = ''; const seen = new Set();
+    going.forEach(e => {
+      if (seen.has(e.city)) return;
+      seen.add(e.city);
+      const [x, y] = proj(+e.lat, +e.lon);
+      labels += `<text x="${(x + 7).toFixed(1)}" y="${(y + 3).toFixed(1)}" class="tm-lbl">${escapeHtml(e.city || '')}</text>`;
+    });
+
+    const home = `<g class="tm-home"><circle cx="${hx.toFixed(1)}" cy="${hy.toFixed(1)}" r="5"/>`
+      + `<text x="${(hx + 7).toFixed(1)}" y="${(hy + 3).toFixed(1)}" class="tm-lbl tm-home-lbl">${escapeHtml(d.home.name || 'Home')}</text></g>`;
+
+    return `<svg viewBox="0 0 ${W} ${H}" class="trip-map-svg" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Trip route map">`
+      + `<path d="${routeD}" class="tm-route"/>${dots}${home}${labels}</svg>`;
+  }
+
   function renderTripPlan(d) {
     const body = document.getElementById('tripBody');
     const stats = document.getElementById('tripStats');
+    const mapEl = document.getElementById('tripMap');
     const meta = document.getElementById('tripMeta');
     if (meta) {
       const cov = d.coord_coverage || {};
@@ -224,10 +277,16 @@
     }
     if (!d.tour_date_count) {
       if (stats) stats.hidden = true;
+      if (mapEl) mapEl.hidden = true;
       body.innerHTML = '<div class="empty">no upcoming geocoded dates for this performer</div>';
       return;
     }
     const o = d.optimal, b = d.baseline_by_date;
+    if (mapEl) {
+      const svg = buildTripMap(d);
+      if (svg) { mapEl.innerHTML = svg; mapEl.hidden = false; }
+      else { mapEl.hidden = true; }
+    }
     if (stats) {
       stats.hidden = false;
       stats.innerHTML =


### PR DESCRIPTION
## What
The Trip Planner showed only a stat line + a date list — no geographic view. This adds an **inline SVG route map** above the itinerary, so the multi-city route is actually visible.

- Self-contained: **no map tiles, no external library** — an equirectangular projection (with a `cos(lat)` longitude correction) rendered as inline SVG. CSP-safe (`script-src 'self'`) and deterministic.
- Plots the **home base**, **every tour stop** (going = filled green, skipped = hollow/dim), and the **optimizer's route** as a dashed polyline, with city labels and per-stop tooltips (city · venue · date).
- Lives in the D0 performer page → Upcoming Events tab → Trip Planner.

Visually this makes the optimizer's logic obvious — e.g. the lone far-west LA stop vs the clustered eastern legs.

## Notes
- Frontend verifies on deploy (no creds to render here); `node --check` clean.
- Follow-up to #463. Same treatment can be mirrored into the D1 store sandbox (`/store/test/trip`) for parity if wanted.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_