### PR TITLE
fix(a1): AXS AQ matcher uses public.events + AXS as first-class aq_event_map source

### DIFF
--- a/supabase/migrations/20260610090000_axs_aq_match_use_events_table.sql
+++ b/supabase/migrations/20260610090000_axs_aq_match_use_events_table.sql
@@ -1,0 +1,67 @@
+-- Fix: axs_aq_match matched only aq_event_map, which is INCOMPLETE.
+--
+-- Eric Church @ Red Rocks (Jul 6/7/8 2026) exists in public.events (3360484/
+-- 3360483/3360482) but NOT in aq_event_map, so the AXS pulls (1400127/129/130)
+-- couldn't map — two stayed null and one (1400130) false-matched a stale
+-- aq_event_map Red Rocks row (3267061). public.events is the authoritative,
+-- complete TEvo event list, so match against it: the snapshot's pegged
+-- tevo_venue_id == events.venue_id is the strongest signal (exact venue), then
+-- date (±window) + event-name trigram. aq_short_event_id is looked up from
+-- aq_event_map when the matched tevo event happens to have one.
+
+create or replace function public.axs_aq_match(
+  p_axs_event_id text,
+  p_date_window_hours int default 48,
+  p_min_score numeric default 0.45)
+returns table(tevo_event_id bigint, aq_short_event_id text, confidence numeric, method text)
+language plpgsql stable set search_path = public, extensions, pg_temp as $$
+declare
+  v_name text; v_venue text; v_date timestamptz; v_tevo_venue bigint;
+begin
+  select event_name, venue_name, occurs_at_local::timestamptz, tevo_venue_id
+    into v_name, v_venue, v_date, v_tevo_venue
+  from public.axs_event_snapshots
+  where axs_event_id = p_axs_event_id and event_name is not null and venue_name is not null
+  order by captured_at desc limit 1;
+  if v_venue is null or v_date is null then return; end if;
+
+  return query
+  with cand as (
+    select ev.id as tid,
+           case when v_tevo_venue is not null and ev.venue_id = v_tevo_venue then 1.0
+                when lower(btrim(ev.venue_name)) = lower(btrim(v_venue)) then 0.95
+                else similarity(lower(coalesce(ev.venue_name,'')), lower(v_venue)) end as vscore,
+           greatest(similarity(lower(coalesce(ev.name,'')), lower(coalesce(v_name,''))), 0) as nscore,
+           abs(extract(epoch from (ev.occurs_at_local::timestamptz - v_date)))/3600.0 as dh
+    from public.events ev
+    where ev.occurs_at_local ~ '^\d{4}-\d{2}-\d{2}T'   -- guard the text->ts cast
+      and ev.occurs_at_local::timestamptz between v_date - make_interval(hours=>p_date_window_hours)
+                                              and v_date + make_interval(hours=>p_date_window_hours)
+      and ( (v_tevo_venue is not null and ev.venue_id = v_tevo_venue)
+            or lower(btrim(ev.venue_name)) = lower(btrim(v_venue))
+            or similarity(lower(coalesce(ev.venue_name,'')), lower(v_venue)) >= 0.6 )
+  ),
+  scored as (
+    select *, (0.45*vscore + 0.40*nscore + 0.15*greatest(0, 1 - dh/p_date_window_hours)) as score
+    from cand
+  )
+  select s.tid,
+         (select a.aq_short_event_id from public.aq_event_map a where a.tevo_event_id = s.tid limit 1),
+         round(s.score::numeric,3),
+         (case when s.vscore=1 and s.nscore>=0.5 then 'venue_id_name_date'
+               when s.vscore=1 then 'venue_id_date'
+               when s.nscore>=0.5 then 'venue_name_date'
+               else 'venue_date_proximity' end)::text
+  from scored s where s.score >= p_min_score
+  order by s.score desc, s.dh asc limit 1;
+end $$;
+
+-- re-map every snapshotted AXS event with the corrected matcher (fixes missing +
+-- the 1400130-style false matches).
+do $$
+declare r record;
+begin
+  for r in select distinct axs_event_id from public.axs_event_snapshots loop
+    perform public.axs_apply_aq(r.axs_event_id);
+  end loop;
+end $$;

--- a/supabase/migrations/20260610100000_aq_event_map_add_axs.sql
+++ b/supabase/migrations/20260610100000_aq_event_map_add_axs.sql
@@ -1,0 +1,143 @@
+-- Make AXS a first-class source in the canonical AQ hub.
+--
+-- aq_event_map carried vivid/sh/sg/tm/sd ids but no AXS. Add axs_event_id; set
+-- it on the 66 events already in the hub; INSERT the 109 AXS-mapped events that
+-- the curated import never created (aq_source='axs', deterministic PK
+-- 'AXS'<id>), so the hub is complete for AXS (this incompleteness is what made
+-- the Eric Church/Red Rocks tab empty). Teach match_to_aq_event_id an AXS
+-- direct-id tier, and point the registry's aq_short_event_id at the new rows.
+
+-- 1) column + index
+alter table public.aq_event_map add column if not exists axs_event_id text;
+create index if not exists aq_event_map_axs_event_idx
+  on public.aq_event_map (axs_event_id) where axs_event_id is not null;
+
+-- 2) populate the 66 events already in the hub
+update public.aq_event_map a
+set axs_event_id = e.axs_event_id
+from public.axs_events e
+where e.tevo_event_id = a.tevo_event_id
+  and e.tevo_event_id is not null and e.axs_event_id is not null
+  and a.axs_event_id is null;
+
+-- 3) insert the 109 AXS-mapped events missing from the hub (latest snapshot per
+-- event for name/venue/date; aq_source='axs'; id auto from the sequence)
+insert into public.aq_event_map
+  (aq_short_event_id, event_name, venue_name, event_date, performer,
+   venue_short_id, tevo_event_id, axs_event_id, aq_source, imported_at)
+select distinct on (e.axs_event_id)
+  'AXS' || e.axs_event_id,
+  s.event_name, s.venue_name,
+  s.occurs_at_local::timestamp,
+  s.event_name,
+  (select m.venue_short_id from public.aq_venue_map m where m.tevo_venue_id = s.tevo_venue_id limit 1),
+  e.tevo_event_id, e.axs_event_id, 'axs', now()
+from public.axs_events e
+join public.axs_event_snapshots s on s.axs_event_id = e.axs_event_id
+where e.tevo_event_id is not null
+  and s.event_name is not null and s.venue_name is not null
+  and not exists (select 1 from public.aq_event_map a where a.tevo_event_id = e.tevo_event_id)
+order by e.axs_event_id, s.captured_at desc
+on conflict (aq_short_event_id) do nothing;
+
+-- 4) point the registry's aq_short_event_id at the (new or existing) hub rows
+update public.axs_events e
+set aq_short_event_id = a.aq_short_event_id
+from public.aq_event_map a
+where a.axs_event_id = e.axs_event_id and e.aq_short_event_id is null;
+
+-- 5) match_to_aq_event_id: add an AXS direct-id tier (axs ids are numeric text)
+create or replace function public.match_to_aq_event_id(p_source text, p_source_event_id bigint, p_event_name text, p_venue_name text, p_event_date timestamp with time zone, p_lat numeric DEFAULT NULL::numeric, p_lon numeric DEFAULT NULL::numeric, p_source_venue_id bigint DEFAULT NULL::bigint)
+ RETURNS TABLE(aq_short_event_id text, confidence numeric, match_method text)
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_aq_id          text;
+  v_venue_short_id text;
+BEGIN
+  IF p_source_event_id IS NOT NULL AND p_source IN ('tevo', 'evo') THEN
+    SELECT a.aq_short_event_id INTO v_aq_id
+    FROM public.aq_event_map a
+    WHERE a.tevo_event_id = p_source_event_id LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 1.00::numeric(3,2), 'tier0_tevo_id'::text; RETURN;
+    END IF;
+  END IF;
+
+  IF p_source_event_id IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE (p_source IN ('vivid')              AND a.vivid_event_id = p_source_event_id)
+       OR (p_source IN ('seatgeek','sg')      AND a.sg_event_id    = p_source_event_id)
+       OR (p_source IN ('stubhub','sh')       AND a.sh_event_id    = p_source_event_id)
+       OR (p_source IN ('ticketmaster','tm')  AND a.tm_event_id    = p_source_event_id)
+       OR (p_source IN ('axs')                AND a.axs_event_id   = p_source_event_id::text)
+    LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 1.00::numeric(3,2), 'tier1_direct_id'::text; RETURN;
+    END IF;
+  END IF;
+
+  IF p_source_venue_id IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT m.venue_short_id INTO v_venue_short_id FROM public.aq_venue_map m
+    WHERE (p_source IN ('tickpick')         AND m.tickpick_venue_id = p_source_venue_id)
+       OR (p_source IN ('seatgeek','sg')    AND m.sg_venue_id       = p_source_venue_id)
+       OR (p_source IN ('tevo','evo')       AND m.tevo_venue_id     = p_source_venue_id)
+    LIMIT 1;
+    IF v_venue_short_id IS NOT NULL THEN
+      SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+      WHERE a.venue_short_id = v_venue_short_id
+        AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                          AND p_event_date + interval '6 hours'
+      ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date))) LIMIT 1;
+      IF v_aq_id IS NOT NULL THEN
+        RETURN QUERY SELECT v_aq_id, 0.93::numeric(3,2), 'tier1_5_venue_id_date'::text; RETURN;
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE lower(trim(a.venue_name)) = lower(trim(p_venue_name))
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date))) LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.95::numeric(3,2), 'tier2_venue_exact_date'::text; RETURN;
+    END IF;
+  END IF;
+
+  IF p_venue_name IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id FROM public.aq_event_map a
+    WHERE similarity(lower(coalesce(a.venue_name,'')), lower(coalesce(p_venue_name,''))) >= 0.7
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY similarity(lower(a.venue_name), lower(p_venue_name)) DESC,
+             abs(extract(epoch FROM (a.event_date::timestamptz - p_event_date))) LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.80::numeric(3,2), 'tier3_venue_fuzzy_date'::text; RETURN;
+    END IF;
+  END IF;
+
+  IF p_lat IS NOT NULL AND p_lon IS NOT NULL AND p_event_date IS NOT NULL THEN
+    SELECT a.aq_short_event_id INTO v_aq_id
+    FROM public.aq_event_map a
+    JOIN public.venue_assets va ON lower(trim(va.venue_name)) = lower(trim(a.venue_name))
+    WHERE va.latitude  BETWEEN p_lat - 0.01 AND p_lat + 0.01
+      AND va.longitude BETWEEN p_lon - 0.02 AND p_lon + 0.02
+      AND a.event_date::timestamptz BETWEEN p_event_date - interval '6 hours'
+                                        AND p_event_date + interval '6 hours'
+    ORDER BY (2 * 6371000 * asin(sqrt(
+       power(sin(radians((va.latitude  - p_lat)/2)), 2)
+       + cos(radians(p_lat)) * cos(radians(va.latitude))
+         * power(sin(radians((va.longitude - p_lon)/2)), 2)
+    ))) LIMIT 1;
+    IF v_aq_id IS NOT NULL THEN
+      RETURN QUERY SELECT v_aq_id, 0.85::numeric(3,2), 'tier4_coord_date'::text; RETURN;
+    END IF;
+  END IF;
+
+  RETURN;
+END;
+$function$;


### PR DESCRIPTION
## What

Surfaced via the live terminal page for **Eric Church @ Red Rocks, Jul 6 2026** (`tevo 3360484`): the AXS Box Office tab was empty. Root cause + a structural gap in the canonical hub.

### 1. `axs_aq_match` matched only `aq_event_map` (incomplete)
All three Eric Church @ Red Rocks shows exist in `public.events` (`3360484`/`3360483`/`3360482`) but **none were in `aq_event_map`**, so the matcher left Jul 6/7 unmapped and **false-matched** Jul 8 to a stale row (`3267061`). Rewrote `axs_aq_match` to match against **`public.events`** (authoritative + complete): strongest signal is the pegged `tevo_venue_id == events.venue_id`, then date (±48 h) + name trigram. Re-mapped all snapshotted events: **80 → 175 AQ-mapped**; Eric Church trio now maps to the correct distinct shows.

### 2. AXS is now a first-class source in `aq_event_map`
The hub carried vivid/sh/sg/tm/sd ids but no AXS, and was missing 109 of our mapped events entirely (the same incompleteness behind #1). This migration:
- adds **`aq_event_map.axs_event_id`** (+ index),
- populates the **66** events already in the hub,
- **inserts the 109** AXS-mapped events the curated import never created (`aq_source='axs'`, deterministic PK `AXS<id>`, name/venue/date from the latest snapshot),
- teaches **`match_to_aq_event_id`** an AXS direct-id tier (`a.axs_event_id = id::text`), and
- points the registry's `aq_short_event_id` at the hub rows.

## Verification
- Eric Church: `1400127`→`3360484` (Jul 6), `1400129`→`3360483` (Jul 7), `1400130`→`3360482` (Jul 8); false `3267061` corrected.
- `3360484` now resolves **207 AXS listing blocks** → that page's AXS tab is populated.
- `aq_event_map`: **167 rows** carry `axs_event_id`, **109** new `aq_source='axs'` rows; `match_to_aq_event_id('axs', 1400127, …)` → `AXS1400127` via `tier1_direct_id`.

Both already applied to prod via MCP; migrations committed for reproducibility.

https://claude.ai/code/session_01Cysx735CRGWND8Bxz7GgAo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cysx735CRGWND8Bxz7GgAo)_