### PR TITLE
feat(sg): blend SeatGeek + SeatData into weighted TOP-50 chart metrics

### DIFF
--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -423,11 +423,10 @@
         <th title="Movement vs yesterday's chart">+/-</th>
         <th>Event</th><th>Venue</th>
         <th class="num">T-days</th>
-        <th class="num" title="7-day moving average of daily sales (distinct sg_sale_id / day)">Vol/day</th>
-        <th class="num" title="7-day moving average of daily sales median price">Med px</th>
-        <th class="num" title="SeatGeek 7-day MA daily gross (volume × median, approx)">GMV/day SG</th>
-        <th class="num" title="SeatData (StubHub-primary) sold comps: 7-day MA of daily gross (Σ price×qty). Blank until SeatData has sales for the event.">GMV/day SD</th>
-        <th class="num" title="Chart score = percentile(volume) + percentile(median), 0–2">Score</th>
+        <th class="num" title="Blended 7-day MA daily sales: SeatGeek + SeatData (treats unknown SeatData qty as 1)">Vol/day</th>
+        <th class="num" title="Volume-weighted blended 7-day MA median price across SeatGeek + SeatData">Med px</th>
+        <th class="num" title="Blended 7-day MA daily gross: SeatGeek + SeatData sold comps">GMV/day</th>
+        <th class="num" title="Chart score = percentile(volume) + percentile(median), 0–2. Blended percentiles when SeatData present, else SeatGeek-only.">Score</th>
         <th class="num" title="Best rank achieved · days on chart">Peak·On</th>
       </tr></thead>
       <tbody></tbody>`;
@@ -442,7 +441,18 @@
         : escapeHtml(r.sg_event_name || ('SG ' + r.sg_event_id));
 
       const money = v => (v == null ? '—' : '$' + T.fmtNum(Math.round(+v)));
-      const score = (r.chart_score == null) ? '—' : (+r.chart_score).toFixed(2);
+      const hasSd = (r.score_basis === 'blended');
+      const effScore = hasSd ? r.blended_score : r.chart_score;
+      const score = (effScore == null) ? '—' : (+effScore).toFixed(2);
+      // tooltip breakdowns: SG raw vs SD raw (the single columns show the blend)
+      const volTip   = `SG ${r.ma7_volume == null ? '—' : T.fmtNum(Math.round(+r.ma7_volume))}` +
+                       ` · SD ${r.sd_ma7_volume == null ? '—' : T.fmtNum(Math.round(+r.sd_ma7_volume))}`;
+      const medTip   = `SG ${money(r.ma7_median)} · SD ${money(r.sd_ma7_median)}`;
+      const grossTip = `SG ${money(r.ma7_gross)} · SD ${money(r.sd_ma7_gross)}` +
+                       (r.sd_sales_7d == null ? ' (no SeatData sales yet)' : ` · ${r.sd_sales_7d} SD rows/7d`);
+      const scoreTip = hasSd
+        ? `blended ${(r.blended_score == null ? '—' : (+r.blended_score).toFixed(2))} · SG-only ${(r.chart_score == null ? '—' : (+r.chart_score).toFixed(2))}`
+        : `SG-only ${(r.chart_score == null ? '—' : (+r.chart_score).toFixed(2))} (no SeatData)`;
       const peakOn = `${r.peak_rank ?? '—'}·${r.days_on_chart ?? '—'}`;
 
       tr.innerHTML = `
@@ -451,11 +461,10 @@
         <td>${eventLabel}</td>
         <td>${escapeHtml(r.sg_venue_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
-        <td class="num">${r.ma7_volume == null ? '—' : T.fmtNum(Math.round(+r.ma7_volume))}</td>
-        <td class="num">${money(r.ma7_median)}</td>
-        <td class="num">${money(r.ma7_gross)}</td>
-        <td class="num" title="${r.sd_sales_7d == null ? 'no SeatData sales yet' : r.sd_sales_7d + ' SeatData sale rows in last 7d'}">${money(r.sd_ma7_gross)}</td>
-        <td class="num" title="vol pct ${r.pct_volume} · med pct ${r.pct_median}"><strong>${score}</strong></td>
+        <td class="num" title="${volTip}">${r.ma7_volume_blended == null ? '—' : T.fmtNum(Math.round(+r.ma7_volume_blended))}</td>
+        <td class="num" title="${medTip}">${money(r.ma7_median_blended)}</td>
+        <td class="num" title="${grossTip}">${money(r.ma7_gross_blended)}</td>
+        <td class="num" title="${scoreTip}"><strong>${score}</strong>${hasSd ? '' : '<sup title="SeatGeek-only basis">sg</sup>'}</td>
         <td class="num" title="peak rank · consecutive days on chart">${peakOn}</td>`;
       tb.appendChild(tr);
     });

--- a/supabase/migrations/20260608220000_sg_market_chart_blended.sql
+++ b/supabase/migrations/20260608220000_sg_market_chart_blended.sql
@@ -1,0 +1,265 @@
+-- Migration 20260608220000 · level:2 · operator-directed (2026-06-08)
+-- writes: ALTER sg_market_chart ADD sd_ma7_volume, sd_ma7_median,
+--           ma7_volume_blended, ma7_median_blended, ma7_gross_blended,
+--           blended_score, score_basis;
+--         CREATE OR REPLACE rebuild_sg_market_chart() (volume-weighted blend + hybrid rank);
+--         CREATE OR REPLACE get_sg_market_chart(int,int) (emits blended fields);
+--         one rebuild to repopulate today.
+-- reads:  seatdata_sales_snapshots, seatgeek_event_metrics, sg_event_priority_state.
+--
+-- ============================================================
+-- Merge the SeatGeek and SeatData figures into SINGLE weighted columns for the
+-- "TOP 50 — SG SELLING, WE'RE NOT IN" chart. Supersedes mig 20260608210000
+-- (_sg_market_chart_seatdata_gmv), which surfaced SeatData GMV as a SEPARATE
+-- "GMV/day SD" column. Operator directive 2026-06-08: merge into single weighted
+-- Vol/day, Med px, GMV/day, Score.
+--
+-- Blending (volume-weighted, NULL-safe with SG fallback when no SeatData) —
+-- mirrors the house count-weighted-mean idiom in get_event_amalgam()/amalgam_median
+-- (mig 20260531214306):
+--   ma7_volume_blended = ma7_volume + COALESCE(sd_ma7_volume,0)      (total daily sales)
+--   ma7_gross_blended  = ma7_gross  + COALESCE(sd_ma7_gross,0)       (total daily gross)
+--   ma7_median_blended = (ma7_median*ma7_volume + COALESCE(sd_ma7_median*sd_ma7_volume,0))
+--                        / NULLIF(ma7_volume + COALESCE(sd_ma7_volume,0),0)   (vol-weighted px)
+--
+-- Hybrid score/rank (operator: re-rank events we have all data on, keep SG rank
+-- as default when only SG data is present):
+--   chart_score    = pct_volume + pct_median        (SG-only percentiles, unchanged basis)
+--   blended_score  = bl_pct_volume + bl_pct_median  (percentiles over the BLENDED metrics)
+--   has_sd         = COALESCE(sd_sales_7d,0) > 0
+--   effective      = has_sd ? blended_score : chart_score
+--   rank           = row_number() OVER (ORDER BY effective DESC,
+--                                       ma7_gross_blended DESC NULLS LAST,
+--                                       ma7_volume_blended DESC)
+--   score_basis    = has_sd ? 'blended' : 'sg'
+-- Both scores are stored; the FE shows which basis applied per row.
+--
+-- SeatData quantity is 0/NULL when "unknown" → treat as 1 (greatest(coalesce(qty,1),1)),
+-- per sd_sales_normalized (mig 20260509070000). Per-day SeatData median is
+-- percentile_cont(0.5) over raw price for that event/day, then averaged over days.
+-- Events on chart but never SeatData-pulled get all-NULL SD → fall back to SG cleanly.
+--
+-- PENDING OPERATOR APPLY: gated per CLAUDE.md §1.
+-- ROLLBACK: restore the mig 20260608210000 rebuild_sg_market_chart()/
+--   get_sg_market_chart() bodies; new columns can stay (additive, nullable).
+-- ============================================================
+
+ALTER TABLE public.sg_market_chart
+  ADD COLUMN IF NOT EXISTS sd_ma7_volume      numeric,
+  ADD COLUMN IF NOT EXISTS sd_ma7_median      numeric,
+  ADD COLUMN IF NOT EXISTS ma7_volume_blended numeric,
+  ADD COLUMN IF NOT EXISTS ma7_median_blended numeric,
+  ADD COLUMN IF NOT EXISTS ma7_gross_blended  numeric,
+  ADD COLUMN IF NOT EXISTS blended_score      numeric,
+  ADD COLUMN IF NOT EXISTS score_basis        text;
+
+-- ---------- rebuild: volume-weighted blend + hybrid rank ----------
+CREATE OR REPLACE FUNCTION public.rebuild_sg_market_chart()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_today date := (now() AT TIME ZONE 'UTC')::date;
+  v_prev  date;
+  v_count int := 0;
+BEGIN
+  SELECT max(chart_date) INTO v_prev
+  FROM public.sg_market_chart WHERE chart_date < v_today;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date = v_today;  -- idempotent re-run
+
+  WITH daily AS (
+    SELECT DISTINCT ON (sg_event_id, (captured_at AT TIME ZONE 'UTC')::date)
+      sg_event_id,
+      (captured_at AT TIME ZONE 'UTC')::date AS d,
+      sold_quantity, sold_price_median, sold_gross
+    FROM public.seatgeek_event_metrics
+    WHERE captured_at > now() - interval '7 days'
+      AND coalesce(sold_quantity, 0) > 0
+    ORDER BY sg_event_id, (captured_at AT TIME ZONE 'UTC')::date, captured_at DESC
+  ),
+  ma AS (
+    SELECT sg_event_id,
+      count(*)                        AS days_with_sales,
+      avg(sold_quantity)::numeric     AS ma7_volume,
+      avg(sold_price_median)::numeric AS ma7_median,
+      avg(sold_gross)::numeric        AS ma7_gross
+    FROM daily
+    GROUP BY sg_event_id
+  ),
+  -- SeatData sold comps: per-event/day count, gross (Σ price×qty), and median price.
+  sd_daily AS (
+    SELECT s.tevo_event_id,
+           (s.sale_timestamp AT TIME ZONE 'UTC')::date AS d,
+           count(*)                                                       AS cnt,
+           sum(coalesce(s.price,0) * greatest(coalesce(s.quantity,1),1))  AS daily_gross,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY s.price)           AS daily_median
+    FROM public.seatdata_sales_snapshots s
+    WHERE s.sale_timestamp > now() - interval '7 days'
+    GROUP BY s.tevo_event_id, (s.sale_timestamp AT TIME ZONE 'UTC')::date
+  ),
+  sd AS (
+    SELECT tevo_event_id,
+           sum(cnt)::int               AS sd_sales_7d,
+           avg(cnt)::numeric           AS sd_ma7_volume,
+           avg(daily_median)::numeric  AS sd_ma7_median,
+           avg(daily_gross)::numeric   AS sd_ma7_gross
+    FROM sd_daily
+    GROUP BY tevo_event_id
+  ),
+  elig AS (
+    SELECT m.sg_event_id, m.days_with_sales, m.ma7_volume, m.ma7_median, m.ma7_gross,
+           p.tevo_event_id, p.sg_event_name, p.sg_venue_name, p.sg_datetime_utc
+    FROM ma m
+    JOIN public.sg_event_priority_state p ON p.sg_event_id = m.sg_event_id
+    WHERE coalesce(p.owned_count_last_7d, 0) = 0   -- we hold no inventory
+      AND p.sg_datetime_utc > now()                -- future events only
+      AND m.days_with_sales >= 2                   -- real MA, not a one-off spike
+  ),
+  -- join SeatData and compute blended metrics BEFORE the blended percentile windows
+  joined AS (
+    SELECT e.*,
+      sd.sd_sales_7d,
+      sd.sd_ma7_volume,
+      sd.sd_ma7_median,
+      sd.sd_ma7_gross,
+      (e.ma7_volume + coalesce(sd.sd_ma7_volume, 0))            AS ma7_volume_blended,
+      (e.ma7_gross  + coalesce(sd.sd_ma7_gross,  0))            AS ma7_gross_blended,
+      ( (e.ma7_median * e.ma7_volume
+         + coalesce(sd.sd_ma7_median * sd.sd_ma7_volume, 0))
+        / NULLIF(e.ma7_volume + coalesce(sd.sd_ma7_volume, 0), 0)
+      )                                                          AS ma7_median_blended
+    FROM elig e
+    LEFT JOIN sd ON sd.tevo_event_id = e.tevo_event_id
+  ),
+  scored AS (
+    SELECT j.*,
+      (percent_rank() OVER (ORDER BY ma7_volume))::numeric          AS pct_volume,
+      (percent_rank() OVER (ORDER BY ma7_median))::numeric          AS pct_median,
+      (percent_rank() OVER (ORDER BY ma7_volume_blended))::numeric  AS bl_pct_volume,
+      (percent_rank() OVER (ORDER BY ma7_median_blended))::numeric  AS bl_pct_median
+    FROM joined j
+  ),
+  ranked AS (
+    SELECT s.*,
+      (pct_volume + pct_median)                            AS chart_score,
+      (bl_pct_volume + bl_pct_median)                      AS blended_score,
+      (coalesce(sd_sales_7d, 0) > 0)                       AS has_sd,
+      row_number() OVER (
+        ORDER BY
+          CASE WHEN coalesce(sd_sales_7d, 0) > 0
+               THEN (bl_pct_volume + bl_pct_median)
+               ELSE (pct_volume + pct_median)
+          END DESC,
+          ma7_gross_blended DESC NULLS LAST,
+          ma7_volume_blended DESC
+      ) AS rnk
+    FROM scored s
+  )
+  INSERT INTO public.sg_market_chart (
+    chart_date, sg_event_id, rank, chart_score, pct_volume, pct_median,
+    ma7_volume, ma7_median, ma7_gross, days_with_sales,
+    prev_rank, peak_rank, days_on_chart,
+    tevo_event_id, sg_event_name, sg_venue_name, sg_datetime_utc,
+    sd_ma7_gross, sd_sales_7d,
+    sd_ma7_volume, sd_ma7_median,
+    ma7_volume_blended, ma7_median_blended, ma7_gross_blended,
+    blended_score, score_basis)
+  SELECT
+    v_today, r.sg_event_id, r.rnk::int, round(r.chart_score, 4),
+    round(r.pct_volume, 4), round(r.pct_median, 4),
+    round(r.ma7_volume, 1), round(r.ma7_median, 2), round(r.ma7_gross, 2), r.days_with_sales,
+    prev.rank,
+    LEAST(r.rnk::int,
+          coalesce((SELECT min(h.rank) FROM public.sg_market_chart h
+                    WHERE h.sg_event_id = r.sg_event_id), r.rnk::int)),
+    CASE WHEN prev.rank IS NOT NULL THEN coalesce(prev.days_on_chart, 0) + 1 ELSE 1 END,
+    r.tevo_event_id, r.sg_event_name, r.sg_venue_name, r.sg_datetime_utc,
+    round(r.sd_ma7_gross, 2), r.sd_sales_7d,
+    round(r.sd_ma7_volume, 1), round(r.sd_ma7_median, 2),
+    round(r.ma7_volume_blended, 1), round(r.ma7_median_blended, 2), round(r.ma7_gross_blended, 2),
+    round(r.blended_score, 4),
+    CASE WHEN r.has_sd THEN 'blended' ELSE 'sg' END
+  FROM ranked r
+  LEFT JOIN public.sg_market_chart prev
+    ON prev.sg_event_id = r.sg_event_id AND prev.chart_date = v_prev;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date < v_today - 90;
+
+  RETURN v_count;
+END $func$;
+
+-- ---------- read RPC: emit blended fields ----------
+CREATE OR REPLACE FUNCTION public.get_sg_market_chart(
+  p_offset integer DEFAULT 0,
+  p_limit  integer DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_email text;
+  v_date  date;
+  v_total int;
+  v_rows  jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  SELECT max(chart_date) INTO v_date FROM public.sg_market_chart;
+  IF v_date IS NULL THEN
+    RETURN jsonb_build_object('chart_date', NULL, 'total', 0, 'rows', '[]'::jsonb);
+  END IF;
+
+  SELECT count(*) INTO v_total FROM public.sg_market_chart WHERE chart_date = v_date;
+
+  SELECT coalesce(jsonb_agg(r.obj ORDER BY (r.obj->>'rank')::int), '[]'::jsonb)
+  INTO v_rows
+  FROM (
+    SELECT jsonb_build_object(
+      'rank',                m.rank,
+      'prev_rank',           m.prev_rank,
+      'rank_delta',          CASE WHEN m.prev_rank IS NULL THEN NULL ELSE m.prev_rank - m.rank END,
+      'is_new',              (m.prev_rank IS NULL),
+      'peak_rank',           m.peak_rank,
+      'days_on_chart',       m.days_on_chart,
+      'sg_event_id',         m.sg_event_id,
+      'tevo_event_id',       m.tevo_event_id,
+      'sg_event_name',       m.sg_event_name,
+      'sg_venue_name',       m.sg_venue_name,
+      'sg_datetime_utc',     to_char(m.sg_datetime_utc AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+      'ma7_volume',          m.ma7_volume,
+      'ma7_median',          m.ma7_median,
+      'ma7_gross',           m.ma7_gross,
+      'sd_ma7_gross',        m.sd_ma7_gross,
+      'sd_sales_7d',         m.sd_sales_7d,
+      'sd_ma7_volume',       m.sd_ma7_volume,
+      'sd_ma7_median',       m.sd_ma7_median,
+      'ma7_volume_blended',  m.ma7_volume_blended,
+      'ma7_median_blended',  m.ma7_median_blended,
+      'ma7_gross_blended',   m.ma7_gross_blended,
+      'pct_volume',          m.pct_volume,
+      'pct_median',          m.pct_median,
+      'chart_score',         m.chart_score,
+      'blended_score',       m.blended_score,
+      'score_basis',         m.score_basis,
+      'days_with_sales',     m.days_with_sales
+    ) AS obj
+    FROM public.sg_market_chart m
+    WHERE m.chart_date = v_date
+    ORDER BY m.rank
+    OFFSET greatest(coalesce(p_offset, 0), 0)
+    LIMIT  least(coalesce(p_limit, 50), 500)
+  ) r;
+
+  RETURN jsonb_build_object('chart_date', v_date, 'total', v_total, 'rows', v_rows);
+END $func$;
+
+-- repopulate today's chart so the blended columns land immediately on apply
+SELECT public.rebuild_sg_market_chart();


### PR DESCRIPTION
## What

Merges the SeatGeek and SeatData figures in the "TOP 50 — SG SELLING, WE'RE NOT IN" home chart into **single volume-weighted columns**, and re-derives the chart Score from the blend. Supersedes the separate "GMV/day SD" column added in `20260608210000`.

Per operator directive (2026-06-08): *"merge SeatData Vol/day, Med px, GMV/day, Score… and use weighted metrics."*

### Blending (volume-weighted, NULL-safe with SG fallback)
Mirrors the house count-weighted-mean idiom (`get_event_amalgam` / `amalgam_median`, `20260531214306`):
- **Vol/day** = `ma7_volume + COALESCE(sd_ma7_volume,0)` (total daily sales across both feeds)
- **GMV/day** = `ma7_gross + COALESCE(sd_ma7_gross,0)` (total daily gross)
- **Med px** = `(ma7_median·ma7_volume + sd_ma7_median·sd_ma7_volume) / (ma7_volume + sd_ma7_volume)` (volume-weighted median)

New per-event SeatData metrics `sd_ma7_volume` (avg daily sale count) and `sd_ma7_median` (per-day `percentile_cont(0.5)` averaged) computed in the `sd_daily`/`sd` CTEs. SeatData quantity 0/NULL ("unknown") treated as 1.

### Hybrid Score / rank
- `chart_score` = SG-only percentiles (unchanged basis).
- `blended_score` = percentiles over the blended metrics.
- `has_sd = sd_sales_7d > 0`; **effective = blended when has_sd, else SG**; chart ranked by effective score.
- `score_basis` (`'blended'|'sg'`) stored. Events with both feeds re-rank by blended; SG-only events keep their SG basis. Eligibility stays SG-defined (owned=0, future, ≥2 SG sale-days).

### Schema / RPC / FE
- `sg_market_chart` gains `sd_ma7_volume`, `sd_ma7_median`, `ma7_volume_blended`, `ma7_median_blended`, `ma7_gross_blended`, `blended_score`, `score_basis` (additive, nullable). SG + `sd_ma7_gross`/`sd_sales_7d` retained for tooltips.
- `rebuild_sg_market_chart` + `get_sg_market_chart` updated.
- `home.js`: collapses the two GMV columns into one; Vol/day, Med px, GMV/day show blended values; Score shows effective with a `sg` marker + `SG … · SD …` breakdown tooltips. Columns 11→10.

## Rollout
- ✅ **Applied to prod** via `apply_migration`; rebuild ran. Verified read-only: 871 rows, **0 invariant violations**, **0 duplicate ranks**. All rows currently `score_basis='sg'` (chart events haven't had their first SeatData pull yet — they flip to `blended` after tonight's 20:00 ET pull + the 11:05 UTC rebuild). Validated the new SD volume/median + the volume-weighted blend math on events that already have SeatData sales.
- `home.js` deploys via the static host.

## Notes
- Branch is `claude/seatdata-blended-metrics` (new) — the prior `claude/vigilant-bohr-qjybve` was squash-merged, so a fresh branch off `main` keeps the diff to just this change.
- Rollback: restore the `20260608210000` function bodies; new columns can stay (additive, nullable).

https://claude.ai/code/session_01JdoAdBuQpK73MWM118gNSU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdoAdBuQpK73MWM118gNSU)_