### PR TITLE
docs(readme): refresh Architecture / Repo layout / Build-run against the tree (v1.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Terminal-2
 
-Ticket-trading intelligence + primary-market ticketing platform. FastAPI on Render + Supabase Postgres + edge functions + cron-driven ingest from TEvo, SeatGeek, TickPick, Vivid, SeatData, ESPN, NWS. Jointly maintained by a small set of specialized bot lanes coordinating through `public.bot_chat`.
+Ticket-trading intelligence + primary-market ticketing platform. FastAPI on Render + Supabase Postgres + edge functions + cron-driven ingest from TEvo, SeatGeek, TickPick, Vivid, SeatData, TicketsData, GoTickets, AXS, Broadway.com, ESPN, NWS. Jointly maintained by a small set of specialized bot lanes coordinating through `public.bot_chat`.
 
-> **Doc version:** v1.2.0 · baseline 2026-05-28 (A1); v1.1.0 2026-06-09 (C1) — *Start here* adds the code knowledge-graph onboarding pointer (→ `PROJECT_BIBLE.md §8`); v1.2.0 2026-06-09 (C1) — pointer now links the committed, viewable chart (`.understand-anything/knowledge-graph-chart.html`). The section-level version + bot-ref convention is defined below under *Doc-writing rules*.
+> **Doc version:** v1.3.0 · baseline 2026-05-28 (A1); v1.1.0 2026-06-09 (C1) — *Start here* adds the code knowledge-graph onboarding pointer (→ `PROJECT_BIBLE.md §8`); v1.2.0 2026-06-09 (C1) — pointer now links the committed, viewable chart (`.understand-anything/knowledge-graph-chart.html`); v1.3.0 2026-06-10 (A1) — *Architecture* + *Repo layout* + *Build/run* refreshed against the tree: full nine-client list, `broadway_extension/` + `trip_planner/` added, dead `.env.example` step replaced. The section-level version + bot-ref convention is defined below under *Doc-writing rules*.
 
 ---
 
@@ -61,13 +61,14 @@ Mirrors `CLAUDE.md §6` (loaded every session) — repeated here because this is
 
 ---
 
-## Architecture at a glance
+## Architecture at a glance *(v1.1 · A1 · 2026-06-10)*
 
 ```
 Browser ─► Render (FastAPI + static) ─► Supabase (Postgres + Auth + Edge Functions)
                  │         │                        ▲
                  │         └─ same-origin session ──┘
-                 ├─► TEvo / SG / TickPick / Vivid    (read-only — no writes, CLAUDE.md §2)
+                 ├─► TEvo / SG / TickPick / Vivid / SeatData / TicketsData /
+                 │   GoTickets / AXS / Broadway     (read-only — no writes, CLAUDE.md §2)
                  │
            ┌── pg_cron jobs ─► Edge Functions ─► upstream APIs ─┐
            │                                                    │
@@ -76,37 +77,45 @@ Browser ─► Render (FastAPI + static) ─► Supabase (Postgres + Auth + Edge
 
 Full deploy chain (Render services, IDs, testing-unified shell) → `BOT_HIERARCHY.md §7` and `D0_BIBLE.md` (PART 1, deploy chain).
 
-## Repo layout
+## Repo layout *(v1.1 · A1 · 2026-06-10)*
 
 ```
 .
 ├── app.py                  FastAPI shell — all /api/* routes; mounts D2 router
-├── *_client.py             TEvo / SeatGeek / TickPick / Vivid / SeatData clients (read-only)
+├── *_client.py             9 read-only listing-source clients: evo · seatgeek ·
+│                           tickpick · vivid · seatdata · ticketsdata · gotickets ·
+│                           axs · broadway (GET-only by construction, CLAUDE.md §2)
 ├── d2_dashboard/           D2 orders dashboard + APIRouter (mounted on app.py)
-├── d4_bridge/              D4 — Exos/Bridge SPA source (Vite → static/bridge/)
+├── d4_bridge/              D4 — Exos/Bridge SPA source + Express server (Vite → static/bridge/)
+├── trip_planner/           shared tour-itinerary optimizer (D0 + D1 trip-plan routes; see its README)
+├── broadway_extension/     browser extension — Broadway.com availability capture (see its README)
 ├── static/
 │   ├── terminal/           D0 — broker terminal (build manual: D0_BIBLE.md PART 1)
-│   ├── store/              D1 — consumer retail storefront
+│   ├── store/              D1 — consumer retail storefront (store/test/ = non-prod sandbox)
 │   ├── home/ undelivered/  D0 hub · D2 undelivered surface
 │   ├── bridge/             D4 — Exos Bridge SPA build artifact (committed)
 │   └── _shared/            cross-surface utilities
 ├── supabase/
 │   ├── migrations/         YYYYMMDDHHMMSS_descriptive.sql (rules: MIGRATION_CONVENTIONS.md)
 │   └── functions/          edge functions
-├── bin/                    CI checks (sync-check.sh, check-docs.sh)
-├── scripts/ tests/         CI helpers · pytest suite
+├── bin/                    CI checks (sync-check.sh, check-docs.sh, graph-drift.mjs)
+├── scripts/                data/ingest tools + check_readonly.py (RULE 2 static audit, CI gate)
+├── tests/                  pytest suite (incl. test_readonly_guards.py — RULE 2 runtime guards)
 ├── docs/                   active references + docs/archive/ (historical)
 ├── design/                 historical wireframes / proposals
 └── <canonical *.md>        the 11 docs in the registry above
 ```
 
-## Build / run / deploy the terminal
+## Build / run / deploy the terminal *(v1.1 · A1 · 2026-06-10)*
 
 The complete cold-start manual — frontend file map, the `T.api()` data-fetch architecture, per-page endpoint/RPC contracts, the auth flow, local dev, and the exact Render deploy chain — lives in **[`D0_BIBLE.md`](D0_BIBLE.md) PART 1**. Quick local run:
 
 ```powershell
 python -m venv .venv; .venv\Scripts\Activate.ps1; pip install -r requirements.txt
-cp .env.example .env   # fill SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, etc.
+# Config comes from real environment variables (no .env loader in app.py):
+$env:SUPABASE_URL = "https://<project>.supabase.co"
+$env:SUPABASE_ANON_KEY = "<anon key>"
+$env:SUPABASE_SERVICE_ROLE_KEY = "<service key>"   # + TEVO_API_TOKEN/SECRET etc. as needed
 uvicorn app:app --reload --port 8765
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Ticket-trading intelligence + primary-market ticketing platform. FastAPI on Render + Supabase Postgres + edge functions + cron-driven ingest from TEvo, SeatGeek, TickPick, Vivid, SeatData, TicketsData, GoTickets, AXS, Broadway.com, ESPN, NWS. Jointly maintained by a small set of specialized bot lanes coordinating through `public.bot_chat`.
 
-> **Doc version:** v1.3.0 · baseline 2026-05-28 (A1); v1.1.0 2026-06-09 (C1) — *Start here* adds the code knowledge-graph onboarding pointer (→ `PROJECT_BIBLE.md §8`); v1.2.0 2026-06-09 (C1) — pointer now links the committed, viewable chart (`.understand-anything/knowledge-graph-chart.html`); v1.3.0 2026-06-10 (A1) — *Architecture* + *Repo layout* + *Build/run* refreshed against the tree: full nine-client list, `broadway_extension/` + `trip_planner/` added, dead `.env.example` step replaced. The section-level version + bot-ref convention is defined below under *Doc-writing rules*.
+> **Doc version:** v1.4.0 · baseline 2026-05-28 (A1); v1.1.0 2026-06-09 (C1) — *Start here* adds the code knowledge-graph onboarding pointer (→ `PROJECT_BIBLE.md §8`); v1.2.0 2026-06-09 (C1) — pointer now links the committed, viewable chart (`.understand-anything/knowledge-graph-chart.html`); v1.3.0 2026-06-10 (A1) — *Architecture* + *Repo layout* + *Build/run* refreshed against the tree: full nine-client list, `broadway_extension/` + `trip_planner/` added, dead `.env.example` step replaced; v1.4.0 2026-06-10 (A1) — bible sweep folded into the entry point: *Start here* surfaces the AQ-mapper #1 fact + lane status, *Conventions* gains cross-source-ID / lane-goals / edge-fn-auth pointers. The section-level version + bot-ref convention is defined below under *Doc-writing rules*.
 
 ---
 
-## Start here (reading order) *(v1.2 · C1 · 2026-06-09)*
+## Start here (reading order) *(v1.3 · A1 · 2026-06-10)*
 
 A cold-started bot should read these four, in order. The first is loaded for you automatically every session; the rest you read once at session start.
 
 1. **[`CLAUDE.md`](CLAUDE.md)** — *(auto-loaded every session)* immutable security + operator lockdown rules. The safety baseline; it directs you to read the bible next.
-2. **[`PROJECT_BIBLE.md`](PROJECT_BIBLE.md)** — the per-session playbook: hard rules, SQL macros, §3 column-name landmines, workflow recipes, 10-item self-check. **Read this first** of the things you choose to open.
-3. **[`BOT_HIERARCHY.md`](BOT_HIERARCHY.md)** — who you are, who can push where, per-lane write scope, Render service ownership.
+2. **[`PROJECT_BIBLE.md`](PROJECT_BIBLE.md)** — the per-session playbook: hard rules, SQL macros, §3 column-name landmines, workflow recipes, 11-item self-check. **Read this first** of the things you choose to open — and read **its §0 before any cross-source SQL**: source event IDs NEVER line up; everything resolves through the `aq_event_map` hub. It's the #1 fact cold sessions miss.
+3. **[`BOT_HIERARCHY.md`](BOT_HIERARCHY.md)** — who you are, who can push where, per-lane write scope, Render service ownership. At a glance: **A1 · B1 · C1 · D0 are ACTIVE** (D0 is the priority lane); D1–D4 and E1 are **PAUSED** until D0 ships.
 4. **[`D0_BIBLE.md`](D0_BIBLE.md)** — cross-source ID architecture **+ the full cold-start manual for building the D0 terminal frontend** (PART 1).
 
 Then check **[`KANBAN.md`](KANBAN.md)** for what's actionable right now (don't claim a row marked `[IN PROGRESS by <lane>]`).
@@ -121,14 +121,17 @@ uvicorn app:app --reload --port 8765
 
 `http://localhost:8765` → home hub; `/static/terminal/event.html?event=<id>` → D0 broker view.
 
-## Conventions — quick pointers (don't restate; link)
+## Conventions — quick pointers (don't restate; link) *(v1.1 · A1 · 2026-06-10)*
 
-- **Column landmines + TEvo gotchas + SQL macros** → `PROJECT_BIBLE.md §3`
+- **Cross-source IDs never line up — resolve through the AQ mapper hub** → `PROJECT_BIBLE.md §0` (one-pager) · `D0_BIBLE.md §3` (full architecture)
+- **Column landmines + TEvo gotchas + SQL macros** → `PROJECT_BIBLE.md §3` + `§7`
 - **Migration filename/header/apply rules** → `MIGRATION_CONVENTIONS.md`
 - **Who can push / per-lane scope** → `BOT_HIERARCHY.md` (A1 is sole pusher to `main`)
-- **What exists before you build something new** → `RESOURCES_BIBLE.md`
+- **What exists before you build something new** (tables · views · crons · edge fns · vault) → `RESOURCES_BIBLE.md`
+- **Where each lane is headed** (north-star + endgame per lane) → `docs/d_tier_goals.md`
+- **Edge functions that mutate or burn paid APIs: platform `verify_jwt` is NOT sufficient** → `PROJECT_BIBLE.md §1` rule 7 (`requireCronSecret` pattern)
 - **Credential rotation** → `MIGRATION_CONVENTIONS.md` vault allowlist + `docs/release-discipline.md §7`
-- **Cross-bot coordination** → `public.bot_chat` (durable, append-only) + Slack `#terminal-2-*`
+- **Cross-bot coordination** → `public.bot_chat` (durable, append-only; conventions: `docs/bot_chat_conventions.md`) + Slack `#terminal-2-*`
 
 ---
 


### PR DESCRIPTION
# README refresh — v1.3.0

Full-tree sweep against what `README.md` claims. Four facts had drifted:

1. **Client list said 5 sources; there are 9.** Intro, architecture diagram, and repo-layout now list all nine read-only listing-source clients (adds `ticketsdata`, `gotickets`, `axs`, `broadway`).
2. **`trip_planner/` and `broadway_extension/` were missing from the repo layout** — both are real, shipped directories with their own READMEs (shared tour-itinerary optimizer behind the D0+D1 trip-plan routes; Broadway.com availability-capture extension).
3. **`bin/` and `scripts/`/`tests/` lines updated** — `graph-drift.mjs` added; the RULE 2 enforcement pair (`scripts/check_readonly.py`, `tests/test_readonly_guards.py`) is now named since it's a CI gate.
4. **Quick-run step said `cp .env.example .env`** — that file doesn't exist anywhere in the tree and `app.py` has no dotenv loader (config is real env vars). Replaced with explicit env-var exports.

Per *Doc-writing rules*: changed sections tagged `(v1.1 · A1 · 2026-06-10)`, doc-version line bumped to v1.3.0 with a dated entry. `bin/check-docs.sh` passes (registry match, no stray notes, version line present).

https://claude.ai/code/session_01ErWLfbKYBJSHtSCwq8guwA

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErWLfbKYBJSHtSCwq8guwA)_