### PR TITLE
refactor(d0): merge D2 orders dashboard into the unified render service

### DIFF
--- a/app.py
+++ b/app.py
@@ -8442,11 +8442,21 @@ def store_test_tour_page(_=Depends(_require_non_prod)):
 # wins for matching). Auth (question B): D2 routes reuse their own dependency
 # injection; the shell's `require_auth` applies on app.py's own routes.
 try:
-    from d2_dashboard.main import router as d2_router  # type: ignore
+    from d2_dashboard.main import router as d2_router, root as d2_dashboard_root  # type: ignore
     app.include_router(d2_router)
-    logging.getLogger(__name__).info("d2_dashboard router mounted at unified shell (%d routes)", len(d2_router.routes))
+    # Fold the standalone d2-orders-dashboard service INTO this unified shell.
+    # The dashboard PAGE (d2's own "/") is shadowed by the hub homescreen
+    # (app.get("/") above), so serve it same-origin at /d2 instead. Its assets
+    # live in d2_dashboard/static and load from /static/d2/* — mount that here,
+    # BEFORE the catch-all /static mount below, so the longer prefix wins.
+    _D2_STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "d2_dashboard", "static")
+    if os.path.isdir(_D2_STATIC_DIR):
+        app.mount("/static/d2", StaticFiles(directory=_D2_STATIC_DIR), name="d2_static")
+    app.add_api_route("/d2", d2_dashboard_root, methods=["GET"], include_in_schema=False)
+    app.add_api_route("/d2/", d2_dashboard_root, methods=["GET"], include_in_schema=False)
+    logging.getLogger(__name__).info("d2_dashboard mounted (router + /d2 page + /static/d2)")
 except Exception as _d2_import_err:  # pragma: no cover — d2 module optional in dev
-    logging.getLogger(__name__).warning("d2_dashboard router NOT mounted: %s", _d2_import_err)
+    logging.getLogger(__name__).warning("d2_dashboard NOT mounted: %s", _d2_import_err)
 
 
 # ---------- Site essentials (SEO + browser-tab UX) ----------

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -35,7 +35,7 @@
       <div class="card-gate" hidden>Sign in with <code>@s4kent.com</code> to access</div>
     </a>
 
-    <a class="card orders" id="cardOrders" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener noreferrer">
+    <a class="card orders" id="cardOrders" href="/d2/">
       <div class="card-tag">D2 · ORDERS</div>
       <h2>Orders</h2>
       <p>Sales-API up/down status, day-over-day sales, and order-fulfillment logistics across every source. The D2 sales-data + CS backend dashboard.</p>

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -11,7 +11,7 @@
   <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <link rel="manifest" href="/manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Sign in</title>
@@ -36,7 +36,7 @@
       </div>
 
       <div class="login-foot">
-        <a href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">D2 Orders Dashboard ↗</a>
+        <a href="/d2/" target="_blank" rel="noopener">D2 Orders Dashboard ↗</a>
         <span class="dot">·</span>
         <span class="muted small">vibepass-terminal-test</span>
       </div>

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -11,7 +11,7 @@
   <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <link rel="manifest" href="/manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
@@ -32,11 +32,11 @@
         <p>
           The orders surface is owned by <strong>D2</strong> (Order Clients lane).
           A unified Evo + SeatGeek + TickPick + Vivid view, plus a SeatData analytics tab,
-          lives at <strong>d2-orders-dashboard.onrender.com</strong>.
+          lives at <strong>/d2</strong> on this service.
           D0's terminal nav routes you there — both lanes converge at this page.
         </p>
         <div class="doorway-cta">
-          <a id="d2Open" class="btn-primary" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">
+          <a id="d2Open" class="btn-primary" href="/d2/" target="_blank" rel="noopener">
             Open Orders Dashboard ↗
           </a>
           <span id="d2HealthBadge" class="health-badge dim">checking…</span>
@@ -64,7 +64,7 @@
           <ul>
             <li>The full orders dashboard implementation</li>
             <li>All 4 order sources (Evo, SeatGeek, TickPick, Vivid) + SeatData tab</li>
-            <li><code>d2-orders-dashboard.onrender.com</code> service</li>
+            <li>The <code>/d2</code> dashboard (merged into this service)</li>
             <li>Auth: Supabase JWT + <code>@s4kent.com</code> allowlist (mirrors <code>app.py</code>)</li>
           </ul>
         </div>

--- a/static/terminal/orders.js
+++ b/static/terminal/orders.js
@@ -6,7 +6,7 @@
 (function () {
   'use strict';
   const T = window.Terminal;
-  const D2_BASE = 'https://d2-orders-dashboard.onrender.com';
+  const D2_BASE = '';  // same-origin — D2 dashboard is merged into this service (/d2 + /api/d2/*)
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();

--- a/static/undelivered/index.html
+++ b/static/undelivered/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Undelivered · VibePass</title>
@@ -30,12 +30,12 @@
       <p>
         Customer service workflow across <strong>Evo · SeatGeek · TickPick · Vivid · SeatData</strong>.
         Per D2's scope decision (<code>bot_chat</code> #199): the unified orders view IS the undelivered surface —
-        D2's <code>/orders</code> tab on <strong>d2-orders-dashboard.onrender.com</strong> evolves into the
+        D2's dashboard at <strong>/d2</strong> evolves into the
         fulfillment-ops workflow described in <code>design/undelivered-window-2026-05-08.md</code>.
         Time-to-event sort · hold-expiry lane · bulk-deliver-per-event · channel logos.
       </p>
       <div class="doorway-cta">
-        <a id="d2Open" class="btn-primary" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">
+        <a id="d2Open" class="btn-primary" href="/d2/" target="_blank" rel="noopener">
           Open Orders Dashboard ↗
         </a>
         <span id="d2HealthBadge" class="health-badge dim">checking…</span>

--- a/static/undelivered/undelivered.js
+++ b/static/undelivered/undelivered.js
@@ -4,7 +4,7 @@
 (function () {
   'use strict';
   const Auth = window.TerminalAuth;
-  const D2_BASE = 'https://d2-orders-dashboard.onrender.com';
+  const D2_BASE = '';  // same-origin — D2 dashboard is merged into this service (/d2 + /api/d2/*)
 
   function isLocalhost() {
     const h = location.hostname;


### PR DESCRIPTION
## What
Consolidates the front end onto **one Render service** (`vibepass-storefront-test`, the only one running the FastAPI backend) by folding the standalone **D2 orders dashboard** into the unified shell and repointing every cross-host link to same-origin.

### Backend (`app.py`)
- The D2 `/api/d2/*` router was already mounted. This adds the **dashboard page** at **`/d2`** (its own `/` is shadowed by the hub homescreen) + mounts its assets at **`/static/d2`** (before the catch-all `/static`, so the longer prefix wins). Guarded inside the existing `try` import block — if the d2 module is absent, the shell still boots.

### Front end — repoint to same-origin
- `static/terminal/orders.js`, `static/undelivered/undelivered.js`: `D2_BASE = ''` → the health ping + data calls hit **this** service, not the standalone d2 host.
- `static/home/index.html` (Orders card), `static/terminal/login.html`, `static/terminal/orders.html`, `static/undelivered/index.html`: D2 links → **`/d2/`**; dropped `https://d2-orders-dashboard.onrender.com` from each **CSP `connect-src`**; refreshed the now-stale copy.

## Net effect
- One service serves the **entire hub with a working backend** — Terminal, Store, Undelivered, **Orders (`/d2`)**, Bridge.
- The static **`terminal-test` CDN** and the standalone **`d2-orders-dashboard`** service are no longer referenced by any live surface → safe to **turn off** (keep for feature testing).
- The Orders card is now **same-origin** (dropped the cross-origin `noopener/noreferrer` since it's no longer external).

## What's NOT in this PR (your Render-dashboard side — I have no Render access)
- Suspend `vibepass-terminal-test` + `d2-orders-dashboard`.
- Ensure `vibepass-storefront-test` has the env/secrets the app reads (it already does — it's the running service).

## Verify (post-deploy on `storefront-test`)
- `GET /d2/` → D2 dashboard renders (assets from `/static/d2/*`, data from `/api/d2/*`).
- Hub **Orders** card → `/d2/` same-tab; Undelivered/Terminal "Open Orders Dashboard" → `/d2/`.
- ⚠️ **OAuth redirect:** the D2 dashboard's Supabase sign-in uses `window.origin` as `redirectTo` — confirm `https://vibepass-storefront-test.onrender.com` (and `/d2`) is in Supabase Auth's allowed redirect URLs, or sign-in on `/d2` will bounce.

## Left as-is (inert, optional cleanup)
CORS allowlists (`d2_dashboard/main.py`, `supabase/functions/espn`) and the standalone `render-d2-dashboard.yaml` still list the old origins — harmless extra entries for now-idle services; trimming them needs an edge-fn redeploy, out of scope here.

https://claude.ai/code/session_01YGkX77Et2fzHAFoSGYCzCe

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGkX77Et2fzHAFoSGYCzCe)_