### PR TITLE
feat(ticketsdata): /match→AQ, /events→search, 250k caps, tiered per-platform polling

### DIFF
--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -130,11 +130,12 @@
     }
 
     function renderResults(d) {
-      const evs   = d.events     || [];
-      const perfs = d.performers || [];
-      const vens  = d.venues     || [];
+      const evs   = d.events      || [];
+      const perfs = d.performers  || [];
+      const vens  = d.venues      || [];
+      const mkt   = d.marketplace || [];
       flat = [];
-      if (!evs.length && !perfs.length && !vens.length) {
+      if (!evs.length && !perfs.length && !vens.length && !mkt.length) {
         sugg.innerHTML = `<div class="ts-empty">no matches for &ldquo;${escapeHtml(d.q || '')}&rdquo;</div>`;
         return;
       }
@@ -172,6 +173,22 @@
           flat.push({ href, label: v.venue_name, kind: 'venue' });
           parts.push(`<a class="ts-row" href="${href}" data-kind="venue">
               <span class="ts-name">${escapeHtml(v.venue_name || '(unnamed)')}</span>
+              <span class="ts-meta">${escapeHtml(meta)}</span>
+            </a>`);
+        });
+        parts.push('</div>');
+      }
+      if (mkt.length) {
+        // Marketplace events discovered via TicketsData /events that we don't
+        // track locally yet. No internal page to link to — open the buy URL.
+        parts.push('<div class="ts-section"><div class="ts-section-lbl">MARKETPLACE</div>');
+        mkt.forEach(m => {
+          const href = m.event_url || '#';
+          const meta = [m.platform, m.venue_name, fmtDateShort(m.event_date)].filter(Boolean).join(' · ');
+          flat.push({ href, label: m.event_name, kind: 'marketplace' });
+          const ext = href !== '#' ? ' target="_blank" rel="noopener"' : '';
+          parts.push(`<a class="ts-row" href="${escapeHtml(href)}"${ext} data-kind="marketplace">
+              <span class="ts-name">${escapeHtml(m.event_name || '(unnamed)')}</span>
               <span class="ts-meta">${escapeHtml(meta)}</span>
             </a>`);
         });

--- a/supabase/migrations/20260609120000_td_match_aq_enrichment.sql
+++ b/supabase/migrations/20260609120000_td_match_aq_enrichment.sql
@@ -1,0 +1,487 @@
+-- Migration 20260609120000 · lane:D0 (TD/AQ subsystem is A1-owned) ·
+--   writes (DDL): ticketsdata_credit_usage (+reports cols), td_charge_credit (sig),
+--                 td_reports_this_month(), td_reports_budget_ok(),
+--                 td_match_queue (new), td_match_results (new),
+--                 td_match_enqueue(), td_match_drain(), td_match_apply() ·
+--   reads: aq_event_map, ticketsdata_event_xref ·
+--   writes on run: td_match_queue/_results; td_match_apply(true) → aq_event_map ·
+--   spends: TicketsData /match = 12 credits + 1 Market-Intelligence report each
+--           (gated by td_budget_ok() AND td_reports_budget_ok()).
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1: apply_migration
+--    on prod requires operator permission; A1 is sole pusher to main). Validate
+--    on a Supabase branch (copy-on-write fork) before any prod apply.
+--
+-- WHY ───────────────────────────────────────────────────────────────────────
+-- The AQ matcher (match_to_aq_event_id) is reliable on Tier-1 platform-native id,
+-- but Tiers 2–4 GUESS from venue+date ±6h. That guesswork is the documented root
+-- cause of (a) false binds (Forrest Frank → Knicks G4; Braves@Giants → A's@Giants)
+-- and (b) ID scatter — A1-OPS-22: 235 tevo events with ≥2 aq_event_map rows whose
+-- platform ids are split across rows, so the TD daily snapshot reads only one
+-- cluster and sibling platforms look "missing".
+--
+-- TicketsData /match is the missing oracle: feed it ONE event URL (any platform)
+-- and it returns the matched id/URL on every other platform PLUS match_confidence
+-- (0–100), match_type (exact|probable), and match_reason (entity-id matched, exact
+-- venue key, same date). It does two jobs for AQ:
+--   1. FILL  — one call resolves sg/sh/vivid ids onto a single aq row (no guessing).
+--   2. ADJUDICATE — for conflicting clusters it tells us if two URLs are the SAME
+--      event (→ mergeable) or genuinely distinct (parking / doubleheader → keep).
+--
+-- SAFETY ─────────────────────────────────────────────────────────────────────
+-- /match output lands in td_match_results (staging). td_match_apply() DEFAULTS TO
+-- DRY-RUN and only COALESCE-fills NULL platform-id columns — it NEVER overwrites a
+-- non-null value; a mismatch is reported as action='CONFLICT' for manual review.
+-- Mirrors the aq_consolidate_safe_dups(p_apply default false) convention.
+-- No cron is scheduled — usage is deliberately manual (reports are scarce: 2,000/mo
+-- plan-wide; this pipeline self-caps at 600/mo via td_reports_budget_ok()).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Reports accounting — /match consumes Market-Intelligence reports, which the
+--    existing credit ledger did not track. Add two nullable columns + extend the
+--    charge helper (trailing optional params → call-compatible with all callers).
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE public.ticketsdata_credit_usage
+  ADD COLUMN IF NOT EXISTS reports           int NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS reports_remaining int;
+
+COMMENT ON COLUMN public.ticketsdata_credit_usage.reports IS
+  'Market-Intelligence reports consumed by this call (1 for /match, 0 otherwise).';
+COMMENT ON COLUMN public.ticketsdata_credit_usage.reports_remaining IS
+  'reports_remaining from the /match response envelope (plan-wide, not just this pipeline).';
+
+CREATE OR REPLACE FUNCTION public.td_charge_credit(
+  p_n               integer DEFAULT 1,
+  p_event_id        bigint  DEFAULT NULL,
+  p_platform        text    DEFAULT NULL,
+  p_endpoint        text    DEFAULT '/fetch',
+  p_status_code     integer DEFAULT NULL,
+  p_quota_remaining integer DEFAULT NULL,
+  p_reports         integer DEFAULT 0,
+  p_reports_remaining integer DEFAULT NULL
+)
+RETURNS void
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  INSERT INTO public.ticketsdata_credit_usage
+    (credits, event_id, platform, endpoint, status_code, quota_remaining,
+     reports, reports_remaining)
+  VALUES
+    (p_n, p_event_id, p_platform, p_endpoint, p_status_code, p_quota_remaining,
+     COALESCE(p_reports, 0), p_reports_remaining);
+$$;
+REVOKE ALL ON FUNCTION public.td_charge_credit(integer,bigint,text,text,integer,integer,integer,integer) FROM anon, public;
+
+-- Monthly report counter (UTC calendar month, matching td_credits_this_month).
+CREATE OR REPLACE FUNCTION public.td_reports_this_month()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT COALESCE(SUM(reports), 0)::integer
+  FROM public.ticketsdata_credit_usage
+  WHERE date_trunc('month', called_at AT TIME ZONE 'UTC')
+      = date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC');
+$$;
+REVOKE ALL ON FUNCTION public.td_reports_this_month() FROM anon, public;
+
+-- Report budget gate for the automated /match pipeline.
+--   Plan provides 2,000 Market-Intelligence reports/month. This pipeline self-caps
+--   at 600/mo so the remaining ~1,400 stay free for manual dashboard + MVP use.
+--   RULE: if the plan or allocation changes, update the 600 here and add a comment.
+CREATE OR REPLACE FUNCTION public.td_reports_budget_ok()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT public.td_reports_this_month() < 600;  -- 600/2,000 plan reports → automated cap
+$$;
+REVOKE ALL ON FUNCTION public.td_reports_budget_ok() FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. td_match_queue — one row per /match job (fire→drain async, pg_net pattern).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.td_match_queue (
+  id                bigserial   PRIMARY KEY,
+  tevo_event_id     bigint,                         -- canonical event being resolved (if known)
+  aq_short_event_id text,                           -- target aq_event_map row to enrich (if known)
+  seed_platform     text,                           -- platform the seed URL came from (audit only)
+  seed_event_url    text        NOT NULL,           -- the URL fed to /match (auto-detects source)
+  purpose           text        NOT NULL DEFAULT 'fill'
+                      CHECK (purpose IN ('fill','adjudicate')),
+  request_id        bigint,                          -- pg_net request id (net._http_response.id)
+  fired_at          timestamptz NOT NULL DEFAULT now(),
+  resolved_at       timestamptz,
+  status_code       int,
+  retry_count       int         NOT NULL DEFAULT 0,
+  error_msg         text
+);
+CREATE INDEX IF NOT EXISTS idx_td_match_queue_open
+  ON public.td_match_queue (fired_at) WHERE resolved_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_td_match_queue_tevo
+  ON public.td_match_queue (tevo_event_id) WHERE tevo_event_id IS NOT NULL;
+
+REVOKE ALL ON public.td_match_queue FROM anon, authenticated;
+ALTER TABLE public.td_match_queue ENABLE ROW LEVEL SECURITY;
+CREATE POLICY td_match_queue_service_only ON public.td_match_queue
+  FOR ALL TO service_role USING (true);
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. td_match_results — parsed /match output (staging; td_match_apply consumes it).
+--    Only sg/sh/vivid ids are reliably URL-extractable as bigint. ticketmaster is
+--    a hex id and tickpick/gametime have no aq column — captured in matches_raw.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.td_match_results (
+  id                bigserial   PRIMARY KEY,
+  queue_id          bigint      REFERENCES public.td_match_queue(id),
+  tevo_event_id     bigint,
+  aq_short_event_id text,
+  purpose           text,
+  match_type        text,                            -- exact | probable
+  match_confidence  numeric(6,2),
+  match_reason      jsonb,
+  event_date        date,
+  event_venue       text,
+  sg_event_id       bigint,
+  sh_event_id       bigint,
+  vivid_event_id    bigint,
+  tm_url            text,
+  tickpick_url      text,
+  gametime_url      text,
+  matches_raw       jsonb,                           -- full matches{} map from the envelope
+  applied_at        timestamptz,                     -- set by td_match_apply(true)
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_td_match_results_unapplied
+  ON public.td_match_results (created_at) WHERE applied_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_td_match_results_tevo
+  ON public.td_match_results (tevo_event_id) WHERE tevo_event_id IS NOT NULL;
+
+REVOKE ALL ON public.td_match_results FROM anon, authenticated;
+ALTER TABLE public.td_match_results ENABLE ROW LEVEL SECURITY;
+CREATE POLICY td_match_results_service_only ON public.td_match_results
+  FOR ALL TO service_role USING (true);
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. td_match_enqueue(p_purpose, p_limit) — fire N /match calls.
+--    Gated by td_budget_ok() AND td_reports_budget_ok(). A report is CHARGED at
+--    drain time (on 200), so the gate here is a pre-flight guard.
+--
+--    Target selection:
+--      'fill'       aq rows missing ≥1 of (sg/sh/vivid)_event_id that HAVE a seed
+--                   URL (via ticketsdata_event_xref.event_url), highest-value first,
+--                   not matched in the last 14 days, not already queued.
+--      'adjudicate' tevo events with ≥2 aq rows carrying DISTINCT non-null
+--                   sg_event_id (the A1-OPS-22 conflicting clusters); /match tells
+--                   us if they're the same event or genuinely split.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_match_enqueue(
+  p_purpose text DEFAULT 'fill',
+  p_limit   integer DEFAULT 5
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $fn$
+DECLARE
+  r       RECORD;
+  v_user  text;
+  v_pass  text;
+  v_req   bigint;
+  v_n     int := 0;
+BEGIN
+  IF p_purpose NOT IN ('fill','adjudicate') THEN
+    RAISE EXCEPTION 'td_match_enqueue: p_purpose must be fill|adjudicate, got %', p_purpose;
+  END IF;
+  IF NOT public.td_budget_ok() THEN
+    RAISE NOTICE 'td_match_enqueue: TD credit budget exhausted — skipping'; RETURN 0;
+  END IF;
+  IF NOT public.td_reports_budget_ok() THEN
+    RAISE NOTICE 'td_match_enqueue: TD report budget exhausted (600/mo cap) — skipping'; RETURN 0;
+  END IF;
+  v_user := public.get_app_secret('TICKETSDATA_USERNAME');
+  v_pass := public.get_app_secret('TICKETSDATA_PASSWORD');
+  IF v_user IS NULL OR v_pass IS NULL THEN
+    RAISE EXCEPTION 'td_match_enqueue: TD creds missing in vault';
+  END IF;
+
+  FOR r IN
+    WITH targets AS (
+      -- ── FILL ───────────────────────────────────────────────────────────────
+      SELECT a.tevo_event_id, a.aq_short_event_id, x.platform AS seed_platform,
+             x.event_url AS seed_url,
+             COALESCE(x.owned_tickets, 0) AS rank_owned,
+             COALESCE(x.rank_score, 0)    AS rank_score
+      FROM public.aq_event_map a
+      JOIN public.ticketsdata_event_xref x
+        ON x.aq_short_event_id = a.aq_short_event_id
+       AND x.active AND x.event_url IS NOT NULL
+      WHERE p_purpose = 'fill'
+        AND (a.sg_event_id IS NULL OR a.sh_event_id IS NULL OR a.vivid_event_id IS NULL)
+        AND NOT EXISTS (
+          SELECT 1 FROM public.td_match_results mr
+          WHERE mr.aq_short_event_id = a.aq_short_event_id
+            AND mr.created_at > now() - interval '14 days')
+        AND NOT EXISTS (
+          SELECT 1 FROM public.td_match_queue q
+          WHERE q.aq_short_event_id = a.aq_short_event_id
+            AND q.resolved_at IS NULL)
+
+      UNION ALL
+
+      -- ── ADJUDICATE (conflicting-sg clusters, A1-OPS-22) ──────────────────────
+      SELECT c.tevo_event_id, c.aq_short_event_id, x.platform, x.event_url,
+             COALESCE(x.owned_tickets, 0), COALESCE(x.rank_score, 0)
+      FROM (
+        SELECT a.tevo_event_id,
+               (array_agg(a.aq_short_event_id ORDER BY a.aq_short_event_id))[1] AS aq_short_event_id
+        FROM public.aq_event_map a
+        WHERE p_purpose = 'adjudicate' AND a.tevo_event_id IS NOT NULL
+        GROUP BY a.tevo_event_id
+        HAVING count(DISTINCT a.sg_event_id) FILTER (WHERE a.sg_event_id IS NOT NULL) >= 2
+      ) c
+      JOIN public.ticketsdata_event_xref x
+        ON x.aq_short_event_id = c.aq_short_event_id
+       AND x.active AND x.event_url IS NOT NULL
+      WHERE NOT EXISTS (
+          SELECT 1 FROM public.td_match_queue q
+          WHERE q.tevo_event_id = c.tevo_event_id AND q.resolved_at IS NULL)
+    )
+    SELECT DISTINCT ON (aq_short_event_id)
+           tevo_event_id, aq_short_event_id, seed_platform, seed_url, rank_owned, rank_score
+    FROM targets
+    ORDER BY aq_short_event_id, rank_owned DESC, rank_score DESC
+    LIMIT GREATEST(p_limit, 0)
+  LOOP
+    SELECT net.http_get(
+      url := 'https://ticketsdata.com/match',
+      params := jsonb_build_object(
+        'event_url', r.seed_url,
+        'username',  v_user,
+        'password',  v_pass),
+      headers := '{}'::jsonb,
+      timeout_milliseconds := 45000   -- /match fans out to all platforms; allow ~12–15s+
+    ) INTO v_req;
+
+    INSERT INTO public.td_match_queue
+      (tevo_event_id, aq_short_event_id, seed_platform, seed_event_url, purpose, request_id)
+    VALUES (r.tevo_event_id, r.aq_short_event_id, r.seed_platform, r.seed_url, p_purpose, v_req);
+    v_n := v_n + 1;
+  END LOOP;
+
+  RETURN v_n;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_match_enqueue(text,integer) FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. td_match_drain(p_max) — parse returned /match responses into td_match_results.
+--    Charges 12 credits + 1 report on a successful (200, status=success) response.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_match_drain(p_max integer DEFAULT 50)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $fn$
+DECLARE
+  r        RECORD;
+  j        jsonb;
+  v_status text;
+  v_n      int := 0;
+BEGIN
+  FOR r IN
+    SELECT q.id AS qid, q.tevo_event_id, q.aq_short_event_id, q.purpose,
+           h.status_code, h.content AS raw
+    FROM public.td_match_queue q
+    JOIN net._http_response h ON h.id = q.request_id
+    WHERE q.resolved_at IS NULL AND q.request_id IS NOT NULL
+    ORDER BY q.fired_at ASC
+    LIMIT GREATEST(p_max, 0)
+  LOOP
+    BEGIN
+      j := r.raw::jsonb;
+      v_status := j->>'status';
+
+      IF r.status_code = 200 AND v_status = 'success' THEN
+        INSERT INTO public.td_match_results
+          (queue_id, tevo_event_id, aq_short_event_id, purpose, match_type,
+           match_confidence, match_reason, event_date, event_venue,
+           sg_event_id, sh_event_id, vivid_event_id, tm_url, tickpick_url,
+           gametime_url, matches_raw)
+        VALUES (
+          r.qid, r.tevo_event_id, r.aq_short_event_id, r.purpose,
+          j->>'match_type',
+          NULLIF(j->>'match_confidence','')::numeric,
+          j->'match_reason',
+          NULLIF(j->'event_details'->>'date','')::date,
+          j->'event_details'->>'venue',
+          -- seatgeek …/concert/<digits>
+          (substring(coalesce(j->'matches'->>'seatgeek',''),   '/concert/([0-9]{4,})'))::bigint,
+          -- stubhub …/event/<digits>/
+          (substring(coalesce(j->'matches'->>'stubhub',''),    '/event/([0-9]{4,})'))::bigint,
+          -- vividseats …/production/<digits>
+          (substring(coalesce(j->'matches'->>'vividseats',''), '/production/([0-9]{4,})'))::bigint,
+          coalesce(j->'matches'->>'ticketmaster_us', j->'matches'->>'ticketmaster_ca'),
+          j->'matches'->>'tickpick',
+          j->'matches'->>'gametime',
+          j->'matches'
+        );
+        PERFORM public.td_charge_credit(
+          12, r.tevo_event_id, NULL, '/match', 200,
+          NULLIF(j->>'quota_remaining','')::int,
+          1, NULLIF(j->>'reports_remaining','')::int);
+
+        UPDATE public.td_match_queue
+        SET resolved_at = clock_timestamp(), status_code = 200
+        WHERE id = r.qid;
+
+      ELSIF r.status_code = 402 THEN
+        -- Plan quota exhausted — stop; do not keep firing.
+        UPDATE public.td_match_queue
+        SET resolved_at = clock_timestamp(), status_code = 402,
+            error_msg = 'quota_exhausted'
+        WHERE id = r.qid;
+        RAISE NOTICE 'td_match_drain: 402 quota exhausted — stopping';
+        EXIT;
+
+      ELSE
+        UPDATE public.td_match_queue
+        SET resolved_at = clock_timestamp(),
+            status_code = r.status_code,
+            error_msg = left(coalesce(v_status, r.raw), 500)
+        WHERE id = r.qid;
+      END IF;
+
+      v_n := v_n + 1;
+
+    EXCEPTION WHEN OTHERS THEN
+      UPDATE public.td_match_queue
+      SET resolved_at = clock_timestamp(), status_code = -1, error_msg = left(SQLERRM, 500)
+      WHERE id = r.qid;
+    END;
+  END LOOP;
+
+  RETURN v_n;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_match_drain(integer) FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 6. td_match_apply(p_min_confidence, p_apply) — COALESCE-fill NULL platform ids
+--    on aq_event_map from staged /match results. DRY-RUN by default. Never
+--    overwrites a non-null value; a disagreement surfaces as action='CONFLICT'.
+--
+--    Returns one row per (aq row × platform column) considered:
+--      action = 'FILL'     — column was NULL, /match has a value (applied if p_apply)
+--               'CONFLICT' — column non-null AND differs from /match (left untouched)
+--               'AGREE'    — column non-null AND equals /match (no-op)
+--               'SKIP_LOWCONF' — match_confidence below threshold (whole row skipped)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_match_apply(
+  p_min_confidence numeric DEFAULT 90,
+  p_apply          boolean DEFAULT false
+)
+RETURNS TABLE (
+  aq_short_event_id text,
+  tevo_event_id     bigint,
+  col               text,
+  old_value         bigint,
+  new_value         bigint,
+  confidence        numeric,
+  action            text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  res  RECORD;
+  a    RECORD;
+  pair RECORD;
+BEGIN
+  FOR res IN
+    SELECT * FROM public.td_match_results
+    WHERE applied_at IS NULL AND aq_short_event_id IS NOT NULL
+    ORDER BY created_at ASC
+  LOOP
+    SELECT m.aq_short_event_id, m.tevo_event_id,
+           m.sg_event_id, m.sh_event_id, m.vivid_event_id
+    INTO a
+    FROM public.aq_event_map m
+    WHERE m.aq_short_event_id = res.aq_short_event_id;
+
+    IF NOT FOUND THEN CONTINUE; END IF;
+
+    IF res.match_confidence IS NULL OR res.match_confidence < p_min_confidence THEN
+      aq_short_event_id := res.aq_short_event_id; tevo_event_id := a.tevo_event_id;
+      col := '*'; old_value := NULL; new_value := NULL;
+      confidence := res.match_confidence; action := 'SKIP_LOWCONF';
+      RETURN NEXT;
+      CONTINUE;
+    END IF;
+
+    -- Evaluate each fillable platform column.
+    FOR pair IN
+      SELECT * FROM (VALUES
+        ('sg_event_id',    a.sg_event_id,    res.sg_event_id),
+        ('sh_event_id',    a.sh_event_id,    res.sh_event_id),
+        ('vivid_event_id', a.vivid_event_id, res.vivid_event_id)
+      ) AS v(col, cur, proposed)
+    LOOP
+      IF pair.proposed IS NULL THEN
+        CONTINUE;  -- /match had nothing for this platform
+      ELSIF pair.cur IS NULL THEN
+        action := 'FILL';
+      ELSIF pair.cur = pair.proposed THEN
+        action := 'AGREE';
+      ELSE
+        action := 'CONFLICT';
+      END IF;
+
+      IF p_apply AND action = 'FILL' THEN
+        -- COALESCE-fill only (column was NULL). imported_at is intentionally
+        -- left unchanged — it records the original AQ import, not edit time.
+        EXECUTE format(
+          'UPDATE public.aq_event_map SET %I = $1 WHERE aq_short_event_id = $2',
+          pair.col)
+        USING pair.proposed, res.aq_short_event_id;
+      END IF;
+
+      aq_short_event_id := res.aq_short_event_id; tevo_event_id := a.tevo_event_id;
+      col := pair.col; old_value := pair.cur; new_value := pair.proposed;
+      confidence := res.match_confidence;
+      RETURN NEXT;
+    END LOOP;
+
+    IF p_apply THEN
+      UPDATE public.td_match_results SET applied_at = now() WHERE id = res.id;
+    END IF;
+  END LOOP;
+
+  RETURN;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_match_apply(numeric,boolean) FROM anon, public;
+
+
+-- ── Operator runbook (manual, budget-gated) ──────────────────────────────────
+--   SELECT public.td_match_enqueue('fill', 5);   -- fire 5 /match calls (60 credits + 5 reports)
+--   -- wait ~30–60s for pg_net responses, then:
+--   SELECT public.td_match_drain();               -- parse → td_match_results
+--   SELECT * FROM public.td_match_apply(90, false);   -- DRY-RUN review
+--   SELECT * FROM public.td_match_apply(90, true);    -- apply FILLs; CONFLICTs left for manual
+--   -- adjudicate the conflicting-sg clusters (A1-OPS-22):
+--   SELECT public.td_match_enqueue('adjudicate', 5);  -- then drain; inspect td_match_results.match_reason

--- a/supabase/migrations/20260609130000_td_events_discovery_search.sql
+++ b/supabase/migrations/20260609130000_td_events_discovery_search.sql
@@ -1,0 +1,428 @@
+-- Migration 20260609130000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): td_discover_targets (new), td_discovered_events (new),
+--                 td_events_discover(), td_events_discover_drain(),
+--                 td_match_discovered_to_local(), v_td_unmatched_discovered_events,
+--                 terminal_search() (v2) ·
+--   reads: aq_performer_map, events, aq_venue_map ·
+--   writes on run: td_discovered_events ·
+--   spends: TicketsData /events = 1 credit/call (budget-gated by td_budget_ok()) ·
+--   pre: 20260517230000 (terminal_search v1)
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1). Validate on a
+--    Supabase branch (copy-on-write fork) before any prod apply.
+--
+-- WHY ───────────────────────────────────────────────────────────────────────
+-- Workstream B: use TicketsData /events (performer → upcoming events, 1 credit,
+-- no report) to ENHANCE SEARCH & RESULTS. Today terminal_search only returns
+-- events already in our local `events` table, and /events discovery is wired
+-- narrowly (td_gt_performers = 4 teams, td_sg_performers = 19 artists, both
+-- feeding the matcher only — never the search surface).
+--
+-- This adds a general, budget-gated discovery layer that:
+--   1. discovers upcoming events for performers we track but whose events we
+--      DON'T have locally (the catalog-coverage gap),
+--   2. stages them in td_discovered_events + flags the unmatched ones via the
+--      v_td_unmatched_discovered_events view,
+--   3. surfaces them in terminal_search as a new 'marketplace' section, so a
+--      user searching for an event we don't track still gets a marketplace hit.
+--
+-- SCOPE NOTE: seeded for platform 'seatgeek' only — its /events envelope shape
+-- (body.items[] with event_id / buy_url / event_date_utc / name|title) is the
+-- proven one (td_sg_discover_drain). td_discover_targets is multi-platform by
+-- design; other platforms are added once their /events shape is verified live.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. td_discover_targets — unified, multi-platform performer/venue discovery
+--    registry. Generalizes td_sg_performers / td_gt_performers.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.td_discover_targets (
+  id                 bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  platform           text NOT NULL
+                       CHECK (platform IN ('seatgeek','stubhub','vividseats',
+                                           'gametime','tickpick','ticketmaster')),
+  performer_url      text,
+  venue_url          text,
+  label              text,
+  tevo_performer_id  bigint,
+  active             boolean NOT NULL DEFAULT true,
+  pending_request_id bigint,
+  last_discovered_at timestamptz,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_at         timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT td_discover_targets_url_present
+    CHECK (performer_url IS NOT NULL OR venue_url IS NOT NULL),
+  UNIQUE (platform, performer_url)
+);
+CREATE INDEX IF NOT EXISTS idx_td_disc_targets_due
+  ON public.td_discover_targets (platform)
+  WHERE active AND pending_request_id IS NULL;
+
+COMMENT ON TABLE public.td_discover_targets IS
+  'Unified TicketsData /events discovery registry (multi-platform). Drives '
+  'td_events_discover(). Budget-gated. Seeded for seatgeek; other platforms '
+  'added once their /events envelope is verified.';
+
+REVOKE ALL ON public.td_discover_targets FROM anon, authenticated;
+ALTER TABLE public.td_discover_targets ENABLE ROW LEVEL SECURITY;
+CREATE POLICY td_disc_targets_service_only ON public.td_discover_targets
+  FOR ALL TO service_role USING (true);
+
+-- Seed: carry forward the existing SG allowlist, then broaden to performers we
+-- TRACK that have upcoming local events (so /events surfaces their untracked
+-- dates). SeatGeek slug pattern matches td_sg_performers' construction.
+INSERT INTO public.td_discover_targets (platform, performer_url, label, tevo_performer_id)
+SELECT 'seatgeek', sp.performer_url, sp.performer_name, sp.tevo_performer_id
+FROM public.td_sg_performers sp
+ON CONFLICT (platform, performer_url) DO NOTHING;
+
+INSERT INTO public.td_discover_targets (platform, performer_url, label, tevo_performer_id)
+SELECT DISTINCT 'seatgeek',
+       'https://seatgeek.com/'
+         || trim(both '-' from regexp_replace(lower(pm.performer_name), '[^a-z0-9]+', '-', 'g'))
+         || '-tickets',
+       pm.performer_name, pm.tevo_performer_id
+FROM public.aq_performer_map pm
+WHERE pm.tevo_performer_id IS NOT NULL
+  AND pm.performer_name IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM public.events e
+    WHERE e.primary_performer_id = pm.tevo_performer_id
+      AND e.occurs_at_local >= now()
+      AND coalesce(e.state,'') <> 'past'
+  )
+ON CONFLICT (platform, performer_url) DO NOTHING;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. td_discovered_events — staging for events returned by /events. One row per
+--    (platform, td_event_id). matched_tevo_event_id is filled when the event
+--    maps to a local `events` row (so we can tell "new to us" from "already have").
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.td_discovered_events (
+  id                    bigserial   PRIMARY KEY,
+  platform              text        NOT NULL,
+  td_event_id           text        NOT NULL,
+  event_url             text,
+  event_name            text,
+  event_date            date,
+  venue_name            text,
+  city                  text,
+  performer_label       text,
+  target_id             bigint      REFERENCES public.td_discover_targets(id),
+  matched_tevo_event_id bigint,
+  raw                   jsonb,
+  discovered_at         timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (platform, td_event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_td_disc_events_unmatched
+  ON public.td_discovered_events (event_date)
+  WHERE matched_tevo_event_id IS NULL;
+CREATE INDEX IF NOT EXISTS idx_td_disc_events_name
+  ON public.td_discovered_events (lower(event_name));
+
+REVOKE ALL ON public.td_discovered_events FROM anon, authenticated;
+ALTER TABLE public.td_discovered_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY td_disc_events_service_only ON public.td_discovered_events
+  FOR ALL TO service_role USING (true);
+-- terminal_search (SECURITY DEFINER, email-gated) reads this on the caller's
+-- behalf; no direct anon/authenticated grant needed.
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. td_events_discover(p_platform, p_limit) — fire /events for due targets.
+--    Generalizes td_sg_discover. Budget-gated by td_budget_ok().
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_events_discover(
+  p_platform text DEFAULT 'seatgeek',
+  p_limit    integer DEFAULT 5
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $fn$
+DECLARE
+  r      RECORD;
+  v_user text;
+  v_pass text;
+  v_req  bigint;
+  v_n    int := 0;
+BEGIN
+  IF NOT public.td_budget_ok() THEN
+    RAISE NOTICE 'td_events_discover: TD budget exhausted — skipping'; RETURN 0;
+  END IF;
+  v_user := public.get_app_secret('TICKETSDATA_USERNAME');
+  v_pass := public.get_app_secret('TICKETSDATA_PASSWORD');
+  IF v_user IS NULL OR v_pass IS NULL THEN
+    RAISE EXCEPTION 'td_events_discover: TD creds missing in vault';
+  END IF;
+
+  FOR r IN
+    SELECT id, performer_url, venue_url
+    FROM public.td_discover_targets
+    WHERE active AND platform = p_platform AND pending_request_id IS NULL
+      AND (last_discovered_at IS NULL OR last_discovered_at < now() - interval '7 days')
+    ORDER BY last_discovered_at NULLS FIRST, id
+    LIMIT GREATEST(p_limit, 0)
+  LOOP
+    SELECT net.http_get(
+      url := 'https://ticketsdata.com/events',
+      params := jsonb_strip_nulls(jsonb_build_object(
+        'platform',     p_platform,
+        'performer_url', r.performer_url,
+        'venue_url',     r.venue_url,
+        'username',      v_user,
+        'password',      v_pass)),
+      headers := '{}'::jsonb,
+      timeout_milliseconds := 35000
+    ) INTO v_req;
+    UPDATE public.td_discover_targets
+    SET pending_request_id = v_req, updated_at = now()
+    WHERE id = r.id;
+    v_n := v_n + 1;
+  END LOOP;
+
+  RETURN v_n;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_events_discover(text,integer) FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. td_events_discover_drain() — parse responses → td_discovered_events, then
+--    match to local events. Charges 1 credit/call on a 200. Common /events
+--    envelope: body.items[] {event_id, buy_url, name|title|display_name,
+--    event_date_utc, venue|display_name}.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_events_discover_drain()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $fn$
+DECLARE
+  r    RECORD;
+  ev   RECORD;
+  v_id text;
+  v_ins int := 0;
+BEGIN
+  FOR r IN
+    SELECT t.id AS tid, t.platform, t.label, h.status_code, h.content AS raw
+    FROM public.td_discover_targets t
+    JOIN net._http_response h ON h.id = t.pending_request_id
+    WHERE t.pending_request_id IS NOT NULL
+  LOOP
+    IF r.status_code = 200 THEN
+      FOR ev IN
+        SELECT item FROM jsonb_array_elements(
+          COALESCE(r.raw::jsonb->'body'->'items', r.raw::jsonb->'items', '[]'::jsonb)
+        ) AS item
+      LOOP
+        v_id := COALESCE(
+          NULLIF(ev.item->>'event_id',''),
+          NULLIF(ev.item->>'id',''),
+          NULLIF(substring(COALESCE(ev.item->>'buy_url', ev.item->>'url',''), '([0-9]{5,})'),''),
+          md5(ev.item::text));
+
+        INSERT INTO public.td_discovered_events
+          (platform, td_event_id, event_url, event_name, event_date,
+           venue_name, city, performer_label, target_id, raw)
+        VALUES (
+          r.platform, v_id,
+          COALESCE(ev.item->>'buy_url', ev.item->>'url', ev.item->>'link'),
+          COALESCE(ev.item->>'name', ev.item->>'title', ev.item->>'display_name', r.label),
+          NULLIF(left(COALESCE(ev.item->>'event_date_utc', ev.item->>'event_date',
+                               ev.item->>'datetime_utc',''), 10), '')::date,
+          COALESCE(ev.item->>'venue', ev.item->>'venue_name'),
+          COALESCE(ev.item->>'city', ev.item->>'venue_city'),
+          r.label, r.tid, ev.item)
+        ON CONFLICT (platform, td_event_id) DO UPDATE
+          SET event_url = EXCLUDED.event_url,
+              event_name = EXCLUDED.event_name,
+              event_date = EXCLUDED.event_date,
+              venue_name = EXCLUDED.venue_name,
+              raw = EXCLUDED.raw;
+        v_ins := v_ins + 1;
+      END LOOP;
+
+      PERFORM public.td_charge_credit(1, NULL,
+              CASE r.platform WHEN 'seatgeek' THEN 'SG' WHEN 'stubhub' THEN 'SH'
+                              WHEN 'vividseats' THEN 'VD' WHEN 'gametime' THEN 'GT'
+                              WHEN 'tickpick' THEN 'TP' WHEN 'ticketmaster' THEN 'TM'
+                              ELSE upper(left(r.platform,2)) END,
+              '/events', 200, (r.raw::jsonb->>'quota_remaining')::int);
+    END IF;
+
+    UPDATE public.td_discover_targets
+    SET pending_request_id = NULL, last_discovered_at = now(), updated_at = now()
+    WHERE id = r.tid;
+  END LOOP;
+
+  IF v_ins > 0 THEN PERFORM public.td_match_discovered_to_local(); END IF;
+  RETURN v_ins;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_events_discover_drain() FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. td_match_discovered_to_local() — best-effort link discovered → local events
+--    by event_date + fuzzy venue (read-only against `events`; sets only the
+--    matched_tevo_event_id back-reference on staging). Conservative: requires a
+--    same-date AND venue trigram ≥ 0.6 single best candidate.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_match_discovered_to_local()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $fn$
+DECLARE v_n int := 0;
+BEGIN
+  WITH cand AS (
+    SELECT d.id AS disc_id,
+           e.id AS tevo_event_id,
+           similarity(lower(coalesce(d.venue_name,'')), lower(coalesce(e.venue_name,''))) AS sim,
+           row_number() OVER (
+             PARTITION BY d.id
+             ORDER BY similarity(lower(coalesce(d.venue_name,'')), lower(coalesce(e.venue_name,''))) DESC
+           ) AS rn
+    FROM public.td_discovered_events d
+    JOIN public.events e
+      ON e.occurs_at_local::date = d.event_date
+    WHERE d.matched_tevo_event_id IS NULL
+      AND d.event_date IS NOT NULL
+      AND d.venue_name IS NOT NULL
+  )
+  UPDATE public.td_discovered_events d
+  SET matched_tevo_event_id = c.tevo_event_id
+  FROM cand c
+  WHERE c.disc_id = d.id AND c.rn = 1 AND c.sim >= 0.6;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_match_discovered_to_local() FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 6. v_td_unmatched_discovered_events — upcoming marketplace events with no local
+--    match = catalog-coverage gaps.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW public.v_td_unmatched_discovered_events AS
+SELECT id, platform, td_event_id, event_url, event_name, event_date,
+       venue_name, city, performer_label, discovered_at
+FROM public.td_discovered_events
+WHERE matched_tevo_event_id IS NULL
+  AND event_date >= (now() AT TIME ZONE 'UTC')::date;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 7. terminal_search() v2 — add a 'marketplace' section (unmatched discovered
+--    events). Additive: existing events/performers/venues keys unchanged, so the
+--    frontend is forward-compatible. Email-gate + caps preserved from v1.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.terminal_search(
+  p_q     text,
+  p_limit integer DEFAULT 6
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email text;
+  v_q     text;
+  v_pat   text;
+  v_cap   integer;
+  v_evs   jsonb;
+  v_perfs jsonb;
+  v_vens  jsonb;
+  v_mkt   jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_q   := trim(coalesce(p_q, ''));
+  v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
+  IF length(v_q) < 2 THEN
+    RETURN jsonb_build_object('q', v_q, 'events', '[]'::jsonb, 'performers', '[]'::jsonb,
+                              'venues', '[]'::jsonb, 'marketplace', '[]'::jsonb);
+  END IF;
+  v_pat := '%' || v_q || '%';
+
+  SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.match_len, e.occurs_at_local), '[]'::jsonb)
+  INTO v_evs
+  FROM (
+    SELECT id AS tevo_event_id, name, venue_name, occurs_at_local,
+           primary_performer_name, length(name) AS match_len
+    FROM public.events
+    WHERE name ILIKE v_pat
+      AND occurs_at_local >= now() - interval '6 hours'
+      AND coalesce(state, '') <> 'past'
+    ORDER BY length(name) ASC, occurs_at_local ASC
+    LIMIT v_cap
+  ) e;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(p) ORDER BY p.match_len, p.performer_name), '[]'::jsonb)
+  INTO v_perfs
+  FROM (
+    SELECT DISTINCT ON (m.tevo_performer_id)
+      m.tevo_performer_id, m.performer_short_id, m.performer_name, m.category,
+      length(m.performer_name) AS match_len
+    FROM public.aq_performer_map m
+    WHERE m.tevo_performer_id IS NOT NULL
+      AND ( m.performer_name ILIKE v_pat
+            OR EXISTS (SELECT 1 FROM unnest(coalesce(m.aliases, ARRAY[]::text[])) AS a(alias)
+                       WHERE a.alias ILIKE v_pat) )
+    ORDER BY m.tevo_performer_id, length(m.performer_name) ASC
+    LIMIT v_cap
+  ) p;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(v) ORDER BY v.match_len, v.venue_name), '[]'::jsonb)
+  INTO v_vens
+  FROM (
+    SELECT DISTINCT ON (m.tevo_venue_id)
+      m.tevo_venue_id, m.venue_short_id, m.venue_name, m.city, m.state,
+      length(m.venue_name) AS match_len
+    FROM public.aq_venue_map m
+    WHERE m.tevo_venue_id IS NOT NULL
+      AND (m.venue_name ILIKE v_pat OR m.city ILIKE v_pat)
+    ORDER BY m.tevo_venue_id, length(m.venue_name) ASC
+    LIMIT v_cap
+  ) v;
+
+  -- NEW: marketplace events we discovered via /events but don't track locally.
+  SELECT coalesce(jsonb_agg(to_jsonb(k) ORDER BY k.event_date), '[]'::jsonb)
+  INTO v_mkt
+  FROM (
+    SELECT DISTINCT ON (lower(event_name), event_date, platform)
+      platform, td_event_id, event_url, event_name, event_date, venue_name, city
+    FROM public.v_td_unmatched_discovered_events
+    WHERE (event_name ILIKE v_pat OR performer_label ILIKE v_pat OR venue_name ILIKE v_pat)
+    ORDER BY lower(event_name), event_date, platform
+    LIMIT v_cap
+  ) k;
+
+  RETURN jsonb_build_object(
+    'q', v_q, 'limit', v_cap,
+    'events', v_evs, 'performers', v_perfs, 'venues', v_vens,
+    'marketplace', v_mkt
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.terminal_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.terminal_search(text, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.terminal_search(text, integer) IS
+  'D0 terminal topbar search — events (upcoming) / performers / venues / marketplace '
+  '(TicketsData-discovered, untracked). Email-gated. Cap 20/section. v2 mig 20260609130000.';
+
+
+-- ── Operator runbook (manual, budget-gated) ──────────────────────────────────
+--   SELECT public.td_events_discover('seatgeek', 5);  -- fire 5 performer searches (5 credits)
+--   -- wait ~30s for pg_net responses, then:
+--   SELECT public.td_events_discover_drain();          -- parse → td_discovered_events + match
+--   -- search now returns a 'marketplace' section for untracked events;
+--   -- SELECT * FROM public.v_td_unmatched_discovered_events;  -- catalog-coverage gaps

--- a/supabase/migrations/20260609140000_td_budget_caps_raise_250k_plan.sql
+++ b/supabase/migrations/20260609140000_td_budget_caps_raise_250k_plan.sql
@@ -1,0 +1,71 @@
+-- Migration 20260609140000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): td_daily_budget_ok(), td_monthly_budget_ok() — threshold raise ·
+--   reads: ticketsdata_credit_usage (via td_credits_today/_this_month) ·
+--   spends: nothing (raises the ceiling; actual spend is enqueue-LIMIT bound) ·
+--   pre: 20260527150000 (daily cap 300), 20260527130000 (monthly cap 9000)
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1). Validate on a
+--    Supabase branch before any prod apply.
+--
+-- WHY ───────────────────────────────────────────────────────────────────────
+-- The 250k/mo plan upgrade went LIVE 2026-06-09 (verified: API quota_remaining
+-- flipped from ~6.9k to 256,911 between 13:40–17:00 UTC; dashboard agrees). The
+-- old caps were sized for the 10k Starter plan and now throttle us 25×+ below
+-- the real pool:
+--     td_daily_budget_ok   < 300      (10k ÷ 30d)
+--     td_monthly_budget_ok < 9,000    (10k − 1k test reserve)
+--
+-- SIZING — why NOT 240k/8k ─────────────────────────────────────────────────
+-- These gates count RECORDED credits (td_charge_credit logs 1/call, only on
+-- HTTP 200). But measured real quota burn is ~1.33× recorded — non-200 traffic
+-- (404/503/timeout/retry) consumes plan quota without being logged. So a
+-- recorded-credit cap of N implies ~1.33·N real burn. To keep real burn under
+-- the 250k pool WITH a reserve for /match reports (≤600/mo × 12 = 7,200 credits)
+-- and manual/MVP use:
+--     real budget for /fetch+/events ≈ 250,000 − ~11,000 reserve ≈ 239,000
+--     recorded-credit cap            ≈ 239,000 ÷ 1.33               ≈ 180,000/mo
+--     daily even-spread              ≈ 180,000 ÷ 30                 =  6,000/day
+--
+-- NOTE: this only RAISES the ceiling. Actual spend stays ~300/day until the
+-- td_enqueue_peak LIMIT / cadence is raised separately — do that incrementally
+-- and watch the real quota_remaining delta vs recorded credits (the 1.33× ratio)
+-- before pushing toward the cap. Best long-term fix: also charge a credit on
+-- terminal non-200s so recorded ≈ real and the 1.33× fudge disappears.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Daily soft cap: 300 → 6,000 recorded (~7,980 real burn/day even-spread).
+CREATE OR REPLACE FUNCTION public.td_daily_budget_ok()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT public.td_credits_today() < 6000;
+  -- 250k/mo plan (live 2026-06-09). 6,000 recorded/day ≈ 7,980 real (×1.33) ≈
+  -- 180,000 recorded/mo. Raise alongside enqueue LIMIT; watch real-burn ratio.
+$$;
+REVOKE ALL ON FUNCTION public.td_daily_budget_ok() FROM anon, public;
+COMMENT ON FUNCTION public.td_daily_budget_ok() IS
+  'True if today''s recorded TD credits < 6,000 (250k/mo plan, live 2026-06-09). '
+  'Recorded under-counts real burn ~1.33×; cap chosen so real stays under pool.';
+
+-- Monthly hard cap: 9,000 → 180,000 recorded (~239k real, leaving ~11k for
+-- /match reports + manual).
+CREATE OR REPLACE FUNCTION public.td_monthly_budget_ok()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT public.td_credits_this_month() < 180000;
+  -- 250k/mo plan (live 2026-06-09). 180,000 recorded ≈ 239,000 real burn (×1.33),
+  -- reserving ~11,000 for /match (≤600 reports × 12) + manual/MVP use.
+  -- RULE: if plan or the recorded-vs-real ratio changes, update here + comment.
+$$;
+REVOKE ALL ON FUNCTION public.td_monthly_budget_ok() FROM anon, public;
+COMMENT ON FUNCTION public.td_monthly_budget_ok() IS
+  'True if month-to-date recorded TD credits < 180,000 (250k/mo plan, live '
+  '2026-06-09; ~239k real burn at the measured 1.33× recorded-to-real ratio).';

--- a/supabase/migrations/20260609150000_td_tier_polling_crons_failures.sql
+++ b/supabase/migrations/20260609150000_td_tier_polling_crons_failures.sql
@@ -1,0 +1,276 @@
+-- Migration 20260609150000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): td_poll_policy (new), td_poll_failures (new),
+--                 td_event_tier(), td_is_peak(), td_tier_enqueue(),
+--                 td_log_poll_failure() + trigger, v_td_poll_health,
+--                 v_td_poll_failures_recent ·
+--   reads: ticketsdata_event_xref, aq_event_map, events ·
+--   writes on run: td_pull_queue (enqueue), td_poll_failures (trigger) ·
+--   spends: feeds /fetch (1 credit/call via the existing drain); budget-gated ·
+--   pre: 20260527050000 (xref/queue/budget), 20260608193000 (drain), cron_policy
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1; cron.schedule +
+--    cron_policy changes are operator-gated). Validate on a Supabase branch first.
+--
+-- WHAT ───────────────────────────────────────────────────────────────────────
+-- Implements the time-to-event tiered polling design as SEPARATE, individually
+-- toggleable per-platform enqueue crons, plus persistent failure tracking.
+--
+--   * Cadence + platform-breadth + peak/off-peak are TABLE-DRIVEN (td_poll_policy)
+--     so they tune without a migration.
+--   * One enqueue cron PER PLATFORM (td_tier_enqueue_{sh,vd,tm,gt,tp,axs}); turn
+--     each on/off via cron_policy.enabled (the existing gate the 402-handler uses).
+--   * Reuses the existing td_pull_queue → td_pull_drain → td_normalize_drain path
+--     for the actual fetch + response handling. This migration only adds the
+--     ENQUEUE side (due-based metronome) + diagnostics.
+--   * SEEDED DISABLED. The old flat td_enqueue_peak_* crons are disabled here to
+--     avoid double-enqueue; operator enables the new per-platform crons when the
+--     owned-book onboarding begins.
+--
+-- Locked design encoded in td_poll_policy:
+--   tier    dte        platforms                      peak / off-peak interval
+--   hot     0–7        SH VD TM GT AXS  (+TP if ≤5d)   12h / 12h  (no halve)
+--   warm    8–30       SH VD TM GT AXS                 ~14.8h / ~29.6h
+--   cool    31–90      SH VD GT                        24h / 48h
+--   cold    91–180     SH VD                           72h / 144h
+--   frozen  >180       SH VD                           weekly / weekly
+--   Off-peak = 9pm–9am in the EVENT's local time (per-event tz from occurs_at_local).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. td_poll_policy — (platform, tier) → cadence + breadth. Absence of a row
+--    means that platform does NOT poll that tier (the breadth decay). max_dte
+--    optionally caps a row to events within N days (TickPick ≤5d).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.td_poll_policy (
+  platform      text NOT NULL,
+  tier          text NOT NULL CHECK (tier IN ('hot','warm','cool','cold','frozen')),
+  peak_min      integer NOT NULL,            -- peak-hours poll interval, minutes
+  offpeak_min   integer NOT NULL,            -- off-peak interval, minutes
+  max_dte       integer,                     -- NULL = no cap; e.g. TP hot = 5
+  active        boolean NOT NULL DEFAULT true,
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (platform, tier)
+);
+REVOKE ALL ON public.td_poll_policy FROM anon, authenticated;
+ALTER TABLE public.td_poll_policy ENABLE ROW LEVEL SECURITY;
+CREATE POLICY td_poll_policy_service_only ON public.td_poll_policy
+  FOR ALL TO service_role USING (true);
+
+INSERT INTO public.td_poll_policy (platform, tier, peak_min, offpeak_min, max_dte, active) VALUES
+  -- SH / VD: full breadth, all tiers
+  ('SH','hot',720,720,NULL,true),  ('SH','warm',888,1776,NULL,true), ('SH','cool',1440,2880,NULL,true), ('SH','cold',4320,8640,NULL,true), ('SH','frozen',10080,10080,NULL,true),
+  ('VD','hot',720,720,NULL,true),  ('VD','warm',888,1776,NULL,true), ('VD','cool',1440,2880,NULL,true), ('VD','cold',4320,8640,NULL,true), ('VD','frozen',10080,10080,NULL,true),
+  -- GT: drops at cold
+  ('GT','hot',720,720,NULL,true),  ('GT','warm',888,1776,NULL,true), ('GT','cool',1440,2880,NULL,true),
+  -- TM: drops at cool
+  ('TM','hot',720,720,NULL,true),  ('TM','warm',888,1776,NULL,true),
+  -- AXS: hot+warm, gated OFF until TicketsData ships AXS
+  ('AXS','hot',720,720,NULL,false),('AXS','warm',888,1776,NULL,false),
+  -- TP: hot only, auto-on inside 5 days (overrides its manual_opt_in demotion)
+  ('TP','hot',720,720,5,true)
+ON CONFLICT (platform, tier) DO NOTHING;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. helpers — tier from days-to-event, peak from per-event local time
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_event_tier(p_dte integer)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE
+    WHEN p_dte IS NULL OR p_dte < 0 THEN NULL
+    WHEN p_dte <= 7   THEN 'hot'
+    WHEN p_dte <= 30  THEN 'warm'
+    WHEN p_dte <= 90  THEN 'cool'
+    WHEN p_dte <= 180 THEN 'cold'
+    ELSE 'frozen' END;
+$$;
+
+-- Off-peak = local hour < 9 or >= 23. The event's tz offset is the trailing
+-- ±HH:MM of occurs_at_local (ISO). If absent, default to peak (poll).
+CREATE OR REPLACE FUNCTION public.td_is_peak(p_occurs_at_local text, p_now timestamptz DEFAULT now())
+RETURNS boolean LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE v_off text; v_hour int;
+BEGIN
+  v_off := substring(coalesce(p_occurs_at_local,'') from '([+-]\d\d:\d\d)$');
+  IF v_off IS NULL THEN RETURN true; END IF;
+  v_hour := extract(hour FROM ((p_now AT TIME ZONE 'UTC') + v_off::interval));
+  RETURN v_hour >= 9 AND v_hour < 23;
+END $$;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. td_tier_enqueue(p_platform) — due-based metronome enqueue for ONE platform.
+--    Gated by its own cron_policy row + the TD budget. Honors td_poll_policy
+--    (cadence + breadth + max_dte) and per-event peak/off-peak. interval_tag is
+--    set to the tier so downstream + failures carry it.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_tier_enqueue(p_platform text, p_max integer DEFAULT 500)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $fn$
+DECLARE
+  v_job text := 'td_tier_enqueue_' || lower(p_platform);
+  r RECORD;
+  v_n int := 0;
+BEGIN
+  IF NOT public.cron_should_fire(v_job) THEN RETURN 0; END IF;
+  IF NOT public.td_budget_ok() THEN
+    RAISE NOTICE 'td_tier_enqueue(%): budget exhausted', p_platform; RETURN 0;
+  END IF;
+
+  FOR r IN
+    WITH cand AS (
+      SELECT x.event_id, x.platform, x.event_url, x.last_fetched_at,
+             COALESCE(e.occurs_at_local, NULL) AS occ,
+             COALESCE( (left(e.occurs_at_local,10))::date,
+                       (a.event_date)::date ) - CURRENT_DATE AS dte
+      FROM public.ticketsdata_event_xref x
+      LEFT JOIN public.aq_event_map a ON a.aq_short_event_id = x.aq_short_event_id
+      LEFT JOIN public.events e ON e.id = COALESCE(x.tevo_event_id, a.tevo_event_id)
+      WHERE x.platform = p_platform AND x.active AND x.event_url IS NOT NULL
+    ),
+    tiered AS (
+      SELECT c.*, public.td_event_tier(c.dte) AS tier,
+             public.td_is_peak(c.occ) AS is_peak
+      FROM cand c
+      WHERE c.dte IS NOT NULL AND c.dte >= 0
+    )
+    SELECT t.event_id, t.platform, t.event_url, t.tier
+    FROM tiered t
+    JOIN public.td_poll_policy p
+      ON p.platform = t.platform AND p.tier = t.tier AND p.active
+    WHERE (p.max_dte IS NULL OR t.dte <= p.max_dte)
+      AND ( t.last_fetched_at IS NULL
+            OR t.last_fetched_at < now()
+                 - (CASE WHEN t.is_peak THEN p.peak_min ELSE p.offpeak_min END) * interval '1 minute' )
+      AND NOT EXISTS (
+        SELECT 1 FROM public.td_pull_queue q
+        WHERE q.event_id = t.event_id AND q.platform = t.platform AND q.resolved_at IS NULL )
+    ORDER BY t.last_fetched_at NULLS FIRST
+    LIMIT GREATEST(p_max, 0)
+  LOOP
+    INSERT INTO public.td_pull_queue (event_id, platform, event_url, interval_tag, retry_count)
+    VALUES (r.event_id, r.platform, r.event_url, r.tier, 0);
+    UPDATE public.ticketsdata_event_xref
+    SET last_enqueued_at = now(), enqueues_today = enqueues_today + 1
+    WHERE (event_id, platform) = (r.event_id, r.platform);
+    v_n := v_n + 1;
+  END LOOP;
+
+  RETURN v_n;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_tier_enqueue(text,integer) FROM anon, public;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. Failure tracking — persistent log + diagnostics. A trigger captures every
+--    td_pull_queue row that resolves with a non-200 status (survives queue
+--    pruning, unlike td_pull_queue itself).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.td_poll_failures (
+  id          bigserial PRIMARY KEY,
+  failed_at   timestamptz NOT NULL DEFAULT now(),
+  event_id    bigint,
+  platform    text,
+  tier        text,
+  status_code int,
+  error_msg   text,
+  request_id  bigint
+);
+CREATE INDEX IF NOT EXISTS idx_td_poll_failures_recent
+  ON public.td_poll_failures (failed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_td_poll_failures_plat
+  ON public.td_poll_failures (platform, status_code, failed_at DESC);
+REVOKE ALL ON public.td_poll_failures FROM anon, authenticated;
+ALTER TABLE public.td_poll_failures ENABLE ROW LEVEL SECURITY;
+CREATE POLICY td_poll_failures_service_only ON public.td_poll_failures
+  FOR ALL TO service_role USING (true);
+
+CREATE OR REPLACE FUNCTION public.td_log_poll_failure()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+BEGIN
+  INSERT INTO public.td_poll_failures
+    (event_id, platform, tier, status_code, error_msg, request_id)
+  VALUES
+    (NEW.event_id, NEW.platform, NEW.interval_tag, NEW.status_code,
+     left(NEW.error_msg, 500), NEW.request_id);
+  RETURN NEW;
+END $fn$;
+
+DROP TRIGGER IF EXISTS trg_td_pull_queue_failure ON public.td_pull_queue;
+CREATE TRIGGER trg_td_pull_queue_failure
+  AFTER UPDATE ON public.td_pull_queue
+  FOR EACH ROW
+  WHEN (NEW.resolved_at IS NOT NULL AND OLD.resolved_at IS NULL
+        AND NEW.status_code IS DISTINCT FROM 200)
+  EXECUTE FUNCTION public.td_log_poll_failure();
+
+-- Live per-platform health (last 24h, from the queue).
+CREATE OR REPLACE VIEW public.v_td_poll_health AS
+SELECT
+  platform,
+  count(*)                                            AS attempts_24h,
+  count(*) FILTER (WHERE status_code = 200)           AS ok_24h,
+  count(*) FILTER (WHERE status_code IS DISTINCT FROM 200) AS fail_24h,
+  round(100.0 * count(*) FILTER (WHERE status_code IS DISTINCT FROM 200)
+        / NULLIF(count(*),0), 1)                      AS fail_pct,
+  max(resolved_at) FILTER (WHERE status_code = 200)   AS last_ok_at,
+  max(resolved_at) FILTER (WHERE status_code IS DISTINCT FROM 200) AS last_fail_at
+FROM public.td_pull_queue
+WHERE resolved_at > now() - interval '24 hours'
+GROUP BY platform;
+
+-- Failure breakdown by platform + status (last 72h, from the persistent log).
+CREATE OR REPLACE VIEW public.v_td_poll_failures_recent AS
+SELECT platform, status_code, tier,
+       count(*) AS n,
+       max(failed_at) AS last_at,
+       (array_agg(DISTINCT left(error_msg,80)))[1:3] AS sample_errors
+FROM public.td_poll_failures
+WHERE failed_at > now() - interval '72 hours'
+GROUP BY platform, status_code, tier
+ORDER BY n DESC;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. Per-platform crons — one per platform, individually toggleable via
+--    cron_policy.enabled. SEEDED DISABLED. Staggered 30-min metronome.
+-- ─────────────────────────────────────────────────────────────────────────────
+INSERT INTO public.cron_policy (jobname, enabled, notes) VALUES
+  ('td_tier_enqueue_sh',  false, 'Tiered per-platform enqueue (SH). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_vd',  false, 'Tiered per-platform enqueue (VD). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_tm',  false, 'Tiered per-platform enqueue (TM). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_gt',  false, 'Tiered per-platform enqueue (GT). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_tp',  false, 'Tiered per-platform enqueue (TP, ≤5d only). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_axs', false, 'Tiered per-platform enqueue (AXS). Keep OFF until TicketsData ships AXS. 2026-06-09.')
+ON CONFLICT (jobname) DO NOTHING;
+
+-- Retire the old flat enqueue crons to prevent double-enqueue (operator enables
+-- the tiered ones above when onboarding the owned book).
+UPDATE public.cron_policy
+SET enabled = false,
+    notes   = notes || ' [superseded by td_tier_enqueue_* 2026-06-09]'
+WHERE jobname IN ('td_enqueue_peak_sh','td_enqueue_peak_vd','td_enqueue_peak_gt',
+                  'td_enqueue_peak_tp','td_enqueue_peak_tm');
+
+-- pg_cron schedules (gated internally by cron_should_fire → cron_policy.enabled).
+SELECT cron.schedule('td_tier_enqueue_sh',  '0,30 * * * *',  $$SELECT public.td_tier_enqueue('SH')$$);
+SELECT cron.schedule('td_tier_enqueue_vd',  '5,35 * * * *',  $$SELECT public.td_tier_enqueue('VD')$$);
+SELECT cron.schedule('td_tier_enqueue_tm',  '10,40 * * * *', $$SELECT public.td_tier_enqueue('TM')$$);
+SELECT cron.schedule('td_tier_enqueue_gt',  '15,45 * * * *', $$SELECT public.td_tier_enqueue('GT')$$);
+SELECT cron.schedule('td_tier_enqueue_tp',  '20,50 * * * *', $$SELECT public.td_tier_enqueue('TP')$$);
+SELECT cron.schedule('td_tier_enqueue_axs', '25,55 * * * *', $$SELECT public.td_tier_enqueue('AXS')$$);
+
+-- ── Operator runbook ─────────────────────────────────────────────────────────
+--   Enable a platform:   UPDATE public.cron_policy SET enabled=true  WHERE jobname='td_tier_enqueue_sh';
+--   Disable a platform:  UPDATE public.cron_policy SET enabled=false WHERE jobname='td_tier_enqueue_sh';
+--   Tune cadence:        UPDATE public.td_poll_policy SET peak_min=..,offpeak_min=.. WHERE platform='SH' AND tier='warm';
+--   Health:              SELECT * FROM public.v_td_poll_health;
+--   Failures:            SELECT * FROM public.v_td_poll_failures_recent;

--- a/supabase/migrations/20260609150000_td_tier_polling_crons_failures.sql
+++ b/supabase/migrations/20260609150000_td_tier_polling_crons_failures.sql
@@ -129,7 +129,7 @@ BEGIN
                        (a.event_date)::date ) - CURRENT_DATE AS dte
       FROM public.ticketsdata_event_xref x
       LEFT JOIN public.aq_event_map a ON a.aq_short_event_id = x.aq_short_event_id
-      LEFT JOIN public.events e ON e.id = COALESCE(x.tevo_event_id, a.tevo_event_id)
+      LEFT JOIN public.events e ON e.id = a.tevo_event_id   -- xref has no tevo col; link via aq
       WHERE x.platform = p_platform AND x.active AND x.event_url IS NOT NULL
     ),
     tiered AS (
@@ -243,13 +243,23 @@ ORDER BY n DESC;
 -- 5. Per-platform crons — one per platform, individually toggleable via
 --    cron_policy.enabled. SEEDED DISABLED. Staggered 30-min metronome.
 -- ─────────────────────────────────────────────────────────────────────────────
-INSERT INTO public.cron_policy (jobname, enabled, notes) VALUES
-  ('td_tier_enqueue_sh',  false, 'Tiered per-platform enqueue (SH). Toggle to enable. 2026-06-09.'),
-  ('td_tier_enqueue_vd',  false, 'Tiered per-platform enqueue (VD). Toggle to enable. 2026-06-09.'),
-  ('td_tier_enqueue_tm',  false, 'Tiered per-platform enqueue (TM). Toggle to enable. 2026-06-09.'),
-  ('td_tier_enqueue_gt',  false, 'Tiered per-platform enqueue (GT). Toggle to enable. 2026-06-09.'),
-  ('td_tier_enqueue_tp',  false, 'Tiered per-platform enqueue (TP, ≤5d only). Toggle to enable. 2026-06-09.'),
-  ('td_tier_enqueue_axs', false, 'Tiered per-platform enqueue (AXS). Keep OFF until TicketsData ships AXS. 2026-06-09.')
+-- cron_policy requires peak_hours_et / peak_min_interval_min / offpeak_min_interval_min
+-- (all NOT NULL). cron_should_fire uses them as a JOB-LEVEL gate (ET hours + min
+-- interval since last fire, tracked in cron_gate_decisions). We make it a LIGHT gate
+-- — all hours "peak", 15-min interval (< the 30-min pg_cron cadence so it always
+-- passes) — because the real per-event tier cadence + per-event-local peak/off-peak
+-- live in td_poll_policy + td_tier_enqueue, not here.
+INSERT INTO public.cron_policy
+  (jobname, peak_hours_et, peak_min_interval_min, offpeak_min_interval_min, enabled, notes)
+SELECT j.jobname, ARRAY(SELECT generate_series(0,23)), 15, 15, false, j.notes
+FROM (VALUES
+  ('td_tier_enqueue_sh',  'Tiered per-platform enqueue (SH). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_vd',  'Tiered per-platform enqueue (VD). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_tm',  'Tiered per-platform enqueue (TM). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_gt',  'Tiered per-platform enqueue (GT). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_tp',  'Tiered per-platform enqueue (TP, ≤5d only). Toggle to enable. 2026-06-09.'),
+  ('td_tier_enqueue_axs', 'Tiered per-platform enqueue (AXS). Keep OFF until TicketsData ships AXS. 2026-06-09.')
+) AS j(jobname, notes)
 ON CONFLICT (jobname) DO NOTHING;
 
 -- Retire the old flat enqueue crons to prevent double-enqueue (operator enables

--- a/supabase/migrations/20260609160000_td_seed_owned_xref.sql
+++ b/supabase/migrations/20260609160000_td_seed_owned_xref.sql
@@ -38,14 +38,20 @@ SET search_path TO 'public', 'pg_temp'
 AS $fn$
 BEGIN
   -- Candidate owned events (highest-value first), expanded to SH + VD rows.
+  -- event_metrics is a time-series (PK event_id, captured_at) — take the LATEST
+  -- row per event via LATERAL so the owned filter + value are current, not summed.
   CREATE TEMP TABLE _seed ON COMMIT DROP AS
   WITH owned AS (
-    SELECT a.aq_short_event_id, a.tevo_event_id, a.sg_event_id,
-           a.sh_event_id, a.vivid_event_id,
+    SELECT a.aq_short_event_id, a.sh_event_id, a.vivid_event_id,
            m.owned_tickets_count, m.owned_median_retail
     FROM public.aq_event_map a
-    JOIN public.event_metrics m
-      ON m.event_id = a.tevo_event_id AND m.owned_tickets_count > 0
+    JOIN LATERAL (
+      SELECT em.owned_tickets_count, em.owned_median_retail
+      FROM public.event_metrics em
+      WHERE em.event_id = a.tevo_event_id
+      ORDER BY em.captured_at DESC
+      LIMIT 1
+    ) m ON m.owned_tickets_count > 0
     WHERE a.tevo_event_id IS NOT NULL
       AND a.event_date >= now()
       AND (a.sh_event_id IS NOT NULL OR a.vivid_event_id IS NOT NULL)
@@ -54,22 +60,21 @@ BEGIN
   )
   SELECT o.sh_event_id AS event_id, 'SH'::text AS platform,
          'https://www.stubhub.com/x/event/' || o.sh_event_id || '/' AS event_url,
-         o.aq_short_event_id, o.tevo_event_id, o.sg_event_id,
-         o.owned_tickets_count, o.owned_median_retail
+         o.aq_short_event_id, o.owned_tickets_count, o.owned_median_retail
   FROM owned o WHERE o.sh_event_id IS NOT NULL
   UNION ALL
   SELECT o.vivid_event_id, 'VD',
          'https://www.vividseats.com/production/' || o.vivid_event_id,
-         o.aq_short_event_id, o.tevo_event_id, o.sg_event_id,
-         o.owned_tickets_count, o.owned_median_retail
+         o.aq_short_event_id, o.owned_tickets_count, o.owned_median_retail
   FROM owned o WHERE o.vivid_event_id IS NOT NULL;
 
   IF p_apply THEN
+    -- xref links to the canonical event via aq_short_event_id (no tevo/sg column).
     INSERT INTO public.ticketsdata_event_xref
-      (event_id, platform, aq_short_event_id, event_url, tevo_event_id, sg_event_id,
+      (event_id, platform, aq_short_event_id, event_url,
        owned_tickets, median_retail_price, active, match_method, meta)
     SELECT s.event_id, s.platform, s.aq_short_event_id, s.event_url,
-           s.tevo_event_id, s.sg_event_id, s.owned_tickets_count, s.owned_median_retail,
+           s.owned_tickets_count, s.owned_median_retail,
            true, 'manual',
            jsonb_build_object('seed','owned_xref','seeded_at', now())
     FROM _seed s

--- a/supabase/migrations/20260609160000_td_seed_owned_xref.sql
+++ b/supabase/migrations/20260609160000_td_seed_owned_xref.sql
@@ -1,0 +1,102 @@
+-- Migration 20260609160000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): td_seed_owned_xref() ·
+--   reads: aq_event_map, event_metrics ·
+--   writes on run (p_apply=true): ticketsdata_event_xref (insert owned watchlist) ·
+--   spends: nothing directly (enqueue/fetch happens via the tier crons) ·
+--   pre: 20260527050000 (xref), 20260609150000 (tier crons)
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1). Validate on a
+--    Supabase branch first. The function itself DEFAULTS TO DRY-RUN.
+--
+-- WHAT ───────────────────────────────────────────────────────────────────────
+-- Onboarding seed: bulk-add the EVO owned-ticket book (event_metrics
+-- owned_tickets_count > 0, upcoming, mapped in aq_event_map) onto the TicketsData
+-- watchlist (ticketsdata_event_xref) so the per-platform tier crons can poll it.
+--
+-- Seeds StubHub + VividSeats only — their /fetch URLs are CONSTRUCTIBLE from the
+-- aq platform ids (verified live 2026-06-09: constructed URLs returned full
+-- inventory, e.g. Dream@Sky SH 1,642 listings / VD 201):
+--     SH  → https://www.stubhub.com/x/event/{sh_event_id}/
+--     VD  → https://www.vividseats.com/production/{vivid_event_id}
+-- GT (internal hex id) and TM (hex id + slug) are NOT constructible from the
+-- numeric ids, so those platforms are left to /events discovery (Workstream B),
+-- not this seed. SH+VD are the universal base of every tier anyway.
+--
+-- DRY-RUN by default. p_limit ranks by owned_tickets_count DESC so a small run
+-- onboards the highest-value owned events first. ON CONFLICT DO NOTHING — never
+-- clobbers an existing xref row (e.g. one already discovered with a real URL).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.td_seed_owned_xref(
+  p_limit integer DEFAULT 100,
+  p_apply boolean DEFAULT false
+)
+RETURNS TABLE (action text, platform text, n bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+BEGIN
+  -- Candidate owned events (highest-value first), expanded to SH + VD rows.
+  CREATE TEMP TABLE _seed ON COMMIT DROP AS
+  WITH owned AS (
+    SELECT a.aq_short_event_id, a.tevo_event_id, a.sg_event_id,
+           a.sh_event_id, a.vivid_event_id,
+           m.owned_tickets_count, m.owned_median_retail
+    FROM public.aq_event_map a
+    JOIN public.event_metrics m
+      ON m.event_id = a.tevo_event_id AND m.owned_tickets_count > 0
+    WHERE a.tevo_event_id IS NOT NULL
+      AND a.event_date >= now()
+      AND (a.sh_event_id IS NOT NULL OR a.vivid_event_id IS NOT NULL)
+    ORDER BY m.owned_tickets_count DESC NULLS LAST
+    LIMIT GREATEST(p_limit, 0)
+  )
+  SELECT o.sh_event_id AS event_id, 'SH'::text AS platform,
+         'https://www.stubhub.com/x/event/' || o.sh_event_id || '/' AS event_url,
+         o.aq_short_event_id, o.tevo_event_id, o.sg_event_id,
+         o.owned_tickets_count, o.owned_median_retail
+  FROM owned o WHERE o.sh_event_id IS NOT NULL
+  UNION ALL
+  SELECT o.vivid_event_id, 'VD',
+         'https://www.vividseats.com/production/' || o.vivid_event_id,
+         o.aq_short_event_id, o.tevo_event_id, o.sg_event_id,
+         o.owned_tickets_count, o.owned_median_retail
+  FROM owned o WHERE o.vivid_event_id IS NOT NULL;
+
+  IF p_apply THEN
+    INSERT INTO public.ticketsdata_event_xref
+      (event_id, platform, aq_short_event_id, event_url, tevo_event_id, sg_event_id,
+       owned_tickets, median_retail_price, active, match_method, meta)
+    SELECT s.event_id, s.platform, s.aq_short_event_id, s.event_url,
+           s.tevo_event_id, s.sg_event_id, s.owned_tickets_count, s.owned_median_retail,
+           true, 'manual',
+           jsonb_build_object('seed','owned_xref','seeded_at', now())
+    FROM _seed s
+    ON CONFLICT (event_id, platform) DO NOTHING;
+
+    RETURN QUERY
+      SELECT 'inserted'::text, x.platform, count(*)
+      FROM public.ticketsdata_event_xref x
+      WHERE x.match_method = 'manual'
+        AND x.meta->>'seed' = 'owned_xref'
+        AND x.created_at > now() - interval '1 minute'
+      GROUP BY x.platform;
+  ELSE
+    -- Dry-run: what WOULD be newly inserted (excludes rows already present).
+    RETURN QUERY
+      SELECT 'would_insert'::text, s.platform, count(*)
+      FROM _seed s
+      WHERE NOT EXISTS (
+        SELECT 1 FROM public.ticketsdata_event_xref x
+        WHERE x.event_id = s.event_id AND x.platform = s.platform)
+      GROUP BY s.platform;
+  END IF;
+END $fn$;
+REVOKE ALL ON FUNCTION public.td_seed_owned_xref(integer,boolean) FROM anon, public;
+
+-- ── Operator runbook ─────────────────────────────────────────────────────────
+--   Preview top-50 owned events (no writes):  SELECT * FROM public.td_seed_owned_xref(50, false);
+--   Onboard a small sample:                   SELECT * FROM public.td_seed_owned_xref(20, true);
+--   Onboard the full owned book incrementally: SELECT * FROM public.td_seed_owned_xref(2200, true);
+--   Then enable per-platform polling:         UPDATE public.cron_policy SET enabled=true WHERE jobname IN ('td_tier_enqueue_sh','td_tier_enqueue_vd');


### PR DESCRIPTION
Six author-only migrations + a frontend tweak, building out the TicketsData integration for the live 250k plan. All pending **A1 review + operator apply** (CLAUDE.md §1); read-only-upstream honored (all `net.http_get`).

| # | File | What |
|---|---|---|
| A | `20260609120000_td_match_aq_enrichment.sql` | `/match` → `aq_event_map` fill + conflict adjudication (staging, dry-run) |
| B | `20260609130000_td_events_discovery_search.sql` + `nav.js` | `/events` → discovery + `terminal_search` v2 `marketplace` section |
| C | `20260609140000_td_budget_caps_raise_250k_plan.sql` | Budget caps for the live 250k plan (300→6k/day, 9k→180k/mo) |
| D | `20260609150000_td_tier_polling_crons_failures.sql` | Per-platform tiered polling crons (toggleable) + failure tracking |
| E | `20260609160000_td_seed_owned_xref.sql` | **Onboard the EVO owned book (2,108 events) to the watchlist** |

### E — onboarding seed (this update)
`td_seed_owned_xref(p_limit, p_apply)` bulk-seeds the EVO owned-ticket book (`event_metrics.owned_tickets_count > 0`, upcoming, aq-mapped) into `ticketsdata_event_xref` so the tier crons have events to poll — closing the gap from ~164 tracked to the ~2,108 owned book.
- Seeds **SH + VD**, whose `/fetch` URLs are **constructible from the aq ids** — `stubhub.com/x/event/{id}/` and `vividseats.com/production/{id}`. GT/TM ids aren't constructible → left to `/events` discovery.
- **DRY-RUN default**; ranks by `owned_tickets_count` DESC (highest value first); `ON CONFLICT DO NOTHING`.

### ✅ Live test (sample of 3 owned events, constructed URLs)
Fired real `/fetch` on 3 owned games × SH+VD — **6/6 returned full inventory**:
| Event | SH | VD |
|---|--:|--:|
| Atlanta Dream @ Chicago Sky | 1,642 | 201 |
| Seattle Mariners @ Baltimore Orioles | 911 | 345 |
| Arizona D-backs @ Miami Marlins | 333 | 240 |

Confirms the seed's URL construction works end-to-end.

### ⚠️ Diagnostic from the test
TicketsData's API `quota_remaining` is **inconsistent across backend nodes mid-rollout** — simultaneous SH=**7.7k** vs VD=**256.9k**. So the vendor's quota field is unreliable as a budget signal; **`td_budget_ok` (recorded credits) is the control to trust** until their meters converge. The per-platform failure/health views in migration D surface exactly this.

### Sizing context (verified live)
- 250k plan live (vendor activation, not our bug). Effective `/fetch` ≈ **1.33× recorded** (baked into the 180k cap). Owned book = **2,108 events**; simulated 3-month usage ramps to a **~160k/mo plateau** (~85% of pool), never breaching budget.

### Validation
libpg_query SQL + plpgsql parse clean (all migrations); `check_readonly` clean; `node --check nav.js` OK; existing TD pytest passes. Live-tested the fetch path on a real sample. **Migrations not DB-applied** (`main` is `MIGRATIONS_FAILED`; preview-branch limit hit) — validate on a Supabase branch before prod apply.

### Suggested apply order
C (caps) → E (seed a sample: `td_seed_owned_xref(20,true)`) → D (enable `td_tier_enqueue_sh`/`_vd`) → scale the seed up → A/B as needed.

https://claude.ai/code/session_012cSUfZfvH4967XsVQydz4t