### PR TITLE
fix(d0/terminal): cache-bust first-party JS/CSS to stop stale bundles

### DIFF
--- a/static/terminal/discovery.html
+++ b/static/terminal/discovery.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Discovery</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="discovery">
 
@@ -136,9 +136,10 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="discovery.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="discovery.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -16,7 +16,7 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Event</title>
   <link rel="stylesheet" href="lib/uplot.min.css" />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="event">
 
@@ -493,10 +493,11 @@
   <script src="lib/supabase.js"></script>
   <script src="lib/uplot.iife.min.js"></script>
   <script src="lib/tevomaps.bundle.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="alerts.js"></script>
-  <script src="event.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="alerts.js?v=20260608"></script>
+  <script src="event.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Home</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="home">
 
@@ -98,9 +98,10 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="home.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="home.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Sign in</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="login">
 
@@ -44,7 +44,8 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="login.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="login.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Movers</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="movers">
 
@@ -117,9 +117,10 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="movers.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="movers.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="orders">
 
@@ -114,9 +114,10 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="orders.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="orders.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Performer</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
   <style>
     .trip-controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-bottom: 14px; }
     .trip-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--muted, #9aa); text-transform: uppercase; letter-spacing: .04em; }
@@ -206,10 +206,11 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="alerts.js"></script>
-  <script src="performer.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="alerts.js?v=20260608"></script>
+  <script src="performer.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Venue</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260608" />
 </head>
 <body data-page="venue">
 
@@ -172,10 +172,11 @@
   </main>
 
   <script src="lib/supabase.js"></script>
-  <script src="auth.js"></script>
-  <script src="app.js"></script>
-  <script src="nav.js"></script>
-  <script src="alerts.js"></script>
-  <script src="venue.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260608"></script>
+  <script src="alerts.js?v=20260608"></script>
+  <script src="venue.js?v=20260608"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

On the deployed event page, the **top-of-page hero weather** card showed its placeholder (`— / °F / climo / — · —`) while the **WEATHER — VENUE + FORECAST** section rendered correct venue weather.

## Root cause

This is **not** a logic bug — it's a stale-bundle problem:

- Both displays are fed by a single call to `get_event_weather_localized(eventId)` and share the *same* `d.forecast` object — the hero (`renderHeroWeather`) and the section (`renderWeather`) cannot legitimately diverge (`static/terminal/event.js:4841-4842`).
- `main`'s `renderHeroWeather` is correct, and prod data confirms every outdoor `weather_kind` row has a non-null `temp_f` (climatology_outdoor 135/135, forecast_outdoor 480/480) — so the `climo` + all-`—` hero state is impossible from current source + data.
- The terminal pages loaded first-party assets by bare filename (`<script src="event.js">`) with **no cache-busting** (`event.html:500`). The static CDN / browser then kept serving an *old* `event.js` across deploys — surfacing the pre-localized-weather hero behavior.

## Fix

Add a `?v=<token>` query string to first-party `style.css` + `*.js` includes across all terminal pages so each deploy serves fresh bundles. `lib/*` third-party assets, favicon, and manifest are left untouched. A comment documents bumping the token on any first-party asset change.

## Effect / verification

- Merging to `main` triggers `terminal-test` auto-deploy (`render-d0-terminal.yaml:21-22`); the fresh deploy serves the correct `event.js` and the new `?v=` URLs defeat any cached stale copy — the hero will render venue weather identical to the section.
- Scope is HTML-only; no JS logic, RPC, or broker-client changes.

https://claude.ai/code/session_012npppt7LLhM2H8VcvzjVod

---
_Generated by [Claude Code](https://claude.ai/code/session_012npppt7LLhM2H8VcvzjVod)_