### PR TITLE
fix(ticketsdata): live-deploy fixes (overload, terminal_search, seed, drain throughput)

### DIFF
--- a/supabase/migrations/20260609120000_td_match_aq_enrichment.sql
+++ b/supabase/migrations/20260609120000_td_match_aq_enrichment.sql
@@ -52,6 +52,10 @@ COMMENT ON COLUMN public.ticketsdata_credit_usage.reports IS
 COMMENT ON COLUMN public.ticketsdata_credit_usage.reports_remaining IS
   'reports_remaining from the /match response envelope (plan-wide, not just this pipeline).';
 
+-- Drop the prior 6-arg overload FIRST — adding params via CREATE OR REPLACE makes
+-- a NEW overload (different signature), leaving the old one to make 6-arg calls
+-- (td_normalize_drain etc.) ambiguous. The 8-arg version is call-compatible.
+DROP FUNCTION IF EXISTS public.td_charge_credit(integer, bigint, text, text, integer, integer);
 CREATE OR REPLACE FUNCTION public.td_charge_credit(
   p_n               integer DEFAULT 1,
   p_event_id        bigint  DEFAULT NULL,

--- a/supabase/migrations/20260609130000_td_events_discovery_search.sql
+++ b/supabase/migrations/20260609130000_td_events_discovery_search.sql
@@ -289,7 +289,7 @@ BEGIN
            ) AS rn
     FROM public.td_discovered_events d
     JOIN public.events e
-      ON e.occurs_at_local::date = d.event_date
+      ON (left(e.occurs_at_local,10))::date = d.event_date   -- occurs_at_local is text
     WHERE d.matched_tevo_event_id IS NULL
       AND d.event_date IS NOT NULL
       AND d.venue_name IS NOT NULL
@@ -359,7 +359,9 @@ BEGIN
            primary_performer_name, length(name) AS match_len
     FROM public.events
     WHERE name ILIKE v_pat
-      AND occurs_at_local >= now() - interval '6 hours'
+      -- occurs_at_local is TEXT (ISO8601 w/ offset); text>=timestamptz errors, so
+      -- compare as a string against the formatted cutoff (fixes latent v1 bug).
+      AND occurs_at_local >= to_char(now() - interval '6 hours', 'YYYY-MM-DD"T"HH24:MI:SS')
       AND coalesce(state, '') <> 'past'
     ORDER BY length(name) ASC, occurs_at_local ASC
     LIMIT v_cap

--- a/supabase/migrations/20260609160000_td_seed_owned_xref.sql
+++ b/supabase/migrations/20260609160000_td_seed_owned_xref.sql
@@ -36,6 +36,7 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path TO 'public', 'pg_temp'
 AS $fn$
+#variable_conflict use_column
 BEGIN
   -- Candidate owned events (highest-value first), expanded to SH + VD rows.
   -- event_metrics is a time-series (PK event_id, captured_at) — take the LATEST

--- a/supabase/migrations/20260609170000_td_pull_drain_throughput.sql
+++ b/supabase/migrations/20260609170000_td_pull_drain_throughput.sql
@@ -1,0 +1,16 @@
+-- Migration 20260609170000 · lane:D0 (author) → A1 (apply) ·
+--   writes: reschedules the existing td_pull_drain pg_cron job ·
+--   pre: 20260609150000 (tier crons)
+--
+-- ## APPLIED to prod 2026-06-09 (operator-authorized activation).
+--
+-- WHY ───────────────────────────────────────────────────────────────────────
+-- td_pull_drain fired only p_max=1 request/minute (~1,440/day) — fine for the old
+-- ~300/day flat regime, but the tiered owned-book design targets ~5k/day. Raise
+-- to 5/minute (~7,200/day capacity). Actual spend stays bounded by td_budget_ok
+-- (6,000/day recorded) at the ENQUEUE side, so 5/min just lets the queue drain at
+-- the budgeted rate instead of bottlenecking. TicketsData concurrency guidance is
+-- 5–15 simultaneous; 5/min keeps in-flight count low. Reversible: set back to (1).
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT cron.schedule('td_pull_drain', '* * * * *',
+  $$DO $body$ BEGIN PERFORM public.td_pull_drain(5); END $body$;$$);


### PR DESCRIPTION
Applied PR #510's migrations to prod and activated the TicketsData owned-book pipeline. Driving it end-to-end surfaced three runtime issues (invisible to parse/schema audit) — all fixed live and synced here so `main` matches prod.

## Fixes
1. **`td_charge_credit` overload ambiguity** (A) — adding params via `CREATE OR REPLACE` made a *new* 8-arg overload, leaving the 6-arg one, so every existing 6-arg call (`td_normalize_drain`) became `function is not unique` and failed. Drop the old 6-arg overload (8-arg is call-compatible). *This was silently failing all fetch normalization.*
2. **`terminal_search` latent bug** (B) — `occurs_at_local` is TEXT; `text >= timestamptz` errors, so the deployed v1 raised on **every** call. Now compares as a formatted string (also fixed `occurs_at_local::date` → `left(...,10)::date` in `td_match_discovered_to_local`).
3. **`td_seed_owned_xref`** (E) — `ON CONFLICT (event_id, platform)` collided with the OUT column `platform` → `#variable_conflict use_column`.
4. **`td_pull_drain` throughput** (new `20260609170000`) — raised 1→5/min (~1.4k→7.2k/day capacity) so the tiered design can reach cadence; spend still budget-gated at enqueue.

## Live activation state (prod)
- 5 migrations applied; **552 owned rows seeded** (SH+VD from constructed aq URLs).
- Tiered crons enabled (SH/VD/GT/TM/TP; AXS off); **722 events enqueued by tier** (hot/warm/cool/cold).
- Pipeline verified flowing: **14,886 listings landed across 15 events**, credits charging, **per-platform failure/health views populating**, budget gate holding (6k/day).
- Backlog draining ~5/min; steady-state thereafter.

https://claude.ai/code/session_012cSUfZfvH4967XsVQydz4t

---
_Generated by [Claude Code](https://claude.ai/code/session_012cSUfZfvH4967XsVQydz4t)_