### PR TITLE
fix(d0/performer): shrink Trip Planner map + scroll itinerary

### DIFF
--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -25,12 +25,13 @@
     .trip-stats .ts-num { font-size: 22px; font-weight: 700; display: block; line-height: 1.1; }
     .trip-stats .ts-num.gain { color: var(--good, #4ade80); }
     .trip-stats .ts-lbl { font-size: 11px; color: var(--muted, #9aa); }
-    .trip-row { display: flex; gap: 14px; padding: 7px 4px; border-bottom: 1px solid rgba(255,255,255,.06); align-items: baseline; font-size: 13px; }
+    .trip-row { display: flex; gap: 14px; padding: 4px 4px; border-bottom: 1px solid rgba(255,255,255,.06); align-items: baseline; font-size: 12px; }
     .trip-row.skip { opacity: .4; }
-    .trip-row .tr-date { width: 110px; color: var(--muted, #9aa); font-variant-numeric: tabular-nums; }
-    .trip-row .tr-city { width: 120px; font-weight: 600; }
+    .trip-row .tr-date { width: 104px; color: var(--muted, #9aa); font-variant-numeric: tabular-nums; }
+    .trip-row .tr-city { width: 116px; font-weight: 600; }
     .trip-row .tr-go { margin-left: auto; color: var(--good, #4ade80); font-size: 11px; }
-    .trip-map { margin: 6px 0 14px; background: var(--panel, #14141b); border: 1px solid rgba(255,255,255,.08); border-radius: 8px; padding: 6px; }
+    .trip-list { max-height: 280px; overflow-y: auto; margin-top: 4px; }
+    .trip-map { max-width: 460px; margin: 6px 0 14px; background: var(--panel, #14141b); border: 1px solid rgba(255,255,255,.08); border-radius: 8px; padding: 5px; }
     .trip-map-svg { width: 100%; height: auto; display: block; }
     .tm-route { fill: none; stroke: var(--good, #4ade80); stroke-width: 1.6; stroke-opacity: .75; stroke-linejoin: round; stroke-dasharray: 5 3; }
     .tm-go { fill: var(--good, #4ade80); stroke: #0a0a0a; stroke-width: 1; }

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -226,7 +226,7 @@
   }
 
   function buildTripMap(d) {
-    const W = 600, H = 340, pad = 42;
+    const W = 560, H = 250, pad = 30;
     const pts = [{ lat: +d.home.lat, lon: +d.home.lon }];
     (d.all_dates || []).forEach(e => pts.push({ lat: +e.lat, lon: +e.lon }));
     if (pts.length < 2) return '';
@@ -306,7 +306,7 @@
         + (on ? '<span class="tr-go">● going</span>' : '')
         + '</div>';
     }).join('');
-    body.innerHTML = (cities ? `<div class="muted small" style="margin:4px 0 8px">${escapeHtml(cities)}</div>` : '') + rows;
+    body.innerHTML = (cities ? `<div class="muted small" style="margin:4px 0 6px">${escapeHtml(cities)}</div>` : '') + `<div class="trip-list">${rows}</div>`;
   }
 
   // ---------- Hero ----------


### PR DESCRIPTION
## What
The Trip Planner's route map and date list were eating the screen on the D0 performer page. Tighten both.

- **Map**: was `width:100%` against a tall viewBox, so it ballooned on wide screens (~1000×567). Now capped at `max-width:460px` with a shorter viewBox (560×250) → renders ~**460×205**.
- **Itinerary**: long tours ran the full list down the page. Wrapped the date rows in a **280px max-height scroll** container and tightened row padding/font.

UI-only; `node --check` clean. Frontend verifies on deploy.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_