### PR TITLE
feat(d0/performer): surface stored cross-event performer metrics on Overview tab

### DIFF
--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -40,6 +40,18 @@
     .tm-home circle { fill: #fff; stroke: var(--good, #4ade80); stroke-width: 2; }
     .tm-lbl { fill: var(--muted, #cbd5e1); font-size: 10px; }
     .tm-home-lbl { fill: #fff; font-weight: 600; }
+    /* Cross-event daily metrics (Overview tab) */
+    #pdmSplit { display: flex; gap: 6px; }
+    .pdm-delta { font-size: 11px; margin-left: 6px; font-weight: 600; }
+    .pdm-delta.up { color: var(--pos, #4ade80); }
+    .pdm-delta.down { color: var(--neg, #f87171); }
+    .pdm-trends { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 14px; }
+    .pdm-trend { flex: 1 1 200px; min-width: 180px; background: var(--panel, #14141b); border: 1px solid rgba(255,255,255,.08); border-radius: 8px; padding: 10px 12px; }
+    .pdm-trend .pt-lbl { font-size: 11px; color: var(--muted, #9aa); text-transform: uppercase; letter-spacing: .04em; }
+    .pdm-trend .pt-val { font-size: 18px; font-weight: 700; margin: 2px 0 6px; }
+    .pdm-spark { width: 100%; height: 40px; display: block; }
+    .pdm-spark path { fill: none; stroke: var(--accent, #4ade80); stroke-width: 1.4; }
+    .pdm-spark circle { fill: var(--accent, #4ade80); }
   </style>
 </head>
 <body data-page="performer">
@@ -98,6 +110,25 @@
           <div class="ru-cell"><span class="ru-num" id="ruRetailMedAvg">—</span><span class="ru-lbl">retail median (wt)</span></div>
           <div class="ru-cell"><span class="ru-num" id="ruEventsWithOwned">—</span><span class="ru-lbl">events with position</span></div>
         </div>
+      </section>
+
+      <!-- Cross-event metrics rolled up daily across ALL of this performer's events
+           (stored timeseries: performer_metrics_daily via get_performer_metrics_daily). -->
+      <section id="perf-daily-metrics" hidden>
+        <div class="panel-title row">
+          <span>CROSS-EVENT METRICS — DAILY</span>
+          <span class="muted small" id="pdmMeta"></span>
+        </div>
+        <div class="muted small" style="margin-bottom: 8px;">
+          Performer-level totals rolled up across every one of this performer's events, stored daily.
+          Inventory is kept per source (units never mixed); prices use the cross-source blended amalgam.
+        </div>
+        <nav id="pdmSplit" class="event-tabs" role="tablist" hidden style="margin-bottom: 10px;">
+          <button class="event-tab active" data-split="all" role="tab" aria-selected="true">All</button>
+          <button class="event-tab" data-split="home" role="tab" aria-selected="false">Home</button>
+          <button class="event-tab" data-split="away" role="tab" aria-selected="false">Away</button>
+        </nav>
+        <div id="pdmBody"><div class="empty">loading…</div></div>
       </section>
 
       <section id="perf-espn-summary" hidden>

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -118,6 +118,7 @@
       _tabState.portfolio = (portfolio && !portfolio.__err) ? portfolio : null;
       try { renderHero(assets, portfolio); }      catch (e) { console.error('hero', e); }
       try { renderRollup(portfolio); }            catch (e) { console.error('rollup', e); }
+      try { initDailyMetrics(performerId, portfolio); } catch (e) { console.error('dailyMetrics', e); }
       try { renderEvents(portfolio); }            catch (e) { console.error('events', e); }
       try { renderBlindSpots(portfolio); }        catch (e) { console.error('blindSpots', e); }
     });
@@ -354,6 +355,145 @@
     setText('ruOwnedShare',     ag.owned_share_weighted != null ? T.fmtPct(ag.owned_share_weighted * 100, 1) : '—');
     setText('ruRetailMedAvg',   ag.retail_median_avg_weighted ? '$' + T.fmtNum(Math.round(ag.retail_median_avg_weighted)) : '—');
     setText('ruEventsWithOwned', T.fmtNum(ag.events_with_owned));
+  }
+
+  // ---------- Cross-event daily metrics (Overview) ----------
+  //
+  // Surfaces the STORED performer-level timeseries (performer_metrics_daily,
+  // refreshed every 4h) via get_performer_metrics_daily(id, days, split). Unlike
+  // the live PORTFOLIO ROLLUP above (computed from /api/portfolio at request time),
+  // this is the persisted daily roll-up across ALL of the performer's events:
+  // per-source inventory (EVO/SG, all + owned), amalgam price band (get-in
+  // min/median, price min/median/p90), and owned-book notional — with day-over-day
+  // deltas + 90d sparklines. Sports performers also get home/away splits.
+
+  function initDailyMetrics(performerId, portfolio) {
+    const isSports = !!(portfolio && !portfolio.__err && portfolio.is_sports_performer);
+    const splitNav = document.getElementById('pdmSplit');
+    if (splitNav) {
+      if (isSports) {
+        splitNav.removeAttribute('hidden');
+        splitNav.addEventListener('click', (e) => {
+          const b = e.target.closest('.event-tab');
+          if (!b) return;
+          splitNav.querySelectorAll('.event-tab').forEach((x) => {
+            const on = x === b;
+            x.classList.toggle('active', on);
+            x.setAttribute('aria-selected', on ? 'true' : 'false');
+          });
+          loadDailyMetrics(performerId, b.dataset.split);
+        });
+      } else {
+        splitNav.setAttribute('hidden', '');
+      }
+    }
+    loadDailyMetrics(performerId, 'all');
+  }
+
+  async function loadDailyMetrics(performerId, split) {
+    const sec = document.getElementById('perf-daily-metrics');
+    const body = document.getElementById('pdmBody');
+    if (!sec || !body) return;
+    sec.removeAttribute('hidden');
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      body.innerHTML = '<div class="empty">daily metrics need auth — sign in with @s4kent.com</div>';
+      return;
+    }
+    body.innerHTML = '<div class="empty">loading daily metrics…</div>';
+    const res = await Auth.client.rpc('get_performer_metrics_daily', {
+      p_performer_id: performerId, p_days: 90, p_split: split || 'all',
+    });
+    if (res.error) {
+      body.innerHTML = `<div class="empty">RPC error: ${escapeHtml(res.error.message)}</div>`;
+      return;
+    }
+    renderDailyMetrics(res.data || [], split || 'all');
+  }
+
+  function renderDailyMetrics(rows, split) {
+    const body = document.getElementById('pdmBody');
+    const meta = document.getElementById('pdmMeta');
+    if (!body) return;
+    if (!rows.length) {
+      if (meta) meta.textContent = '';
+      body.innerHTML = `<div class="empty">no daily metrics stored yet for this performer${split && split !== 'all' ? ' (' + escapeHtml(split) + ')' : ''}</div>`;
+      return;
+    }
+    const latest = rows[rows.length - 1];
+    const prev = rows.length > 1 ? rows[rows.length - 2] : null;
+    if (meta) meta.textContent = `${rows.length} day${rows.length === 1 ? '' : 's'} · latest ${dayLabel(latest.snapshot_date)} · split: ${split || 'all'}`;
+
+    const usd = (v) => (v != null && isFinite(v)) ? '$' + T.fmtNum(Math.round(v)) : '—';
+    const cell = (num, lbl, extra) => `<div class="ru-cell"><span class="ru-num">${num}${extra || ''}</span><span class="ru-lbl">${lbl}</span></div>`;
+    const d = (cur, prv) => prv ? deltaChip(cur, prv) : '';
+
+    const kpis = [
+      cell(T.fmtNum(latest.event_count), 'events'),
+      cell(T.fmtNum(latest.evo_tickets_total), 'EVO tix (all)'),
+      cell(T.fmtNum(latest.evo_owned_tickets_total), 'EVO tix (owned)'),
+      cell(T.fmtNum(latest.sg_all_tickets_total), 'SG tix (all)'),
+      cell(T.fmtNum(latest.sg_owned_tickets_total), 'SG tix (owned)'),
+      cell(usd(latest.getin_min), 'get-in min', d(latest.getin_min, prev && prev.getin_min)),
+      cell(usd(latest.getin_median), 'get-in median'),
+      cell(usd(latest.price_min), 'price min'),
+      cell(usd(latest.price_median), 'price median', d(latest.price_median, prev && prev.price_median)),
+      cell(usd(latest.price_p90), 'price p90'),
+      cell(usd(latest.owned_book_notional), 'owned book notional', d(latest.owned_book_notional, prev && prev.owned_book_notional)),
+    ].join('');
+
+    const sparkPrice = sparkline(rows.map((r) => numOrNull(r.price_median)));
+    const sparkGetin = sparkline(rows.map((r) => numOrNull(r.getin_min)));
+    const sparkInv   = sparkline(rows.map((r) => numOrNull(r.evo_owned_tickets_total)));
+    const n = rows.length;
+    const trends = `
+      <div class="pdm-trends">
+        ${sparkPrice ? `<div class="pdm-trend"><div class="pt-lbl">price median · last ${n}d</div><div class="pt-val">${usd(latest.price_median)}</div>${sparkPrice}</div>` : ''}
+        ${sparkGetin ? `<div class="pdm-trend"><div class="pt-lbl">get-in min · last ${n}d</div><div class="pt-val">${usd(latest.getin_min)}</div>${sparkGetin}</div>` : ''}
+        ${sparkInv   ? `<div class="pdm-trend"><div class="pt-lbl">owned EVO tix · last ${n}d</div><div class="pt-val">${T.fmtNum(latest.evo_owned_tickets_total)}</div>${sparkInv}</div>` : ''}
+      </div>`;
+
+    body.innerHTML = `<div class="rollup-grid">${kpis}</div>${trends}`;
+  }
+
+  function numOrNull(v) {
+    if (v === null || v === undefined) return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  // Day-over-day percent-change chip (direction-coloured, like .chart-move).
+  function deltaChip(cur, prv) {
+    const a = numOrNull(cur), b = numOrNull(prv);
+    if (a === null || b === null || b === 0) return '';
+    const pct = (a - b) / Math.abs(b) * 100;
+    if (Math.abs(pct) < 0.05) return '';
+    const cls = pct >= 0 ? 'up' : 'down';
+    return ` <span class="pdm-delta ${cls}">${pct >= 0 ? '▲' : '▼'} ${Math.abs(pct).toFixed(1)}%</span>`;
+  }
+
+  // Minimal CSP-safe inline sparkline (no external libs). Skips null gaps.
+  function sparkline(series, w, h) {
+    w = w || 240; h = h || 40;
+    const pts = series.map((v, i) => [i, v]).filter((p) => p[1] !== null);
+    if (pts.length < 2) return '';
+    const xs = pts.map((p) => p[0]), ys = pts.map((p) => p[1]);
+    const minX = Math.min(...xs), maxX = Math.max(...xs);
+    const minY = Math.min(...ys), maxY = Math.max(...ys);
+    const spanX = (maxX - minX) || 1, spanY = (maxY - minY) || 1;
+    const pad = 3;
+    const proj = (x, y) => [pad + (x - minX) / spanX * (w - 2 * pad), h - pad - (y - minY) / spanY * (h - 2 * pad)];
+    const dPath = pts.map((p, i) => { const [px, py] = proj(p[0], p[1]); return (i ? 'L' : 'M') + px.toFixed(1) + ' ' + py.toFixed(1); }).join(' ');
+    const lastP = pts[pts.length - 1];
+    const [lx, ly] = proj(lastP[0], lastP[1]);
+    return `<svg class="pdm-spark" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" role="img" aria-label="trend">`
+      + `<path d="${dPath}"/><circle cx="${lx.toFixed(1)}" cy="${ly.toFixed(1)}" r="2"/></svg>`;
+  }
+
+  function dayLabel(d) {
+    if (!d) return '—';
+    try { return new Date(d + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }); }
+    catch (_) { return d; }
   }
 
   // ---------- Events list ----------


### PR DESCRIPTION
## What

Adds a **CROSS-EVENT METRICS — DAILY** panel to the performer page Overview tab in the D0 terminal frontend.

The page already showed a live **PORTFOLIO ROLLUP** (computed per-request from `/api/portfolio`). This adds the *persisted* performer-level timeseries that we roll up across **all** of a performer's events — previously generated and stored but never surfaced in the UI.

## Where the data comes from

`get_performer_metrics_daily(p_performer_id, p_days, p_split)` → `performer_metrics_daily` (refreshed every 4h by `entity-metrics-daily-refresh`). Email-gated `@s4kent.com`, granted to `authenticated`. No new backend.

## What it shows (per latest stored day)

- **Inventory, per source** (units never mixed): EVO tix all/owned, SG tix all/owned
- **Amalgam price band**: get-in min/median, price min/median/p90
- **Owned-book notional** (Σ owned EVO inventory × retail median)
- **Day-over-day deltas** on get-in min, price median, owned notional (direction-coloured)
- **90-day inline sparklines**: price median, get-in min, owned EVO tix

For sports performers (`is_sports_performer` from the portfolio payload), an **All / Home / Away** split toggle re-fetches the corresponding stored split.

## Notes

- CSP-safe: inline SVG sparklines, no external libs, no new script sources.
- Lane: `static/terminal/*` (D0) — within lane, HTML/JS free-reign per CLAUDE.md §3.
- Files: `static/terminal/performer.html` (panel + styles), `static/terminal/performer.js` (fetch/render/sparkline/split logic).

https://claude.ai/code/session_01VLCypzZ7fczKmt8KTAoFXn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLCypzZ7fczKmt8KTAoFXn)_