### PR TITLE
fix(security): 2026-06-10 audit remediations — RULE 2 mechanical enforcement + app/FE hardening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,12 @@ jobs:
           # Tolerate missing requirements.txt early in repo lifecycle.
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
+      - name: RULE 2 read-only static audit
+        # Standalone invocation so the audit survives even if the pytest case
+        # that shells out to it (test_readonly_guards.py) is ever skipped or
+        # deleted. CLAUDE.md §2: this gate is mandatory, no bypass.
+        run: python scripts/check_readonly.py
+
       - name: Run pytest
         env:
           AUTH_DISABLED: "true"

--- a/app.py
+++ b/app.py
@@ -435,6 +435,13 @@ def require_auth(authorization: str | None = Header(None)):
     if not r.ok:
         raise HTTPException(401, "invalid session")
     user = r.json()
+    # Stop-gap hardening, mirrors d2_dashboard/main.py require_auth:
+    #   - aud must be "authenticated"  → rejects service-role / anon tokens
+    #   - email_confirmed_at must be set → rejects unconfirmed signups
+    if user.get("aud") != "authenticated":
+        raise HTTPException(401, "invalid token audience")
+    if not user.get("email_confirmed_at"):
+        raise HTTPException(403, "email not confirmed")
     email = (user.get("email") or "").lower()
     if not email.endswith("@" + ALLOWED_EMAIL_DOMAIN.lower()):
         raise HTTPException(403, f"access restricted to @{ALLOWED_EMAIL_DOMAIN}")
@@ -597,10 +604,13 @@ class _RateLimitMiddleware(BaseHTTPMiddleware):
         # rate cap. (/health never existed as a route — A1-OPS-5.)
         if request.method == "OPTIONS" or path in ("/", "/healthz"):
             return await call_next(request)
-        # Trust X-Forwarded-For when present (Railway sets it). Fall back to
-        # request.client. First entry of XFF is the original client.
+        # Trust X-Forwarded-For when present (Render/Railway set it). Fall back
+        # to request.client. Use the RIGHTMOST entry: that's the hop appended
+        # by our own edge proxy and is the only one a client can't forge. The
+        # leftmost entry is client-supplied — keying on it let a single client
+        # rotate fake IPs and bypass every per-IP bucket (audit 2026-06-10).
         xff = request.headers.get("x-forwarded-for") or ""
-        ip = (xff.split(",")[0].strip() if xff else (request.client.host if request.client else "unknown")) or "unknown"
+        ip = (xff.split(",")[-1].strip() if xff else (request.client.host if request.client else "unknown")) or "unknown"
         n, w = self._bucket(path)
         # Key is ip + bucket-prefix, NOT the full path. Using the raw path lets
         # a bot cycle resource IDs (e.g. /api/store/events/1, /2, …) to get a

--- a/d2_dashboard/main.py
+++ b/d2_dashboard/main.py
@@ -165,7 +165,11 @@ app.add_middleware(
         "https://vibepass-terminal-test.onrender.com",  # if D0 terminal also fetches /api/d2/*
         "https://d2-orders-dashboard.onrender.com",      # same-origin is fine without CORS, but listing keeps the matrix explicit
     ],
-    allow_origin_regex=r"https?://localhost(:\d+)?",
+    # Localhost origins are a dev convenience only — on a production deploy a
+    # credentialed allow-any-localhost-port grant is broader than needed
+    # (audit 2026-06-10). _is_production() is the same detector the
+    # AUTH_DISABLED kill switch uses.
+    allow_origin_regex=(None if _is_production() else r"https?://localhost(:\d+)?"),
     allow_credentials=True,
     allow_methods=["GET", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type"],

--- a/d4_bridge/server.ts
+++ b/d4_bridge/server.ts
@@ -188,13 +188,23 @@ async function startServer() {
     res.status(200).json({ status: "ok", uptime: process.uptime() });
   });
 
+  // Canonical public base URL for crawler-facing absolute links. Pinned to
+  // VITE_APP_URL (same env Stripe redirect URLs use) so a forged Host /
+  // X-Forwarded-Proto header can't poison robots.txt or the cached sitemap.
+  // Request-header fallback is dev-only convenience when the env is unset.
+  const publicBase = (req: express.Request): string => {
+    const configured = (process.env.VITE_APP_URL || '').replace(/\/$/, '');
+    if (configured) return configured;
+    const host = req.get('host') || 'localhost';
+    const proto = (req.get('x-forwarded-proto') || req.protocol || 'https') as string;
+    return `${proto}://${host}`;
+  };
+
   // -- robots.txt -----------------------------------------------------------
   // Allow indexing of public surfaces, deny embed routes (those are
   // for iframe consumption, not for crawler ingestion). Points at the
   // sitemap so Googlebot finds the full event list.
   app.get('/robots.txt', (req, res) => {
-    const host = req.get('host') || 'localhost';
-    const proto = (req.get('x-forwarded-proto') || req.protocol || 'https') as string;
     res.type('text/plain').send(
       [
         'User-agent: *',
@@ -207,7 +217,7 @@ async function startServer() {
         'Disallow: /checkin/',
         'Disallow: /onboarding',
         '',
-        `Sitemap: ${proto}://${host}/sitemap.xml`,
+        `Sitemap: ${publicBase(req)}/sitemap.xml`,
         '',
       ].join('\n'),
     );
@@ -245,9 +255,7 @@ async function startServer() {
         sb.from('exos_public_orgs').select('slug').limit(500),
       ]);
 
-      const host = req.get('host') || 'localhost';
-      const proto = (req.get('x-forwarded-proto') || req.protocol || 'https') as string;
-      const base = `${proto}://${host}`;
+      const base = publicBase(req);
       const urls: string[] = [
         `<url><loc>${base}/</loc><changefreq>daily</changefreq><priority>1.0</priority></url>`,
       ];

--- a/scripts/check_readonly.py
+++ b/scripts/check_readonly.py
@@ -53,6 +53,11 @@ FORBIDDEN_HOSTS = (
     "ticketsdata.com",
     "www.broadway.com",
     "checkout.broadway.com",
+    # AXS has order/hold endpoints that must never be touched. All sanctioned
+    # AXS traffic proxies through ticketsdata.com (covered above); a direct
+    # call to axs.com is forbidden outright. Bare "axs.com" substring-matches
+    # www.axs.com / api.axs.com / any future subdomain.
+    "axs.com",
 )
 
 # Client modules that legitimately reference these hosts, mapped to the HTTP
@@ -96,6 +101,11 @@ PY_FORBIDDEN_PATTERNS = (
     re.compile(r"\.session\.\s*(post|put|patch|delete)\s*\("),
     re.compile(r"http\.\s*(post|put|patch|delete)\s*\("),
     re.compile(r"httpx\.\s*(post|put|patch|delete)\s*\("),
+    # method-as-string variants: session.request("POST", ...), requests.request('PUT', ...)
+    re.compile(r"""\.request\s*\(\s*['"](?:POST|PUT|PATCH|DELETE)['"]""", re.IGNORECASE),
+    re.compile(r"""requests\.request\s*\(\s*['"](?:POST|PUT|PATCH|DELETE)['"]""", re.IGNORECASE),
+    # urllib.request.urlopen(..., data=...) silently becomes a POST
+    re.compile(r"urlopen\s*\([^)]*\bdata\s*="),
 )
 
 # Patterns that signal a write attempt in TS/JS edge functions.
@@ -195,7 +205,8 @@ def check_ts_writes() -> list[str]:
     targets a forbidden host either by literal URL or by a variable that
     resolves to one."""
     violations: list[str] = []
-    for f in _walk((".ts", ".js", ".tsx", ".jsx")):
+    # .html covers inline <script> blocks; .mjs/.cjs cover module/CommonJS JS.
+    for f in _walk((".ts", ".js", ".tsx", ".jsx", ".mjs", ".cjs", ".html")):
         text = f.read_text(encoding="utf-8", errors="ignore")
         host_vars = _ts_forbidden_host_vars(text)
         for m in TS_FORBIDDEN_PATTERN.finditer(text):
@@ -206,7 +217,20 @@ def check_ts_writes() -> list[str]:
             # 'fetch(' and the next ',' or method keyword.
             i = preceding.rfind("fetch(")
             if i == -1:
-                # No fetch() context — skip (probably XHR or something else).
+                # No fetch() context — axios/XHR/got-style call. We can't parse
+                # the URL arg structurally, so fall back to a proximity check:
+                # flag if a forbidden host (or a var bound to one) appears in
+                # the surrounding window.
+                window = text[max(0, m.start() - 800) : min(len(text), m.end() + 400)]
+                hits = [h for h in FORBIDDEN_HOSTS if h in window]
+                var_hits = [n for n in host_vars if re.search(rf"\b{re.escape(n)}\b", window)]
+                if hits or var_hits:
+                    line_no = text[: m.start()].count("\n") + 1
+                    violations.append(
+                        f"{f.relative_to(ROOT)}:{line_no}: "
+                        f"'{m.group(0)}' (non-fetch HTTP call) near forbidden "
+                        f"host(s) {hits or var_hits}"
+                    )
                 continue
             url_arg_region = preceding[i + len("fetch(") :]
             # Strip leading whitespace / quotes context up to the comma.
@@ -296,7 +320,7 @@ def main() -> int:
     mig_count = len(list((ROOT / "supabase" / "migrations").glob("*.sql"))) if (ROOT / "supabase" / "migrations").exists() else 0
     print("RULE 2 clean — no write paths detected to TEvo, SeatGeek, TickPick, or Vivid Seats hosts.")
     print(f"  - Python files scanned   : {len(_walk(('.py',)))}")
-    print(f"  - TS/JS files scanned    : {len(_walk(('.ts', '.js', '.tsx', '.jsx')))}")
+    print(f"  - TS/JS/HTML files scanned: {len(_walk(('.ts', '.js', '.tsx', '.jsx', '.mjs', '.cjs', '.html')))}")
     print(f"  - plpgsql migrations     : {mig_count}")
     print(f"  - Client guards present  : {', '.join(sorted(CLIENT_FILES))}")
     return 0

--- a/seatdata_client.py
+++ b/seatdata_client.py
@@ -57,21 +57,35 @@ API_BASE = "https://seatdata.io/api"
 # coverage. Everything else is GET.
 # NOTE: ALLOWED_HTTP_METHODS uses "POST" (not a sentinel) because the guard
 # function is called with the real HTTP method string ("POST"), not a
-# route-specific label. The docstring above clarifies POST is scoped to
-# event-add only; enforcement is by call-site discipline, not method-name alone.
+# route-specific label. POST is additionally path-scoped: the guard raises on
+# any POST whose path is not in SANCTIONED_POST_PATHS, so the carve-out is
+# enforced mechanically, not by call-site discipline.
 ALLOWED_HTTP_METHODS = frozenset({"GET", "POST"})
 
+# The ONLY path POST may ever target. Adding a path here is a security-CRIT
+# change (CLAUDE.md §2) and requires explicit operator authorization.
+SANCTIONED_POST_PATHS = frozenset({"v0.4/events/event-request-add"})
 
-def _assert_readonly_method(method: str) -> None:
+
+def _assert_readonly_method(method: str, path: str | None = None) -> None:
     """Hard guard: SeatData reads are always GET except for the event-add
     request endpoint (/v0.4/events/event-request-add), which is metadata-only.
-    Any other write method (PUT, DELETE, PATCH) is a bug and raises."""
+    Any other write method (PUT, DELETE, PATCH) is a bug and raises, as is a
+    POST to any path other than the sanctioned event-add endpoint."""
     if method.upper() not in ALLOWED_HTTP_METHODS:
         raise SeatDataError(
             f"READ-ONLY violation: method {method} is not allowed. "
             "SeatData integration is strictly read-only (RULE 2 in SCHEMA.md). "
             "The only POST we use is /v0.4/events/event-request-add (metadata only)."
         )
+    if method.upper() == "POST":
+        normalized = (path or "").strip().lstrip("/").split("?", 1)[0]
+        if normalized not in SANCTIONED_POST_PATHS:
+            raise SeatDataError(
+                f"READ-ONLY violation: POST to {path!r} is not sanctioned. "
+                "SeatData POST is scoped to /v0.4/events/event-request-add "
+                "only (RULE 2 / CLAUDE.md §2 listing-source lockdown)."
+            )
 
 # === BASIC-PLAN HARD CAPS — DO NOT BUMP WITHOUT UPDATING MIGRATION ===
 # Both values are also persisted in seatdata_pull_budget table defaults.
@@ -190,7 +204,7 @@ class SeatDataClient:
     def _request(self, method: str, path: str, *, params: dict | None = None,
                  json_body: dict | None = None, max_429_retries: int = 3,
                  expect_gzip: bool = False) -> tuple[int, dict | list | bytes, dict]:
-        _assert_readonly_method(method)  # RULE 2 enforcement
+        _assert_readonly_method(method, path)  # RULE 2 enforcement
         """Low-level HTTP. Returns (status, parsed_json, response_headers).
         Handles 429 with exponential backoff respecting Retry-After.
         """

--- a/static/store/test/index.html
+++ b/static/store/test/index.html
@@ -81,6 +81,8 @@
 
   <script src="/static/store/test/test.js"></script>
   <script>
+    // HTML-escape API-sourced strings before innerHTML interpolation (XSS).
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     const { $, fmtMoney, fmtWhen } = Test;
 
     // Hero search -> hand off to the search page.
@@ -141,8 +143,8 @@
                 : "distance n/a";
               c.innerHTML = `
                 <div class="when">${fmtWhen(ev.occurs_at_local)} · ${distLabel}</div>
-                <div class="name">${ev.name || "—"}</div>
-                <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+                <div class="name">${esc(ev.name || "—")}</div>
+                <div class="where">${esc([ev.venue_name, ev.venue_location].filter(Boolean).join(" · "))}</div>
                 <div class="price">${ev.from_price != null ? "from " + fmtMoney(ev.from_price) : ""}</div>
               `;
               nearGrid.append(c);
@@ -199,8 +201,8 @@
           }
           c.innerHTML = `
             <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
-            <div class="name">${ev.name || "—"}</div>
-            <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+            <div class="name">${esc(ev.name || "—")}</div>
+            <div class="where">${esc([ev.venue_name, ev.venue_location].filter(Boolean).join(" · "))}</div>
             <div class="price">from ${fmtMoney(ev.from_price)}</div>
           `;
           grid.append(c);

--- a/static/store/test/media_test.html
+++ b/static/store/test/media_test.html
@@ -221,6 +221,8 @@
 
   <script src="/static/store/test/test.js"></script>
   <script>
+    // HTML-escape API-sourced strings before innerHTML interpolation (XSS).
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     const { $, fmtMoney, fmtWhen, api } = Test;
 
     // Compute "is dark" for a hex color so we can pick contrasting text on
@@ -254,19 +256,19 @@
       // Build context badges from the payload's optional fields.
       const badgeBits = [];
       if (ev.primary_performer_league) {
-        badgeBits.push(`<span class="badge league">${ev.primary_performer_league}</span>`);
+        badgeBits.push(`<span class="badge league">${esc(ev.primary_performer_league)}</span>`);
       }
       if (ev.rivalry) badgeBits.push(`<span class="badge">⚡ rivalry</span>`);
       if (ev.playoff) badgeBits.push(`<span class="badge">★ playoff</span>`);
       if (ev.mlb_series) badgeBits.push(`<span class="badge">series</span>`);
       if (ev.tournament) badgeBits.push(`<span class="badge">tournament</span>`);
-      if (ev.weather) badgeBits.push(`<span class="badge">${ev.weather}</span>`);
-      if (ev.holiday) badgeBits.push(`<span class="badge">${ev.holiday}</span>`);
+      if (ev.weather) badgeBits.push(`<span class="badge">${esc(ev.weather)}</span>`);
+      if (ev.holiday) badgeBits.push(`<span class="badge">${esc(ev.holiday)}</span>`);
 
       // Logo frame — img if URL present, otherwise initials on the brand color.
       const logoFrame = ev.primary_performer_logo
-        ? `<div class="logo-frame"><img src="${ev.primary_performer_logo}" alt="" loading="lazy" /></div>`
-        : `<div class="logo-frame"><span class="fallback">${initials(ev.primary_performer_name || ev.name)}</span></div>`;
+        ? `<div class="logo-frame"><img src="${esc(ev.primary_performer_logo)}" alt="" loading="lazy" /></div>`
+        : `<div class="logo-frame"><span class="fallback">${esc(initials(ev.primary_performer_name || ev.name))}</span></div>`;
 
       c.innerHTML = `
         <div class="accent-bar"></div>
@@ -274,8 +276,8 @@
           ${logoFrame}
           <div class="card-meta">
             <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
-            <div class="name">${ev.name || "—"}</div>
-            <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+            <div class="name">${esc(ev.name || "—")}</div>
+            <div class="where">${esc([ev.venue_name, ev.venue_location].filter(Boolean).join(" · "))}</div>
             <div class="price">${ev.from_price != null ? "from " + fmtMoney(ev.from_price) : "—"}</div>
             ${badgeBits.length ? `<div class="badges">${badgeBits.join("")}</div>` : ""}
           </div>
@@ -336,16 +338,16 @@
       try {
         const { body } = await api(`/api/store/search?q=${encodeURIComponent(q)}&limit=6`);
         renderBucket("searchEvents", body.events, (h) => `
-          <div><strong>${h.name || "—"}</strong>${h.we_own ? ' <span class="badge">owned</span>' : ""}</div>
-          <div class="where">${[h.venue_name, h.location].filter(Boolean).join(" · ")}</div>
+          <div><strong>${esc(h.name || "—")}</strong>${h.we_own ? ' <span class="badge">owned</span>' : ""}</div>
+          <div class="where">${esc([h.venue_name, h.location].filter(Boolean).join(" · "))}</div>
         `);
         renderBucket("searchPerformers", body.performers, (h) => `
-          <div><strong>${h.name || "—"}</strong>${h.league ? ` · ${h.league}` : ""}</div>
-          <div class="where">${h.location || ""}</div>
+          <div><strong>${esc(h.name || "—")}</strong>${h.league ? ` · ${esc(h.league)}` : ""}</div>
+          <div class="where">${esc(h.location || "")}</div>
         `);
         renderBucket("searchVenues", body.venues, (h) => `
-          <div><strong>${h.name || "—"}</strong></div>
-          <div class="where">${h.location || ""}</div>
+          <div><strong>${esc(h.name || "—")}</strong></div>
+          <div class="where">${esc(h.location || "")}</div>
         `);
       } catch (e) {
         Test.log("search probe failed: " + e.message, "err");

--- a/static/store/test/performer.html
+++ b/static/store/test/performer.html
@@ -50,6 +50,8 @@
 
   <script src="/static/store/test/test.js"></script>
   <script>
+    // HTML-escape API-sourced strings before innerHTML interpolation (XSS).
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     const { $, $$, fmtMoney, fmtWhen } = Test;
 
     // All events with owned inventory — fetched once, filtered client-side
@@ -127,8 +129,8 @@
         }
         c.innerHTML = `
           <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
-          <div class="name">${ev.name || "—"}</div>
-          <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+          <div class="name">${esc(ev.name || "—")}</div>
+          <div class="where">${esc([ev.venue_name, ev.venue_location].filter(Boolean).join(" · "))}</div>
           <div class="price">from ${fmtMoney(ev.from_price)}</div>
         `;
         grid.append(c);

--- a/static/store/test/search.html
+++ b/static/store/test/search.html
@@ -43,6 +43,8 @@
 
   <script src="/static/store/test/test.js"></script>
   <script>
+    // HTML-escape API-sourced strings before innerHTML interpolation (XSS).
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     const { $, fmtMoney, fmtWhen } = Test;
 
     let allEvents = [];
@@ -67,8 +69,8 @@
         }
         c.innerHTML = `
           <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
-          <div class="name">${ev.name || "—"}</div>
-          <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+          <div class="name">${esc(ev.name || "—")}</div>
+          <div class="where">${esc([ev.venue_name, ev.venue_location].filter(Boolean).join(" · "))}</div>
           <div class="price">from ${fmtMoney(ev.from_price)}</div>
         `;
         grid.append(c);

--- a/static/store/test/trip.html
+++ b/static/store/test/trip.html
@@ -86,6 +86,8 @@
   </div>
 
   <script>
+    // HTML-escape API-sourced strings before innerHTML interpolation (XSS).
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     (function () {
       const $ = (id) => document.getElementById(id);
       const budget = $('budget');
@@ -140,8 +142,8 @@
           if (!on) li.className = 'skip';
           li.innerHTML =
             `<span class="d">${fmtDate(e.date)}</span>` +
-            `<span class="c">${e.city || ''}</span>` +
-            `<span>${e.venue || ''}</span>` +
+            `<span class="c">${esc(e.city || '')}</span>` +
+            `<span>${esc(e.venue || '')}</span>` +
             (on ? `<span class="badge">● going</span>` : '');
           ul.appendChild(li);
         }

--- a/static/store/test/venue.html
+++ b/static/store/test/venue.html
@@ -48,6 +48,8 @@
 
   <script src="/static/store/test/test.js"></script>
   <script>
+    // HTML-escape API-sourced strings before innerHTML interpolation (XSS).
+    const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
     const { $, $$, fmtMoney, fmtWhen } = Test;
 
     let allEvents = [];
@@ -129,8 +131,8 @@
         }
         c.innerHTML = `
           <div class="when">${fmtWhen(ev.occurs_at_local)}</div>
-          <div class="name">${ev.name || "—"}</div>
-          <div class="where">${[ev.venue_name, ev.venue_location].filter(Boolean).join(" · ")}</div>
+          <div class="name">${esc(ev.name || "—")}</div>
+          <div class="where">${esc([ev.venue_name, ev.venue_location].filter(Boolean).join(" · "))}</div>
           <div class="price">from ${fmtMoney(ev.from_price)}</div>
         `;
         grid.append(c);

--- a/static/terminal/app.js
+++ b/static/terminal/app.js
@@ -25,8 +25,22 @@
   //
   // Override via localStorage.terminalApiBase for ad-hoc preview/staging.
   const API_BASE = (function () {
+    // The override is allowlist-pinned: a planted localStorage value must not
+    // be able to redirect authenticated calls (Bearer token attached in
+    // getAuthHeader) to an arbitrary host. Same-origin, localhost, and
+    // *.onrender.com preview/staging hosts only (audit 2026-06-10).
     const override = (typeof localStorage !== 'undefined') && localStorage.getItem('terminalApiBase');
-    if (override) return override.replace(/\/$/, '');
+    if (override) {
+      let ok = false;
+      try {
+        const u = new URL(override, location.origin);
+        ok = u.origin === location.origin ||
+             u.hostname === 'localhost' || u.hostname === '127.0.0.1' ||
+             (u.protocol === 'https:' && u.hostname.endsWith('.onrender.com'));
+      } catch (_) { ok = false; }
+      if (ok) return override.replace(/\/$/, '');
+      console.warn('terminalApiBase override ignored (host not in allowlist):', override);
+    }
     const h = location.hostname;
     // Topology 1: localhost dev.
     if (h === 'localhost' || h === '127.0.0.1' || h === '') return '';

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -1948,7 +1948,7 @@
       const rec = t.record_summary || `${t.wins || 0}-${t.losses || 0}${t.ties ? '-' + t.ties : ''}`;
       card.innerHTML = `
         <div class="espn-card-hd">${escapeHtml(t.espn_team_id || '')}</div>
-        <div class="espn-card-row"><span class="lbl">record</span><span class="val">${rec}</span></div>
+        <div class="espn-card-row"><span class="lbl">record</span><span class="val">${escapeHtml(rec)}</span></div>
         <div class="espn-card-row"><span class="lbl">win %</span><span class="val">${t.win_pct != null ? (t.win_pct * 100).toFixed(1) + '%' : '—'}</span></div>
         <div class="espn-card-row"><span class="lbl">streak</span><span class="val">${escapeHtml(t.streak || '—')}</span></div>
         <div class="espn-card-row"><span class="lbl">seed</span><span class="val">${t.playoff_seed || '—'}</span></div>

--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -268,7 +268,7 @@
       const cov  = s.data_coverage_pct != null ? ` · ${Math.round(s.data_coverage_pct)}% cov` : '';
       const turn = (+s.entries_24h || 0) + (+s.exits_24h || 0);
       const turnStr = turn ? ` · ${turn} Δ/24h` : '';
-      return `<span class="badge" title="source=${s.source} window=${s.window_days}d">${escapeHtml(s.source)}·${s.window_days}d·${escapeHtml(s.category || '')}: ${sz}${cov}${turnStr}</span>`;
+      return `<span class="badge" title="source=${escapeHtml(s.source)} window=${s.window_days}d">${escapeHtml(s.source)}·${s.window_days}d·${escapeHtml(s.category || '')}: ${sz}${cov}${turnStr}</span>`;
     }).join(' ');
   }
 

--- a/static/terminal/movers.js
+++ b/static/terminal/movers.js
@@ -197,7 +197,7 @@
       const cov = s.data_coverage_pct != null ? ` · ${Math.round(s.data_coverage_pct)}% cov` : '';
       const turn = ((s.entries_24h || 0) + (s.exits_24h || 0));
       const turnStr = turn ? ` · ${turn} Δ/24h` : '';
-      return `<span class="badge" title="source=${s.source} window=${s.window_days}d">${escapeHtml(s.source)}·${s.window_days}d·${escapeHtml(s.category||'')}: ${sz}${cov}${turnStr}</span>`;
+      return `<span class="badge" title="source=${escapeHtml(s.source)} window=${s.window_days}d">${escapeHtml(s.source)}·${s.window_days}d·${escapeHtml(s.category||'')}: ${sz}${cov}${turnStr}</span>`;
     }).join(' ');
   }
 

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -183,7 +183,10 @@
         // track locally yet. No internal page to link to — open the buy URL.
         parts.push('<div class="ts-section"><div class="ts-section-lbl">MARKETPLACE</div>');
         mkt.forEach(m => {
-          const href = m.event_url || '#';
+          // Scheme-validate the third-party URL: TicketsData supplies
+          // event_url verbatim — only http(s) may reach an href (blocks
+          // javascript:/data: if the feed is ever compromised).
+          const href = /^https?:\/\//i.test(m.event_url || '') ? m.event_url : '#';
           const meta = [m.platform, m.venue_name, fmtDateShort(m.event_date)].filter(Boolean).join(' · ');
           flat.push({ href, label: m.event_name, kind: 'marketplace' });
           const ext = href !== '#' ? ' target="_blank" rel="noopener"' : '';

--- a/tests/test_readonly_guards.py
+++ b/tests/test_readonly_guards.py
@@ -168,6 +168,133 @@ def test_axs_venue_norm_matches_axs_venues_generated_column():
     assert venue_norm("Red Rocks Amphitheatre") == "redrocksamphitheatre"
 
 
+# ---------- seatdata_client ----------
+#
+# SeatData is the one client with a sanctioned POST — and it is path-scoped:
+# only /v0.4/events/event-request-add may ever receive it (CLAUDE.md §2).
+
+def test_seatdata_assert_readonly_raises_on_put_patch_delete():
+    from seatdata_client import _assert_readonly_method, SeatDataError
+    for method in ("PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"):
+        with pytest.raises(SeatDataError):
+            _assert_readonly_method(method)
+
+
+def test_seatdata_assert_readonly_allows_get_any_path():
+    from seatdata_client import _assert_readonly_method
+    _assert_readonly_method("GET")
+    _assert_readonly_method("get", "v1/events/search")
+
+
+def test_seatdata_post_allowed_only_for_event_request_add():
+    from seatdata_client import _assert_readonly_method
+    # Sanctioned path passes regardless of leading-slash spelling.
+    _assert_readonly_method("POST", "v0.4/events/event-request-add")
+    _assert_readonly_method("POST", "/v0.4/events/event-request-add")
+
+
+def test_seatdata_post_to_any_other_path_raises():
+    from seatdata_client import _assert_readonly_method, SeatDataError
+    for path in (
+        "v0.1.1/listings/get",
+        "v0.3/salesdata/get",
+        "v9/orders",
+        "v0.4/events/event-request-add/../../orders",
+        "",
+        None,
+    ):
+        with pytest.raises(SeatDataError) as exc:
+            _assert_readonly_method("POST", path)
+        assert "READ-ONLY violation" in str(exc.value)
+
+
+def test_seatdata_allowlist_and_sanctioned_paths_constants():
+    from seatdata_client import ALLOWED_HTTP_METHODS, SANCTIONED_POST_PATHS
+    assert ALLOWED_HTTP_METHODS == frozenset({"GET", "POST"})
+    assert SANCTIONED_POST_PATHS == frozenset({"v0.4/events/event-request-add"})
+
+
+# ---------- gotickets_client ----------
+
+def test_gotickets_assert_readonly_raises_on_post():
+    from gotickets_client import _assert_readonly_method, GoTicketsReadOnlyError
+    with pytest.raises(GoTicketsReadOnlyError) as exc:
+        _assert_readonly_method("POST")
+    assert "READ-ONLY violation" in str(exc.value)
+
+
+def test_gotickets_assert_readonly_raises_on_put_patch_delete():
+    from gotickets_client import _assert_readonly_method, GoTicketsReadOnlyError
+    for method in ("PUT", "PATCH", "DELETE"):
+        with pytest.raises(GoTicketsReadOnlyError):
+            _assert_readonly_method(method)
+
+
+def test_gotickets_assert_readonly_allows_get():
+    from gotickets_client import _assert_readonly_method
+    _assert_readonly_method("GET")
+    _assert_readonly_method("get")
+
+
+def test_gotickets_allowlist_constant_is_get_only():
+    from gotickets_client import ALLOWED_HTTP_METHODS
+    assert ALLOWED_HTTP_METHODS == frozenset({"GET"})
+
+
+# ---------- ticketsdata_client ----------
+
+def test_ticketsdata_assert_readonly_raises_on_post():
+    from ticketsdata_client import _assert_readonly_method, TicketsDataReadOnlyError
+    with pytest.raises(TicketsDataReadOnlyError) as exc:
+        _assert_readonly_method("POST")
+    assert "READ-ONLY violation" in str(exc.value)
+
+
+def test_ticketsdata_assert_readonly_raises_on_put_patch_delete():
+    from ticketsdata_client import _assert_readonly_method, TicketsDataReadOnlyError
+    for method in ("PUT", "PATCH", "DELETE"):
+        with pytest.raises(TicketsDataReadOnlyError):
+            _assert_readonly_method(method)
+
+
+def test_ticketsdata_assert_readonly_allows_get():
+    from ticketsdata_client import _assert_readonly_method
+    _assert_readonly_method("GET")
+    _assert_readonly_method("get")
+
+
+def test_ticketsdata_allowlist_constant_is_get_only():
+    from ticketsdata_client import ALLOWED_HTTP_METHODS
+    assert ALLOWED_HTTP_METHODS == frozenset({"GET"})
+
+
+# ---------- broadway_client ----------
+
+def test_broadway_assert_readonly_raises_on_post():
+    from broadway_client import _assert_readonly_method, BroadwayError
+    with pytest.raises(BroadwayError) as exc:
+        _assert_readonly_method("POST")
+    assert "READ-ONLY violation" in str(exc.value)
+
+
+def test_broadway_assert_readonly_raises_on_put_patch_delete():
+    from broadway_client import _assert_readonly_method, BroadwayError
+    for method in ("PUT", "PATCH", "DELETE"):
+        with pytest.raises(BroadwayError):
+            _assert_readonly_method(method)
+
+
+def test_broadway_assert_readonly_allows_get():
+    from broadway_client import _assert_readonly_method
+    _assert_readonly_method("GET")
+    _assert_readonly_method("get")
+
+
+def test_broadway_allowlist_constant_is_get_only():
+    from broadway_client import ALLOWED_HTTP_METHODS
+    assert ALLOWED_HTTP_METHODS == frozenset({"GET"})
+
+
 # ---------- audit script catches synthetic violations ----------
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -225,6 +352,61 @@ def test_audit_script_catches_ts_post_to_seatgeek(tmp_path: Path):
     finally:
         bad_file.unlink(missing_ok=True)
         bad_file.parent.rmdir()
+
+
+def test_audit_script_catches_method_as_string_request(tmp_path: Path):
+    """session.request('POST', ...) must be flagged — the pre-2026-06 scanner
+    only matched requests.post(...) and missed the method-as-string spelling."""
+    bad_file = REPO_ROOT / "_test_synthetic_request_violation.py"
+    bad_file.write_text(
+        "import requests\n"
+        "# synthetic violation for tests/test_readonly_guards.py\n"
+        "s = requests.Session()\n"
+        "s.request('POST', 'https://seatdata.io/api/v9/orders', json={})\n",
+        encoding="utf-8",
+    )
+    try:
+        rc, out = _run_check()
+        assert rc == 1, f"audit script should flag .request('POST', ...):\n{out}"
+        assert "_test_synthetic_request_violation.py" in out
+    finally:
+        bad_file.unlink(missing_ok=True)
+
+
+def test_audit_script_catches_non_fetch_ts_write(tmp_path: Path):
+    """An axios/XHR-style write near a forbidden host must be flagged — the
+    pre-2026-06 scanner skipped any method:'POST' without a fetch( nearby."""
+    bad_file = REPO_ROOT / "supabase" / "functions" / "_test_synthetic_axios" / "index.ts"
+    bad_file.parent.mkdir(parents=True, exist_ok=True)
+    bad_file.write_text(
+        '// synthetic violation\n'
+        'await axios({ url: "https://api.tickpick.com/orders", method: "POST" });\n',
+        encoding="utf-8",
+    )
+    try:
+        rc, out = _run_check()
+        assert rc == 1, f"audit script should flag non-fetch TS write:\n{out}"
+        assert "_test_synthetic_axios" in out
+    finally:
+        bad_file.unlink(missing_ok=True)
+        bad_file.parent.rmdir()
+
+
+def test_audit_script_scans_inline_html_scripts(tmp_path: Path):
+    """Inline <script> in .html files is scanned — previously a blind spot."""
+    bad_file = REPO_ROOT / "_test_synthetic_inline.html"
+    bad_file.write_text(
+        "<script>\n"
+        'fetch("https://brokers.vividseats.com/orders", { method: "POST" });\n'
+        "</script>\n",
+        encoding="utf-8",
+    )
+    try:
+        rc, out = _run_check()
+        assert rc == 1, f"audit script should flag inline HTML script write:\n{out}"
+        assert "_test_synthetic_inline.html" in out
+    finally:
+        bad_file.unlink(missing_ok=True)
 
 
 def test_audit_script_catches_removed_guard(tmp_path: Path):

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,143 @@
+"""Tests for the 2026-06-10 security-audit hardening in app.py.
+
+Covers:
+  1. require_auth — rejects non-"authenticated" token audience and
+     unconfirmed-email accounts (parity with d2_dashboard's require_auth).
+  2. _RateLimitMiddleware — keys per-IP buckets on the RIGHTMOST
+     X-Forwarded-For entry (appended by our edge proxy), not the leftmost
+     (client-forgeable), so a client can't rotate fake IPs to bypass caps.
+
+No real Supabase or network calls — auth lookups are monkeypatched.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("TEVO_API_TOKEN", "test-token")
+os.environ.setdefault("TEVO_API_SECRET", "test-secret")
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
+os.environ.setdefault("AUTH_DISABLED", "true")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+fastapi = pytest.importorskip("fastapi")
+starlette_testclient = pytest.importorskip("fastapi.testclient")
+
+import app as app_module  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+TestClient = starlette_testclient.TestClient
+
+
+# ---------- require_auth hardening ----------
+
+class _FakeAuthResponse:
+    def __init__(self, payload: dict, ok: bool = True):
+        self._payload = payload
+        self.ok = ok
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _good_user(**overrides) -> dict:
+    user = {
+        "aud": "authenticated",
+        "email": f"ops@{app_module.ALLOWED_EMAIL_DOMAIN}",
+        "email_confirmed_at": "2026-01-01T00:00:00Z",
+    }
+    user.update(overrides)
+    return user
+
+
+@pytest.fixture()
+def live_auth(monkeypatch):
+    """Force the auth gate ON and stub the Supabase /auth/v1/user lookup."""
+    monkeypatch.setattr(app_module, "AUTH_DISABLED", False)
+
+    def _set_user(payload: dict, ok: bool = True):
+        monkeypatch.setattr(
+            app_module.requests, "get",
+            lambda *a, **kw: _FakeAuthResponse(payload, ok=ok),
+        )
+
+    return _set_user
+
+
+def test_require_auth_accepts_confirmed_domain_user(live_auth):
+    live_auth(_good_user())
+    user = app_module.require_auth("Bearer test-jwt")
+    assert user["aud"] == "authenticated"
+
+
+def test_require_auth_rejects_wrong_audience(live_auth):
+    live_auth(_good_user(aud="anon"))
+    with pytest.raises(HTTPException) as exc:
+        app_module.require_auth("Bearer test-jwt")
+    assert exc.value.status_code == 401
+    assert "audience" in exc.value.detail
+
+
+def test_require_auth_rejects_unconfirmed_email(live_auth):
+    live_auth(_good_user(email_confirmed_at=None))
+    with pytest.raises(HTTPException) as exc:
+        app_module.require_auth("Bearer test-jwt")
+    assert exc.value.status_code == 403
+    assert "confirmed" in exc.value.detail
+
+
+def test_require_auth_rejects_foreign_domain(live_auth):
+    live_auth(_good_user(email="mallory@evil.example"))
+    with pytest.raises(HTTPException) as exc:
+        app_module.require_auth("Bearer test-jwt")
+    assert exc.value.status_code == 403
+
+
+# ---------- rate limiter XFF handling ----------
+
+@pytest.fixture()
+def captured_keys(monkeypatch):
+    """Capture the keys _RateLimitMiddleware feeds to the limiter (always
+    allowing the request through)."""
+    keys: list[str] = []
+
+    def _check(key: str, n: int, w: float) -> bool:
+        keys.append(key)
+        return True
+
+    monkeypatch.setattr(app_module._ip_limiter, "check", _check)
+    return keys
+
+
+def test_rate_limit_keys_on_rightmost_xff_entry(captured_keys):
+    client = TestClient(app_module.app)
+    client.get(
+        "/version.json",
+        headers={"X-Forwarded-For": "6.6.6.6, 203.0.113.9"},
+    )
+    assert captured_keys, "rate limiter was not consulted"
+    ip = captured_keys[-1].split("|")[0]
+    assert ip == "203.0.113.9", (
+        "limiter must key on the proxy-appended (rightmost) XFF hop, "
+        f"got {ip!r} — leftmost is client-forgeable"
+    )
+
+
+def test_rate_limit_client_cannot_rotate_buckets_via_xff(captured_keys):
+    client = TestClient(app_module.app)
+    for fake in ("1.1.1.1", "2.2.2.2", "3.3.3.3"):
+        client.get(
+            "/version.json",
+            headers={"X-Forwarded-For": f"{fake}, 203.0.113.9"},
+        )
+    ips = {k.split("|")[0] for k in captured_keys}
+    assert ips == {"203.0.113.9"}, (
+        f"prepending fake XFF entries must not change the bucket key: {ips}"
+    )


### PR DESCRIPTION
# Security audit remediations (2026-06-10)

Full-codebase audit (app.py, all 9 upstream clients, static/ FE, browser extension, 573 migrations + 27 edge functions, d2/d4 services). **No live CRIT/HIGH in core surfaces**; this PR fixes everything actionable except the d4_bridge Stripe checkout (operator: explicitly deferred).

## RULE 2 — make "enforced mechanically" true (CLAUDE.md §2)

- **seatdata_client**: POST carve-out is now **path-scoped** — the runtime guard raises on any POST whose path isn't `v0.4/events/event-request-add` (was call-site discipline only).
- **check_readonly.py**: adds `axs.com` to FORBIDDEN_HOSTS; catches `.request("POST"…)` / `requests.request` / `urlopen(data=…)` spellings; flags non-fetch (axios/XHR) TS writes near forbidden hosts; scans `.html` inline scripts + `.mjs`/`.cjs` (previously blind spots).
- **Guard tests**: all 9 clients now covered (seatdata/gotickets/ticketsdata/broadway were untested) + synthetic-violation tests for each new scanner capability. 25 → 45 tests.
- **CI**: `check_readonly.py` runs as a standalone workflow step — previously the "CI static audit" existed only because one pytest case shelled out to it.

## app.py

- **Rate limiter** keys on the **rightmost** X-Forwarded-For hop (proxy-appended) instead of the leftmost (client-forgeable). Before: a single client could rotate fake IPs to bypass every per-IP bucket, including the `/api/admin/` 5/min cap.
- **require_auth** now enforces `aud == "authenticated"` + `email_confirmed_at` (parity with d2's gate).

## Frontend

- Escape ESPN `record_summary` (`event.js`), `source` in `title=` attrs (`home.js`/`movers.js`); scheme-validate TicketsData `event_url` hrefs (`nav.js`, blocks `javascript:`).
- `localStorage.terminalApiBase` override pinned to same-origin / localhost / `*.onrender.com` — a planted value could previously redirect Bearer-token API calls to an arbitrary host.
- `store/test/` sandbox pages (6): added `esc()` and escaped all API-sourced innerHTML interpolations.

## Services

- **d4_bridge**: `robots.txt` / `sitemap.xml` absolute URLs pinned to `VITE_APP_URL`; request-Host fallback is dev-only (forged Host could poison the 10-min sitemap cache).
- **d2_dashboard**: credentialed `localhost:*` CORS regex disabled in production.

## Not addressed (deliberate)

- d4_bridge Stripe checkout trusting client-supplied price + no auth — **deferred per operator**. Must be fixed before a live `STRIPE_SECRET_KEY` is provisioned.
- DB-side items needing lane/operator sign-off: 3 espn anon `USING(true)` policies (pending D3), `leads` anon INSERT (by design).

## Verification

- `python scripts/check_readonly.py` → clean (30 py, 283 ts/js/html, 573 migrations)
- Full suite: **289 passed, 13 skipped** (was 263) — includes new `tests/test_security_hardening.py` (require_auth audience/confirmation + XFF bucket-keying)
- `tsc --noEmit` clean for d4_bridge; `node --check` clean on all edited JS + extracted inline HTML scripts
- Live RLS spot-check (read-only): all four PII order tables enforce `admin_only qual=false`; `evo_orders` RLS confirmed enabled

https://claude.ai/code/session_01ErWLfbKYBJSHtSCwq8guwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErWLfbKYBJSHtSCwq8guwA)_