### PR TITLE
feat(store): separate away vs home games when following a team

### DIFF
--- a/static/store/store.js
+++ b/static/store/store.js
@@ -2707,11 +2707,13 @@
           .map((ev) => `<a href="/store/event/${ev.event_id}">${esc(ev.city || "")} ${fmtD(ev.date)}</a>`)
           .join("");
         const price = t.price_from != null ? ` · from ${money(t.price_from)}` : "";
+        const isTeam = t.kind === "sports";
         const follow = `/store/tour?performer=${t.performer_id}`
-          + `&home_lat=${encodeURIComponent($("dLat").value)}&home_lon=${encodeURIComponent($("dLon").value)}`;
+          + `&home_lat=${encodeURIComponent($("dLat").value)}&home_lon=${encodeURIComponent($("dLon").value)}`
+          + (isTeam ? "&side=home" : "");
         return `<div class="tour-card"><h3>${esc(t.performer || "")}${badges}</h3>`
-          + `<div class="tour-meta">${t.nearby_shows} shows · ${t.cities} cit${t.cities === 1 ? "y" : "ies"} · nearest ${t.nearest_mi} mi${price}</div>`
-          + `<div style="margin:6px 0"><a href="${follow}"><b>Follow this tour →</b></a></div>`
+          + `<div class="tour-meta">${isTeam ? "team · " : ""}${t.nearby_shows} ${isTeam ? "home games" : "shows"} · ${t.cities} cit${t.cities === 1 ? "y" : "ies"} · nearest ${t.nearest_mi} mi${price}</div>`
+          + `<div style="margin:6px 0"><a href="${follow}"><b>${isTeam ? "Follow this team →" : "Follow this tour →"}</b></a></div>`
           + `<div class="tour-shows">${shows}</div></div>`;
       }).join("") || "<p>No multi-show tours found near you in that window — widen the radius or window.</p>";
     }
@@ -2743,6 +2745,7 @@
     };
     const u = new URLSearchParams(location.search);
     const performer = parseInt(u.get("performer"), 10);
+    let side = u.get("side") || "auto";   // teams: away (road trip) vs home (home stand)
     if (u.get("home_lat")) $("ftLat").value = u.get("home_lat");
     if (u.get("home_lon")) $("ftLon").value = u.get("home_lon");
     if (u.get("qty")) $("ftQty").value = u.get("qty");
@@ -2754,7 +2757,7 @@
       }
       const p = new URLSearchParams({
         home_lat: $("ftLat").value, home_lon: $("ftLon").value,
-        qty: $("ftQty").value || "2", budget_km: "50000", days: "365",
+        qty: $("ftQty").value || "2", budget_km: "50000", days: "365", side: side,
       });
       if ($("ftBudget").value) p.set("budget_usd", $("ftBudget").value);
       $("ftStatus").textContent = "Building your tour…";
@@ -2769,15 +2772,38 @@
     function render(d) {
       const pk = (d && d.package) || {};
       const qty = d.qty_per_show;
-      const name = (pk.legs && pk.legs[0] && pk.legs[0].performer)
-        || (d.all_stops && d.all_stops[0] && d.all_stops[0].performer) || "this performer";
-      $("ftTitle").textContent = `Follow ${name}'s tour`;
+      const isTeam = String(d.mode || "").indexOf("team") === 0;
+      const away = d.mode === "team_away";
+      let name;
+      if (isTeam) {
+        const ev = (d.all_stops && d.all_stops[0]) || {};
+        const parts = String(ev.event_name || "").split(" at ");   // "Away at Home"
+        name = parts.length === 2 ? (away ? parts[0] : parts[1]) : (ev.performer || "this team");
+      } else {
+        name = (pk.legs && pk.legs[0] && pk.legs[0].performer)
+          || (d.all_stops && d.all_stops[0] && d.all_stops[0].performer) || "this performer";
+      }
+      $("ftTitle").textContent = isTeam
+        ? `Follow ${name} ${away ? "on the road" : "at home"}`
+        : `Follow ${name}'s tour`;
+      // team -> show the away/home toggle, highlight current side
+      const sideEl = $("ftSide");
+      if (sideEl) {
+        sideEl.hidden = !isTeam;
+        sideEl.querySelectorAll(".ftside").forEach((b) => {
+          b.classList.toggle("active", away ? b.dataset.side === "away" : b.dataset.side === "home");
+        });
+      }
       if (!d.stops_available || !pk.count) {
-        $("ftStatus").textContent = "No routable tour right now — try a wider budget.";
+        $("ftStatus").textContent = isTeam
+          ? `No ${away ? "away" : "home"} games in range — try the other side.`
+          : "No routable tour right now — try a wider budget.";
         $("ftResult").hidden = true;
         return;
       }
-      $("ftStatus").textContent = `${d.stops_available} tour dates available`;
+      $("ftStatus").textContent = isTeam
+        ? `${away ? "Away games · road trip" : "Home stand"} · ${d.stops_available} dates`
+        : `${d.stops_available} tour dates available`;
       $("ftStat").innerHTML =
         `<div><span class="l">Total</span><b>${money(pk.fan_total_bundled)}</b></div>` +
         `<div><span class="l">Tickets</span><b>${pk.count * qty}</b></div>` +
@@ -2805,6 +2831,13 @@
     }
 
     $("ftGo").addEventListener("click", run);
+    const sideToggle = $("ftSide");
+    if (sideToggle) sideToggle.addEventListener("click", (e) => {
+      const b = e.target.closest(".ftside");
+      if (!b) return;
+      side = b.dataset.side;     // "away" | "home"
+      run();
+    });
     $("ftGeo").addEventListener("click", () => {
       if (!navigator.geolocation) return;
       $("ftStatus").textContent = "Locating…";

--- a/static/store/tour.html
+++ b/static/store/tour.html
@@ -17,6 +17,8 @@
     .ft-controls input { padding: 9px 10px; box-sizing: border-box; }
     .ft-controls input[type=number] { width: 110px; }
     .ft-wrap button { padding: 9px 18px; margin: 0 8px 8px 0; cursor: pointer; }
+    .ftside { padding: 6px 14px !important; border: 1px solid rgba(127,127,127,.4); border-radius: 999px; background: transparent; }
+    .ftside.active { background: #2563eb; color: #fff; border-color: #2563eb; }
     .ft-stat { display: flex; gap: 24px; flex-wrap: wrap; margin: 14px 0; padding: 14px 16px; border: 1px solid rgba(127,127,127,.22); border-radius: 10px; }
     .ft-stat b { font-size: 22px; display: block; line-height: 1.1; }
     .ft-stat .l { font-size: 11px; color: #8a93a6; text-transform: uppercase; letter-spacing: .04em; }
@@ -47,6 +49,11 @@
       <div><label>Max spend ($, optional)</label><input id="ftBudget" type="number" step="250" placeholder="whole tour" /></div>
       <button id="ftGo">Follow tour</button>
       <button id="ftGeo">Use my location</button>
+    </div>
+    <div id="ftSide" hidden style="margin: 2px 0 6px">
+      <span style="font-size:12px;color:#8a93a6;margin-right:8px">This is a team — follow them:</span>
+      <button class="ftside" data-side="away">Away · road trip</button>
+      <button class="ftside" data-side="home">Home stand</button>
     </div>
     <div id="ftStatus" style="color:#8a93a6;font-size:13px;margin:12px 0"></div>
     <div id="ftResult" hidden>

--- a/trip_planner/planner.py
+++ b/trip_planner/planner.py
@@ -557,6 +557,11 @@ def _miles(lat1, lon1, lat2, lon2) -> float:
     return haversine_km(lat1, lon1, lat2, lon2) * 0.621371
 
 
+_SPORTS_TYPES = {"game", "mlb", "wnba", "nwsl", "mls-major-league-soccer", "ncaa", "ncaa--2",
+                 "formula-1", "world-cup", "miscellaneous-sports", "horse-racing",
+                 "independent-league-baseball"}
+
+
 def rank_tours_near(events: list[dict], lat: float, lon: float, within_mi: float,
                     min_shows: int) -> list[dict]:
     """Pure: group nearby events by performer into candidate 'tours' (>= min_shows reachable)."""
@@ -576,10 +581,12 @@ def rank_tours_near(events: list[dict], lat: float, lon: float, within_mi: float
             continue
         evs.sort(key=lambda x: str(x.get("event_date")))
         cities = sorted({x.get("venue_city") for x in evs if x.get("venue_city")})
+        et = (evs[0].get("event_type") or "").lower()
         tours.append({
             "performer": evs[0].get("primary_performer_name"),
             "performer_id": int(pid),
             "event_type": evs[0].get("event_type"),
+            "kind": "sports" if et in _SPORTS_TYPES else "live",
             "nearby_shows": len(evs),
             "cities": len(cities) or 1,
             "nearest_mi": round(min(x["_mi"] for x in evs)),


### PR DESCRIPTION
## What
For **sports teams**, away (road trip) and home (home stand) are different tours — so the buyer can now choose.

- **Follow page** (`/store/tour`): when the result is a team (backend `mode` = `team_away`/`team_home`), an **`Away · road trip` | `Home stand`** toggle appears and re-runs with `side=away`/`home`. Title reads "Follow X **on the road**" vs "**at home**". Concerts are unaffected (no toggle).
- **Discover**: each tour is tagged `kind=sports|live` (`_SPORTS_TYPES` on `event_type`, e.g. `game`/`mlb`/`wnba`). Sports cards read "**team · N home games**" and hand off with **`side=home`** (you found their home stand near you), so the Follow page opens on the right side — with the toggle to flip to the road trip.

Team name is derived from the `"Away at Home"` `event_name` per side (away games are keyed under the opponent, so the leg performer isn't the followed team). Read-only; reuses the existing `side` support in the engine.

Follow-up to #508. `node --check` + `py_compile` + `test_discover`/`test_tour` green.

https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN2gh9nPHjE8yVspddHSMF)_