### PR TITLE
feat(tour-agent): retail tour-with-the-artist dual-mode pricing (D0 + store)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1211,6 +1211,54 @@ def broker_performer_trip_plan(
                               home_name, days, max_events, budget_usd, qty)
 
 
+def _tour_package_payload(performer_id: int, home_lat: float, home_lon: float,
+                          qty: int, budget_km: float, home_name: str, days: int,
+                          budget_usd: float | None, side: str,
+                          clear_at: float, away_margin: float) -> dict:
+    """Shared body for the retail 'tour with the artist' routes (D0 + store).
+
+    Dual-mode: owned-splits where we hold inventory (concerts), market-sourced buy-to-fulfill
+    for a team's away games (road owned ~ 0). Pure read + compute — no writes, no upstream API.
+    """
+    from datetime import date, timedelta
+
+    from trip_planner import plan_performer_tour
+
+    db = require_sb()
+    start = date.today()
+    end = start + timedelta(days=max(1, min(int(days), 730)))
+    spend = None if budget_usd is None else max(0.0, min(float(budget_usd), 10_000_000.0))
+    return plan_performer_tour(
+        db, int(performer_id), float(home_lat), float(home_lon),
+        max(1, min(int(qty), 50)), max(100.0, min(float(budget_km), 50000.0)),
+        start, end, home_name=(home_name or "Home").strip()[:60], budget_usd=spend,
+        side=(side if side in ("auto", "away", "home", "concert") else "auto"),
+        clear_at=min(max(float(clear_at), 0.01), 1.0),
+        away_margin=min(max(float(away_margin), 0.0), 2.0),
+    )
+
+
+@app.get("/api/broker/performers/{performer_id}/tour-package")
+def broker_performer_tour_package(
+    performer_id: int,
+    home_lat: float,
+    home_lon: float,
+    qty: int = 3,
+    budget_km: float = 8000.0,
+    home_name: str = "Home",
+    days: int = 365,
+    budget_usd: float | None = None,
+    side: str = "auto",
+    clear_at: float = 0.15,
+    away_margin: float = 0.18,
+    _=Depends(require_auth),
+):
+    """D0: retail 'tour with the artist' package — routed multi-city tour priced via the
+    dual-mode model (owned-splits for concerts, market-sourced for a team's away games)."""
+    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km,
+                                 home_name, days, budget_usd, side, clear_at, away_margin)
+
+
 def _bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
     """Fetch performer_metadata for many performer_ids at once. Returns map
     {performer_id: {logo_default_url, color_primary, ...}}. Used by event
@@ -6716,6 +6764,27 @@ def store_performer_trip_plan(
                               home_name, days, max_events, budget_usd, qty)
 
 
+@app.get("/api/store/performers/{performer_id}/tour-package")
+def store_performer_tour_package(
+    performer_id: int,
+    home_lat: float,
+    home_lon: float,
+    qty: int = 3,
+    budget_km: float = 8000.0,
+    home_name: str = "Home",
+    days: int = 365,
+    budget_usd: float | None = None,
+    side: str = "auto",
+    clear_at: float = 0.15,
+    away_margin: float = 0.18,
+):
+    """D1 store: retail 'tour with the artist' agent. Builds a routed multi-city package and
+    prices it — owned-splits where we hold inventory (concerts), market-sourced for a team's
+    away games. Shares the engine with the D0 route via `trip_planner`."""
+    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km,
+                                 home_name, days, budget_usd, side, clear_at, away_margin)
+
+
 def _section_sort_key(s: str) -> tuple:
     """Sort key for venue sections. Letters before digits (Floor, Courtside,
     GA come before 100, 101, etc.); within each group, natural-numeric for
@@ -8011,6 +8080,13 @@ def store_test_trip_page(_=Depends(_require_non_prod)):
     """Sandbox for the per-performer trip planner (/api/store/performers/{id}/trip-plan).
     Pick a performer + home + travel budget → optimal multi-city itinerary vs sort-by-date."""
     return FileResponse(os.path.join(STATIC_DIR, "store", "test", "trip.html"))
+
+
+@app.get("/store/test/tour")
+def store_test_tour_page(_=Depends(_require_non_prod)):
+    """Sandbox for the retail 'tour with the artist' agent
+    (/api/store/performers/{id}/tour-package). Dual-mode priced multi-city package."""
+    return FileResponse(os.path.join(STATIC_DIR, "store", "test", "tour.html"))
 
 
 # ============================================================

--- a/static/store/test/tour.html
+++ b/static/store/test/tour.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tour agent — VibePass</title>
+  <link rel="stylesheet" href="/static/store/test/test.css" />
+  <style>
+    .tour-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 12px; margin: 16px 0 8px; }
+    .tour-form label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+    .tour-form input, .tour-form select { width: 100%; padding: 9px 11px; font-size: 14px; box-sizing: border-box; }
+    .modebar { margin: 14px 0 6px; font-size: 13px; }
+    .pill2 { display: inline-block; padding: 2px 9px; border-radius: 999px; font-size: 11px; font-weight: 600; }
+    .pill2.owned { background: rgba(74,222,128,.15); color: #4ade80; }
+    .pill2.market { background: rgba(96,165,250,.15); color: #60a5fa; }
+    .stat { display: flex; gap: 24px; flex-wrap: wrap; margin: 12px 0; padding: 14px 16px; background: var(--card,#15151c); border-radius: 10px; }
+    .stat b { font-size: 22px; display: block; }
+    .stat .lbl { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+    .save { color: #4ade80; } .prem { color: #fbbf24; }
+    ul.legs { list-style: none; padding: 0; margin: 8px 0 0; }
+    ul.legs li { display: flex; gap: 12px; padding: 9px 12px; border-bottom: 1px solid rgba(255,255,255,.06); align-items: baseline; }
+    ul.legs li.skip { opacity: .4; }
+    ul.legs .d { width: 92px; color: var(--muted); font-size: 13px; font-variant-numeric: tabular-nums; }
+    ul.legs .c { width: 130px; font-weight: 600; }
+    ul.legs .src { font-size: 10px; }
+    ul.legs .px { margin-left: auto; font-variant-numeric: tabular-nums; }
+    ul.legs .mm { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; width: 64px; text-align: right; }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/store/test">VibePass</a>
+    <span class="pill" id="serverEnv">sandbox</span>
+  </header>
+
+  <div class="layout">
+    <nav class="sidebar">
+      <h3>Browse</h3>
+      <a href="/store/test"><span class="num"></span> Home</a>
+      <a href="/store/test/search"><span class="num"></span> Search</a>
+      <a href="/store/test/trip"><span class="num"></span> Trip planner</a>
+      <a href="/store/test/tour"><span class="num"></span> Tour agent</a>
+    </nav>
+
+    <main class="content">
+      <h1>Tour with the artist</h1>
+      <p class="subtitle">Follow a performer across cities — one curated package, priced off our own inventory. For a team it defaults to <b>away games</b> (the road trip).</p>
+
+      <div class="tour-form">
+        <div><label>Performer ID</label><input id="pid" type="number" value="87567" /></div>
+        <div><label>Home lat</label><input id="hlat" type="number" step="0.0001" value="40.7128" /></div>
+        <div><label>Home lon</label><input id="hlon" type="number" step="0.0001" value="-74.0060" /></div>
+        <div><label>Home label</label><input id="hname" type="text" value="New York City" /></div>
+        <div><label>Tickets / show</label><input id="qty" type="number" min="1" max="12" value="3" /></div>
+        <div><label>Travel budget (km)</label><input id="bkm" type="number" step="500" value="6000" /></div>
+        <div><label>Spend cap ($, optional)</label><input id="busd" type="number" step="250" placeholder="none" /></div>
+        <div><label>Side</label><select id="side"><option value="auto">auto</option><option value="away">away (team)</option><option value="home">home / primary</option></select></div>
+      </div>
+      <button id="go" style="padding: 11px 22px">Build tour</button>
+      <span style="font-size:12px;color:var(--muted);margin-left:10px">Default: Megan Moroney (87567). Try a team, e.g. Yankees 15533.</span>
+
+      <div id="status" style="color: var(--muted); font-size: 13px; margin: 16px 0"></div>
+      <div id="result" hidden>
+        <div class="modebar" id="modebar"></div>
+        <div class="stat" id="stat"></div>
+        <h2 style="margin:16px 0 4px" id="legsHead">Your tour</h2>
+        <ul class="legs" id="legs"></ul>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    (function () {
+      const $ = (id) => document.getElementById(id);
+      const money = (n) => '$' + Math.round(n).toLocaleString();
+      function fmtDate(iso) { try { return new Date(iso + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' }); } catch (_) { return iso; } }
+
+      async function build() {
+        const pid = parseInt($('pid').value, 10);
+        const p = new URLSearchParams({
+          home_lat: $('hlat').value, home_lon: $('hlon').value, home_name: $('hname').value,
+          qty: $('qty').value || '3', budget_km: $('bkm').value || '6000',
+          side: $('side').value, days: '365',
+        });
+        if ($('busd').value) p.set('budget_usd', $('busd').value);
+        $('status').textContent = 'Building tour…';
+        $('result').hidden = true;
+        try {
+          const r = await fetch(`/api/store/performers/${pid}/tour-package?` + p);
+          if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + (await r.text()).slice(0, 200));
+          render(await r.json());
+        } catch (e) { $('status').textContent = 'Error: ' + e.message; }
+      }
+
+      function render(d) {
+        const pk = d.package || {};
+        if (!d.stops_available || !pk.count) {
+          $('status').textContent = `No routable tour for performer ${d.performer_id} (${d.mode}).`;
+          $('result').hidden = true;
+          return;
+        }
+        const modeLabel = d.mode === 'team_away' ? 'team · away games · market-sourced'
+          : d.mode === 'team_home' ? 'team · home stand · owned-splits'
+          : 'concert · owned-splits';
+        $('status').textContent = `${d.mode} · ${d.stops_available} candidate stops · ${d.qty_per_show} tix/show`;
+        $('modebar').innerHTML = `mode: <b>${modeLabel}</b>`;
+
+        const fan = pk.fan_total_bundled, vsm = pk.vs_market;
+        const cells = [
+          `<div><span class="lbl">Package (${pk.count * d.qty_per_show} tix)</span><b>${money(fan)}</b></div>`,
+          `<div><span class="lbl">${vsm < 0 ? 'fan saves vs market' : 'premium vs market'}</span><b class="${vsm < 0 ? 'save' : 'prem'}">${vsm < 0 ? money(-vsm) : '+' + money(vsm)}</b></div>`,
+          `<div><span class="lbl">${pk.owned_moved ? 'owned tickets moved' : 'fulfillment margin'}</span><b>${pk.owned_moved ? pk.owned_moved : money(pk.gross_margin || 0)}</b></div>`,
+          `<div><span class="lbl">cities / travel</span><b>${pk.cities} / ${Math.round(pk.travel_km)} km</b></div>`,
+        ];
+        $('stat').innerHTML = cells.join('');
+
+        $('legsHead').textContent = `Your tour — ${pk.count} cities, ${d.qty_per_show} each`;
+        const picked = new Set((pk.legs || []).map(l => l.event_id));
+        $('legs').innerHTML = (d.all_stops || []).map(l => {
+          const on = picked.has(l.event_id);
+          const srcCls = l.sourcing === 'owned' ? 'owned' : 'market';
+          const src = l.unit_price == null ? '' : `<span class="pill2 ${srcCls} src">${l.sourcing}</span>`;
+          const price = l.unit_price == null ? '<span class="mm">n/a</span>' : `<span class="px">${money(l.unit_price)}</span>`;
+          const mm = l.market_median != null ? `<span class="mm">mkt ${money(l.market_median)}</span>` : '<span class="mm"></span>';
+          return `<li class="${on ? '' : 'skip'}">`
+            + `<span class="d">${fmtDate(l.date)}</span>`
+            + `<span class="c">${(l.city || '—')}</span>`
+            + `<span>${l.event_name || l.venue || ''}</span>`
+            + src + price + mm
+            + `</li>`;
+        }).join('');
+        $('result').hidden = false;
+      }
+
+      $('go').addEventListener('click', build);
+      build();
+    })();
+  </script>
+</body>
+</html>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -43,6 +43,11 @@
     .tm-home circle { fill: #fff; stroke: var(--good, #4ade80); stroke-width: 2; }
     .tm-lbl { fill: var(--muted, #cbd5e1); font-size: 10px; }
     .tm-home-lbl { fill: #fff; font-weight: 600; }
+    .trip-controls select { padding: 7px 9px; background: var(--panel, #14141b); color: inherit; border: 1px solid rgba(255,255,255,.12); border-radius: 6px; font: inherit; }
+    .tsrc { font-size: 10px; padding: 1px 6px; border-radius: 999px; }
+    .tsrc.owned { background: rgba(74,222,128,.15); color: var(--good, #4ade80); }
+    .tsrc.market { background: rgba(96,165,250,.15); color: #60a5fa; }
+    .trip-row .tr-mm { color: var(--muted, #9aa); font-size: 11px; font-variant-numeric: tabular-nums; width: 70px; text-align: right; }
     /* Cross-event daily metrics (Overview tab) */
     #pdmSplit { display: flex; gap: 6px; }
     .pdm-delta { font-size: 11px; margin-left: 6px; font-weight: 600; }
@@ -163,6 +168,23 @@
         <div id="tripStats" class="trip-stats" hidden></div>
         <div id="tripMap" class="trip-map" hidden></div>
         <div id="tripBody"><div class="empty">tap Plan to compute</div></div>
+      </section>
+
+      <section id="perf-tour" style="margin-top: 18px;">
+        <div class="panel-title row">
+          <span>RETAIL TOUR PACKAGE — dual-mode pricing</span>
+          <span class="muted small" id="tourMeta"></span>
+        </div>
+        <div class="muted small" style="margin-bottom: 8px;">
+          "Tour with the artist", priced off our inventory: <b>owned-splits</b> for concerts,
+          <b>market-sourced</b> for a team's away games. Uses the home + tickets/show above.
+        </div>
+        <div class="trip-controls">
+          <label>side<select id="tourSide"><option value="auto">auto</option><option value="away">away (team)</option><option value="home">home / primary</option></select></label>
+          <button id="tourGo" class="event-tab">Price tour</button>
+        </div>
+        <div id="tourStats" class="trip-stats" hidden></div>
+        <div id="tourBody"></div>
       </section>
 
       <section id="perf-events" style="margin-top: 18px;">

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -181,7 +181,73 @@
     if (slider && label) slider.addEventListener('input', () => { label.textContent = slider.value; });
     const go = document.getElementById('tripGo');
     if (go) go.addEventListener('click', () => runTripPlan(performerId));
+    const tourGo = document.getElementById('tourGo');
+    if (tourGo) tourGo.addEventListener('click', () => priceTour(performerId));
     runTripPlan(performerId);
+  }
+
+  // ---------- Retail tour package (dual-mode pricing) ----------
+  async function priceTour(performerId) {
+    const body = document.getElementById('tourBody');
+    const stats = document.getElementById('tourStats');
+    if (!body) return;
+    const q = new URLSearchParams({
+      home_lat: document.getElementById('tripLat').value,
+      home_lon: document.getElementById('tripLon').value,
+      home_name: document.getElementById('tripHome').value,
+      qty: document.getElementById('tripQty').value || '3',
+      budget_km: document.getElementById('tripBudget').value,
+      side: document.getElementById('tourSide').value,
+      days: '365',
+    });
+    body.innerHTML = '<div class="empty">pricing tour…</div>';
+    if (stats) stats.hidden = true;
+    try {
+      const d = await T.api(`/api/broker/performers/${performerId}/tour-package?` + q.toString());
+      renderTour(d);
+    } catch (e) {
+      body.innerHTML = `<div class="empty">error: ${escapeHtml(e.message || String(e))}</div>`;
+    }
+  }
+
+  function _money(n) { return '$' + Math.round(n || 0).toLocaleString(); }
+
+  function renderTour(d) {
+    const body = document.getElementById('tourBody');
+    const stats = document.getElementById('tourStats');
+    const meta = document.getElementById('tourMeta');
+    const pk = d.package || {};
+    const modeLabel = d.mode === 'team_away' ? 'team · away games · market-sourced'
+      : d.mode === 'team_home' ? 'team · home stand · owned-splits'
+      : 'concert · owned-splits';
+    if (meta) meta.textContent = `${modeLabel} · ${d.stops_available || 0} stops · ${d.qty_per_show} tix/show`;
+    if (!d.stops_available || !pk.count) {
+      if (stats) stats.hidden = true;
+      body.innerHTML = '<div class="empty">no routable tour for this performer</div>';
+      return;
+    }
+    const vsm = pk.vs_market;
+    if (stats) {
+      stats.hidden = false;
+      stats.innerHTML =
+        `<div><span class="ts-num">${_money(pk.fan_total_bundled)}</span><span class="ts-lbl">package · ${pk.count * d.qty_per_show} tix</span></div>` +
+        `<div><span class="ts-num ${vsm < 0 ? 'gain' : ''}">${vsm < 0 ? _money(-vsm) : '+' + _money(vsm)}</span><span class="ts-lbl">${vsm < 0 ? 'fan saves vs market' : 'premium vs market'}</span></div>` +
+        `<div><span class="ts-num">${pk.owned_moved ? pk.owned_moved : _money(pk.gross_margin || 0)}</span><span class="ts-lbl">${pk.owned_moved ? 'owned tix moved' : 'fulfillment margin'}</span></div>` +
+        `<div><span class="ts-num">${pk.cities} / ${Math.round(pk.travel_km)}</span><span class="ts-lbl">cities / km</span></div>`;
+    }
+    const picked = new Set((pk.legs || []).map(l => l.event_id));
+    const rows = (d.all_stops || []).map(l => {
+      const on = picked.has(l.event_id);
+      const src = l.unit_price == null ? '' : `<span class="tsrc ${l.sourcing === 'owned' ? 'owned' : 'market'}">${l.sourcing}</span>`;
+      const px = l.unit_price == null ? '<span class="tr-px">n/a</span>' : `<span class="tr-px">${_money(l.unit_price)}</span>`;
+      const mm = l.market_median != null ? `<span class="tr-mm">mkt ${_money(l.market_median)}</span>` : '<span class="tr-mm"></span>';
+      return `<div class="trip-row${on ? '' : ' skip'}">`
+        + `<span class="tr-date">${escapeHtml(_tripDate(l.date))}</span>`
+        + `<span class="tr-city">${escapeHtml(l.city || '—')}</span>`
+        + `<span>${escapeHtml(l.event_name || l.venue || '')}</span>`
+        + src + px + mm + '</div>';
+    }).join('');
+    body.innerHTML = `<div class="trip-list">${rows}</div>`;
   }
 
   async function runTripPlan(performerId) {

--- a/trip_planner/README.md
+++ b/trip_planner/README.md
@@ -48,6 +48,20 @@ against inter-city legs. Cities not in the gazetteer fall through to `dropped_no
 the UI can show selected vs skipped. `baseline_by_date` is the naive sort-by-date trip, kept
 so the UI can show the value the optimizer adds.
 
+## Retail "tour with the artist" agent (`retail.py`)
+`GET /api/{store,broker}/performers/{id}/tour-package` turns the routed itinerary into a
+priced consumer package via two **auto-selected** sourcing modes:
+- **owned-splits** (we hold ≥ qty): price our inventory, clearing toward market median in
+  proportion to our share of listed supply. Moderate overhang → hold a premium (concerts);
+  heavy overhang → clear to market (team home stands).
+- **market-sourced** (we hold < qty — e.g. a team's away games): buy-to-fulfill at get-in +
+  fulfillment margin; fan beats the browse-median, we earn the spread.
+
+**Team performers default to away games** (`<pid> = ANY(performer_ids) AND
+primary_performer_id ≠ <pid>`) — the away schedule is the multi-city road trip; home games
+are one city. `side=auto|away|home`. Dials: `clear_at` (0.15), `away_margin` (0.18).
+Offline test: `python3 -m trip_planner.test_tour` (owned-splits premium + market-sourced spread).
+
 ## Test
 ```bash
 python3 -m trip_planner.test_ariana

--- a/trip_planner/__init__.py
+++ b/trip_planner/__init__.py
@@ -7,12 +7,16 @@ axiom-orion/gigtrip (MIT) — see NOTICE.md.
 from .planner import (
     fetch_performer_rows,
     plan_from_rows,
+    plan_performer_tour,
     plan_performer_trip,
+    plan_tour_package,
     row_to_event,
 )
 
 __all__ = [
     "plan_performer_trip",
+    "plan_performer_tour",
+    "plan_tour_package",
     "plan_from_rows",
     "fetch_performer_rows",
     "row_to_event",

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -14,6 +14,7 @@ from datetime import date, timedelta
 
 from .budget_optimizer import plan_by_date_2b, plan_optimal_2b
 from .city_centroids import centroid_for
+from .retail import DEFAULT_AWAY_MARGIN, DEFAULT_CLEAR_AT, price_leg, summarize_package
 from .gigtrip.model import Constraints, Event, Itinerary
 from .gigtrip.optimizer import plan_by_date, plan_optimal
 
@@ -251,5 +252,156 @@ def plan_performer_trip(db, performer_id: int, home_lat: float, home_lon: float,
     payload = plan_from_rows(rows, home, budget_km, start, end,
                              max_events=max_events, max_km_per_day=max_km_per_day,
                              budget_usd=budget_usd, qty=qty)
+    payload["performer_id"] = int(performer_id)
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Retail "tour with the artist" agent — dual-mode (owned-splits / market-sourced)
+# --------------------------------------------------------------------------- #
+_TOUR_SELECT = ("tevo_event_id, event_name, primary_performer_name, venue_name, "
+                "venue_city, venue_state, event_date, venue_lat, venue_lon")
+
+
+def fetch_event_pricing(db, ids: list[int], lookback_days: int = 21) -> dict[int, dict]:
+    """Latest EVO owned + ask + market context per event (event_listing_snapshot_daily)."""
+    if not ids:
+        return {}
+    since = (date.today() - timedelta(days=lookback_days)).isoformat()
+    rows = (db.table("event_listing_snapshot_daily")
+            .select("event_id, evo_owned_tickets, evo_owned_median, evo_retail_getin, "
+                    "evo_retail_median, evo_tickets_count, captured_at")
+            .in_("event_id", ids)
+            .gte("snapshot_date", since)
+            .order("captured_at", desc=True)
+            .limit(6000)
+            .execute().data) or []
+    out: dict[int, dict] = {}
+    for r in rows:
+        eid = int(r["event_id"])
+        if eid in out:
+            continue
+        def _f(k):
+            v = r.get(k)
+            return float(v) if v is not None else None
+        out[eid] = {
+            "owned": int(r.get("evo_owned_tickets") or 0),
+            "our_ask": _f("evo_owned_median"),
+            "getin": _f("evo_retail_getin"),
+            "med": _f("evo_retail_median"),
+            "qty": int(r.get("evo_tickets_count") or 0),
+        }
+    return out
+
+
+def fetch_tour_events(db, performer_id: int, start: date, end: date,
+                      side: str = "auto") -> tuple[list[dict], str]:
+    """Return (rows, mode). For a TEAM performer the tour defaults to AWAY games (the team is
+    a participant but not the host/primary) — that's the multi-city road trip. For a concert
+    performer there are no away appearances, so we use its own (primary) events.
+
+    side: 'auto' (team->away, else concert), 'away' (force away), 'home'/'concert' (primary).
+    """
+    end_excl = (end + timedelta(days=1)).isoformat()
+    away_ids: list[int] = []
+    if side in ("auto", "away"):
+        away = (db.table("events").select("id")
+                .contains("performer_ids", [performer_id])
+                .neq("primary_performer_id", performer_id)
+                .gte("occurs_at_local", start.isoformat())
+                .lt("occurs_at_local", end_excl)
+                .limit(300).execute().data) or []
+        away_ids = [int(r["id"]) for r in away]
+
+    use_away = side == "away" or (side == "auto" and len(away_ids) >= 3)
+    if use_away and away_ids:
+        rows = (db.table("v_event_base").select(_TOUR_SELECT)
+                .in_("tevo_event_id", away_ids)
+                .order("event_date").limit(500).execute().data) or []
+        return rows, "team_away"
+
+    return fetch_performer_rows(db, performer_id, start, end), (
+        "team_home" if away_ids else "concert")
+
+
+def plan_tour_package(rows: list[dict], home: dict, qty: int, budget_km: float,
+                      start: date, end: date, budget_usd: float | None = None,
+                      max_events: int | None = None, max_km_per_day: float = 1200.0,
+                      clear_at: float = DEFAULT_CLEAR_AT,
+                      away_margin: float = DEFAULT_AWAY_MARGIN, mode: str = "concert") -> dict:
+    """Pure: route the multi-city tour (within travel + fan-$ budget) and price every leg via
+    the dual-mode retail model. Rows carry `_owned/_our_ask/_getin/_med/_qty` + coords."""
+    qty = max(1, int(qty))
+    usable = [r for r in rows if r.get("venue_lat") is not None and r.get("venue_lon") is not None]
+    events = [row_to_event(r) for r in usable]
+    prefs = {e.title.lower(): 1.0 for e in events}
+
+    legmeta: dict[int, dict] = {}
+    costs: dict[int, float] = {}
+    for r in usable:
+        eid = int(r["tevo_event_id"])
+        pl = price_leg(qty, r.get("_owned"), r.get("_our_ask"), r.get("_getin"),
+                       r.get("_med"), r.get("_qty"), clear_at, away_margin)
+        pl["city"] = r.get("venue_city")
+        pl["event_name"] = r.get("event_name")
+        pl["coord_source"] = r.get("_coord_source", "venue")
+        legmeta[eid] = pl
+        u = pl.get("unit_price")
+        costs[eid] = (u * qty) if u is not None else 0.0    # the fan's spend at this stop
+
+    c = Constraints(home_name=home["name"], home_lat=float(home["lat"]), home_lon=float(home["lon"]),
+                    start=start, end=end, max_travel_km=float(budget_km),
+                    max_events=max_events, max_km_per_day=max_km_per_day)
+    spend_cap = float(budget_usd) if budget_usd is not None else 1e12
+    optimal, _ = plan_optimal_2b(events, prefs, c, costs, spend_cap)
+    picked = {int(e.id) for e in optimal.events}
+
+    def _leg(e, selected):
+        m = dict(legmeta[int(e.id)])
+        m.update(event_id=int(e.id), date=e.day.isoformat(),
+                 city=(e.city or m.get("city")), venue=e.venue, selected=selected)
+        return m
+
+    pkg_legs = [_leg(e, True) for e in optimal.events]
+    summ = summarize_package(pkg_legs, qty)
+    return {
+        "mode": mode,
+        "qty_per_show": qty,
+        "home": home,
+        "budget_km": float(budget_km),
+        "budget_usd": budget_usd,
+        "window": {"start": start.isoformat(), "end": end.isoformat()},
+        "stops_available": len(events),
+        "package": {
+            "legs": pkg_legs,
+            "count": len(pkg_legs),
+            "cities": len({l["city"] for l in pkg_legs if l.get("city")}),
+            "travel_km": round(optimal.travel_km, 1),
+            **summ,
+        },
+        "all_stops": [_leg(e, int(e.id) in picked)
+                      for e in sorted(events, key=lambda e: (e.day, e.id))],
+    }
+
+
+def plan_performer_tour(db, performer_id: int, home_lat: float, home_lon: float,
+                        qty: int, budget_km: float, start: date, end: date,
+                        home_name: str = "Home", budget_usd: float | None = None,
+                        side: str = "auto", clear_at: float = DEFAULT_CLEAR_AT,
+                        away_margin: float = DEFAULT_AWAY_MARGIN,
+                        max_events: int | None = None) -> dict:
+    """End-to-end retail tour package: detect concert vs team-away, route + dual-mode price."""
+    rows, mode = fetch_tour_events(db, performer_id, start, end, side)
+    _apply_coord_fallback(db, rows)
+    pricing = fetch_event_pricing(db, [int(r["tevo_event_id"]) for r in rows])
+    for r in rows:
+        p = pricing.get(int(r["tevo_event_id"]))
+        if p:
+            r["_owned"], r["_our_ask"] = p["owned"], p["our_ask"]
+            r["_getin"], r["_med"], r["_qty"] = p["getin"], p["med"], p["qty"]
+    home = {"name": home_name, "lat": home_lat, "lon": home_lon}
+    payload = plan_tour_package(rows, home, qty, budget_km, start, end,
+                                budget_usd=budget_usd, max_events=max_events,
+                                clear_at=clear_at, away_margin=away_margin, mode=mode)
     payload["performer_id"] = int(performer_id)
     return payload

--- a/trip_planner/retail.py
+++ b/trip_planner/retail.py
@@ -1,0 +1,104 @@
+"""Retail "tour with the artist" pricing — turns a routed multi-city itinerary into a
+priced consumer package, with two auto-selected sourcing modes:
+
+  * **owned-splits** (we hold >= qty at the stop): price our owned inventory, clearing toward
+    the market median in proportion to how much of the listed supply WE are. Moderate
+    overhang -> we hold a premium; heavy overhang -> we clear to market (validated: concerts
+    capture a premium, team home stands don't).
+  * **market-sourced** (we hold < qty — e.g. a team's away games, where road owned ~ 0):
+    buy-to-fulfill at the market get-in plus a fulfillment margin; the fan still beats the
+    browse-median while we earn the spread.
+
+Pure functions — no DB, unit-testable. The DB wiring + routing live in `planner.py`.
+"""
+from __future__ import annotations
+
+# tunable dials (qualitative outcomes are robust to these; exact dollars move with them)
+DEFAULT_CLEAR_AT = 0.15      # owned share of listed supply at which we clear FULLY to market
+DEFAULT_AWAY_MARGIN = 0.18   # fulfillment margin over get-in when buying to fulfill
+DEFAULT_BUNDLE = 0.05        # extra multi-city discount applied to the package (>= 3 cities)
+
+
+def price_leg(qty: int, owned, our_ask, getin, market_median, market_qty,
+              clear_at: float = DEFAULT_CLEAR_AT,
+              away_margin: float = DEFAULT_AWAY_MARGIN) -> dict:
+    """Price one show for `qty` tickets. Returns a dict with unit price, sourcing, economics.
+
+    owned-splits when we hold >= qty AND have an ask + market context; else market-sourced.
+    `unit_price` is None only when neither our ask nor a market price exists (unpriceable).
+    """
+    qty = max(1, int(qty))
+    owned = int(owned or 0)
+
+    if owned >= qty and our_ask is not None and market_median is not None and market_qty:
+        share = owned / market_qty if market_qty else 1.0
+        clear = min(1.0, share / clear_at) if clear_at > 0 else 1.0
+        unit = our_ask - clear * (our_ask - market_median)
+        unit = round(max(unit, 0.0), 2)
+        return {
+            "unit_price": unit,
+            "sourcing": "owned",
+            "owned": owned,
+            "our_ask": round(float(our_ask), 2),
+            "market_median": round(float(market_median), 2),
+            "supply_share": round(share, 4),
+            # we move `qty` of our own seats; margin vs our standalone ask (positive = discount given)
+            "moved": qty,
+        }
+
+    basis = getin if getin is not None else market_median
+    if basis is None:
+        return {"unit_price": None, "sourcing": "unpriceable", "owned": owned, "moved": 0}
+    unit = round(float(basis) * (1 + away_margin), 2)
+    return {
+        "unit_price": unit,
+        "sourcing": "market",
+        "owned": owned,
+        "acquire_basis": round(float(basis), 2),
+        "getin": round(float(getin), 2) if getin is not None else None,
+        "market_median": round(float(market_median), 2) if market_median is not None else None,
+        "margin": away_margin,
+        "moved": 0,                     # buy-to-fulfill: none of our inventory
+    }
+
+
+def summarize_package(legs: list[dict], qty: int, bundle: float = DEFAULT_BUNDLE) -> dict:
+    """Roll a list of priced+selected legs into a package: fan total, vs-market, our economics.
+
+    Each leg dict must carry the `price_leg(...)` output plus `event_id`. `legs` are the
+    optimizer-selected stops (the package), in date order.
+    """
+    qty = max(1, int(qty))
+    fan = 0.0
+    market = 0.0          # what the fan would pay at market median, qty each
+    our_ask_total = 0.0   # our standalone asks on owned legs
+    acquire = 0.0         # our acquisition cost on market legs
+    owned_moved = 0
+    for lg in legs:
+        up = lg.get("unit_price")
+        if up is None:
+            continue
+        fan += up * qty
+        mm = lg.get("market_median")
+        if mm is not None:
+            market += mm * qty
+        if lg.get("sourcing") == "owned":
+            our_ask_total += lg.get("our_ask", up) * qty
+            owned_moved += qty
+        elif lg.get("sourcing") == "market":
+            acquire += lg.get("acquire_basis", up) * qty
+
+    cities = len({lg.get("city") for lg in legs if lg.get("city")})
+    bundle_rate = bundle if cities >= 3 else 0.0
+    fan_after = round(fan * (1 - bundle_rate), 2)
+    return {
+        "fan_total": round(fan, 2),
+        "fan_total_bundled": fan_after,
+        "bundle_rate": bundle_rate,
+        "market_total": round(market, 2),               # fan's market-median alternative
+        "vs_market": round(fan_after - market, 2),       # + = premium over market, - = fan saves
+        "our_standalone_ask": round(our_ask_total, 2),   # owned legs at our list price
+        "our_acquisition": round(acquire, 2),            # market legs we'd buy
+        "owned_moved": owned_moved,
+        "gross_margin": round(fan_after - acquire, 2) if acquire else None,  # market-sourced profit
+    }

--- a/trip_planner/test_tour.py
+++ b/trip_planner/test_tour.py
@@ -1,0 +1,79 @@
+"""Offline test of the retail tour-package planner — both sourcing modes.
+
+Fixtures are real snapshots: Megan Moroney (we own deep -> owned-splits, premium capture) and
+Yankees away games (road owned ~0 -> market-sourced, fan beats market, we earn the spread).
+
+Run from repo root:  python3 -m trip_planner.test_tour
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from .planner import plan_tour_package
+from .retail import price_leg
+
+HOME = {"name": "NYC", "lat": 40.7128, "lon": -74.0060}
+START, END = date(2026, 6, 1), date(2026, 9, 1)
+
+
+def _row(eid, name, city, d, lat, lon, owned, ask, getin, med, qty):
+    return {"tevo_event_id": eid, "event_name": name,
+            "primary_performer_name": name.split(" at ")[0],
+            "venue_city": city, "venue_state": "XX", "event_date": d,
+            "venue_lat": lat, "venue_lon": lon, "_coord_source": "venue",
+            "_owned": owned, "_our_ask": ask, "_getin": getin, "_med": med, "_qty": qty}
+
+CONCERT = [  # Megan Moroney NE run — we own deep
+    _row(1, "Megan Moroney", "Boston",       "2026-07-06", 42.36, -71.06,  88, 542.29, 140, 302.82, 1480),
+    _row(2, "Megan Moroney", "Newark",       "2026-07-09", 40.73, -74.17, 143, 455.26, 138, 301.23, 1510),
+    _row(3, "Megan Moroney", "Philadelphia", "2026-07-11", 39.95, -75.16, 116, 594.83, 202, 422.30, 737),
+]
+AWAY = [  # Yankees road trip — owned ~0
+    _row(11, "New York Yankees at Detroit Tigers", "Detroit", "2026-06-22", 42.33, -83.04, 0, None, 20.19, 55.14, 659),
+    _row(12, "New York Yankees at Boston Red Sox", "Boston",  "2026-06-26", 42.36, -71.06, 0, None, 131.54, 208.98, 2205),
+]
+
+
+def test_price_leg_modes():
+    o = price_leg(3, 88, 542.29, 140, 302.82, 1480)
+    assert o["sourcing"] == "owned" and 302 < o["unit_price"] < 542
+    m = price_leg(3, 0, None, 20.19, 55.14, 659)
+    assert m["sourcing"] == "market" and abs(m["unit_price"] - 20.19 * 1.18) < 0.5
+    assert price_leg(3, 0, None, None, None, 0)["unit_price"] is None
+    # heavy overhang clears fully to market (team home-stand behaviour)
+    heavy = price_leg(3, 682, 97.72, None, 67.32, 3851)   # share 18% > 15% -> clear=1
+    assert abs(heavy["unit_price"] - 67.32) < 0.01
+
+
+def test_concert_owned_splits():
+    pk = plan_tour_package(CONCERT, HOME, 3, 20000, START, END)["package"]
+    assert all(l["sourcing"] == "owned" for l in pk["legs"])
+    assert pk["owned_moved"] == 3 * len(pk["legs"])
+    assert pk["vs_market"] > 0                       # premium over market median
+    assert pk["fan_total"] < pk["our_standalone_ask"]  # but below our standalone ask
+
+
+def test_team_away_market_sourced():
+    pk = plan_tour_package(AWAY, HOME, 3, 20000, START, END, mode="team_away")["package"]
+    assert all(l["sourcing"] == "market" for l in pk["legs"])
+    assert pk["owned_moved"] == 0
+    assert pk["vs_market"] < 0                        # fan beats market median
+    assert pk["gross_margin"] > 0                     # we earn the fulfillment spread
+
+
+def main():
+    print("\nRetail tour-package — dual mode, qty=3\n")
+    for label, rows, mode in [("concert", CONCERT, "concert"), ("team-away", AWAY, "team_away")]:
+        pk = plan_tour_package(rows, HOME, 3, 20000, START, END, mode=mode)["package"]
+        gm = pk["gross_margin"]
+        print(f"  {label:9} {pk['count']} stops / {pk['cities']} cities  "
+              f"fan ${pk['fan_total_bundled']:>6,.0f}  vs market ${pk['vs_market']:>+6,.0f}  "
+              f"owned moved {pk['owned_moved']:>2}  margin {('$'+format(gm,',.0f')) if gm else '—'}")
+    test_price_leg_modes()
+    test_concert_owned_splits()
+    test_team_away_market_sourced()
+    print("\n  asserts passed: owned-splits premium (concert) + market-sourced spread (team away)\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
A retail **"tour with the artist"** agent on both the store and D0, turning the routed multi-city tour into a *priced consumer package* via two **auto-selected** sourcing modes:

- **owned-splits** (we hold ≥ qty): price our inventory, clearing toward the market median in proportion to our share of listed supply. Moderate overhang → hold a premium (concerts); heavy overhang → clear to market (team home stands).
- **market-sourced** (we hold < qty — a team's away games, road owned ≈ 0): buy-to-fulfill at get-in + fulfillment margin; the fan beats browse-median, we earn the spread.

**Team performers default to away games** (the away schedule *is* the multi-city road trip; home = one city), detected as events where the performer is in `performer_ids` but not `primary_performer_id`. `side=auto|away|home`.

## Tested on real data (offline, qty 3)
`python3 -m trip_planner.test_tour` cross-checks both modes on real snapshots:
- **Concert** (Megan Moroney, owned): 3 cities → fan **$3,499**, **+$420 premium** over market, **9 owned tickets moved**.
- **Team away** (Yankees road trip, market): 2 cities → fan **$537** (**−$255 vs market**), **$82 fulfillment margin**, 0 owned moved.

## Surfaces
- `GET /api/{broker,store}/performers/{id}/tour-package` (shared `plan_performer_tour`).
- **Store**: `/store/test/tour` consumer agent page.
- **D0**: a "RETAIL TOUR PACKAGE" section in the performer Upcoming tab (mode badge, per-leg sourcing/price/market-median, package totals).

## Notes
- Pure read + compute (v_event_base, events, event_listing_snapshot_daily) — no writes, no upstream API.
- Vendored gigtrip engine untouched; routing reuses the existing 2-budget optimizer.
- Dials (`clear_at` 0.15, `away_margin` 0.18) are query params, defaults match the validated tests.
- Frontends verify on deploy; `node --check` + `py_compile` + tests all green here.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_