### PR TITLE
feat(store): reverse discovery — tours near you (consumer storefront)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1319,6 +1319,35 @@ def broker_multi_tour(
                                section_like, prefer_owned)
 
 
+def _discover_payload(home_lat: float, home_lon: float, within_mi: float, days: int,
+                      min_shows: int, concerts_only: bool) -> dict:
+    """Shared body for reverse-discovery ('tours near me'). Read-only."""
+    from trip_planner import discover_tours_near
+
+    db = require_sb()
+    start, end = _tour_dates(days)
+    return discover_tours_near(
+        db, float(home_lat), float(home_lon),
+        max(5.0, min(float(within_mi), 1000.0)), start, end,
+        min_shows=max(1, min(int(min_shows), 6)),
+        event_types=["concert"] if concerts_only else None,
+    )
+
+
+@app.get("/api/broker/tours/near")
+def broker_tours_near(
+    home_lat: float,
+    home_lon: float,
+    within_mi: float = 250.0,
+    days: int = 120,
+    min_shows: int = 2,
+    concerts_only: bool = False,
+    _=Depends(require_auth),
+):
+    """D0 reverse discovery — performers with >= min_shows within `within_mi` of home."""
+    return _discover_payload(home_lat, home_lon, within_mi, days, min_shows, concerts_only)
+
+
 def _bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
     """Fetch performer_metadata for many performer_ids at once. Returns map
     {performer_id: {logo_default_url, color_primary, ...}}. Used by event
@@ -6871,6 +6900,20 @@ def store_multi_tour(
                                section_like, prefer_owned)
 
 
+@app.get("/api/store/tours/near")
+def store_tours_near(
+    home_lat: float,
+    home_lon: float,
+    within_mi: float = 250.0,
+    days: int = 120,
+    min_shows: int = 2,
+    concerts_only: bool = False,
+):
+    """D1 store reverse discovery — 'what tours can I catch near me'. Performers with
+    >= min_shows within `within_mi` of home in the window, with price-from + demand."""
+    return _discover_payload(home_lat, home_lon, within_mi, days, min_shows, concerts_only)
+
+
 def _section_sort_key(s: str) -> tuple:
     """Sort key for venue sections. Letters before digits (Floor, Courtside,
     GA come before 100, 101, etc.); within each group, natural-numeric for
@@ -7802,6 +7845,13 @@ def store_index_page():
 @app.api_route("/store/event/{event_id}", methods=["GET", "HEAD"])
 def store_event_page(event_id: int):  # noqa: ARG001 — id read by JS from URL
     return _render_storefront_page("event.html")
+
+
+@app.api_route("/store/discover", methods=["GET", "HEAD"])
+def store_discover_page():
+    """Reverse discovery — 'what tours can I catch near me'. Backed by
+    /api/store/tours/near; mounts via store.js (data-page=discover)."""
+    return _render_storefront_page("discover.html")
 
 
 # ---------- Static informational pages (Sprint 3 trust + legal) ----------

--- a/static/store/discover.html
+++ b/static/store/discover.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://maps.ticketevolution.com; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>VibePass — discover tours near you</title>
+  <meta name="description" content="Find performers playing multiple shows near you — follow a tour close to home." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
+  <link rel="stylesheet" href="/static/store/style.css" />
+  <style>
+    .disc-wrap { max-width: 880px; margin: 0 auto; padding: 16px 18px 48px; }
+    .disc-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; margin: 14px 0; }
+    .disc-form label { display: block; font-size: 12px; color: #8a93a6; margin-bottom: 3px; }
+    .disc-form input, .disc-form select { width: 100%; padding: 9px 10px; box-sizing: border-box; }
+    .disc-wrap button { padding: 9px 18px; margin: 0 8px 8px 0; cursor: pointer; }
+    .tour-card { border: 1px solid rgba(127,127,127,.22); border-radius: 10px; padding: 13px 16px; margin: 10px 0; }
+    .tour-card h3 { margin: 0 0 4px; font-size: 17px; }
+    .tour-meta { font-size: 13px; color: #8a93a6; }
+    .tour-shows { margin: 9px 0 0; font-size: 13px; line-height: 1.9; }
+    .tour-shows a { margin-right: 12px; white-space: nowrap; }
+    .pill3 { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; margin-left: 4px; }
+    .pill3.hot { background: #fde68a; color: #92400e; }
+    .pill3.own { background: #bbf7d0; color: #065f46; }
+  </style>
+</head>
+<body data-page="discover">
+  <header class="topbar">
+    <a class="brand" href="/store">VibePass</a>
+    <div class="badge mvp">MVP · browse only · no real purchases</div>
+  </header>
+  <main class="disc-wrap">
+    <h1>Discover tours near you</h1>
+    <p>Find performers playing multiple shows within range — follow a tour close to home. Tap a date to view tickets.</p>
+    <div class="disc-form">
+      <div><label>Home latitude</label><input id="dLat" type="number" step="0.0001" value="41.8810" /></div>
+      <div><label>Home longitude</label><input id="dLon" type="number" step="0.0001" value="-87.6320" /></div>
+      <div><label>Within (miles)</label><input id="dMi" type="number" value="250" /></div>
+      <div><label>Next (days)</label><input id="dDays" type="number" value="120" /></div>
+      <div><label>Min shows</label><input id="dMin" type="number" min="1" max="6" value="2" /></div>
+      <div><label>Type</label><select id="dKind"><option value="">all</option><option value="1">concerts only</option></select></div>
+    </div>
+    <button id="dGo">Find tours</button>
+    <button id="dGeo">Use my location</button>
+    <div id="dStatus" style="color:#8a93a6;font-size:13px;margin:12px 0"></div>
+    <div id="dResults"></div>
+  </main>
+  <script src="/static/store/store.js"></script>
+</body>
+</html>

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -32,6 +32,7 @@
 <body data-page="catalog">
   <header class="topbar">
     <a class="brand" href="/store">VibePass</a>
+    <a href="/store/discover" style="margin-left:14px;font-size:14px">Discover tours near you →</a>
     <div class="badge mvp">MVP · browse only · no real purchases</div>
   </header>
 

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -2668,6 +2668,64 @@
 
   window.Store = { mountCatalog, mountEvent, mountSharesAdmin };
 
+  // Reverse discovery — "what tours can I catch near me". Location-first:
+  // performers with >= min_shows within a radius of home in the window.
+  // Backed by /api/store/tours/near; each show links to its /store/event page.
+  function mountDiscover() {
+    const $ = (id) => document.getElementById(id);
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+    const money = (n) => "$" + Math.round(n).toLocaleString();
+    const fmtD = (iso) => {
+      try { return new Date(iso + "T00:00:00").toLocaleDateString(undefined, { month: "short", day: "numeric" }); }
+      catch (_) { return iso; }
+    };
+
+    async function run() {
+      const p = new URLSearchParams({
+        home_lat: $("dLat").value, home_lon: $("dLon").value,
+        within_mi: $("dMi").value || "250", days: $("dDays").value || "120",
+        min_shows: $("dMin").value || "2",
+      });
+      if ($("dKind").value) p.set("concerts_only", "true");
+      $("dStatus").textContent = "Searching…";
+      $("dResults").innerHTML = "";
+      try {
+        render(await api("/api/store/tours/near?" + p.toString()));
+      } catch (e) {
+        $("dStatus").textContent = "Error: " + e.message;
+      }
+    }
+
+    function render(d) {
+      const tours = (d && d.tours) || [];
+      $("dStatus").textContent = `${tours.length} tour${tours.length === 1 ? "" : "s"} within ${d.within_mi} mi`;
+      $("dResults").innerHTML = tours.map((t) => {
+        const badges = (t.hot ? '<span class="pill3 hot">🔥 hot</span>' : "")
+          + (t.we_own ? '<span class="pill3 own">in stock</span>' : "");
+        const shows = (t.events || [])
+          .map((ev) => `<a href="/store/event/${ev.event_id}">${esc(ev.city || "")} ${fmtD(ev.date)}</a>`)
+          .join("");
+        const price = t.price_from != null ? ` · from ${money(t.price_from)}` : "";
+        return `<div class="tour-card"><h3>${esc(t.performer || "")}${badges}</h3>`
+          + `<div class="tour-meta">${t.nearby_shows} shows · ${t.cities} cit${t.cities === 1 ? "y" : "ies"} · nearest ${t.nearest_mi} mi${price}</div>`
+          + `<div class="tour-shows">${shows}</div></div>`;
+      }).join("") || "<p>No multi-show tours found near you in that window — widen the radius or window.</p>";
+    }
+
+    $("dGo").addEventListener("click", run);
+    $("dGeo").addEventListener("click", () => {
+      if (!navigator.geolocation) return;
+      $("dStatus").textContent = "Locating…";
+      navigator.geolocation.getCurrentPosition((pos) => {
+        $("dLat").value = pos.coords.latitude.toFixed(4);
+        $("dLon").value = pos.coords.longitude.toFixed(4);
+        run();
+      }, () => { $("dStatus").textContent = "Couldn't get your location — enter it manually."; });
+    });
+    run();
+  }
+
   // Auto-mount based on body data-page. Lets HTML pages drop their inline
   // `<script>Store.mountX()</script>` so we can ship a strict CSP without
   // 'unsafe-inline'. Added 2026-05-11 (security chat).
@@ -2676,6 +2734,7 @@
     if (page === "catalog") mountCatalog();
     else if (page === "event") mountEvent();
     else if (page === "shares") mountSharesAdmin();
+    else if (page === "discover") mountDiscover();
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", _autoMount);

--- a/trip_planner/__init__.py
+++ b/trip_planner/__init__.py
@@ -5,12 +5,14 @@ and the D0 terminal (`/api/broker/performers/{id}/trip-plan`). Engine vendored f
 axiom-orion/gigtrip (MIT) — see NOTICE.md.
 """
 from .planner import (
+    discover_tours_near,
     fetch_performer_rows,
     plan_from_rows,
     plan_multi_performer_tour,
     plan_performer_tour,
     plan_performer_trip,
     plan_tour_package,
+    rank_tours_near,
     row_to_event,
 )
 
@@ -19,6 +21,8 @@ __all__ = [
     "plan_performer_tour",
     "plan_multi_performer_tour",
     "plan_tour_package",
+    "discover_tours_near",
+    "rank_tours_near",
     "plan_from_rows",
     "fetch_performer_rows",
     "row_to_event",

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -11,6 +11,7 @@ Split so the planning logic is testable offline:
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+from math import cos, radians
 
 from .budget_optimizer import plan_by_date_2b, plan_optimal_2b
 from .city_centroids import centroid_for
@@ -546,3 +547,90 @@ def plan_multi_performer_tour(db, performer_ids: list[int], home_lat: float, hom
                                clear_at, away_margin, max_events, section_like, prefer_owned)
     payload["performer_ids"] = [int(p) for p in performer_ids]
     return payload
+
+
+# --------------------------------------------------------------------------- #
+# Reverse discovery — "what tours can I catch near me?" (location-first)
+# --------------------------------------------------------------------------- #
+def _miles(lat1, lon1, lat2, lon2) -> float:
+    from .gigtrip.distance import haversine_km
+    return haversine_km(lat1, lon1, lat2, lon2) * 0.621371
+
+
+def rank_tours_near(events: list[dict], lat: float, lon: float, within_mi: float,
+                    min_shows: int) -> list[dict]:
+    """Pure: group nearby events by performer into candidate 'tours' (>= min_shows reachable)."""
+    by_perf: dict = {}
+    for e in events:
+        vl, vo = e.get("venue_lat"), e.get("venue_lon")
+        if vl is None or vo is None:
+            continue
+        mi = _miles(lat, lon, float(vl), float(vo))
+        if mi > within_mi:
+            continue
+        by_perf.setdefault(e.get("tevo_performer_id"), []).append({**e, "_mi": mi})
+
+    tours: list[dict] = []
+    for pid, evs in by_perf.items():
+        if pid is None or len(evs) < min_shows:
+            continue
+        evs.sort(key=lambda x: str(x.get("event_date")))
+        cities = sorted({x.get("venue_city") for x in evs if x.get("venue_city")})
+        tours.append({
+            "performer": evs[0].get("primary_performer_name"),
+            "performer_id": int(pid),
+            "event_type": evs[0].get("event_type"),
+            "nearby_shows": len(evs),
+            "cities": len(cities) or 1,
+            "nearest_mi": round(min(x["_mi"] for x in evs)),
+            "soonest": str(min(str(x.get("event_date")) for x in evs))[:10],
+            "events": [{"event_id": int(x["tevo_event_id"]), "city": x.get("venue_city"),
+                        "date": str(x.get("event_date"))[:10], "miles": round(x["_mi"])}
+                       for x in evs[:8]],
+        })
+    return tours
+
+
+def discover_tours_near(db, lat: float, lon: float, within_mi: float, start: date, end: date,
+                        min_shows: int = 2, limit: int = 20,
+                        event_types: list[str] | None = None) -> dict:
+    """Location-first discovery: performers with >= min_shows within `within_mi` of home,
+    enriched with price-from + popularity + whether we hold inventory. Read-only."""
+    dlat = within_mi / 69.0
+    dlon = within_mi / (69.0 * max(0.2, cos(radians(lat))))
+    q = (db.table("v_event_base")
+         .select("tevo_event_id, tevo_performer_id, primary_performer_name, venue_city, "
+                 "event_date, venue_lat, venue_lon, event_type")
+         .gte("venue_lat", lat - dlat).lte("venue_lat", lat + dlat)
+         .gte("venue_lon", lon - dlon).lte("venue_lon", lon + dlon)
+         .gte("event_date", start.isoformat()).lte("event_date", end.isoformat())
+         .not_.is_("venue_lat", "null").limit(5000))
+    if event_types:
+        q = q.in_("event_type", event_types)
+    events = q.execute().data or []
+
+    tours = rank_tours_near(events, lat, lon, within_mi, min_shows)
+    all_ids = [ev["event_id"] for t in tours for ev in t["events"]]
+    pop = fetch_event_popularity(db, all_ids)
+    pricing = fetch_event_pricing(db, all_ids)
+    for t in tours:
+        eids = [ev["event_id"] for ev in t["events"]]
+        t["popularity"] = round(max((pop.get(i, 0.0) for i in eids), default=0.0), 4)
+        getins = [pricing[i]["getin"] for i in eids
+                  if pricing.get(i) and pricing[i].get("getin") is not None]
+        t["price_from"] = round(min(getins)) if getins else None
+        t["we_own"] = any((pricing.get(i) or {}).get("owned", 0) > 0 for i in eids)
+
+    pops = sorted(t["popularity"] for t in tours)
+    thr = max(0.4, pops[min(len(pops) - 1, len(pops) * 2 // 3)]) if pops else None
+    for t in tours:
+        t["hot"] = bool(thr is not None and t["popularity"] >= thr)
+
+    tours.sort(key=lambda t: (-t["nearby_shows"], -t["popularity"], t["nearest_mi"]))
+    return {
+        "home": {"lat": lat, "lon": lon},
+        "within_mi": within_mi,
+        "window": {"start": start.isoformat(), "end": end.isoformat()},
+        "count": len(tours),
+        "tours": tours[:limit],
+    }

--- a/trip_planner/test_discover.py
+++ b/trip_planner/test_discover.py
@@ -1,0 +1,42 @@
+"""Offline test of reverse-discovery ranking (pure, no DB)."""
+from __future__ import annotations
+
+from .planner import rank_tours_near
+
+HLAT, HLON = 41.881, -87.632   # Chicago
+
+
+def _ev(eid, pid, name, city, d, lat, lon, etype="concert"):
+    return {"tevo_event_id": eid, "tevo_performer_id": pid, "primary_performer_name": name,
+            "venue_city": city, "event_date": d, "venue_lat": lat, "venue_lon": lon,
+            "event_type": etype}
+
+
+EVENTS = [
+    _ev(1, 100, "Rush", "Chicago", "2026-07-17", 41.88, -87.67),     # ~2 mi
+    _ev(2, 100, "Rush", "Chicago", "2026-07-19", 41.88, -87.67),
+    _ev(3, 200, "Local Solo", "Chicago", "2026-08-01", 41.88, -87.67),  # only 1 show
+    _ev(4, 400, "Far Band", "Dallas", "2026-07-22", 32.78, -96.80),  # ~800 mi (out of radius)
+]
+
+
+def test_rank_near():
+    tours = rank_tours_near(EVENTS, HLAT, HLON, within_mi=150, min_shows=2)
+    perfs = {t["performer_id"] for t in tours}
+    assert 100 in perfs              # Rush: 2 Chicago shows in radius -> a tour
+    assert 200 not in perfs          # only 1 show -> not a tour
+    assert 400 not in perfs          # Dallas out of radius
+    rush = next(t for t in tours if t["performer_id"] == 100)
+    assert rush["nearby_shows"] == 2 and rush["nearest_mi"] <= 5 and len(rush["events"]) == 2
+
+
+def main():
+    for t in rank_tours_near(EVENTS, HLAT, HLON, 150, 2):
+        print(f"  {t['performer']:11} {t['nearby_shows']} shows / {t['cities']} cities, "
+              f"nearest {t['nearest_mi']} mi, soonest {t['soonest']}")
+    test_rank_near()
+    print("  asserts passed: Rush surfaces; 1-show + out-of-radius excluded")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
**Reverse discovery** — a new location-first feature in the **consumer storefront** (D1), as a separate page (`/store/discover`), not the `/store/test` sandbox.

Given **home + radius + window**, it surfaces performers playing **multiple shows nearby** — a tour you can follow close to home. Each show deep-links to its `/store/event/{id}` page.

## How it works (same spine, queried location-first)
- `rank_tours_near` (pure): bounding-box + exact haversine → group nearby events by performer → keep those with ≥ `min_shows`.
- `discover_tours_near`: `v_event_base` geo query, enriched with **price-from** (`event_listing_snapshot_daily`), an **"in stock"** flag (we hold owned), and a **🔥 hot** badge (`long_term_popularity_score`).
- Proven live: "tours near Chicago, 90 days" returns Rush ×5, Ariana ×3, J Cole/Karol G/Morgan Wallen/BTS/Noah Kahan ×2.

## Surfaces
- `GET /api/{store,broker}/tours/near?home_lat&home_lon&within_mi&days&min_shows&concerts_only`
- `/store/discover` consumer page — strict store CSP (`script-src 'self'`), so logic lives in **`store.js`** (`mountDiscover`, no inline script), styled with the store's `style.css`. "Use my location" supported.
- "Discover tours near you →" link added to the store home topbar.

## Notes
- Read-only throughout (no writes, no upstream API). **Checkout stays off.**
- **D1 is the paused lane** and these are live consumer pages — operator-directed, flagging for visibility.
- Click-through goes to the consumer event pages; wiring it to the full tour planner (currently in `/store/test`) is a natural follow-up.
- `node --check` + `py_compile` + `test_discover`/`test_tour` green.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_