### PR TITLE
feat(tour-agent): plan-my-summer + seat prefs, hot badges, share

### DIFF
--- a/app.py
+++ b/app.py
@@ -1211,22 +1211,31 @@ def broker_performer_trip_plan(
                               home_name, days, max_events, budget_usd, qty)
 
 
+def _clean_section(s: str | None) -> str | None:
+    s = (s or "").strip()[:24]
+    return s or None
+
+
+def _tour_dates(days: int):
+    from datetime import date, timedelta
+    start = date.today()
+    return start, start + timedelta(days=max(1, min(int(days), 730)))
+
+
 def _tour_package_payload(performer_id: int, home_lat: float, home_lon: float,
                           qty: int, budget_km: float, home_name: str, days: int,
-                          budget_usd: float | None, side: str,
-                          clear_at: float, away_margin: float) -> dict:
+                          budget_usd: float | None, side: str, clear_at: float,
+                          away_margin: float, section_like: str | None = None,
+                          prefer_owned: bool = False) -> dict:
     """Shared body for the retail 'tour with the artist' routes (D0 + store).
 
     Dual-mode: owned-splits where we hold inventory (concerts), market-sourced buy-to-fulfill
     for a team's away games (road owned ~ 0). Pure read + compute — no writes, no upstream API.
     """
-    from datetime import date, timedelta
-
     from trip_planner import plan_performer_tour
 
     db = require_sb()
-    start = date.today()
-    end = start + timedelta(days=max(1, min(int(days), 730)))
+    start, end = _tour_dates(days)
     spend = None if budget_usd is None else max(0.0, min(float(budget_usd), 10_000_000.0))
     return plan_performer_tour(
         db, int(performer_id), float(home_lat), float(home_lon),
@@ -1235,6 +1244,31 @@ def _tour_package_payload(performer_id: int, home_lat: float, home_lon: float,
         side=(side if side in ("auto", "away", "home", "concert") else "auto"),
         clear_at=min(max(float(clear_at), 0.01), 1.0),
         away_margin=min(max(float(away_margin), 0.0), 2.0),
+        section_like=_clean_section(section_like), prefer_owned=bool(prefer_owned),
+    )
+
+
+def _multi_tour_payload(performer_ids: str, home_lat: float, home_lon: float, qty: int,
+                        budget_km: float, home_name: str, days: int, budget_usd: float | None,
+                        side: str, clear_at: float, away_margin: float,
+                        section_like: str | None, prefer_owned: bool) -> dict:
+    """'Plan my summer': one routed+priced package across several performers' events."""
+    from trip_planner import plan_multi_performer_tour
+
+    ids = [int(x) for x in str(performer_ids).replace(" ", "").split(",") if x][:8]
+    if not ids:
+        raise HTTPException(400, "performer_ids required (comma-separated, up to 8)")
+    db = require_sb()
+    start, end = _tour_dates(days)
+    spend = None if budget_usd is None else max(0.0, min(float(budget_usd), 10_000_000.0))
+    return plan_multi_performer_tour(
+        db, ids, float(home_lat), float(home_lon),
+        max(1, min(int(qty), 50)), max(100.0, min(float(budget_km), 50000.0)),
+        start, end, home_name=(home_name or "Home").strip()[:60], budget_usd=spend,
+        side=(side if side in ("auto", "away", "home", "concert") else "auto"),
+        clear_at=min(max(float(clear_at), 0.01), 1.0),
+        away_margin=min(max(float(away_margin), 0.0), 2.0),
+        section_like=_clean_section(section_like), prefer_owned=bool(prefer_owned),
     )
 
 
@@ -1251,12 +1285,38 @@ def broker_performer_tour_package(
     side: str = "auto",
     clear_at: float = 0.15,
     away_margin: float = 0.18,
+    section_like: str | None = None,
+    prefer_owned: bool = False,
     _=Depends(require_auth),
 ):
     """D0: retail 'tour with the artist' package — routed multi-city tour priced via the
     dual-mode model (owned-splits for concerts, market-sourced for a team's away games)."""
-    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km,
-                                 home_name, days, budget_usd, side, clear_at, away_margin)
+    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km, home_name,
+                                 days, budget_usd, side, clear_at, away_margin,
+                                 section_like, prefer_owned)
+
+
+@app.get("/api/broker/tours/multi")
+def broker_multi_tour(
+    performer_ids: str,
+    home_lat: float,
+    home_lon: float,
+    qty: int = 3,
+    budget_km: float = 10000.0,
+    home_name: str = "Home",
+    days: int = 365,
+    budget_usd: float | None = None,
+    side: str = "auto",
+    clear_at: float = 0.15,
+    away_margin: float = 0.18,
+    section_like: str | None = None,
+    prefer_owned: bool = False,
+    _=Depends(require_auth),
+):
+    """D0 'plan my summer' — one package across several performers (comma-separated ids)."""
+    return _multi_tour_payload(performer_ids, home_lat, home_lon, qty, budget_km, home_name,
+                               days, budget_usd, side, clear_at, away_margin,
+                               section_like, prefer_owned)
 
 
 def _bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
@@ -6777,12 +6837,38 @@ def store_performer_tour_package(
     side: str = "auto",
     clear_at: float = 0.15,
     away_margin: float = 0.18,
+    section_like: str | None = None,
+    prefer_owned: bool = False,
 ):
     """D1 store: retail 'tour with the artist' agent. Builds a routed multi-city package and
     prices it — owned-splits where we hold inventory (concerts), market-sourced for a team's
     away games. Shares the engine with the D0 route via `trip_planner`."""
-    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km,
-                                 home_name, days, budget_usd, side, clear_at, away_margin)
+    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km, home_name,
+                                 days, budget_usd, side, clear_at, away_margin,
+                                 section_like, prefer_owned)
+
+
+@app.get("/api/store/tours/multi")
+def store_multi_tour(
+    performer_ids: str,
+    home_lat: float,
+    home_lon: float,
+    qty: int = 3,
+    budget_km: float = 10000.0,
+    home_name: str = "Home",
+    days: int = 365,
+    budget_usd: float | None = None,
+    side: str = "auto",
+    clear_at: float = 0.15,
+    away_margin: float = 0.18,
+    section_like: str | None = None,
+    prefer_owned: bool = False,
+):
+    """D1 store 'plan my summer' — one routed+priced package across several performers
+    (comma-separated `performer_ids`, up to 8). Shares the engine with the D0 route."""
+    return _multi_tour_payload(performer_ids, home_lat, home_lon, qty, budget_km, home_name,
+                               days, budget_usd, side, clear_at, away_margin,
+                               section_like, prefer_owned)
 
 
 def _section_sort_key(s: str) -> tuple:

--- a/static/store/test/tour.html
+++ b/static/store/test/tour.html
@@ -27,6 +27,8 @@
     ul.legs .mm { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; width: 64px; text-align: right; }
     ul.legs .seat { font-size: 11px; color: #cbd5e1; }
     ul.legs .seat.est { opacity: .55; }
+    ul.legs .hot { margin-left: 5px; font-size: 12px; }
+    ul.legs .perf { font-size: 11px; color: #a78bfa; }
   </style>
 </head>
 <body>
@@ -49,7 +51,7 @@
       <p class="subtitle">Follow a performer across cities — one curated package. On <b>Build</b> we auto-select real tickets (your quantity, together) at each stop that fit your budget, priced off our own inventory. For a team it defaults to <b>away games</b> (the road trip).</p>
 
       <div class="tour-form">
-        <div><label>Performer ID</label><input id="pid" type="number" value="87567" /></div>
+        <div><label>Performer ID(s)</label><input id="pid" type="text" value="87567" placeholder="87567 or 87567,40010" /></div>
         <div><label>Home lat</label><input id="hlat" type="number" step="0.0001" value="40.7128" /></div>
         <div><label>Home lon</label><input id="hlon" type="number" step="0.0001" value="-74.0060" /></div>
         <div><label>Home label</label><input id="hname" type="text" value="New York City" /></div>
@@ -57,9 +59,12 @@
         <div><label>Travel budget (km)</label><input id="bkm" type="number" step="500" value="6000" /></div>
         <div><label>Spend cap ($, optional)</label><input id="busd" type="number" step="250" placeholder="none" /></div>
         <div><label>Side</label><select id="side"><option value="auto">auto</option><option value="away">away (team)</option><option value="home">home / primary</option></select></div>
+        <div><label>Section filter</label><input id="section" type="text" placeholder="e.g. FLOOR, 211" /></div>
+        <div><label>Our seats first</label><select id="preferOwned"><option value="">no</option><option value="1">prefer ours</option></select></div>
       </div>
       <button id="go" style="padding: 11px 22px">Build tour</button>
-      <span style="font-size:12px;color:var(--muted);margin-left:10px">Default: Megan Moroney (87567). Try a team, e.g. Yankees 15533.</span>
+      <button id="share" style="padding: 11px 16px; margin-left:8px">Copy link</button>
+      <span style="font-size:12px;color:var(--muted);margin-left:10px">One ID, or comma-separate for "plan my summer". Megan 87567 · Yankees 15533.</span>
 
       <div id="status" style="color: var(--muted); font-size: 13px; margin: 16px 0"></div>
       <div id="result" hidden>
@@ -78,21 +83,47 @@
       const money = (n) => '$' + Math.round(n).toLocaleString();
       function fmtDate(iso) { try { return new Date(iso + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' }); } catch (_) { return iso; } }
 
-      async function build() {
-        const pid = parseInt($('pid').value, 10);
+      const FIELDS = ['pid', 'hlat', 'hlon', 'hname', 'qty', 'bkm', 'busd', 'side', 'section', 'preferOwned'];
+
+      function params() {
         const p = new URLSearchParams({
           home_lat: $('hlat').value, home_lon: $('hlon').value, home_name: $('hname').value,
           qty: $('qty').value || '3', budget_km: $('bkm').value || '6000',
           side: $('side').value, days: '365',
         });
         if ($('busd').value) p.set('budget_usd', $('busd').value);
+        if ($('section').value.trim()) p.set('section_like', $('section').value.trim());
+        if ($('preferOwned').value) p.set('prefer_owned', 'true');
+        return p;
+      }
+
+      async function build() {
+        const ids = $('pid').value.replace(/\s/g, '');
+        const multi = ids.includes(',');
+        const p = params();
+        const url = multi
+          ? `/api/store/tours/multi?performer_ids=${encodeURIComponent(ids)}&` + p
+          : `/api/store/performers/${parseInt(ids, 10)}/tour-package?` + p;
         $('status').textContent = 'Building tour…';
         $('result').hidden = true;
         try {
-          const r = await fetch(`/api/store/performers/${pid}/tour-package?` + p);
+          const r = await fetch(url);
           if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + (await r.text()).slice(0, 200));
           render(await r.json());
         } catch (e) { $('status').textContent = 'Error: ' + e.message; }
+      }
+
+      function loadFromUrl() {
+        const u = new URLSearchParams(location.search);
+        FIELDS.forEach(f => { if (u.has(f)) $(f).value = u.get(f); });
+      }
+
+      function copyShareLink() {
+        const u = new URLSearchParams();
+        FIELDS.forEach(f => { if ($(f).value) u.set(f, $(f).value); });
+        const link = location.origin + location.pathname + '?' + u.toString();
+        navigator.clipboard?.writeText(link);
+        $('status').textContent = 'Share link copied: ' + link;
       }
 
       function render(d) {
@@ -128,17 +159,21 @@
           const s = l.seats;
           const seat = s ? `<span class="seat">${esc(s.section || 'GA')}${s.row ? ' ' + esc(s.row) : ''}${s.is_owned ? ' ·ours' : ''}</span>`
             : (l.selection === 'estimate' ? '<span class="seat est">est. price</span>' : '');
+          const hot = l.hot ? '<span class="hot" title="high demand">🔥</span>' : '';
+          const perf = (d.mode === 'multi' && l.performer) ? `<span class="perf">${esc(l.performer)}</span>` : '';
           return `<li class="${on ? '' : 'skip'}">`
             + `<span class="d">${fmtDate(l.date)}</span>`
             + `<span class="c">${esc(l.city || '—')}</span>`
-            + `<span>${esc(l.event_name || l.venue || '')}</span>`
-            + seat + src + price + mm
+            + `<span>${esc(l.event_name || l.venue || '')}${hot}</span>`
+            + perf + seat + src + price + mm
             + `</li>`;
         }).join('');
         $('result').hidden = false;
       }
 
       $('go').addEventListener('click', build);
+      $('share').addEventListener('click', copyShareLink);
+      loadFromUrl();
       build();
     })();
   </script>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -182,6 +182,8 @@
         </div>
         <div class="trip-controls">
           <label>side<select id="tourSide"><option value="auto">auto</option><option value="away">away (team)</option><option value="home">home / primary</option></select></label>
+          <label>section<input id="tourSection" type="text" placeholder="FLOOR, 211" /></label>
+          <label>our seats<select id="tourPreferOwned"><option value="">market</option><option value="1">ours first</option></select></label>
           <button id="tourGo" class="event-tab">Price tour</button>
         </div>
         <div id="tourStats" class="trip-stats" hidden></div>

--- a/static/terminal/performer.js
+++ b/static/terminal/performer.js
@@ -200,6 +200,10 @@
       side: document.getElementById('tourSide').value,
       days: '365',
     });
+    const sec = document.getElementById('tourSection');
+    if (sec && sec.value.trim()) q.set('section_like', sec.value.trim());
+    const po = document.getElementById('tourPreferOwned');
+    if (po && po.value) q.set('prefer_owned', 'true');
     body.innerHTML = '<div class="empty">pricing tour…</div>';
     if (stats) stats.hidden = true;
     try {
@@ -244,10 +248,11 @@
       const s = l.seats;
       const seat = s ? `<span class="muted small" title="auto-selected ticket group${s.is_owned ? ' (ours)' : ''}">${escapeHtml(s.section || 'GA')}${s.row ? ' ' + escapeHtml(s.row) : ''}${s.is_owned ? ' ·ours' : ''}</span>`
         : (l.selection === 'estimate' ? '<span class="muted small" style="opacity:.55">est</span>' : '');
+      const hot = l.hot ? ' <span title="high demand">🔥</span>' : '';
       return `<div class="trip-row${on ? '' : ' skip'}">`
         + `<span class="tr-date">${escapeHtml(_tripDate(l.date))}</span>`
         + `<span class="tr-city">${escapeHtml(l.city || '—')}</span>`
-        + `<span>${escapeHtml(l.event_name || l.venue || '')}</span>`
+        + `<span>${escapeHtml(l.event_name || l.venue || '')}${hot}</span>`
         + seat + src + px + mm + '</div>';
     }).join('');
     body.innerHTML = `<div class="trip-list">${rows}</div>`;

--- a/trip_planner/__init__.py
+++ b/trip_planner/__init__.py
@@ -7,6 +7,7 @@ axiom-orion/gigtrip (MIT) — see NOTICE.md.
 from .planner import (
     fetch_performer_rows,
     plan_from_rows,
+    plan_multi_performer_tour,
     plan_performer_tour,
     plan_performer_trip,
     plan_tour_package,
@@ -16,6 +17,7 @@ from .planner import (
 __all__ = [
     "plan_performer_trip",
     "plan_performer_tour",
+    "plan_multi_performer_tour",
     "plan_tour_package",
     "plan_from_rows",
     "fetch_performer_rows",

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -295,7 +295,8 @@ def fetch_event_pricing(db, ids: list[int], lookback_days: int = 21) -> dict[int
 
 
 def fetch_event_listings(db, ids: list[int], qty: int, lookback_hours: int = 36,
-                         cap: int = 12000) -> dict[int, dict]:
+                         cap: int = 12000, section_like: str | None = None,
+                         prefer_owned: bool = False) -> dict[int, dict]:
     """Auto-select a concrete listing per event that satisfies `qty` and is cheapest.
 
     From the EVO firehose (`listings_snapshots`): qualifying = `quantity >= qty` AND
@@ -307,20 +308,21 @@ def fetch_event_listings(db, ids: list[int], qty: int, lookback_hours: int = 36,
     if not ids:
         return {}
     since = (datetime.now(timezone.utc) - timedelta(hours=lookback_hours)).isoformat()
-    rows = (db.table("listings_snapshots")
-            .select("event_id, tevo_ticket_group_id, section, row, quantity, retail_price, "
-                    "is_owned, eticket, instant_delivery, format, captured_at")
-            .in_("event_id", ids)
-            .gte("captured_at", since)
-            .gte("quantity", qty)
-            .contains("splits", [qty])
-            .not_.is_("retail_price", "null")
-            .order("captured_at", desc=True)
-            .limit(cap)
-            .execute().data) or []
+    q = (db.table("listings_snapshots")
+         .select("event_id, tevo_ticket_group_id, section, row, quantity, retail_price, "
+                 "is_owned, eticket, instant_delivery, format, captured_at")
+         .in_("event_id", ids)
+         .gte("captured_at", since)
+         .gte("quantity", qty)
+         .contains("splits", [qty])
+         .not_.is_("retail_price", "null"))
+    if section_like:                              # seat preference: only matching sections
+        q = q.ilike("section", f"%{section_like}%")
+    rows = q.order("captured_at", desc=True).limit(cap).execute().data or []
 
     seen: set[tuple] = set()
-    best: dict[int, dict] = {}
+    cheapest: dict[int, dict] = {}        # cheapest qualifying overall
+    cheapest_owned: dict[int, dict] = {}  # cheapest qualifying that's ours
     counts: dict[int, int] = {}
     for r in rows:
         key = (r["event_id"], r["tevo_ticket_group_id"])
@@ -331,18 +333,26 @@ def fetch_event_listings(db, ids: list[int], qty: int, lookback_hours: int = 36,
         counts[eid] = counts.get(eid, 0) + 1
         price = float(r["retail_price"])
         owned = bool(r.get("is_owned"))
-        cur = best.get(eid)
-        if cur is None or price < cur["unit_price"] - 1e-9 or (
-                abs(price - cur["unit_price"]) <= 1e-9 and owned and not cur["is_owned"]):
-            best[eid] = {
-                "ticket_group_id": int(r["tevo_ticket_group_id"]),
-                "section": r.get("section"), "row": r.get("row"),
-                "available_qty": int(r["quantity"]), "unit_price": round(price, 2),
-                "is_owned": owned, "eticket": bool(r.get("eticket")),
-                "instant": bool(r.get("instant_delivery")), "format": r.get("format"),
-            }
-    for eid, c in best.items():
-        c["candidates"] = counts.get(eid, 0)
+        cand = {
+            "ticket_group_id": int(r["tevo_ticket_group_id"]),
+            "section": r.get("section"), "row": r.get("row"),
+            "available_qty": int(r["quantity"]), "unit_price": round(price, 2),
+            "is_owned": owned, "eticket": bool(r.get("eticket")),
+            "instant": bool(r.get("instant_delivery")), "format": r.get("format"),
+        }
+        if eid not in cheapest or price < cheapest[eid]["unit_price"] - 1e-9 or (
+                abs(price - cheapest[eid]["unit_price"]) <= 1e-9 and owned and not cheapest[eid]["is_owned"]):
+            cheapest[eid] = cand
+        if owned and (eid not in cheapest_owned or price < cheapest_owned[eid]["unit_price"] - 1e-9):
+            cheapest_owned[eid] = cand
+
+    best: dict[int, dict] = {}
+    for eid in cheapest:
+        # prefer_owned -> our cheapest owned group if we have one, else cheapest overall
+        chosen = (cheapest_owned.get(eid) or cheapest[eid]) if prefer_owned else cheapest[eid]
+        chosen = dict(chosen)
+        chosen["candidates"] = counts.get(eid, 0)
+        best[eid] = chosen
     return best
 
 
@@ -413,10 +423,18 @@ def plan_tour_package(rows: list[dict], home: dict, qty: int, budget_km: float,
             pl["selection"] = "estimate"
         pl["city"] = r.get("venue_city")
         pl["event_name"] = r.get("event_name")
+        pl["performer"] = r.get("primary_performer_name") or ""
+        pl["popularity"] = round(float(r["_pop"]), 4) if r.get("_pop") is not None else None
         pl["coord_source"] = r.get("_coord_source", "venue")
         legmeta[eid] = pl
         u = pl.get("unit_price")
         costs[eid] = (u * qty) if u is not None else 0.0    # the fan's spend at this stop
+
+    # "hot" demand badge: top third of the tour by long-term popularity (and meaningfully high)
+    pops = sorted(v["popularity"] for v in legmeta.values() if v.get("popularity") is not None)
+    thr = max(0.4, pops[min(len(pops) - 1, len(pops) * 2 // 3)]) if pops else None
+    for v in legmeta.values():
+        v["hot"] = bool(thr is not None and v.get("popularity") is not None and v["popularity"] >= thr)
 
     c = Constraints(home_name=home["name"], home_lat=float(home["lat"]), home_lon=float(home["lon"]),
                     start=start, end=end, max_travel_km=float(budget_km),
@@ -453,18 +471,31 @@ def plan_tour_package(rows: list[dict], home: dict, qty: int, budget_km: float,
     }
 
 
-def plan_performer_tour(db, performer_id: int, home_lat: float, home_lon: float,
-                        qty: int, budget_km: float, start: date, end: date,
-                        home_name: str = "Home", budget_usd: float | None = None,
-                        side: str = "auto", clear_at: float = DEFAULT_CLEAR_AT,
-                        away_margin: float = DEFAULT_AWAY_MARGIN,
-                        max_events: int | None = None) -> dict:
-    """End-to-end retail tour package: detect concert vs team-away, route + dual-mode price."""
-    rows, mode = fetch_tour_events(db, performer_id, start, end, side)
+def fetch_event_popularity(db, ids: list[int]) -> dict[int, float]:
+    """Long-term popularity score per event (events table) — powers the 'hot' demand badge."""
+    if not ids:
+        return {}
+    rows = (db.table("events").select("id, long_term_popularity_score")
+            .in_("id", ids).execute().data) or []
+    out: dict[int, float] = {}
+    for r in rows:
+        v = r.get("long_term_popularity_score")
+        if v is not None:
+            out[int(r["id"])] = float(v)
+    return out
+
+
+def _enrich_and_plan(db, rows: list[dict], mode: str, qty: int, home: dict,
+                     budget_km: float, start: date, end: date, budget_usd: float | None,
+                     clear_at: float, away_margin: float, max_events: int | None,
+                     section_like: str | None, prefer_owned: bool) -> dict:
+    """Shared: coord fallback + pricing + popularity + auto-selected listings -> tour package."""
     _apply_coord_fallback(db, rows)
     ids = [int(r["tevo_event_id"]) for r in rows]
     pricing = fetch_event_pricing(db, ids)
-    listings = fetch_event_listings(db, ids, max(1, int(qty)))   # auto-select real seats
+    listings = fetch_event_listings(db, ids, max(1, int(qty)),
+                                    section_like=section_like, prefer_owned=prefer_owned)
+    popularity = fetch_event_popularity(db, ids)
     for r in rows:
         eid = int(r["tevo_event_id"])
         p = pricing.get(eid)
@@ -472,9 +503,46 @@ def plan_performer_tour(db, performer_id: int, home_lat: float, home_lon: float,
             r["_owned"], r["_our_ask"] = p["owned"], p["our_ask"]
             r["_getin"], r["_med"], r["_qty"] = p["getin"], p["med"], p["qty"]
         r["_listing"] = listings.get(eid)
+        r["_pop"] = popularity.get(eid)
+    return plan_tour_package(rows, home, qty, budget_km, start, end,
+                             budget_usd=budget_usd, max_events=max_events,
+                             clear_at=clear_at, away_margin=away_margin, mode=mode)
+
+
+def plan_performer_tour(db, performer_id: int, home_lat: float, home_lon: float,
+                        qty: int, budget_km: float, start: date, end: date,
+                        home_name: str = "Home", budget_usd: float | None = None,
+                        side: str = "auto", clear_at: float = DEFAULT_CLEAR_AT,
+                        away_margin: float = DEFAULT_AWAY_MARGIN, max_events: int | None = None,
+                        section_like: str | None = None, prefer_owned: bool = False) -> dict:
+    """End-to-end retail tour package: detect concert vs team-away, route + dual-mode price."""
+    rows, mode = fetch_tour_events(db, performer_id, start, end, side)
     home = {"name": home_name, "lat": home_lat, "lon": home_lon}
-    payload = plan_tour_package(rows, home, qty, budget_km, start, end,
-                                budget_usd=budget_usd, max_events=max_events,
-                                clear_at=clear_at, away_margin=away_margin, mode=mode)
+    payload = _enrich_and_plan(db, rows, mode, qty, home, budget_km, start, end, budget_usd,
+                               clear_at, away_margin, max_events, section_like, prefer_owned)
     payload["performer_id"] = int(performer_id)
+    return payload
+
+
+def plan_multi_performer_tour(db, performer_ids: list[int], home_lat: float, home_lon: float,
+                              qty: int, budget_km: float, start: date, end: date,
+                              home_name: str = "Home", budget_usd: float | None = None,
+                              side: str = "auto", clear_at: float = DEFAULT_CLEAR_AT,
+                              away_margin: float = DEFAULT_AWAY_MARGIN,
+                              max_events: int | None = None, section_like: str | None = None,
+                              prefer_owned: bool = False) -> dict:
+    """"Plan my summer": route + price one package across SEVERAL performers' events at once."""
+    rows: list[dict] = []
+    seen: set[int] = set()
+    for pid in performer_ids:
+        prows, _ = fetch_tour_events(db, int(pid), start, end, side)
+        for r in prows:
+            eid = int(r["tevo_event_id"])
+            if eid not in seen:
+                seen.add(eid)
+                rows.append(r)
+    home = {"name": home_name, "lat": home_lat, "lon": home_lon}
+    payload = _enrich_and_plan(db, rows, "multi", qty, home, budget_km, start, end, budget_usd,
+                               clear_at, away_margin, max_events, section_like, prefer_owned)
+    payload["performer_ids"] = [int(p) for p in performer_ids]
     return payload

--- a/trip_planner/test_tour.py
+++ b/trip_planner/test_tour.py
@@ -77,6 +77,20 @@ def test_listing_selection():
     assert other["selection"] == "estimate"
 
 
+def test_popularity_hot_and_multi():
+    # a multi-performer package with popularity scores -> legs carry performer + hot badge
+    rows = [dict(r) for r in CONCERT]
+    rows[0]["primary_performer_name"] = "Megan Moroney"; rows[0]["_pop"] = 0.66
+    rows[1]["primary_performer_name"] = "Zach Bryan"; rows[1]["_pop"] = 0.20
+    rows[2]["primary_performer_name"] = "Megan Moroney"; rows[2]["_pop"] = 0.61
+    p = plan_tour_package(rows, HOME, 3, 20000, START, END, mode="multi")
+    legs = p["all_stops"]
+    assert all(set(("hot", "popularity", "performer")) <= set(l) for l in legs)
+    assert {l["performer"] for l in legs} == {"Megan Moroney", "Zach Bryan"}   # multi
+    assert any(l["hot"] and l["popularity"] == 0.66 for l in legs)             # top-third flagged
+    assert not any(l["hot"] and l["popularity"] == 0.20 for l in legs)
+
+
 def main():
     print("\nRetail tour-package — dual mode, qty=3\n")
     for label, rows, mode in [("concert", CONCERT, "concert"), ("team-away", AWAY, "team_away")]:
@@ -89,6 +103,7 @@ def main():
     test_concert_owned_splits()
     test_team_away_market_sourced()
     test_listing_selection()
+    test_popularity_hot_and_multi()
     print("\n  asserts passed: owned-splits premium (concert) + market-sourced spread (team away)\n")
 
 


### PR DESCRIPTION
## What
A new planning mode + the low-effort enhancements (**checkout intentionally left off**).

### New planning mode
- **"Plan my summer" (multi-performer)** — `GET /api/{store,broker}/tours/multi?performer_ids=87567,40010` routes + prices **one package across several performers'** events at once. The engine already supported a `prefs` map; `plan_multi_performer_tour` just unions their events and runs the same dual-mode pricing + listing auto-selection.

### Low-effort enhancements
- **Seat preferences** — `section_like` (ILIKE section filter, e.g. `FLOOR`/`211`) + `prefer_owned` (pick our cheapest *owned* group when we hold one), threaded into the listing auto-selection.
- **"Hot" demand badge** — `long_term_popularity_score` per event; legs in the **top third** of the tour get a 🔥.
- **Save / share** — the store tour page reads its params from the **URL** on load + a **Copy link** button (pure frontend, no backend).

## Surfaces
- Store `/store/test/tour`: comma-separate IDs for plan-my-summer, section + "ours first" filters, 🔥 + per-leg performer name (multi), Copy-link.
- D0 performer tour section: section + "ours first" + 🔥 (multi stays store-only — doesn't fit a single-performer page).

Shared via `_enrich_and_plan`. `test_tour` covers the hot-badge + multi leg shape. Read-only throughout (no writes, no upstream API). `node --check` + `py_compile` + tests green.

**Next PR:** reverse discovery ("what tours can I catch near me").

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_