### PR TITLE
chore(d1): serve VibePass hub at the root of both Render surfaces

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -55,11 +55,13 @@ services:
       - key: STOREFRONT_SQL_ONLY
         value: "true"
       # ---- Storefront-as-landing flag ----
-      # Makes / redirect to /store so customers don't see the debug
-      # data-collection JSON. Storefront-test service is the only Render
-      # service that should set this true.
+      # false (operator directive 2026-06-15): / serves the VibePass unified
+      # hub (static/home/index.html) as the main screen — the 4-surface
+      # selector (Terminal / Undelivered / Store / Bridge), auth-gated in
+      # home.js. Set "true" to revert to the old behavior where / redirects
+      # to /store (customers land directly on the storefront).
       - key: STOREFRONT_AS_LANDING
-        value: "true"
+        value: "false"
       # ---- Storefront constants ----
       - key: ALLOWED_EMAIL_DOMAIN
         value: s4kent.com

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Root index for the static CDN (vibepass-terminal-test, publishPath=static).
+       A static site serves this file at / by default, so the bare root lands on
+       the VibePass hub regardless of whether the blueprint's /->/home rewrite is
+       active in the Render dashboard. Canonical hub lives at /home/. -->
+  <meta http-equiv="refresh" content="0; url=/home/" />
+  <link rel="canonical" href="/home/" />
+  <title>VibePass</title>
+  <script>location.replace('/home/');</script>
+</head>
+<body>
+  <p>Redirecting to the <a href="/home/">VibePass hub</a>&hellip;</p>
+</body>
+</html>


### PR DESCRIPTION
## What
Make the **VibePass hub the root landing** on both Render front-end surfaces, via two complementary, no-Render-access-required changes:

1. **`render.yaml`** — flip `STOREFRONT_AS_LANDING` `true`→`false` on **`vibepass-storefront-test`** (FastAPI). `root_landing()` in `app.py` already serves the hub when the flag is `false`; this selects that path instead of redirecting to `/store`. *(Takes effect on merge → auto-deploy, since this service is blueprint-connected.)*
2. **`static/index.html`** (new) — a root index for **`vibepass-terminal-test`** (static CDN, `publishPath=static`). A static site serves `index.html` at `/` by default, so the bare root lands on the hub **without** depending on the blueprint's `/`→`/home/index.html` rewrite (which the repo notes isn't the active Render config). Forwards to the canonical hub at `/home/`.

Together: `/` serves the hub on **both** hosts after merge.

## Why
Operator directive (2026-06-15): make the D-tier hub the main landing screen on the live Render URLs.

## How it goes live
Both services `autoDeploy` from `main`, so **merging this PR auto-deploys** both changes — no dashboard trip or Render MCP needed. Caveats:
- If `STOREFRONT_AS_LANDING` was overridden in the storefront's **dashboard** env vars, the dashboard value wins — flip it there too.
- `static/index.html` only affects the static CDN root; the storefront root is governed by `root_landing()` + the env flag (no conflict — FastAPI's `/` route takes precedence over static mounts).

## ⚠️ Reviewer note (unchanged)
The hub at `/` exposes the selector (incl. gated Terminal/Undelivered cards) on the **public** storefront root — reverses the prior "customers land on `/store`" choice. Cards are gated client-side (`home.js`) + server-side (email gate), so this exposes tiles, not data. Flagging for D1/A1 sign-off; operator-directed.

## Verification (post-deploy)
- `GET https://vibepass-storefront-test.onrender.com/` → hub HTML (`<title>VibePass</title>`, 4 cards), 200, not a 302 → `/store`.
- `GET https://vibepass-terminal-test.onrender.com/` → lands on the hub (redirects to `/home/`).

https://claude.ai/code/session_01YGkX77Et2fzHAFoSGYCzCe