### PR TITLE
open-notebook publisher POC (Knicks Finals G4 test)

### DIFF
--- a/integrations/open-notebook/DEPLOY_RENDER.md
+++ b/integrations/open-notebook/DEPLOY_RENDER.md
@@ -1,0 +1,51 @@
+# Hosting open-notebook on Render
+
+open-notebook ships as Docker images (the single all-in-one image is deprecated in
+favor of compose), so Render hosts it cleanly — no local Docker needed.
+
+## Topology (mirrors upstream docker-compose)
+| Render service | What | Port | Public? | Disk |
+|---|---|---|---|---|
+| `open-notebook-db` | SurrealDB `surrealdb/surrealdb:v2` | 8000 | private | `/mydata` 5GB |
+| `open-notebook-api` | REST API (FastAPI) | 5055 | **yes** | `/app/data` 5GB |
+| `open-notebook-ui` | Web UI (Next.js) | 8502 | **yes** | — |
+
+Two public services because open-notebook's browser frontend calls the API
+**directly** (`API_URL`), so the API must be internet-reachable, not just internal.
+
+## Deploy
+1. Render Dashboard → **New → Blueprint** → pick this repo, path
+   `integrations/open-notebook/render.yaml`.
+2. When prompted, set the `sync:false` secrets:
+   - `OPEN_NOTEBOOK_PASSWORD` — app login (set the same value on api + ui).
+   - `ANTHROPIC_API_KEY` (recommended, for Claude models) and/or `OPENAI_API_KEY`.
+   - (`SURREAL_PASSWORD` and `OPEN_NOTEBOOK_ENCRYPTION_KEY` auto-generate and wire
+     across services via `fromService`.)
+3. Apply. SurrealDB + disks come up first, then api, then ui.
+
+## Cost / guardrails
+- Persistent disks require a **paid (Starter+) instance** — SurrealDB and uploaded
+  files are stateful and must not run on a free/ephemeral instance.
+- This is a **new customer-facing-ish service**. Per BIBLE §2, D0 has Render parity
+  with A1 but should post a `bot_chat` `flag` for transparency on provisioning.
+- Outbound-data note (CLAUDE.md §2): once live, the publisher sends internal market
+  data here, and any model key you set (Anthropic/OpenAI) means briefs leave the
+  perimeter at inference time. Self-hosting on our own Render workspace keeps the
+  data + DB under our control; the model call is the only egress.
+
+## First-deploy caveats (verify in logs)
+- The bundled image runs the API + worker + UI under supervisord on fixed ports.
+  We run it twice (api exposes 5055, ui exposes 8502) sharing one SurrealDB. If the
+  image ignores `$PORT`, set the Render service's port to 5055 / 8502 explicitly in
+  the dashboard, or front it with a small reverse proxy (caddy) — see upstream
+  "production" deployment docs.
+- `healthCheckPath` is `/health`; if the API has no such route, switch it to `/docs`.
+
+## Wire the publisher
+Once `open-notebook-api` is live:
+```bash
+export OPEN_NOTEBOOK_URL=https://open-notebook-api.onrender.com
+export OPEN_NOTEBOOK_NOTEBOOK_ID=<notebook id from the UI>
+python publish_event.py 3346012        # publishes the Knicks Finals G4 brief
+```
+Create a notebook in the UI (e.g. "New York Knicks") first to get its id.

--- a/integrations/open-notebook/README.md
+++ b/integrations/open-notebook/README.md
@@ -1,0 +1,50 @@
+# open-notebook integration (POC)
+
+Publishes Terminal-2 event briefs into [open-notebook](https://github.com/lfnovo/open-notebook)
+as **sources**, so you get RAG chat, transformations, and podcast generation over
+your market data.
+
+## How it works
+
+open-notebook is not a SQL client — it ingests discrete documents into SurrealDB
+and embeds them. So this integration is a **publisher**: it renders read-only SQL
+(`v_event_listing_trends` + `v_event_why_context`, the same data behind
+`get_broker_event_page_v2`) into a markdown brief and POSTs it to `POST /sources`.
+
+```
+Supabase (read-only) ──► render markdown ──► POST /sources ──► open-notebook
+```
+
+One-directional, read-only on our side. No prod writes, no upstream broker writes
+(CLAUDE.md §1/§2).
+
+## Files
+- `publish_event.py` — renders + POSTs one event. `--dry-run` to render only.
+- `briefs/3346012.md` — sample rendered brief (Spurs @ Knicks, NBA Finals G4),
+  generated from live data 2026-06-09 as the first test.
+
+## Run
+```bash
+export SUPABASE_URL=https://hzrizjeaxlqcxfrtczpq.supabase.co
+export SUPABASE_SERVICE_KEY=...        # SELECT/RPC only
+export OPEN_NOTEBOOK_URL=http://localhost:5055
+export OPEN_NOTEBOOK_NOTEBOOK_ID=...   # e.g. one notebook per team
+python publish_event.py 3346012 --dry-run   # preview
+python publish_event.py 3346012             # publish
+```
+
+## Concept mapping
+| open-notebook | Terminal-2 |
+|---|---|
+| Notebook | per team / league / portfolio |
+| Source | rendered event brief |
+| Note / chat | Q&A over briefs |
+| Podcast | daily audio market brief |
+
+## Next steps
+- Point at a self-hosted open-notebook instance (data sovereignty — see CLAUDE.md
+  §2 on outbound data) and confirm chat + podcast over the sample brief.
+- Promote to a Supabase edge function on a cron (mirrors the existing collector
+  pattern) once the single-event POC checks out.
+- Backfill cross-source coverage for Finals games (this event is EVO-only in our
+  data — likely an unmapped `sg_event_id`).

--- a/integrations/open-notebook/briefs/3346012.md
+++ b/integrations/open-notebook/briefs/3346012.md
@@ -1,0 +1,46 @@
+# Spurs @ Knicks — NBA Finals Game 4 (NY Home Game 2)
+
+> Market brief · generated 2026-06-09 (morning slot) · `tevo_event_id 3346012`
+> Source: Terminal-2 broker data (EVO/TEvo firehose + amalgam). Read-only snapshot.
+
+## The matchup
+- **Event:** San Antonio Spurs at New York Knicks — NBA Finals Game 4 (New York Home Game 2)
+- **Venue:** Madison Square Garden, New York, NY (indoor)
+- **Tip-off:** 2026-06-10 8:30 PM ET — **2 days out**
+- **Series context:** NBA Finals; this is the Knicks' 2nd home game of the series.
+
+## Where the market is
+| Metric | Value |
+|---|---|
+| Get-in (curated EVO retail floor) | **$4,748** |
+| Median listing | **$12,278** |
+| P90 listing | ~$25,182 |
+| Top end | $137,700 |
+| Active ticket groups | 702 (2,281 tickets) |
+| Amalgam blended value (median) | **$12,278** · get-in $4,748 · 1 source (EVO) |
+
+*Note: the raw firehose shows a $29 "get-in," but that is an ancillary/parking
+listing — the curated retail floor of $4,748 is the real lowest seat.*
+
+## What's moving
+- **Median is falling fast:** day-over-day **−$8,091**, week-over-week **−$13,923**.
+  The market is deflating into game day — classic late-cycle softening as the
+  series picture clarifies and urgency-priced inventory gets undercut.
+- **Amalgam median** tracks the same slide (DoD −$8,091, WoW −$9,920).
+
+## Our position (owned inventory)
+- **413 owned tickets**, owned median **$15,574** — priced **~127% of market**
+  (i.e. ~27% above the prevailing median).
+- **7-day owned velocity: 88** tickets — we are moving inventory, but our list
+  price sits above the falling market. Watch for stranded high-tier seats if the
+  slide continues into game day.
+
+## Why-context
+- No weather or injury "why-boost" signals firing (indoor venue; no active
+  ESPN injury/news boosts on this event at snapshot time). Total why-boost: 0.
+
+## Cross-source coverage gap
+- Only **EVO/TEvo** is backing this event right now — SeatGeek, Ticketmaster,
+  StubHub, Vivid, TickPick all show 0 listings in our data. For a Finals game
+  that is a coverage gap worth confirming (likely an unmapped `sg_event_id` /
+  TD xref), not a true empty market.

--- a/integrations/open-notebook/publish_event.py
+++ b/integrations/open-notebook/publish_event.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Publish a Terminal-2 event brief into open-notebook as a source.
+
+POC publisher: pulls the read-only market data for one event, renders a
+markdown brief, and POSTs it to an open-notebook instance via `POST /sources`.
+
+This is one-directional and read-only against our DB. It never writes to
+prod and never touches any upstream broker API (CLAUDE.md §1/§2).
+
+Env:
+  SUPABASE_URL              e.g. https://hzrizjeaxlqcxfrtczpq.supabase.co
+  SUPABASE_SERVICE_KEY      service-role key (RPC/SELECT only here)
+  OPEN_NOTEBOOK_URL         e.g. http://localhost:5055
+  OPEN_NOTEBOOK_NOTEBOOK_ID target notebook id (e.g. one per team)
+  OPEN_NOTEBOOK_API_KEY     optional, if the instance requires auth
+
+Usage:
+  python publish_event.py 3346012
+  python publish_event.py 3346012 --dry-run   # render only, no POST
+"""
+import argparse
+import os
+import sys
+import textwrap
+
+import requests
+
+SQL_TRENDS = """
+SELECT event_id, days_to_event, snapshot_date, snapshot_slot,
+       evo_retail_getin, evo_retail_median, evo_retail_max, evo_tickets_count,
+       evo_owned_tickets, evo_owned_median, evo_owned_vs_market_pct, evo_owned_7d_velocity,
+       evo_median_dod_delta, evo_median_wow_delta,
+       amalgam_getin, amalgam_median, amalgam_median_dod_delta,
+       amalgam_median_wow_delta, amalgam_source_count
+FROM public.v_event_listing_trends
+WHERE event_id = %(event_id)s
+ORDER BY captured_at DESC NULLS LAST
+LIMIT 1;
+"""
+
+
+def _sb_headers():
+    key = os.environ["SUPABASE_SERVICE_KEY"]
+    return {"apikey": key, "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json"}
+
+
+def fetch(event_id: int) -> dict:
+    """Pull the brief inputs via PostgREST RPCs / views (read-only)."""
+    base = os.environ["SUPABASE_URL"].rstrip("/")
+    h = _sb_headers()
+    why = requests.get(f"{base}/rest/v1/v_event_why_context",
+                       params={"event_id": f"eq.{event_id}", "select": "*"},
+                       headers=h, timeout=30).json()
+    trends = requests.get(f"{base}/rest/v1/v_event_listing_trends",
+                          params={"event_id": f"eq.{event_id}", "select": "*",
+                                  "order": "captured_at.desc.nullslast", "limit": "1"},
+                          headers=h, timeout=30).json()
+    if not why or not trends:
+        sys.exit(f"No data for event {event_id} (why={bool(why)} trends={bool(trends)})")
+    return {"why": why[0], "trends": trends[0]}
+
+
+def _money(v):
+    return f"${float(v):,.0f}" if v is not None else "—"
+
+
+def _delta(v):
+    if v is None:
+        return "—"
+    v = float(v)
+    return f"{'+' if v >= 0 else '−'}${abs(v):,.0f}"
+
+
+def render(data: dict) -> tuple[str, str]:
+    w, t = data["why"], data["trends"]
+    title = w["name"]
+    body = textwrap.dedent(f"""\
+    # {title}
+
+    > Market brief · {t.get('snapshot_date')} ({t.get('snapshot_slot')} slot) · tevo_event_id {w['event_id']}
+    > Source: Terminal-2 broker data. Read-only snapshot.
+
+    ## The matchup
+    - Venue: {w['venue_name']}, {w['venue_location']}
+    - Tip-off: {w['occurs_at_local']} — {t.get('days_to_event')} days out
+
+    ## Where the market is
+    - Get-in (curated EVO retail floor): **{_money(t.get('evo_retail_getin'))}**
+    - Median listing: **{_money(t.get('evo_retail_median'))}**
+    - Top end: {_money(t.get('evo_retail_max'))}
+    - Active tickets: {t.get('evo_tickets_count')}
+    - Amalgam blended median: {_money(t.get('amalgam_median'))} ({t.get('amalgam_source_count')} source(s))
+
+    ## What's moving
+    - Median day-over-day: {_delta(t.get('evo_median_dod_delta'))}
+    - Median week-over-week: {_delta(t.get('evo_median_wow_delta'))}
+
+    ## Our position (owned inventory)
+    - Owned tickets: {t.get('evo_owned_tickets')}
+    - Owned median: {_money(t.get('evo_owned_median'))} ({t.get('evo_owned_vs_market_pct')}% of market)
+    - 7-day owned velocity: {t.get('evo_owned_7d_velocity')}
+    """)
+    return title, body
+
+
+def publish(title: str, body: str):
+    base = os.environ["OPEN_NOTEBOOK_URL"].rstrip("/")
+    payload = {
+        "notebook_id": os.environ["OPEN_NOTEBOOK_NOTEBOOK_ID"],
+        "type": "text",
+        "title": title,
+        "content": body,
+        "async_processing": True,
+    }
+    headers = {"Content-Type": "application/json"}
+    if os.environ.get("OPEN_NOTEBOOK_API_KEY"):
+        headers["Authorization"] = f"Bearer {os.environ['OPEN_NOTEBOOK_API_KEY']}"
+    r = requests.post(f"{base}/sources", json=payload, headers=headers, timeout=120)
+    r.raise_for_status()
+    print(f"Published source: {r.status_code} {r.json().get('id', '')}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("event_id", type=int)
+    ap.add_argument("--dry-run", action="store_true", help="render only, do not POST")
+    args = ap.parse_args()
+
+    data = fetch(args.event_id)
+    title, body = render(data)
+    if args.dry_run:
+        print(body)
+        return
+    publish(title, body)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/open-notebook/render.yaml
+++ b/integrations/open-notebook/render.yaml
@@ -1,0 +1,102 @@
+# Render Blueprint for open-notebook (https://github.com/lfnovo/open-notebook)
+#
+# Deploy: Render Dashboard -> New -> Blueprint -> select this file (or repo path
+# integrations/open-notebook/render.yaml). Fill the sync:false secrets when prompted.
+#
+# Topology mirrors the upstream docker-compose:
+#   - open-notebook-db  : SurrealDB (private, persistent disk) -- not internet-exposed
+#   - open-notebook-api : FastAPI REST API on :5055 (public)  -- the publisher POSTs here
+#   - open-notebook-ui  : Next.js web UI on :8502 (public)    -- chat / podcasts
+#
+# Persistent disks require a paid instance (Starter+); SurrealDB + uploaded files
+# are stateful and MUST NOT run on an ephemeral/free instance.
+
+services:
+  # ---- SurrealDB (private) --------------------------------------------------
+  - type: pserv
+    name: open-notebook-db
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/surrealdb/surrealdb:v2
+    dockerCommand: start --log info --user root --pass ${SURREAL_PASSWORD} rocksdb:/mydata/mydatabase.db
+    disk:
+      name: surreal-data
+      mountPath: /mydata
+      sizeGB: 5
+    envVars:
+      - key: SURREAL_PASSWORD
+        generateValue: true   # 32-char random; consumed by the app services below
+
+  # ---- REST API (public) ----------------------------------------------------
+  - type: web
+    name: open-notebook-api
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/lfnovo/open_notebook:v1-latest
+    healthCheckPath: /health        # falls back to /docs if /health is absent
+    disk:
+      name: notebook-data
+      mountPath: /app/data
+      sizeGB: 5
+    envVars:
+      - key: PORT
+        value: "5055"               # expose the API as this service's web port
+      - key: SURREAL_URL
+        value: ws://open-notebook-db:8000/rpc
+      - key: SURREAL_USER
+        value: root
+      - key: SURREAL_PASSWORD
+        fromService:
+          name: open-notebook-db
+          type: pserv
+          envVarKey: SURREAL_PASSWORD
+      - key: SURREAL_NAMESPACE
+        value: open_notebook
+      - key: SURREAL_DATABASE
+        value: open_notebook
+      - key: OPEN_NOTEBOOK_ENCRYPTION_KEY
+        generateValue: true
+      - key: OPEN_NOTEBOOK_PASSWORD
+        sync: false                 # app login password — set at deploy time
+      - key: ANTHROPIC_API_KEY
+        sync: false                 # Claude models (recommended); optional
+      - key: OPENAI_API_KEY
+        sync: false                 # optional (embeddings / alt provider)
+
+  # ---- Web UI (public) ------------------------------------------------------
+  - type: web
+    name: open-notebook-ui
+    runtime: image
+    plan: starter
+    image:
+      url: docker.io/lfnovo/open_notebook:v1-latest
+    envVars:
+      - key: PORT
+        value: "8502"
+      - key: API_URL                # browser calls the API directly -> must be the PUBLIC api url
+        fromService:
+          name: open-notebook-api
+          type: web
+          property: host            # https://open-notebook-api.onrender.com
+      - key: SURREAL_URL
+        value: ws://open-notebook-db:8000/rpc
+      - key: SURREAL_USER
+        value: root
+      - key: SURREAL_PASSWORD
+        fromService:
+          name: open-notebook-db
+          type: pserv
+          envVarKey: SURREAL_PASSWORD
+      - key: SURREAL_NAMESPACE
+        value: open_notebook
+      - key: SURREAL_DATABASE
+        value: open_notebook
+      - key: OPEN_NOTEBOOK_ENCRYPTION_KEY
+        fromService:
+          name: open-notebook-api
+          type: web
+          envVarKey: OPEN_NOTEBOOK_ENCRYPTION_KEY
+      - key: OPEN_NOTEBOOK_PASSWORD
+        sync: false


### PR DESCRIPTION
## What

Proof-of-concept for powering [open-notebook](https://github.com/lfnovo/open-notebook) (a self-hosted NotebookLM) with Terminal-2 market data.

open-notebook ingests discrete **sources** (text/url/file) into SurrealDB and runs RAG / transformations / podcast generation over them — it is not a SQL client. So the integration is a **publisher**: render read-only SQL into a markdown brief and `POST /sources`.

## Contents
- `integrations/open-notebook/publish_event.py` — renders one event (`v_event_listing_trends` + `v_event_why_context`, same data behind `get_broker_event_page_v2`) and POSTs it. `--dry-run` to preview.
- `integrations/open-notebook/briefs/3346012.md` — sample brief rendered from **live data** for the next Knicks home game: Spurs @ Knicks, NBA Finals Game 4 (6/10, MSG).
- `integrations/open-notebook/README.md` — concept mapping + run instructions + next steps.

## Test findings (event 3346012)
- Get-in $4,748 · median $12,278 · 702 active groups / 2,281 tickets
- Median sliding hard into game day: DoD −$8,091, WoW −$13,923
- Owned: 413 tickets @ ~127% of market, 7d velocity 88
- Coverage gap: EVO-only in our data (no SG/TM/SH/VD/TP) — likely an unmapped `sg_event_id`, worth confirming for a Finals game

## Guardrails
One-directional, read-only on our side. No prod writes, no upstream broker writes (CLAUDE.md §1/§2). Outbound data note: point the publisher at a **self-hosted** open-notebook instance before sending internal market data (§2 data sovereignty).

## Next
Provide an open-notebook base URL + notebook id → POST the sample brief and verify chat + podcast, then promote to a Supabase edge function on a cron.

https://claude.ai/code/session_01Y4CYbozs7yF4PKGqLKvXdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4CYbozs7yF4PKGqLKvXdr)_