### PR TITLE
fix(terminal): freeze event chart 2h after start (stop post-event axis drift)

### DIFF
--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -830,7 +830,17 @@
   function clipRangeForHours(hours, xs) {
     if (!xs || !xs.length) return undefined;
     const nowSec = Math.floor(Date.now() / 1000);
-    const reqMin = nowSec - hours * 3600;
+    // Freeze 2h after the event starts: once a game/show is underway the market
+    // is settled, so the live "now" should stop dragging the axis rightward.
+    // Past the freeze point the whole window anchors to it (left edge included)
+    // so the chart becomes STATIC instead of scrolling into empty post-event
+    // space. Pre-freeze (future event, or first 2h after start) liveEdge === now,
+    // so behaviour is unchanged. No event start → never freeze.
+    const freezeSec = isFinite(_eventStartMs)
+      ? Math.floor(_eventStartMs / 1000) + 2 * 3600
+      : Infinity;
+    const liveEdge = Math.min(nowSec, freezeSec);
+    const reqMin = liveEdge - hours * 3600;
     const dataMin = xs[0];                 // xs is chronological (buildSeriesData sorts)
     const dataMax = xs[xs.length - 1];
     // Fit-to-history (UI rebuild 2026-06-03): when the window is WIDER than the
@@ -839,9 +849,10 @@
     // gutter with the data crammed at the right. When we have MORE history than
     // the window (short ranges), reqMin wins and the window is honored as before.
     const minSec = Math.max(reqMin, dataMin);
-    // Right edge: max(now, dataMax) so a future-dated event still shows its
-    // most recent snapshot inside the window.
-    return [minSec, Math.max(nowSec, dataMax)];
+    // Right edge: max(liveEdge, dataMax) so a future-dated event still shows its
+    // most recent snapshot — but never past the freeze point, so any stray
+    // post-event snapshot can't un-freeze the axis.
+    return [minSec, Math.max(liveEdge, Math.min(dataMax, freezeSec))];
   }
 
   // ---------- PRICE CHART ----------


### PR DESCRIPTION
## What

Fixes a bug on the event-detail composite **CROSS-SOURCE CHART · PRICE · INVENTORY · SALES** chart: it kept **moving after the event ended**. The chart should become **static 2 hours after the event start**.

## Root cause

`clipRangeForHours()` (`static/terminal/event.js`) computed the x-axis right edge as `max(now, dataMax)`. Because it tracked `Date.now()`, the live "now" kept dragging the time axis rightward indefinitely — so long after the event was over the chart scrolled on into empty post-event space on every realtime re-render.

## Fix

`clipRangeForHours` now anchors the window to a **freeze point = `event_start + 2h`**:

- `liveEdge = min(now, freezeSec)` — once the event is underway the axis stops following `now`, so **both** edges of the window anchor to the freeze point and the chart goes static.
- Right edge is additionally capped at the freeze point (`min(dataMax, freezeSec)`) so a stray post-event snapshot can't un-freeze the axis.
- **Pre-freeze behaviour is unchanged**: for future-dated events, or during the first 2h after start, `liveEdge === now`, so the existing live-tracking is preserved.
- Events with no known start (`_eventStartMs` NaN) → `freezeSec = Infinity` → never freeze (safe fallback).

`clipRangeForHours` is shared by both the **price** pane and the **inventory & sales** pane, so the whole composite chart freezes together.

## Scope / safety

- D0 terminal-FE lane only — single function in `static/terminal/event.js`. No backend, no data, no upstream-API changes (CLAUDE.md §1/§2 untouched).
- `node -c` parses clean.

## Verification suggestion

Open an event whose start was >2h ago and watch the chart over a realtime refresh cycle: the right edge should hold at `start + 2h` instead of advancing. A future event (or one started <2h ago) should still track live.

https://claude.ai/code/session_01PEza9YHL1McrMjy1a4ATG1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEza9YHL1McrMjy1a4ATG1)_