### PR TITLE
feat(trip-planner): add ticket-spend budget + owned-tickets

### DIFF
--- a/app.py
+++ b/app.py
@@ -1164,12 +1164,14 @@ def broker_performer_assets(performer_id: int, _=Depends(require_auth)):
 
 def _trip_plan_payload(performer_id: int, home_lat: float, home_lon: float,
                        budget_km: float, home_name: str, days: int,
-                       max_events: int | None) -> dict:
+                       max_events: int | None,
+                       budget_usd: float | None = None, qty: int = 1) -> dict:
     """Shared body for the D0/D1 per-performer trip-plan routes.
 
     Plans the maximum-value multi-city itinerary around a performer's upcoming dates within
-    a round-trip km budget. Pure read (v_event_base) + compute — no writes, no upstream API.
-    Engine + planner live in the shared `trip_planner` package.
+    a round-trip km budget — and, when `budget_usd` is given, also within a ticket-spend
+    budget (get-in x max(0, qty - owned), owned tickets free). Pure read (v_event_base +
+    event_listing_snapshot_daily) + compute — no writes, no upstream API.
     """
     from datetime import date, timedelta
 
@@ -1179,9 +1181,11 @@ def _trip_plan_payload(performer_id: int, home_lat: float, home_lon: float,
     start = date.today()
     end = start + timedelta(days=max(1, min(int(days), 730)))
     budget = max(100.0, min(float(budget_km), 50000.0))
+    spend = None if budget_usd is None else max(0.0, min(float(budget_usd), 10_000_000.0))
     return plan_performer_trip(
         db, int(performer_id), float(home_lat), float(home_lon), budget,
         start, end, home_name=(home_name or "Home").strip()[:60], max_events=max_events,
+        budget_usd=spend, qty=max(1, min(int(qty), 50)),
     )
 
 
@@ -1194,15 +1198,17 @@ def broker_performer_trip_plan(
     home_name: str = "Home",
     days: int = 365,
     max_events: int | None = None,
+    budget_usd: float | None = None,
+    qty: int = 1,
     _=Depends(require_auth),
 ):
     """D0 terminal: optimal trip around a touring performer's upcoming concert dates.
 
-    Given a home location + round-trip travel budget, returns the maximum-value itinerary
-    (which shows to attend, in date order) plus the sort-by-date baseline for comparison.
+    Given a home location + travel budget (and optional ticket-spend budget + tickets/show),
+    returns the maximum-value itinerary plus the sort-by-date baseline for comparison.
     """
     return _trip_plan_payload(performer_id, home_lat, home_lon, budget_km,
-                              home_name, days, max_events)
+                              home_name, days, max_events, budget_usd, qty)
 
 
 def _bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
@@ -6695,17 +6701,19 @@ def store_performer_trip_plan(
     home_name: str = "Home",
     days: int = 365,
     max_events: int | None = None,
+    budget_usd: float | None = None,
+    qty: int = 1,
 ):
     """D1 store: 'plan a trip around <performer>'.
 
     Consumer-facing. Given a fan's home location + how far they're willing to travel
-    (round-trip km budget), returns the best set of this performer's upcoming shows to
-    attend, in date order, alongside the naive sort-by-date plan for comparison.
+    (and optionally a ticket-spend budget + tickets/show), returns the best set of this
+    performer's upcoming shows to attend, alongside the naive sort-by-date plan.
 
     Shares the optimizer with the D0 broker route via `trip_planner`.
     """
     return _trip_plan_payload(performer_id, home_lat, home_lon, budget_km,
-                              home_name, days, max_events)
+                              home_name, days, max_events, budget_usd, qty)
 
 
 def _section_sort_key(s: str) -> tuple:

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -29,7 +29,10 @@
     .trip-row.skip { opacity: .4; }
     .trip-row .tr-date { width: 104px; color: var(--muted, #9aa); font-variant-numeric: tabular-nums; }
     .trip-row .tr-city { width: 116px; font-weight: 600; }
-    .trip-row .tr-go { margin-left: auto; color: var(--good, #4ade80); font-size: 11px; }
+    .trip-row .tr-px { margin-left: auto; color: var(--muted, #9aa); font-variant-numeric: tabular-nums; }
+    .trip-row .tr-own { color: #fbbf24; font-size: 11px; }
+    .trip-row .tr-cost { color: var(--muted, #9aa); font-variant-numeric: tabular-nums; min-width: 42px; text-align: right; }
+    .trip-row .tr-go { color: var(--good, #4ade80); font-size: 11px; }
     .trip-list { max-height: 280px; overflow-y: auto; margin-top: 4px; }
     .trip-map { max-width: 460px; margin: 6px 0 14px; background: var(--panel, #14141b); border: 1px solid rgba(255,255,255,.08); border-radius: 8px; padding: 5px; }
     .trip-map-svg { width: 100%; height: auto; display: block; }
@@ -121,7 +124,9 @@
           <label>home lat<input id="tripLat" type="number" step="0.0001" value="40.7128" /></label>
           <label>home lon<input id="tripLon" type="number" step="0.0001" value="-74.0060" /></label>
           <label>label<input id="tripHome" type="text" value="New York City" /></label>
-          <label>budget <b id="tripBudgetLabel">6000</b> km<input id="tripBudget" type="range" min="1000" max="16000" step="500" value="6000" /></label>
+          <label>travel <b id="tripBudgetLabel">6000</b> km<input id="tripBudget" type="range" min="1000" max="16000" step="500" value="6000" /></label>
+          <label>tickets/show<input id="tripQty" type="number" min="1" max="20" value="2" /></label>
+          <label>$ budget<input id="tripUsd" type="number" min="0" step="250" value="3000" /></label>
           <button id="tripGo" class="event-tab">Plan</button>
         </div>
         <div id="tripStats" class="trip-stats" hidden></div>

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -192,6 +192,8 @@
       home_lon: document.getElementById('tripLon').value,
       home_name: document.getElementById('tripHome').value,
       budget_km: document.getElementById('tripBudget').value,
+      budget_usd: document.getElementById('tripUsd').value || '0',
+      qty: document.getElementById('tripQty').value || '1',
       days: '365',
     });
     body.innerHTML = '<div class="empty">planning…</div>';
@@ -274,10 +276,12 @@
     if (meta) {
       const cov = d.coord_coverage || {};
       const extra = [];
+      if (d.qty_per_show) extra.push(`${d.qty_per_show} tix/show`);
       if (cov.city_fallback) extra.push(`${cov.city_fallback} ≈ city`);
       if (cov.dropped_no_coords) extra.push(`${cov.dropped_no_coords} no-coords dropped`);
+      if (d.unpriced_events) extra.push(`${d.unpriced_events} no price`);
       meta.textContent = d.tour_date_count
-        ? `${d.tour_date_count} dates · budget ${Math.round(d.budget_km)} km${extra.length ? ' · ' + extra.join(', ') : ''}`
+        ? `${d.tour_date_count} dates · ${Math.round(d.budget_km)} km${d.budget_usd != null ? ' · $' + Math.round(d.budget_usd) : ''}${extra.length ? ' · ' + extra.join(', ') : ''}`
         : '';
     }
     if (!d.tour_date_count) {
@@ -293,9 +297,11 @@
       else { mapEl.hidden = true; }
     }
     if (stats) {
+      const spendLbl = `ticket spend${d.budget_usd != null ? ' / $' + Math.round(d.budget_usd) : ''}`;
       stats.hidden = false;
       stats.innerHTML =
         `<div><span class="ts-num">${o.count}</span><span class="ts-lbl">optimal shows · ${Math.round(o.travel_km)} km</span></div>` +
+        `<div><span class="ts-num">$${Math.round(o.spend_usd || 0).toLocaleString()}</span><span class="ts-lbl">${spendLbl}</span></div>` +
         `<div><span class="ts-num">${b.count}</span><span class="ts-lbl">sort-by-date · ${Math.round(b.travel_km)} km</span></div>` +
         `<div><span class="ts-num gain">+${d.shows_gained}</span><span class="ts-lbl">shows gained</span></div>`;
     }
@@ -304,10 +310,16 @@
     const rows = (d.all_dates || []).map(e => {
       const on = picked.has(e.event_id);
       const approx = e.coord_source === 'city' ? ' <span class="muted small" title="approximate city-centroid location">≈</span>' : '';
+      const owned = e.owned ? `<span class="tr-own" title="EVO owned tickets">own ${e.owned}</span>` : '';
+      const price = e.getin != null ? `$${Math.round(e.getin)}` : (e.cost_known ? '' : '<span class="muted">n/a</span>');
+      const cost = e.ticket_cost != null
+        ? `<span class="tr-cost" title="get-in × max(0, qty − owned)">${e.ticket_cost === 0 ? 'free' : '$' + Math.round(e.ticket_cost).toLocaleString()}</span>`
+        : '';
       return `<div class="trip-row${on ? '' : ' skip'}">`
         + `<span class="tr-date">${escapeHtml(_tripDate(e.date))}</span>`
         + `<span class="tr-city">${escapeHtml(e.city || '')}${approx}</span>`
         + `<span class="tr-venue">${escapeHtml(e.venue || '')}</span>`
+        + `<span class="tr-px">${price}</span>${owned}${cost}`
         + (on ? '<span class="tr-go">● going</span>' : '')
         + '</div>';
     }).join('');

--- a/trip_planner/README.md
+++ b/trip_planner/README.md
@@ -59,5 +59,9 @@ budget.
 ## Notes / next
 - Single performer = uniform preference weights (every show valued 1.0); the engine already
   supports a `prefs` map for the multi-performer "plan my whole summer" case.
-- The km budget can become a **$ budget** by making `prize`/cost price-aware — the cost model
-  is isolated in `gigtrip/distance.py` by design.
+- **Two-budget mode** (`budget_optimizer.py`): pass `budget_usd` + `qty` and the trip must fit
+  BOTH the travel-km budget and a ticket-spend budget. Per-show cost = `evo_retail_getin ×
+  max(0, qty − evo_owned_tickets)` (owned tickets free), pulled from
+  `event_listing_snapshot_daily`. The 2-budget solver is an exact Pareto label-setting DP
+  (cross-checked against a brute-force oracle in `test_ariana.py`). The vendored gigtrip
+  engine is untouched — this is a sibling module reusing its geometry helpers.

--- a/trip_planner/budget_optimizer.py
+++ b/trip_planner/budget_optimizer.py
@@ -1,0 +1,108 @@
+"""Two-budget itinerary optimizer — extends the (vendored) gigtrip selection model with a
+second resource constraint: a ticket-spend budget, alongside the travel-km budget.
+
+The base gigtrip optimizer constrains only round-trip km. Brokers also care about ticket
+outlay, so here a trip must satisfy BOTH `max_travel_km` AND `max_spend_usd`. Per-event cost
+is supplied externally (get-in price x tickets-to-buy, with owned tickets free) via a
+`costs` map keyed on event id.
+
+The vendored engine is left untouched; this reuses its geometry helpers (candidates,
+feasible_leg, route_km, haversine) and reimplements the Pareto label-setting DP with the
+extra cost dimension. Exact, same dominance idea as upstream, plus a sort-by-date baseline
+that honours both budgets.
+"""
+from __future__ import annotations
+
+from .gigtrip.distance import haversine_km
+from .gigtrip.model import Constraints, Event, Itinerary, prize
+from .gigtrip.optimizer import candidates, feasible_leg, route_km
+
+EPS = 1e-9
+
+
+def trip_cost(seq, costs: dict[int, float]) -> float:
+    return round(sum(costs.get(int(e.id), 0.0) for e in seq), 2)
+
+
+# --------------------------------------------------------------------------- #
+# exact — Pareto label-setting on (open_km, spend, count) ↓ vs value ↑
+# --------------------------------------------------------------------------- #
+def _pareto2(labels):
+    labels = sorted(labels, key=lambda l: (l[0], l[1], l[2], -l[3]))
+    kept = []
+    for lab in labels:
+        okm, oc, cnt, val, _ = lab
+        if not any(k[0] <= okm + EPS and k[1] <= oc + EPS and k[2] <= cnt
+                   and k[3] >= val - 1e-12 for k in kept):
+            kept.append(lab)
+    return kept
+
+
+def plan_optimal_2b(events, prefs, c: Constraints, costs: dict[int, float],
+                    max_spend_usd: float):
+    """Exact max-value itinerary within BOTH the km budget and the spend budget.
+
+    Returns (Itinerary, total_spend).
+    """
+    cand = candidates(events, c)
+    n = len(cand)
+    p = [prize(e, prefs, c.default_pref) for e in cand]
+    cst = [costs.get(int(e.id), 0.0) for e in cand]
+    home_km = [haversine_km(c.home_lat, c.home_lon, e.lat, e.lon) for e in cand]
+    labels = [[] for _ in range(n)]
+    best = Itinerary((), 0.0, 0.0)
+    best_spend = 0.0
+
+    def consider(open_km, spend, value, path):
+        nonlocal best, best_spend
+        last = cand[path[-1]]
+        total_km = open_km + haversine_km(last.lat, last.lon, c.home_lat, c.home_lon)
+        if total_km > c.max_travel_km + EPS or spend > max_spend_usd + EPS:
+            return
+        if value > best.value + 1e-12 or (
+                abs(value - best.value) <= 1e-12 and total_km < best.travel_km - 1e-12):
+            best = Itinerary(tuple(cand[i] for i in path), value, total_km)
+            best_spend = round(spend, 2)
+
+    for i in range(n):
+        new = []
+        if (home_km[i] <= c.max_travel_km + EPS and cst[i] <= max_spend_usd + EPS
+                and (c.max_events is None or c.max_events >= 1)):
+            new.append((home_km[i], cst[i], 1, p[i], (i,)))
+        for j in range(i):
+            if not feasible_leg(cand[j], cand[i], c):
+                continue
+            leg = haversine_km(cand[j].lat, cand[j].lon, cand[i].lat, cand[i].lon)
+            for okm, oc, cnt, val, path in labels[j]:
+                if c.max_events is not None and cnt + 1 > c.max_events:
+                    continue
+                nokm = okm + leg
+                noc = oc + cst[i]
+                if nokm > c.max_travel_km + EPS or noc > max_spend_usd + EPS:
+                    continue
+                new.append((nokm, noc, cnt + 1, val + p[i], path + (i,)))
+        labels[i] = _pareto2(new)
+        for okm, oc, _, val, path in labels[i]:
+            consider(okm, oc, val, path)
+    return best, best_spend
+
+
+def plan_by_date_2b(events, prefs, c: Constraints, costs: dict[int, float],
+                    max_spend_usd: float):
+    """Baseline: take shows soonest-first while the trip stays inside BOTH budgets."""
+    seq: list[Event] = []
+    spend = 0.0
+    for e in candidates(events, c):          # already (day, id) sorted -> seq stays in order
+        trial = seq + [e]
+        if c.max_events is not None and len(trial) > c.max_events:
+            continue
+        if not all(feasible_leg(a, b, c) for a, b in zip(trial, trial[1:])):
+            continue
+        if route_km(trial, c) > c.max_travel_km + EPS:
+            continue
+        ncost = spend + costs.get(int(e.id), 0.0)
+        if ncost > max_spend_usd + EPS:
+            continue
+        seq, spend = trial, ncost
+    value = sum(prize(e, prefs, c.default_pref) for e in seq)
+    return Itinerary(tuple(seq), value, route_km(seq, c)), round(spend, 2)

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -10,8 +10,9 @@ Split so the planning logic is testable offline:
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
+from .budget_optimizer import plan_by_date_2b, plan_optimal_2b
 from .city_centroids import centroid_for
 from .gigtrip.model import Constraints, Event, Itinerary
 from .gigtrip.optimizer import plan_by_date, plan_optimal
@@ -39,7 +40,8 @@ def row_to_event(r: dict) -> Event:
     )
 
 
-def _event_dict(e: Event, csrc: dict[int, str]) -> dict:
+def _event_dict(e: Event, meta: dict[int, dict]) -> dict:
+    m = meta.get(int(e.id), {})
     return {
         "event_id": int(e.id),
         "performer": e.title,
@@ -48,17 +50,34 @@ def _event_dict(e: Event, csrc: dict[int, str]) -> dict:
         "date": e.day.isoformat(),
         "lat": e.lat,
         "lon": e.lon,
-        "coord_source": csrc.get(int(e.id), "venue"),  # "venue" (precise) | "city" (centroid)
+        "coord_source": m.get("coord_source", "venue"),  # "venue" (precise) | "city" (centroid)
+        "owned": m.get("owned"),                          # EVO owned tickets at this event
+        "getin": m.get("getin"),                          # EVO retail get-in price
+        "ticket_cost": m.get("ticket_cost"),              # getin x max(0, qty - owned)
+        "cost_known": m.get("cost_known", True),
     }
 
 
-def _itin_dict(it: Itinerary, csrc: dict[int, str]) -> dict:
+def _itin_dict(it: Itinerary, meta: dict[int, dict]) -> dict:
     return {
         "count": it.count,
         "value": round(it.value, 4),
         "travel_km": round(it.travel_km, 1),
-        "events": [_event_dict(e, csrc) for e in it.events],
+        "spend_usd": round(sum((meta.get(int(e.id), {}).get("ticket_cost") or 0.0)
+                               for e in it.events), 2),
+        "events": [_event_dict(e, meta) for e in it.events],
     }
+
+
+def _ticket_cost(getin, owned, qty: int):
+    """Cost to attend a show with `qty` tickets — owned tickets are free.
+    Returns (cost, known); an unknown price with a remaining buy-need -> (0.0, False)."""
+    need = max(0, qty - int(owned or 0))
+    if need == 0:
+        return 0.0, True                 # fully covered by tickets we already own
+    if getin is None:
+        return 0.0, False                # price unknown -> don't let it block the budget
+    return round(float(getin) * need, 2), True
 
 
 # --------------------------------------------------------------------------- #
@@ -66,37 +85,65 @@ def _itin_dict(it: Itinerary, csrc: dict[int, str]) -> dict:
 # --------------------------------------------------------------------------- #
 def plan_from_rows(rows: list[dict], home: dict, budget_km: float,
                    start: date, end: date, prefs: dict[str, float] | None = None,
-                   max_events: int | None = None,
-                   max_km_per_day: float = 1200.0) -> dict:
+                   max_events: int | None = None, max_km_per_day: float = 1200.0,
+                   budget_usd: float | None = None, qty: int = 1) -> dict:
     """Build the optimal itinerary (and the sort-by-date baseline) from raw rows.
 
     `home` is {"name", "lat", "lon"}. `prefs` maps lowercased performer title -> weight;
-    when omitted every distinct performer is weighted 1.0 (the single-performer case is
-    just the uniform-weight degenerate of the general multi-performer optimizer).
+    when omitted every distinct performer is weighted 1.0.
+
+    When `budget_usd` is given, the trip must also fit a ticket-spend budget: each show
+    costs `getin x max(0, qty - owned)` (owned tickets free), pulled from `_getin`/`_owned`
+    attached to the rows. Travel-km and spend are then BOTH enforced by the 2-budget solver.
     """
     usable = [r for r in rows if r.get("venue_lat") is not None
               and r.get("venue_lon") is not None]
     events = [row_to_event(r) for r in usable]
-    csrc = {int(r["tevo_event_id"]): r.get("_coord_source", "venue") for r in usable}
     if prefs is None:
         prefs = {e.title.lower(): 1.0 for e in events}
+
+    qty = max(1, int(qty or 1))
+    costs: dict[int, float] = {}
+    meta: dict[int, dict] = {}
+    n_unpriced = 0
+    for r in usable:
+        eid = int(r["tevo_event_id"])
+        getin, owned = r.get("_getin"), r.get("_owned")
+        cst, known = _ticket_cost(getin, owned, qty)
+        if not known:
+            n_unpriced += 1
+        costs[eid] = cst
+        meta[eid] = {
+            "coord_source": r.get("_coord_source", "venue"),
+            "owned": int(owned) if owned is not None else None,
+            "getin": round(float(getin), 2) if getin is not None else None,
+            "ticket_cost": cst,
+            "cost_known": known,
+        }
 
     c = Constraints(
         home_name=home["name"], home_lat=float(home["lat"]), home_lon=float(home["lon"]),
         start=start, end=end, max_travel_km=float(budget_km),
         max_events=max_events, max_km_per_day=max_km_per_day,
     )
-    optimal = plan_optimal(events, prefs, c)
-    baseline = plan_by_date(events, prefs, c)
+
+    if budget_usd is not None:
+        optimal, _ = plan_optimal_2b(events, prefs, c, costs, float(budget_usd))
+        baseline, _ = plan_by_date_2b(events, prefs, c, costs, float(budget_usd))
+    else:
+        optimal = plan_optimal(events, prefs, c)
+        baseline = plan_by_date(events, prefs, c)
 
     titles = sorted({e.title for e in events})
     performer_label = titles[0] if len(titles) == 1 else f"{len(titles)} performers"
-    n_city = sum(1 for v in csrc.values() if v == "city")
+    n_city = sum(1 for m in meta.values() if m["coord_source"] == "city")
 
     return {
         "performer": performer_label,
         "home": home,
         "budget_km": float(budget_km),
+        "budget_usd": float(budget_usd) if budget_usd is not None else None,
+        "qty_per_show": qty,
         "window": {"start": start.isoformat(), "end": end.isoformat()},
         "tour_date_count": len(events),
         "coord_coverage": {
@@ -104,10 +151,11 @@ def plan_from_rows(rows: list[dict], home: dict, budget_km: float,
             "city_fallback": n_city,              # approximated to city centroid
             "dropped_no_coords": len(rows) - len(usable),  # neither available -> excluded
         },
-        "optimal": _itin_dict(optimal, csrc),
-        "baseline_by_date": _itin_dict(baseline, csrc),
+        "unpriced_events": n_unpriced,
+        "optimal": _itin_dict(optimal, meta),
+        "baseline_by_date": _itin_dict(baseline, meta),
         "shows_gained": optimal.count - baseline.count,
-        "all_dates": [_event_dict(e, csrc) for e in sorted(events, key=lambda e: (e.day, e.id))],
+        "all_dates": [_event_dict(e, meta) for e in sorted(events, key=lambda e: (e.day, e.id))],
     }
 
 
@@ -157,15 +205,51 @@ def _apply_coord_fallback(db, rows: list[dict]) -> None:
             r["venue_lat"], r["venue_lon"], r["_coord_source"] = c[0], c[1], "city"
 
 
+def fetch_event_costs(db, ids: list[int], lookback_days: int = 21) -> dict[int, dict]:
+    """Latest EVO get-in price + owned-ticket count per event, from event_listing_snapshot_daily.
+
+    Returns {event_id: {"getin": float|None, "owned": int}}; events with no recent snapshot
+    are simply absent (treated as no price / 0 owned downstream).
+    """
+    if not ids:
+        return {}
+    since = (date.today() - timedelta(days=lookback_days)).isoformat()
+    rows = (db.table("event_listing_snapshot_daily")
+            .select("event_id, evo_retail_getin, evo_owned_tickets, captured_at")
+            .in_("event_id", ids)
+            .gte("snapshot_date", since)
+            .order("captured_at", desc=True)
+            .limit(4000)
+            .execute().data) or []
+    out: dict[int, dict] = {}
+    for r in rows:
+        eid = int(r["event_id"])
+        if eid in out:                       # first seen = latest (ordered captured_at desc)
+            continue
+        g = r.get("evo_retail_getin")
+        out[eid] = {
+            "getin": float(g) if g is not None else None,
+            "owned": int(r.get("evo_owned_tickets") or 0),
+        }
+    return out
+
+
 def plan_performer_trip(db, performer_id: int, home_lat: float, home_lon: float,
                         budget_km: float, start: date, end: date,
                         home_name: str = "Home", max_events: int | None = None,
-                        max_km_per_day: float = 1200.0) -> dict:
-    """End-to-end: pull a performer's upcoming dates and plan the optimal trip."""
+                        max_km_per_day: float = 1200.0,
+                        budget_usd: float | None = None, qty: int = 1) -> dict:
+    """End-to-end: pull a performer's upcoming dates (+ EVO price/owned) and plan the trip."""
     rows = fetch_performer_rows(db, performer_id, start, end)
     _apply_coord_fallback(db, rows)
+    costs = fetch_event_costs(db, [int(r["tevo_event_id"]) for r in rows])
+    for r in rows:
+        c = costs.get(int(r["tevo_event_id"]))
+        if c:
+            r["_getin"], r["_owned"] = c["getin"], c["owned"]
     home = {"name": home_name, "lat": home_lat, "lon": home_lon}
     payload = plan_from_rows(rows, home, budget_km, start, end,
-                             max_events=max_events, max_km_per_day=max_km_per_day)
+                             max_events=max_events, max_km_per_day=max_km_per_day,
+                             budget_usd=budget_usd, qty=qty)
     payload["performer_id"] = int(performer_id)
     return payload

--- a/trip_planner/test_ariana.py
+++ b/trip_planner/test_ariana.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 
 from datetime import date
 
+from .budget_optimizer import plan_optimal_2b
 from .city_centroids import centroid_for
 from .gigtrip.model import Constraints
-from .gigtrip.optimizer import brute_force_optimal, plan_optimal
-from .planner import plan_from_rows, row_to_event
+from .gigtrip.optimizer import (
+    brute_force_optimal,
+    candidates,
+    plan_optimal,
+    route_km,
+)
+from .gigtrip.optimizer import _legs_feasible
+from .planner import _ticket_cost, plan_from_rows, row_to_event
 
 ROWS = [
     {"tevo_event_id": 3094846, "primary_performer_name": "Ariana Grande", "venue_name": "Crypto.com Arena",   "venue_city": "Los Angeles", "event_date": "2026-06-14", "venue_lat": 34.042998, "venue_lon": -118.267135},
@@ -80,6 +87,56 @@ def test_city_centroid_fallback():
     assert p["tour_date_count"] == len(ROWS) + 1   # the centroid row counts, the coord-less one doesn't
 
 
+def _brute_2b(events, prefs, c, costs, budget_usd):
+    """Ground-truth 2-budget optimum (max value within km AND spend) by enumeration."""
+    from itertools import combinations
+    cand = candidates(events, c)
+    best_val, best_km = 0.0, 0.0
+    for r in range(1, len(cand) + 1):
+        for combo in combinations(cand, r):
+            if not _legs_feasible(combo, c):
+                continue
+            km = route_km(combo, c)
+            if km > c.max_travel_km + 1e-9:
+                continue
+            if sum(costs.get(int(e.id), 0.0) for e in combo) > budget_usd + 1e-9:
+                continue
+            val = sum(prefs.get(e.title.lower(), 0.0) for e in combo)
+            if val > best_val + 1e-12 or (abs(val - best_val) <= 1e-12 and km < best_km - 1e-12):
+                best_val, best_km = val, km
+    return best_val
+
+
+def test_two_budget():
+    # attach EVO price + owned to the real fixture: $500 get-in, we own 2 at every 5th show.
+    rows = [dict(r) for r in ROWS]
+    for i, r in enumerate(rows):
+        r["_getin"] = 500.0
+        r["_owned"] = 2 if i % 5 == 0 else 0
+    qty = 1
+
+    # owned >= qty -> that show is free (ticket_cost 0); otherwise getin * (qty - owned).
+    assert _ticket_cost(500.0, 2, 1) == (0.0, True)
+    assert _ticket_cost(500.0, 0, 2) == (1000.0, True)
+    assert _ticket_cost(None, 0, 1) == (0.0, False)      # unknown price doesn't block
+
+    p = plan_from_rows(rows, HOME, 14000, START, END, budget_usd=2000, qty=qty)
+    assert p["budget_usd"] == 2000 and p["qty_per_show"] == 1
+    assert p["optimal"]["spend_usd"] <= 2000 + 1e-6           # spend budget respected
+    assert p["baseline_by_date"]["spend_usd"] <= 2000 + 1e-6
+    owned_ev = next(e for e in p["all_dates"] if (e["owned"] or 0) >= 1)
+    assert owned_ev["ticket_cost"] == 0.0                     # owned tickets are free
+
+    # exact 2-budget optimum matches the brute-force oracle on value.
+    events = [row_to_event(r) for r in rows]
+    prefs = {"ariana grande": 1.0}
+    costs = {int(r["tevo_event_id"]): _ticket_cost(r["_getin"], r["_owned"], qty)[0] for r in rows}
+    c = Constraints(HOME["name"], HOME["lat"], HOME["lon"], START, END, 14000)
+    opt, spend = plan_optimal_2b(events, prefs, c, costs, 2000)
+    assert abs(opt.value - _brute_2b(events, prefs, c, costs, 2000)) < 1e-9
+    assert spend <= 2000 + 1e-6
+
+
 def main():
     print(f"\nPer-performer trip planner — Ariana Grande (home {HOME['name']})")
     print(f"window {START}..{END}  ·  {len(ROWS)} geocoded tour dates\n")
@@ -93,6 +150,7 @@ def main():
     test_optimal_matches_oracle()
     test_optimal_beats_baseline_at_binding_budget()
     test_city_centroid_fallback()
+    test_two_budget()
     print("\n  asserts passed: optimal == brute-force oracle; optimal > baseline at 9000 km;")
     print("  city-centroid fallback recovers un-geocoded shows (Inglewood/Brooklyn)\n")
 


### PR DESCRIPTION
## What
Adds a **second budget** to the Trip Planner: a trip must now satisfy **both** the travel-km budget **and** a ticket-spend budget — with **owned tickets free**.

- Per-show cost = `evo_retail_getin × max(0, qty − evo_owned_tickets)`. Tickets we already hold cost nothing; price + owned come from `event_listing_snapshot_daily`.
- **Quantity** = one global "tickets/show" input (per the chosen model).
- Both budgets enforced together by an exact **2-budget Pareto label-setting DP** (`budget_optimizer.py`), cross-checked against a brute-force oracle. The vendored gigtrip engine is left untouched — this is a sibling module reusing its geometry helpers.

## Surfaces
- `GET …/trip-plan` (D0 broker + D1 store) gain `budget_usd` + `qty` params.
- D0 performer page: **tickets/show** + **$ budget** inputs, a **ticket-spend** stat (`$spent / $budget`), and per-row **price / "own N" / cost** (shows `free` when fully owned-covered).
- Payload adds `budget_usd`, `qty_per_show`, `unpriced_events`, per-itinerary `spend_usd`, and per-event `owned`/`getin`/`ticket_cost`.

## Honest notes
- Most concerts are EVO-only and some have no `evo_retail_getin`; unpriced shows are surfaced (`N no price`) and treated as non-blocking (cost 0) rather than dropped.
- `python3 -m trip_planner.test_ariana` passes incl. the new 2-budget vs brute-force check; `node --check` + `py_compile` clean. Frontend verifies on deploy.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_