### PR TITLE
feat(d0/home): add Orders (D2) card to the hub

### DIFF
--- a/static/home/home.js
+++ b/static/home/home.js
@@ -1,6 +1,7 @@
-// VibePass unified homescreen. Auth-aware: signed-in @s4kent.com sees all 4
-// cards; everyone else sees Store + Bridge unlocked and the two operator
-// cards gated. localhost dev is treated as authed (parity with terminal).
+// VibePass unified homescreen. Auth-aware: signed-in @s4kent.com sees all 5
+// cards; everyone else sees Store + Bridge unlocked and the three operator
+// cards (Terminal / Undelivered / Orders) gated. localhost dev is treated as
+// authed (parity with terminal).
 // Bridge runs at /bridge/ on the same Railway origin — same localStorage,
 // so the Supabase session from the hub carries over to Bridge automatically.
 
@@ -9,6 +10,7 @@
 
   const cardTerminal    = document.getElementById('cardTerminal');
   const cardUndelivered = document.getElementById('cardUndelivered');
+  const cardOrders      = document.getElementById('cardOrders');
   const cardBridge      = document.getElementById('cardBridge');
   const bridgeNote      = document.getElementById('bridgeNote');
   const authCtrl        = document.getElementById('auth-ctrl');
@@ -55,6 +57,7 @@
     // supabase-js or auth.js failed to load — treat as not signed in.
     lockCard(cardTerminal);
     lockCard(cardUndelivered);
+    lockCard(cardOrders);
     setBridgeNote(false);
     setFootStatus('auth offline');
     renderAuth(null);
@@ -72,6 +75,7 @@
     } else {
       lockCard(cardTerminal);
       lockCard(cardUndelivered);
+      lockCard(cardOrders);
       setBridgeNote(!!email);
       renderAuth(email);
       setFootStatus(email ? 'not on @s4kent.com — operator surfaces gated' : 'sign in to unlock operator surfaces');
@@ -80,6 +84,7 @@
     console.error('auth ready failed', err);
     lockCard(cardTerminal);
     lockCard(cardUndelivered);
+    lockCard(cardOrders);
     setBridgeNote(false);
     setFootStatus('auth init failed');
   });

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -35,7 +35,7 @@
       <div class="card-gate" hidden>Sign in with <code>@s4kent.com</code> to access</div>
     </a>
 
-    <a class="card orders" id="cardOrders" href="https://d2-orders-dashboard.onrender.com">
+    <a class="card orders" id="cardOrders" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener noreferrer">
       <div class="card-tag">D2 · ORDERS</div>
       <h2>Orders</h2>
       <p>Sales-API up/down status, day-over-day sales, and order-fulfillment logistics across every source. The D2 sales-data + CS backend dashboard.</p>

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -35,6 +35,14 @@
       <div class="card-gate" hidden>Sign in with <code>@s4kent.com</code> to access</div>
     </a>
 
+    <a class="card orders" id="cardOrders" href="https://d2-orders-dashboard.onrender.com">
+      <div class="card-tag">D2 · ORDERS</div>
+      <h2>Orders</h2>
+      <p>Sales-API up/down status, day-over-day sales, and order-fulfillment logistics across every source. The D2 sales-data + CS backend dashboard.</p>
+      <div class="card-cta">Open Orders →</div>
+      <div class="card-gate" hidden>Sign in with <code>@s4kent.com</code> to access</div>
+    </a>
+
     <a class="card store" id="cardStore" href="/store">
       <div class="card-tag">PUBLIC · STORE</div>
       <h2>Store</h2>

--- a/static/home/style.css
+++ b/static/home/style.css
@@ -65,6 +65,7 @@ main.grid {
 }
 .card.terminal    { border-top-color: var(--accent); }
 .card.undelivered { border-top-color: var(--warn); }
+.card.orders      { border-top-color: var(--pos); }
 .card.store       { border-top-color: var(--info); }
 .card.bridge      { border-top-color: #c084fc; }
 .card.locked {
@@ -83,6 +84,7 @@ main.grid {
 }
 .card.terminal    .card-tag { color: var(--accent); }
 .card.undelivered .card-tag { color: var(--warn); }
+.card.orders      .card-tag { color: var(--pos); }
 .card.store       .card-tag { color: var(--info); }
 .card.bridge      .card-tag { color: #c084fc; }
 
@@ -103,6 +105,7 @@ main.grid {
   text-transform: uppercase; letter-spacing: 0.5px;
   color: var(--accent);
 }
+.card.orders .card-cta { color: var(--pos); }
 .card.bridge .card-cta { color: #c084fc; }
 .card-note {
   margin-top: 8px;


### PR DESCRIPTION
## What
Adds an **Orders** card to the VibePass hub (`static/home/`), wiring the **D2 orders/ops dashboard** in as a first-class surface — the one user-facing D-tier surface that wasn't on the hub.

- `index.html` — new `Orders` card (`D2 · ORDERS`): sales-API up/down status, day-over-day sales, order-fulfillment logistics. Cross-origin link hardened with `target="_blank" rel="noopener noreferrer"`.
- `style.css` — green (`--pos`) accent for the card / tag / CTA.
- `home.js` — gates the card like Terminal/Undelivered (operator surface): unlocked for `@s4kent.com`/localhost, locked otherwise.

## Hub coverage after this
Every D-lane with a UI is now a first-class hub card: D0 Terminal · D1 Store · D2 Undelivered · **D2 Orders (new)** · D4 Bridge. D3 (headless Broadway scraper) and E1 (unbuilt) have no UI.

## Authorization posture (audited)
The real boundary is **server-side on the D2 dashboard**, and it holds:
- All data routes (`/api/d2/orders|metrics|sales-feed|health|cron-freshness|order/*|config`, `/healthz/detail`) require `Depends(require_auth)`: Supabase JWT → `aud=authenticated` (rejects anon/service-role) → `email_confirmed_at` → `@s4kent.com`.
- Public-by-design routes (`/`, `/healthz`, `/readyz`, `/config-public`) carry **no secrets** (anon key only; `<` escaped against `</script>` injection).
- `AUTH_DISABLED` kill switch is **production-locked** (self-disables on Render); missing Supabase creds → **503**, not open. CORS is explicit-origin + credentialed, GET/OPTIONS only.

**Two layers for Orders:** client-side card gating (hub) + server-side `require_auth` (dashboard). The card link is also `noopener`/`noreferrer` so the external service can't reach back into the hub or read its referrer.

## Why this href (not a same-origin `/orders` route)
The D2 dashboard page renders at `@router.get("/")`, which `app.py` shadows with the hub in the unified shell, so the dashboard HTML only renders on its own Render service. Browsers don't send the Bearer JWT on a link navigation, so a same-origin page route couldn't be server-gated anyway — every surface uses the same model (open shell + client gate + `require_auth` on data APIs). A future same-origin proxy mount could remove the cross-origin re-auth; out of scope here.

## Verification (post-deploy)
- Hub shows 5 cards; **Orders** has a green top-border and opens the D2 dashboard in a new tab.
- Signed out / non-`@s4kent`: Orders is locked + shows the sign-in gate.
- D2 dashboard rejects any non-`@s4kent` / unauthenticated `/api/d2/*` request (401/403).

https://claude.ai/code/session_01YGkX77Et2fzHAFoSGYCzCe