### PR TITLE
revert(d0): keep D2 orders dashboard standalone (revert #553)

### DIFF
--- a/app.py
+++ b/app.py
@@ -8399,21 +8399,11 @@ def store_test_tour_page(_=Depends(_require_non_prod)):
 # wins for matching). Auth (question B): D2 routes reuse their own dependency
 # injection; the shell's `require_auth` applies on app.py's own routes.
 try:
-    from d2_dashboard.main import router as d2_router, root as d2_dashboard_root  # type: ignore
+    from d2_dashboard.main import router as d2_router  # type: ignore
     app.include_router(d2_router)
-    # Fold the standalone d2-orders-dashboard service INTO this unified shell.
-    # The dashboard PAGE (d2's own "/") is shadowed by the hub homescreen
-    # (app.get("/") above), so serve it same-origin at /d2 instead. Its assets
-    # live in d2_dashboard/static and load from /static/d2/* — mount that here,
-    # BEFORE the catch-all /static mount below, so the longer prefix wins.
-    _D2_STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "d2_dashboard", "static")
-    if os.path.isdir(_D2_STATIC_DIR):
-        app.mount("/static/d2", StaticFiles(directory=_D2_STATIC_DIR), name="d2_static")
-    app.add_api_route("/d2", d2_dashboard_root, methods=["GET"], include_in_schema=False)
-    app.add_api_route("/d2/", d2_dashboard_root, methods=["GET"], include_in_schema=False)
-    logging.getLogger(__name__).info("d2_dashboard mounted (router + /d2 page + /static/d2)")
+    logging.getLogger(__name__).info("d2_dashboard router mounted at unified shell (%d routes)", len(d2_router.routes))
 except Exception as _d2_import_err:  # pragma: no cover — d2 module optional in dev
-    logging.getLogger(__name__).warning("d2_dashboard NOT mounted: %s", _d2_import_err)
+    logging.getLogger(__name__).warning("d2_dashboard router NOT mounted: %s", _d2_import_err)
 
 
 # ---------- Site essentials (SEO + browser-tab UX) ----------

--- a/static/home/index.html
+++ b/static/home/index.html
@@ -35,7 +35,7 @@
       <div class="card-gate" hidden>Sign in with <code>@s4kent.com</code> to access</div>
     </a>
 
-    <a class="card orders" id="cardOrders" href="/d2/">
+    <a class="card orders" id="cardOrders" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener noreferrer">
       <div class="card-tag">D2 · ORDERS</div>
       <h2>Orders</h2>
       <p>Sales-API up/down status, day-over-day sales, and order-fulfillment logistics across every source. The D2 sales-data + CS backend dashboard.</p>

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -11,7 +11,7 @@
   <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <link rel="manifest" href="/manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Sign in</title>
@@ -36,7 +36,7 @@
       </div>
 
       <div class="login-foot">
-        <a href="/d2/" target="_blank" rel="noopener">D2 Orders Dashboard ↗</a>
+        <a href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">D2 Orders Dashboard ↗</a>
         <span class="dot">·</span>
         <span class="muted small">vibepass-terminal-test</span>
       </div>

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -11,7 +11,7 @@
   <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <link rel="manifest" href="/manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
@@ -32,11 +32,11 @@
         <p>
           The orders surface is owned by <strong>D2</strong> (Order Clients lane).
           A unified Evo + SeatGeek + TickPick + Vivid view, plus a SeatData analytics tab,
-          lives at <strong>/d2</strong> on this service.
+          lives at <strong>d2-orders-dashboard.onrender.com</strong>.
           D0's terminal nav routes you there — both lanes converge at this page.
         </p>
         <div class="doorway-cta">
-          <a id="d2Open" class="btn-primary" href="/d2/" target="_blank" rel="noopener">
+          <a id="d2Open" class="btn-primary" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">
             Open Orders Dashboard ↗
           </a>
           <span id="d2HealthBadge" class="health-badge dim">checking…</span>
@@ -64,7 +64,7 @@
           <ul>
             <li>The full orders dashboard implementation</li>
             <li>All 4 order sources (Evo, SeatGeek, TickPick, Vivid) + SeatData tab</li>
-            <li>The <code>/d2</code> dashboard (merged into this service)</li>
+            <li><code>d2-orders-dashboard.onrender.com</code> service</li>
             <li>Auth: Supabase JWT + <code>@s4kent.com</code> allowlist (mirrors <code>app.py</code>)</li>
           </ul>
         </div>

--- a/static/terminal/orders.js
+++ b/static/terminal/orders.js
@@ -6,7 +6,7 @@
 (function () {
   'use strict';
   const T = window.Terminal;
-  const D2_BASE = '';  // same-origin — D2 dashboard is merged into this service (/d2 + /api/d2/*)
+  const D2_BASE = 'https://d2-orders-dashboard.onrender.com';
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();

--- a/static/undelivered/index.html
+++ b/static/undelivered/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=1440, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Undelivered · VibePass</title>
@@ -30,12 +30,12 @@
       <p>
         Customer service workflow across <strong>Evo · SeatGeek · TickPick · Vivid · SeatData</strong>.
         Per D2's scope decision (<code>bot_chat</code> #199): the unified orders view IS the undelivered surface —
-        D2's dashboard at <strong>/d2</strong> evolves into the
+        D2's <code>/orders</code> tab on <strong>d2-orders-dashboard.onrender.com</strong> evolves into the
         fulfillment-ops workflow described in <code>design/undelivered-window-2026-05-08.md</code>.
         Time-to-event sort · hold-expiry lane · bulk-deliver-per-event · channel logos.
       </p>
       <div class="doorway-cta">
-        <a id="d2Open" class="btn-primary" href="/d2/" target="_blank" rel="noopener">
+        <a id="d2Open" class="btn-primary" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">
           Open Orders Dashboard ↗
         </a>
         <span id="d2HealthBadge" class="health-badge dim">checking…</span>

--- a/static/undelivered/undelivered.js
+++ b/static/undelivered/undelivered.js
@@ -4,7 +4,7 @@
 (function () {
   'use strict';
   const Auth = window.TerminalAuth;
-  const D2_BASE = '';  // same-origin — D2 dashboard is merged into this service (/d2 + /api/d2/*)
+  const D2_BASE = 'https://d2-orders-dashboard.onrender.com';
 
   function isLocalhost() {
     const h = location.hostname;


### PR DESCRIPTION
## What
Reverts PR #553 ("merge D2 orders dashboard into the unified render service"). Per operator direction — **keep D2 as its own standalone service** (`d2-orders-dashboard`) rather than folding `/d2` into the unified shell.

Undoes:
- `app.py` — removes the `/d2` page route + `/static/d2` mount (D2 is back to router-only `/api/d2/*`).
- Hub Orders card, terminal/undelivered "Open Dashboard", login link → back to `https://d2-orders-dashboard.onrender.com` (cross-origin, hardened).
- `D2_BASE` → standalone host; CSPs restore the `d2-orders-dashboard` origin.

## Why
The merge surfaced friction (missing `SUPABASE_ANON_KEY` on `storefront-test`, plus cross-origin OAuth redirect setup). Cleaner to leave D2 standalone for now; the other surfaces still consolidate onto `storefront-test`.

## Net state after this
- `storefront-test` serves Terminal / Store / Undelivered / Bridge + the hub.
- `d2-orders-dashboard` stays live as the D2 Orders surface (don't suspend it).
- `terminal-test` static CDN is still safe to retire (nothing backend-dependent relies on it).

https://claude.ai/code/session_01YGkX77Et2fzHAFoSGYCzCe

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGkX77Et2fzHAFoSGYCzCe)_