### PR TITLE
feat(store): follow-the-tour — buyer picks tickets, attends the whole tour

### DIFF
--- a/app.py
+++ b/app.py
@@ -7854,6 +7854,14 @@ def store_discover_page():
     return _render_storefront_page("discover.html")
 
 
+@app.api_route("/store/tour", methods=["GET", "HEAD"])
+def store_tour_page():
+    """Follow-the-tour — pick a ticket count and attend a performer's whole tour;
+    tickets auto-selected per date. Backed by /api/store/performers/{id}/tour-package;
+    mounts via store.js (data-page=tour). Performer id read from ?performer=."""
+    return _render_storefront_page("tour.html")
+
+
 # ---------- Static informational pages (Sprint 3 trust + legal) ----------
 # Plain HTML shells with no JS. Same Cache-Control: no-cache pattern as
 # the rest of the storefront so future edits propagate without browser

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -2707,8 +2707,11 @@
           .map((ev) => `<a href="/store/event/${ev.event_id}">${esc(ev.city || "")} ${fmtD(ev.date)}</a>`)
           .join("");
         const price = t.price_from != null ? ` · from ${money(t.price_from)}` : "";
+        const follow = `/store/tour?performer=${t.performer_id}`
+          + `&home_lat=${encodeURIComponent($("dLat").value)}&home_lon=${encodeURIComponent($("dLon").value)}`;
         return `<div class="tour-card"><h3>${esc(t.performer || "")}${badges}</h3>`
           + `<div class="tour-meta">${t.nearby_shows} shows · ${t.cities} cit${t.cities === 1 ? "y" : "ies"} · nearest ${t.nearest_mi} mi${price}</div>`
+          + `<div style="margin:6px 0"><a href="${follow}"><b>Follow this tour →</b></a></div>`
           + `<div class="tour-shows">${shows}</div></div>`;
       }).join("") || "<p>No multi-show tours found near you in that window — widen the radius or window.</p>";
     }
@@ -2726,6 +2729,94 @@
     run();
   }
 
+  // Follow-the-tour — pick a ticket count, attend a performer's whole tour;
+  // seats auto-selected per date. Backed by /api/store/performers/{id}/tour-package.
+  // Performer id + home come from the URL (set by the Discover page).
+  function mountTourFollow() {
+    const $ = (id) => document.getElementById(id);
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+    const money = (n) => "$" + Math.round(n).toLocaleString();
+    const fmtD = (iso) => {
+      try { return new Date(iso + "T00:00:00").toLocaleDateString(undefined, { month: "short", day: "numeric" }); }
+      catch (_) { return iso; }
+    };
+    const u = new URLSearchParams(location.search);
+    const performer = parseInt(u.get("performer"), 10);
+    if (u.get("home_lat")) $("ftLat").value = u.get("home_lat");
+    if (u.get("home_lon")) $("ftLon").value = u.get("home_lon");
+    if (u.get("qty")) $("ftQty").value = u.get("qty");
+
+    async function run() {
+      if (!Number.isFinite(performer) || performer <= 0) {
+        $("ftStatus").textContent = "No performer selected — start from Discover.";
+        return;
+      }
+      const p = new URLSearchParams({
+        home_lat: $("ftLat").value, home_lon: $("ftLon").value,
+        qty: $("ftQty").value || "2", budget_km: "50000", days: "365",
+      });
+      if ($("ftBudget").value) p.set("budget_usd", $("ftBudget").value);
+      $("ftStatus").textContent = "Building your tour…";
+      $("ftResult").hidden = true;
+      try {
+        render(await api(`/api/store/performers/${performer}/tour-package?` + p.toString()));
+      } catch (e) {
+        $("ftStatus").textContent = "Error: " + e.message;
+      }
+    }
+
+    function render(d) {
+      const pk = (d && d.package) || {};
+      const qty = d.qty_per_show;
+      const name = (pk.legs && pk.legs[0] && pk.legs[0].performer)
+        || (d.all_stops && d.all_stops[0] && d.all_stops[0].performer) || "this performer";
+      $("ftTitle").textContent = `Follow ${name}'s tour`;
+      if (!d.stops_available || !pk.count) {
+        $("ftStatus").textContent = "No routable tour right now — try a wider budget.";
+        $("ftResult").hidden = true;
+        return;
+      }
+      $("ftStatus").textContent = `${d.stops_available} tour dates available`;
+      $("ftStat").innerHTML =
+        `<div><span class="l">Total</span><b>${money(pk.fan_total_bundled)}</b></div>` +
+        `<div><span class="l">Tickets</span><b>${pk.count * qty}</b></div>` +
+        `<div><span class="l">Shows</span><b>${pk.count}</b></div>` +
+        `<div><span class="l">Cities</span><b>${pk.cities}</b></div>`;
+      $("ftHead").textContent = `Your shows — ${qty} ticket${qty === 1 ? "" : "s"} at each of ${pk.count}`;
+      const picked = new Set((pk.legs || []).map((l) => l.event_id));
+      $("ftLegs").innerHTML = (d.all_stops || []).map((l) => {
+        const on = picked.has(l.event_id);
+        const s = l.seats;
+        const seat = s
+          ? `<span class="seat">${esc(s.section || "GA")}${s.row ? " " + esc(s.row) : ""}${s.is_owned ? " · in stock" : ""}</span>`
+          : (l.selection === "estimate" ? '<span class="seat">est. price</span>' : '<span class="seat">no group of that size</span>');
+        const hot = l.hot ? '<span class="hot" title="high demand">🔥</span>' : "";
+        const line = l.unit_price != null
+          ? `<span class="line">${money(l.unit_price * qty)} <span class="ea">(${money(l.unit_price)} ea)</span></span>`
+          : "";
+        return `<li class="${on ? "" : "skip"}">`
+          + `<span class="d">${fmtD(l.date)}</span>`
+          + `<span class="c">${esc(l.city || "—")}${hot}</span>`
+          + `<span>${esc(l.event_name || l.venue || "")}</span>`
+          + seat + line + "</li>";
+      }).join("");
+      $("ftResult").hidden = false;
+    }
+
+    $("ftGo").addEventListener("click", run);
+    $("ftGeo").addEventListener("click", () => {
+      if (!navigator.geolocation) return;
+      $("ftStatus").textContent = "Locating…";
+      navigator.geolocation.getCurrentPosition((pos) => {
+        $("ftLat").value = pos.coords.latitude.toFixed(4);
+        $("ftLon").value = pos.coords.longitude.toFixed(4);
+        run();
+      }, () => { $("ftStatus").textContent = "Couldn't get your location — enter it manually."; });
+    });
+    run();
+  }
+
   // Auto-mount based on body data-page. Lets HTML pages drop their inline
   // `<script>Store.mountX()</script>` so we can ship a strict CSP without
   // 'unsafe-inline'. Added 2026-05-11 (security chat).
@@ -2735,6 +2826,7 @@
     else if (page === "event") mountEvent();
     else if (page === "shares") mountSharesAdmin();
     else if (page === "discover") mountDiscover();
+    else if (page === "tour") mountTourFollow();
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", _autoMount);

--- a/static/store/tour.html
+++ b/static/store/tour.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://maps.ticketevolution.com; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>VibePass — follow the tour</title>
+  <meta name="description" content="Pick how many tickets and follow a performer across their whole tour — seats picked for you at every show." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
+  <link rel="stylesheet" href="/static/store/style.css" />
+  <style>
+    .ft-wrap { max-width: 820px; margin: 0 auto; padding: 16px 18px 48px; }
+    .ft-controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin: 14px 0; }
+    .ft-controls label { display: block; font-size: 12px; color: #8a93a6; margin-bottom: 3px; }
+    .ft-controls input { padding: 9px 10px; box-sizing: border-box; }
+    .ft-controls input[type=number] { width: 110px; }
+    .ft-wrap button { padding: 9px 18px; margin: 0 8px 8px 0; cursor: pointer; }
+    .ft-stat { display: flex; gap: 24px; flex-wrap: wrap; margin: 14px 0; padding: 14px 16px; border: 1px solid rgba(127,127,127,.22); border-radius: 10px; }
+    .ft-stat b { font-size: 22px; display: block; line-height: 1.1; }
+    .ft-stat .l { font-size: 11px; color: #8a93a6; text-transform: uppercase; letter-spacing: .04em; }
+    ul.ft-legs { list-style: none; padding: 0; margin: 10px 0 0; }
+    ul.ft-legs li { display: flex; gap: 12px; padding: 10px 4px; border-bottom: 1px solid rgba(127,127,127,.14); align-items: baseline; flex-wrap: wrap; }
+    ul.ft-legs li.skip { opacity: .45; }
+    ul.ft-legs .d { width: 92px; color: #8a93a6; font-size: 13px; font-variant-numeric: tabular-nums; }
+    ul.ft-legs .c { width: 130px; font-weight: 600; }
+    ul.ft-legs .seat { font-size: 12px; color: #8a93a6; }
+    ul.ft-legs .line { margin-left: auto; font-variant-numeric: tabular-nums; }
+    ul.ft-legs .ea { color: #8a93a6; font-size: 12px; }
+    .hot { margin-left: 5px; }
+  </style>
+</head>
+<body data-page="tour">
+  <header class="topbar">
+    <a class="brand" href="/store">VibePass</a>
+    <a href="/store/discover" style="margin-left:14px;font-size:14px">← Discover</a>
+    <div class="badge mvp">MVP · browse only · no real purchases</div>
+  </header>
+  <main class="ft-wrap">
+    <h1 id="ftTitle">Follow the tour</h1>
+    <p>Pick how many tickets and we'll follow this performer across their tour — seats chosen for you at every show.</p>
+    <div class="ft-controls">
+      <div><label>Tickets</label><input id="ftQty" type="number" min="1" max="12" value="2" /></div>
+      <div><label>Home latitude</label><input id="ftLat" type="number" step="0.0001" value="40.7128" /></div>
+      <div><label>Home longitude</label><input id="ftLon" type="number" step="0.0001" value="-74.0060" /></div>
+      <div><label>Max spend ($, optional)</label><input id="ftBudget" type="number" step="250" placeholder="whole tour" /></div>
+      <button id="ftGo">Follow tour</button>
+      <button id="ftGeo">Use my location</button>
+    </div>
+    <div id="ftStatus" style="color:#8a93a6;font-size:13px;margin:12px 0"></div>
+    <div id="ftResult" hidden>
+      <div class="ft-stat" id="ftStat"></div>
+      <h2 id="ftHead" style="margin:16px 0 4px">Your shows</h2>
+      <ul class="ft-legs" id="ftLegs"></ul>
+    </div>
+  </main>
+  <script src="/static/store/store.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What
The core idea, made real on the consumer storefront: **a buyer picks how many tickets and follows a performer across their whole tour** — seats chosen for them at every show.

Flow: **Discover** ("tours near you") → **"Follow this tour →"** → **`/store/tour`**, where you set the ticket count and get the full tour with auto-selected seats per date and a grand total.

## How
- `/store/tour` page (`data-page=tour`) backed by the existing `/api/store/performers/{id}/tour-package` with `budget_km=50000` → the **whole tour** (every reachable date selected); an optional **max-spend** trims it.
- `mountTourFollow()` in `store.js`: reads `?performer` + home handed off from Discover, a **ticket-count** input, "use my location"; renders per-date **auto-selected seats** (section/row, "in stock" when it's our inventory), per-show **line total**, and a **grand total** + tickets/shows/cities stats.
- Discover cards now carry a prominent **"Follow this tour →"** link (passing performer + home).

Reuses the dual-mode pricing + real-ticket auto-selection already shipped — this is the consumer front-end for the whole machine. Read-only, strict store CSP (logic in `store.js`, no inline script). **Checkout stays off.**

`node --check` + `py_compile` + tour engine tests green. (D1 is the paused lane; operator-directed — flagging.)

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_