### PR TITLE
feat(sg): SeatData autopoll tiers + SeatData GMV/day on the SG-market chart

### DIFF
--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -425,7 +425,8 @@
         <th class="num">T-days</th>
         <th class="num" title="7-day moving average of daily sales (distinct sg_sale_id / day)">Vol/day</th>
         <th class="num" title="7-day moving average of daily sales median price">Med px</th>
-        <th class="num" title="7-day MA daily gross (volume × median, approx)">GMV/day</th>
+        <th class="num" title="SeatGeek 7-day MA daily gross (volume × median, approx)">GMV/day SG</th>
+        <th class="num" title="SeatData (StubHub-primary) sold comps: 7-day MA of daily gross (Σ price×qty). Blank until SeatData has sales for the event.">GMV/day SD</th>
         <th class="num" title="Chart score = percentile(volume) + percentile(median), 0–2">Score</th>
         <th class="num" title="Best rank achieved · days on chart">Peak·On</th>
       </tr></thead>
@@ -453,6 +454,7 @@
         <td class="num">${r.ma7_volume == null ? '—' : T.fmtNum(Math.round(+r.ma7_volume))}</td>
         <td class="num">${money(r.ma7_median)}</td>
         <td class="num">${money(r.ma7_gross)}</td>
+        <td class="num" title="${r.sd_sales_7d == null ? 'no SeatData sales yet' : r.sd_sales_7d + ' SeatData sale rows in last 7d'}">${money(r.sd_ma7_gross)}</td>
         <td class="num" title="vol pct ${r.pct_volume} · med pct ${r.pct_median}"><strong>${score}</strong></td>
         <td class="num" title="peak rank · consecutive days on chart">${peakOn}</td>`;
       tb.appendChild(tr);

--- a/supabase/functions/seatdata-poll/index.ts
+++ b/supabase/functions/seatdata-poll/index.ts
@@ -1,0 +1,189 @@
+// seatdata-poll
+//
+// AUTOPOLL (twice daily 11:00/20:00 ET, scheduled by cron seatdata_poll_twice_daily):
+// for due events (next-25 owned + top-40 of the sg_market_chart "TOP 50 — SG
+// SELLING, WE'RE NOT IN"), map to SeatData (events/search) and fill/refresh sold
+// comps (salesdata.get). Selection + upcoming-only + staleness live in SQL
+// (seatdata_due_events). aq_event_map.sd_event_id is synced by resolve_aq_seatdata_link.
+//
+// Spend is hard-capped at daily_cap PAID pulls/day (default 75), counted across both
+// runs from the log via seatdata_autopoll_paid_today(). Per run: <= limit searches
+// (events_search is 6/min, so 429s are retried) and <= max_paid fills, to stay inside
+// the edge-fn time budget; the daily cap is the real ceiling.
+//
+// GET /functions/v1/seatdata-poll?limit=8&max_paid=30&daily_cap=75&min_score=55&dry_run=false
+// Body-gated via requireCronSecret per PROJECT_BIBLE §1 rule #7.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
+
+// Inlined from ../_shared/cron-auth.ts (kept self-contained for single-fn deploy).
+// Fails CLOSED if CRON_SECRET is unset; constant-time compare.
+function requireCronSecret(req: Request): Response | null {
+  const expected = Deno.env.get("CRON_SECRET");
+  if (!expected) return new Response("server misconfigured: CRON_SECRET unset", { status: 500 });
+  const provided = req.headers.get("x-cron-secret") ?? "";
+  let mismatch = provided.length ^ expected.length;
+  const n = Math.max(provided.length, expected.length);
+  for (let i = 0; i < n; i++) mismatch |= (provided.charCodeAt(i) || 0) ^ (expected.charCodeAt(i) || 0);
+  if (mismatch !== 0) return new Response("unauthorized", { status: 401 });
+  return null;
+}
+
+const BASE = "https://seatdata.io/api";
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const slug = (s: string) => (s ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+const cleanVenue = (s: string) => slug((s ?? "").replace(/\s*-\s*[A-Za-z .]{2,20}$/, ""));
+
+function venueDateScore(cand: any, ourVenue: string, ourDate: string): number {
+  let s = 0;
+  const cv = cleanVenue(cand.venue_name ?? ""), ov = cleanVenue(ourVenue);
+  if (cv && ov && cv === ov) s += 60;
+  else if (cv && ov && (cv.startsWith(ov) || ov.startsWith(cv))) s += 35;
+  if (String(cand.event_date) === ourDate) s += 30;
+  return s;
+}
+
+async function sha256_32(s: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  let hex = ""; for (const b of new Uint8Array(buf)) hex += b.toString(16).padStart(2, "0");
+  return hex.slice(0, 32);
+}
+
+Deno.serve(async (req) => {
+  const authErr = requireCronSecret(req);
+  if (authErr) return authErr;
+
+  const sb = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  // key: prefer the function secret, else Vault (service_role can read get_app_secret)
+  let KEY = Deno.env.get("SEATDATA_API_KEY") ?? "";
+  if (!KEY) {
+    const { data: vkey } = await sb.rpc("get_app_secret", { p_name: "SEATDATA_API_KEY" });
+    KEY = typeof vkey === "string" ? vkey : "";
+  }
+  if (!KEY) {
+    return new Response(JSON.stringify({ ok: false, error: "missing SEATDATA_API_KEY (env + vault)" }),
+      { status: 500, headers: { "content-type": "application/json" } });
+  }
+  const sdHeaders = { "Authorization": `Bearer ${KEY}`, "User-Agent": "Terminal-2/seatdata-poll" };
+
+  const url = new URL(req.url);
+  const searchCap = Math.max(0, Math.min(40, Number(url.searchParams.get("limit") ?? "8")));
+  const maxPaid   = Math.max(0, Math.min(75, Number(url.searchParams.get("max_paid") ?? "30")));
+  const dailyCap  = Math.max(0, Math.min(200, Number(url.searchParams.get("daily_cap") ?? "75")));
+  const minScore  = Number(url.searchParams.get("min_score") ?? "55");
+  const dryRun    = url.searchParams.get("dry_run") === "true";
+
+  const { data: paidToday } = await sb.rpc("seatdata_autopoll_paid_today");
+  let paidRemaining = Math.min(maxPaid, Math.max(0, dailyCap - (paidToday ?? 0)));
+
+  const { data: due, error: dueErr } = await sb.rpc("seatdata_due_events", { p_limit: 200 });
+  if (dueErr) {
+    return new Response(JSON.stringify({ ok: false, error: dueErr.message }),
+      { status: 500, headers: { "content-type": "application/json" } });
+  }
+
+  async function sdSearch(params: URLSearchParams): Promise<any[]> {
+    let backoff = 2000;
+    for (let i = 0; i < 4; i++) {
+      const r = await fetch(`${BASE}/v1/events/search?${params}`, { headers: sdHeaders });
+      if (r.status === 429) { await sleep(backoff); backoff = Math.min(30000, backoff * 2); continue; }
+      if (r.status !== 200) return [];
+      return (await r.json())?.data ?? [];
+    }
+    return [];
+  }
+
+  let mapped = 0, refreshed = 0, noResults = 0, errored = 0, paid = 0, salesRows = 0, searches = 0;
+
+  for (const ev of (due ?? [])) {
+    if (paidRemaining <= 0 && searches >= searchCap) break;
+    let sdId: number | null = ev.sd_event_id ?? null;
+    const wasMapped = sdId != null;
+
+    if (!sdId) {
+      if (searches >= searchCap) continue;
+      searches++;
+      const qVenue = (ev.venue_name ?? "").replace(/\s*-\s*[A-Za-z .]{2,20}$/, "");
+      let cands: any[] = [];
+      try {
+        cands = await sdSearch(new URLSearchParams({ venue_name: qVenue, event_date: ev.event_date, limit: "50" }));
+        if (cands.length === 0 && ev.venue_city) {
+          const p2 = new URLSearchParams({ venue_city: ev.venue_city, event_date: ev.event_date, limit: "50" });
+          if (ev.venue_state) p2.set("venue_state", ev.venue_state);
+          cands = await sdSearch(p2);
+        }
+      } catch (e) {
+        errored++;
+        await sb.from("seatdata_search_attempts").upsert(
+          { tevo_event_id: ev.tevo_event_id, attempted_at: new Date().toISOString(), result: "error", meta: { msg: String(e).slice(0, 200) } },
+          { onConflict: "tevo_event_id" });
+        continue;
+      }
+      let best: any = null, bestScore = -1;
+      for (const c of cands) { const sc = venueDateScore(c, ev.venue_name, ev.event_date); if (sc > bestScore) { bestScore = sc; best = c; } }
+      if (!best || bestScore < minScore) {
+        noResults++;
+        await sb.from("seatdata_search_attempts").upsert(
+          { tevo_event_id: ev.tevo_event_id, attempted_at: new Date().toISOString(),
+            result: best ? "low_score" : "no_results", meta: { best_score: bestScore, best_sd: best?.event_id, n_cand: cands.length } },
+          { onConflict: "tevo_event_id" });
+        continue;
+      }
+      if (dryRun) { mapped++; continue; }
+      sdId = best.event_id;
+      await sb.from("seatdata_event_xref").upsert(
+        { tevo_event_id: ev.tevo_event_id, sd_event_id: sdId, sd_tm_event_id: best.tm_event_id ?? null,
+          sd_std_event_id: best.std_event_id ?? null, sd_std_venue_id: best.std_venue_id ?? null,
+          match_method: "auto_search", match_confidence: Math.min(1, bestScore / 90), matched_at: new Date().toISOString() },
+        { onConflict: "tevo_event_id" });
+      await sb.from("seatdata_search_attempts").upsert(
+        { tevo_event_id: ev.tevo_event_id, attempted_at: new Date().toISOString(), result: "matched", sd_event_id: sdId, meta: { score: bestScore } },
+        { onConflict: "tevo_event_id" });
+      mapped++;
+    }
+
+    if (dryRun || sdId == null || paidRemaining <= 0) continue;
+    const { data: budget } = await sb.rpc("seatdata_check_budget", { p_endpoint: "paid" });
+    if (!budget?.allowed) continue;
+    try {
+      const sr = await fetch(`${BASE}/v0.3/salesdata/get?event_id=${sdId}`, { headers: sdHeaders });
+      paid++; paidRemaining--;
+      const body = sr.status === 200 ? await sr.json() : null;
+      const rows = Array.isArray(body) ? body : [];
+      const out: any[] = [];
+      for (const s of rows) {
+        const saleTs = typeof s.timestamp === "number" ? new Date(s.timestamp * 1000).toISOString() : (s.timestamp ?? null);
+        const ch = await sha256_32([saleTs, s.quantity, s.price, s.zone, s.section, s.row].map((x: any) => x == null ? "" : String(x)).join("|"));
+        out.push({ tevo_event_id: ev.tevo_event_id, sd_event_id: sdId, sale_timestamp: saleTs,
+          quantity: s.quantity, price: s.price, zone: s.zone, section: s.section, row: s.row, content_hash: ch });
+      }
+      const charged = out.length > 0;
+      if (out.length) {
+        await sb.from("seatdata_sales_snapshots").upsert(out, { onConflict: "tevo_event_id,content_hash", ignoreDuplicates: true });
+        salesRows += out.length;
+      }
+      await sb.from("seatdata_event_xref")
+        .update({ last_paid_pull_at: new Date().toISOString(), last_refresh_ts: new Date().toISOString() })
+        .eq("tevo_event_id", ev.tevo_event_id);
+      await sb.rpc("seatdata_increment_budget", { p_endpoint: "v0.3/salesdata/get", p_was_charged: charged });
+      await sb.from("seatdata_pull_log").insert({ endpoint: "v0.3/salesdata/get", tevo_event_id: ev.tevo_event_id,
+        sd_event_id: sdId, was_charged: charged, http_status: sr.status, rows_returned: out.length, error_message: null, request_meta: { via: "seatdata-poll" } });
+      if (wasMapped) refreshed++;
+    } catch (e) {
+      await sb.from("seatdata_pull_log").insert({ endpoint: "v0.3/salesdata/get", tevo_event_id: ev.tevo_event_id,
+        sd_event_id: sdId, was_charged: false, http_status: 0, rows_returned: 0, error_message: String(e).slice(0, 300), request_meta: { via: "seatdata-poll" } });
+    }
+  }
+
+  if (!dryRun && mapped > 0) { await sb.rpc("resolve_aq_seatdata_link"); }
+
+  return new Response(JSON.stringify({ ok: true, considered: (due ?? []).length,
+    mapped, refreshed, no_results: noResults, errored, paid_pulls: paid, sales_rows: salesRows,
+    searches, paid_today_before: paidToday ?? 0, daily_cap: dailyCap, dry_run: dryRun }),
+    { headers: { "content-type": "application/json" } });
+});

--- a/supabase/migrations/20260608200000_seatdata_due_owned25_chart40.sql
+++ b/supabase/migrations/20260608200000_seatdata_due_owned25_chart40.sql
@@ -1,0 +1,157 @@
+-- Migration 20260608200000 · level:2 · operator-directed (2026-06-08)
+-- writes: CREATE OR REPLACE public.seatdata_due_events(int);
+--         cron.schedule('seatdata_poll_twice_daily', ...) — new URL caps.
+-- reads:  event_metrics (owned), seatgeek_seller_listings (owned), events,
+--         sg_market_chart (TOP-50 non-owned chart), seatdata_event_xref,
+--         seatdata_search_attempts.
+--
+-- ============================================================
+-- SeatData autopoll candidate redesign — two explicit tiers.
+--
+-- Operator directive 2026-06-08:
+--   "pull sales for the next 25 events we own tickets for, then also pull
+--    TOP 50 — SG SELLING, WE'RE NOT IN for those events daily when that
+--    list updates."
+--
+-- TIER 1 (owned, 25): the next 25 UPCOMING events we hold inventory in
+--   (TEvo owned_tickets_count > 0  OR  rows in our SG seller listings),
+--   soonest-first. These pull SeatData sold comps (v0.3/salesdata/get).
+--
+-- TIER 2 (chart, top 40): the daily "TOP 50 — SG SELLING, WE'RE NOT IN"
+--   Billboard chart (public.sg_market_chart, rebuilt 11:05 UTC by
+--   rebuild_sg_market_chart). The chart is the canonical non-owned
+--   leaderboard; we take its top ranks, mapped to a TEvo event id, and
+--   pull the same sold comps so we can see where the market is moving
+--   in names we're NOT exposed to.
+--
+-- WHY top 40 not top 50 (budget): each tier pulls 1 PAID salesdata call
+-- per event per day. SeatData BASIC = 100/day but 2,000/MONTH. 25 + 50 =
+-- 75/day → ~2,250/mo, over the monthly cap (would stall ~day 26). Trimming
+-- the chart tier to 40 → 65/day → ~1,950/mo, inside the monthly cap with
+-- full daily coverage. The monthly cap (seatdata_check_budget) remains the
+-- hard backstop regardless. To change coverage, edit the `rank <= 40` line.
+--
+-- Chart rows without a tevo_event_id are skipped: the SeatData pipeline is
+-- keyed on tevo_event_id (NOT NULL in seatdata_event_xref/_sales_snapshots).
+-- An owned event that also charts is pulled once (owned tier wins; chart
+-- excludes the owned-25 set).
+--
+-- Unchanged: the edge fn `seatdata-poll` does the per-event work (search-map
+-- unmapped events, then paid salesdata pull, dedup into
+-- seatdata_sales_snapshots). Staleness gates are also unchanged: unmapped
+-- retried ≤1×/24h (seatdata_search_attempts guard); mapped refreshed when
+-- last_paid_pull_at is NULL or older than 10h.
+--
+-- Cron caps bumped so two daily runs cover all 65: max_paid 30→35,
+-- daily_cap 75→70, search limit 8→20 (40 chart events are unmapped on
+-- first run and must be searched before they can be pulled).
+--
+-- PENDING OPERATOR APPLY: gated per CLAUDE.md §1.
+-- ROLLBACK: restore the prior seatdata_due_events body (owned-only, no chart
+--   tier, no 25-cap) and re-schedule the cron with the prior URL
+--   (limit=8&max_paid=30&daily_cap=75&min_score=55).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.seatdata_due_events(p_limit integer DEFAULT 200)
+ RETURNS TABLE(tevo_event_id bigint, name text, venue_name text, event_date text,
+               venue_city text, venue_state text, sd_event_id bigint)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH owned_ids AS (
+    -- events we hold inventory in: latest TEvo owned count > 0, OR our SG seller book
+    SELECT event_id AS tevo_event_id
+    FROM (
+      SELECT DISTINCT ON (event_id) event_id, owned_tickets_count
+      FROM public.event_metrics
+      WHERE captured_at > now() - interval '2 days'
+      ORDER BY event_id, captured_at DESC
+    ) m
+    WHERE owned_tickets_count > 0
+    UNION
+    SELECT DISTINCT tevo_event_id
+    FROM public.seatgeek_seller_listings
+    WHERE tevo_event_id IS NOT NULL
+  ),
+  -- TIER 1 — next 25 upcoming events we own tickets for (soonest first)
+  owned25 AS (
+    SELECT e.id AS tevo_event_id,
+           e.name, e.venue_name,
+           left(e.occurs_at_local, 10)                              AS event_date,
+           btrim(split_part(e.venue_location, ',', 1))              AS venue_city,
+           nullif(btrim(split_part(e.venue_location, ',', 2)), '')  AS venue_state,
+           e.occurs_at_local::timestamp                             AS occurs_ts,
+           0                                                        AS tier
+    FROM public.events e
+    JOIN owned_ids o ON o.tevo_event_id = e.id
+    WHERE e.state = 'shown'
+      AND e.occurs_at_local::timestamp >= now()::timestamp
+    ORDER BY e.occurs_at_local::timestamp
+    LIMIT 25
+  ),
+  -- TIER 2 — the daily "TOP 50 — SG SELLING, WE'RE NOT IN" chart, trimmed to
+  -- top 40 (monthly-budget fit). Mapped to a TEvo event; excludes owned-25.
+  chart40 AS (
+    SELECT e.id AS tevo_event_id,
+           e.name, e.venue_name,
+           left(e.occurs_at_local, 10)                              AS event_date,
+           btrim(split_part(e.venue_location, ',', 1))              AS venue_city,
+           nullif(btrim(split_part(e.venue_location, ',', 2)), '')  AS venue_state,
+           e.occurs_at_local::timestamp                             AS occurs_ts,
+           1                                                        AS tier
+    FROM public.sg_market_chart c
+    JOIN public.events e ON e.id = c.tevo_event_id
+    WHERE c.chart_date = (SELECT max(chart_date) FROM public.sg_market_chart)
+      AND c.rank <= 40
+      AND c.tevo_event_id IS NOT NULL
+      AND e.state = 'shown'
+      AND e.occurs_at_local::timestamp >= now()::timestamp
+      AND e.id NOT IN (SELECT tevo_event_id FROM owned25)
+  ),
+  candidates AS (
+    SELECT * FROM owned25
+    UNION ALL
+    SELECT * FROM chart40
+  )
+  SELECT c.tevo_event_id, c.name, c.venue_name, c.event_date,
+         c.venue_city, c.venue_state, x.sd_event_id
+  FROM candidates c
+  LEFT JOIN public.seatdata_event_xref x ON x.tevo_event_id = c.tevo_event_id
+  WHERE (
+    -- not yet mapped: try a search, but at most once / 24h
+    (x.tevo_event_id IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.seatdata_search_attempts a
+                       WHERE a.tevo_event_id = c.tevo_event_id
+                         AND a.attempted_at > now() - interval '24 hours'))
+    OR
+    -- mapped: refresh sold comps once last pull is > 10h old
+    (x.tevo_event_id IS NOT NULL
+      AND (x.last_paid_pull_at IS NULL OR x.last_paid_pull_at < now() - interval '10 hours'))
+  )
+  ORDER BY c.tier, c.occurs_ts          -- owned tier first, then chart by event date
+  LIMIT greatest(1, least(p_limit, 500));
+$function$;
+
+COMMENT ON FUNCTION public.seatdata_due_events(integer) IS
+  'SeatData autopoll candidates, two tiers: (1) next 25 upcoming owned events '
+  '(event_metrics owned OR our SG seller book), (2) top 40 of the daily '
+  'sg_market_chart ("TOP 50 — SG SELLING, WE''RE NOT IN"), TEvo-mapped, '
+  'owned-25 excluded. 25+40=65 paid salesdata pulls/day, inside the SeatData '
+  '2,000/mo cap. Staleness: unmapped ≤1 search/24h; mapped refresh > 10h.';
+
+-- ---------- cron: same twice-daily 11:00/20:00 ET, bumped URL caps ----------
+-- max_paid 30→35, daily_cap 75→70, search limit 8→20 (40 chart events need a
+-- search-map on first run before they can be pulled). Gating (ET-hour + the
+-- cron_policy.enabled flag) is identical to the prior body.
+SELECT cron.schedule('seatdata_poll_twice_daily', '0 0,1,15,16 * * *', $cron$
+  DO $cronbody$
+    BEGIN
+      IF extract(hour FROM (now() AT TIME ZONE 'America/New_York'))::int NOT IN (11, 20) THEN RETURN; END IF;
+      IF NOT coalesce((SELECT enabled FROM public.cron_policy WHERE jobname = 'seatdata_poll_twice_daily'), false) THEN RETURN; END IF;
+      PERFORM public._cron_invoke_edge_fn(
+        'https://hzrizjeaxlqcxfrtczpq.supabase.co/functions/v1/seatdata-poll?limit=20&max_paid=35&daily_cap=70&min_score=55',
+        '{}'::jsonb
+      );
+    END $cronbody$;
+$cron$);

--- a/supabase/migrations/20260608210000_sg_market_chart_seatdata_gmv.sql
+++ b/supabase/migrations/20260608210000_sg_market_chart_seatdata_gmv.sql
@@ -1,0 +1,207 @@
+-- Migration 20260608210000 · level:2 · operator-directed (2026-06-08)
+-- writes: ALTER sg_market_chart ADD sd_ma7_gross, sd_sales_7d;
+--         CREATE OR REPLACE rebuild_sg_market_chart() (adds SeatData GMV);
+--         CREATE OR REPLACE get_sg_market_chart(int,int) (emits SeatData GMV);
+--         one rebuild to repopulate today.
+-- reads:  seatdata_sales_snapshots (new), + everything rebuild already read.
+--
+-- ============================================================
+-- Add SeatData sold-comp GMV/day to the "TOP 50 — SG SELLING, WE'RE NOT IN"
+-- chart. Operator directive 2026-06-08: "add the seatdata data to the GMV/day".
+--
+-- The chart already shows ma7_gross = SeatGeek-observed daily gross (7d-MA of
+-- volume × median). Now that seatdata-poll fills SeatData sold comps for the
+-- chart's top-40 events (mig 20260608200000), surface a SECOND, independent
+-- GMV/day from SeatData (StubHub-primary marketplace) alongside the SG one so
+-- the panel compares the two markets. They are NOT summed — different
+-- marketplaces; double-counting would be wrong.
+--
+-- sd_ma7_gross = 7-day moving average of daily SeatData gross, where a day's
+--   gross = Σ(price × qty) over that event's sales that day, averaged over the
+--   days-with-sales in the trailing 7 days (mirrors the SG ma7_gross basis).
+--   SeatData quantity is 0/NULL when "unknown" (data-sources doc caveat) → we
+--   treat unknown as 1 ticket so the comp still contributes.
+-- sd_sales_7d = raw count of SeatData sale rows in the trailing 7d (tooltip).
+--
+-- Keyed on tevo_event_id (seatdata_sales_snapshots' key). Chart rows without a
+-- tevo_event_id, or without SeatData sales yet, get NULL → FE renders "—".
+-- The chart rebuilds 11:05 UTC daily; SeatData pulls 11:00/20:00 ET — so the
+-- chart reflects SeatData sales accumulated through the prior evening's pulls.
+--
+-- PENDING OPERATOR APPLY: gated per CLAUDE.md §1.
+-- ROLLBACK: restore the prior rebuild_sg_market_chart()/get_sg_market_chart()
+--   bodies; columns can stay (additive, nullable) or be dropped.
+-- ============================================================
+
+ALTER TABLE public.sg_market_chart
+  ADD COLUMN IF NOT EXISTS sd_ma7_gross numeric,
+  ADD COLUMN IF NOT EXISTS sd_sales_7d  integer;
+
+-- ---------- rebuild: same logic + a SeatData GMV join ----------
+CREATE OR REPLACE FUNCTION public.rebuild_sg_market_chart()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_today date := (now() AT TIME ZONE 'UTC')::date;
+  v_prev  date;
+  v_count int := 0;
+BEGIN
+  SELECT max(chart_date) INTO v_prev
+  FROM public.sg_market_chart WHERE chart_date < v_today;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date = v_today;  -- idempotent re-run
+
+  WITH daily AS (
+    SELECT DISTINCT ON (sg_event_id, (captured_at AT TIME ZONE 'UTC')::date)
+      sg_event_id,
+      (captured_at AT TIME ZONE 'UTC')::date AS d,
+      sold_quantity, sold_price_median, sold_gross
+    FROM public.seatgeek_event_metrics
+    WHERE captured_at > now() - interval '7 days'
+      AND coalesce(sold_quantity, 0) > 0
+    ORDER BY sg_event_id, (captured_at AT TIME ZONE 'UTC')::date, captured_at DESC
+  ),
+  ma AS (
+    SELECT sg_event_id,
+      count(*)                        AS days_with_sales,
+      avg(sold_quantity)::numeric     AS ma7_volume,
+      avg(sold_price_median)::numeric AS ma7_median,
+      avg(sold_gross)::numeric        AS ma7_gross
+    FROM daily
+    GROUP BY sg_event_id
+  ),
+  -- SeatData sold comps: per-event 7d-MA daily gross (Σ price×qty over days w/ sales)
+  sd_daily AS (
+    SELECT s.tevo_event_id,
+           (s.sale_timestamp AT TIME ZONE 'UTC')::date AS d,
+           count(*)                                                       AS cnt,
+           sum(coalesce(s.price,0) * greatest(coalesce(s.quantity,1),1))  AS daily_gross
+    FROM public.seatdata_sales_snapshots s
+    WHERE s.sale_timestamp > now() - interval '7 days'
+    GROUP BY s.tevo_event_id, (s.sale_timestamp AT TIME ZONE 'UTC')::date
+  ),
+  sd AS (
+    SELECT tevo_event_id,
+           sum(cnt)::int               AS sd_sales_7d,
+           avg(daily_gross)::numeric   AS sd_ma7_gross
+    FROM sd_daily
+    GROUP BY tevo_event_id
+  ),
+  elig AS (
+    SELECT m.sg_event_id, m.days_with_sales, m.ma7_volume, m.ma7_median, m.ma7_gross,
+           p.tevo_event_id, p.sg_event_name, p.sg_venue_name, p.sg_datetime_utc
+    FROM ma m
+    JOIN public.sg_event_priority_state p ON p.sg_event_id = m.sg_event_id
+    WHERE coalesce(p.owned_count_last_7d, 0) = 0   -- we hold no inventory
+      AND p.sg_datetime_utc > now()                -- future events only
+      AND m.days_with_sales >= 2                   -- real MA, not a one-off spike
+  ),
+  scored AS (
+    SELECT e.*,
+      (percent_rank() OVER (ORDER BY ma7_volume))::numeric AS pct_volume,
+      (percent_rank() OVER (ORDER BY ma7_median))::numeric AS pct_median
+    FROM elig e
+  ),
+  ranked AS (
+    SELECT s.*,
+      (pct_volume + pct_median) AS chart_score,
+      row_number() OVER (
+        ORDER BY (pct_volume + pct_median) DESC, ma7_gross DESC NULLS LAST, ma7_volume DESC
+      ) AS rnk
+    FROM scored s
+  )
+  INSERT INTO public.sg_market_chart (
+    chart_date, sg_event_id, rank, chart_score, pct_volume, pct_median,
+    ma7_volume, ma7_median, ma7_gross, days_with_sales,
+    prev_rank, peak_rank, days_on_chart,
+    tevo_event_id, sg_event_name, sg_venue_name, sg_datetime_utc,
+    sd_ma7_gross, sd_sales_7d)
+  SELECT
+    v_today, r.sg_event_id, r.rnk::int, round(r.chart_score, 4),
+    round(r.pct_volume, 4), round(r.pct_median, 4),
+    round(r.ma7_volume, 1), round(r.ma7_median, 2), round(r.ma7_gross, 2), r.days_with_sales,
+    prev.rank,
+    LEAST(r.rnk::int,
+          coalesce((SELECT min(h.rank) FROM public.sg_market_chart h
+                    WHERE h.sg_event_id = r.sg_event_id), r.rnk::int)),
+    CASE WHEN prev.rank IS NOT NULL THEN coalesce(prev.days_on_chart, 0) + 1 ELSE 1 END,
+    r.tevo_event_id, r.sg_event_name, r.sg_venue_name, r.sg_datetime_utc,
+    round(sd.sd_ma7_gross, 2), sd.sd_sales_7d
+  FROM ranked r
+  LEFT JOIN public.sg_market_chart prev
+    ON prev.sg_event_id = r.sg_event_id AND prev.chart_date = v_prev
+  LEFT JOIN sd ON sd.tevo_event_id = r.tevo_event_id;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date < v_today - 90;
+
+  RETURN v_count;
+END $func$;
+
+-- ---------- read RPC: emit the SeatData GMV fields ----------
+CREATE OR REPLACE FUNCTION public.get_sg_market_chart(
+  p_offset integer DEFAULT 0,
+  p_limit  integer DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_email text;
+  v_date  date;
+  v_total int;
+  v_rows  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT max(chart_date) INTO v_date FROM public.sg_market_chart;
+  IF v_date IS NULL THEN
+    RETURN jsonb_build_object('chart_date', NULL, 'total', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  SELECT count(*) INTO v_total FROM public.sg_market_chart WHERE chart_date = v_date;
+
+  SELECT coalesce(jsonb_agg(r.obj ORDER BY (r.obj->>'rank')::int), '[]'::jsonb)
+  INTO v_rows
+  FROM (
+    SELECT jsonb_build_object(
+      'rank',            m.rank,
+      'prev_rank',       m.prev_rank,
+      'rank_delta',      CASE WHEN m.prev_rank IS NULL THEN NULL ELSE m.prev_rank - m.rank END,
+      'is_new',          (m.prev_rank IS NULL),
+      'peak_rank',       m.peak_rank,
+      'days_on_chart',   m.days_on_chart,
+      'sg_event_id',     m.sg_event_id,
+      'tevo_event_id',   m.tevo_event_id,
+      'sg_event_name',   m.sg_event_name,
+      'sg_venue_name',   m.sg_venue_name,
+      'sg_datetime_utc', to_char(m.sg_datetime_utc AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'ma7_volume',      m.ma7_volume,
+      'ma7_median',      m.ma7_median,
+      'ma7_gross',       m.ma7_gross,
+      'sd_ma7_gross',    m.sd_ma7_gross,
+      'sd_sales_7d',     m.sd_sales_7d,
+      'pct_volume',      m.pct_volume,
+      'pct_median',      m.pct_median,
+      'chart_score',     m.chart_score,
+      'days_with_sales', m.days_with_sales
+    ) AS obj
+    FROM public.sg_market_chart m
+    WHERE m.chart_date = v_date
+    ORDER BY m.rank
+    OFFSET greatest(coalesce(p_offset, 0), 0)
+    LIMIT  least(coalesce(p_limit, 50), 500)
+  ) r;
+
+  RETURN jsonb_build_object('chart_date', v_date, 'total', v_total, 'rows', v_rows);
+END $func$;
+
+-- repopulate today's chart so the new SeatData column lands immediately on apply
+SELECT public.rebuild_sg_market_chart();


### PR DESCRIPTION
## What

Two related SeatData changes on the `claude/vigilant-bohr-qjybve` branch.

### 1. Autopoll candidate redesign (`seatdata_due_events`)

Reworked into two explicit tiers, per operator directive (2026-06-08):

1. **Owned (25)** — the next 25 *upcoming* events we hold inventory in (TEvo `owned_tickets_count > 0` **or** a row in our SG seller book), soonest-first.
2. **Chart (top 40)** — the top 40 of the daily `sg_market_chart` (**"TOP 50 — SG SELLING, WE'RE NOT IN"**), mapped to a TEvo event, owned-25 excluded.

Both tiers pull SeatData sold comps (`v0.3/salesdata/get`) via the existing twice-daily `seatdata-poll` edge function (11:00 / 20:00 ET).

**Why top 40 not 50 (budget):** 1 paid `salesdata` pull/event/day. SeatData BASIC = 100/day but **2,000/month**. 25+50 = 75/day → ~2,250/mo (over cap, stalls ~day 26). 25+40 = **65/day → ~1,950/mo**, inside the monthly cap; the monthly gate (`seatdata_check_budget`) is the hard backstop. Cron caps bumped (`max_paid` 30→35, `daily_cap` 75→70, search `limit` 8→20) so two daily runs cover all 65 incl. search-mapping the chart tier on first run.

Also checks in the previously-uncommitted live `seatdata-poll` edge function source.

### 2. SeatData GMV/day on the chart (`feat: add seatdata data to GMV/day`)

The chart panel showed only `ma7_gross` (SeatGeek-observed GMV/day). Now that the chart's top-40 are getting SeatData sold comps, added an **independent SeatData GMV/day** beside it:

- New `sg_market_chart` columns `sd_ma7_gross`, `sd_sales_7d`, computed in the daily `rebuild_sg_market_chart` from `seatdata_sales_snapshots` (7-day MA of daily Σ price×qty; unknown qty→1 per the SeatData quantity-0 caveat).
- `get_sg_market_chart` emits the new fields; `home.js` renders a **"GMV/day SD"** column next to **"GMV/day SG"**.
- The two GMV figures are shown **side by side, not summed** (distinct marketplaces — SeatGeek vs StubHub-primary).

## Rollout

- ✅ **Applied to prod** (operator-directed) via `apply_migration` for both migrations; functions/cron verified live.
- SeatData GMV is **blank (—) for chart events until they're pulled**: the top-40 are unmapped today, get their first SeatData pull tonight (20:00 ET), and `sd_ma7_gross` populates at tomorrow's 11:05 UTC rebuild. Verified the GMV computation on events that already have SeatData sales (sane market-wide daily-gross figures).
- `home.js` (FE) deploys via the static host.

## Notes

- Chart rows without a `tevo_event_id` (SeatData keys are `NOT NULL` on it) get NULL SD GMV — no schema change needed; all 50 current top-50 rows are TEvo-mapped.
- Drift: the broader live `seatdata-poll` stack (`seatdata_search_attempts`, `seatdata_autopoll_paid_today`, original cron) was created live and isn't in repo migrations — flagged for a future drift-capture migration; these migrations apply cleanly against prod where those objects exist.
- `CRON_HIERARCHY.md` (A1-owned) doesn't yet list the SeatData crons — leaving that to A1.

https://claude.ai/code/session_01JdoAdBuQpK73MWM118gNSU