### PR TITLE
feat(d0): World Cup across all platforms + real chart/markets view + fresh-data catch-up

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -16,7 +16,7 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Event</title>
   <link rel="stylesheet" href="lib/uplot.min.css" />
-  <link rel="stylesheet" href="style.css?v=20260615" />
+  <link rel="stylesheet" href="style.css?v=20260616" />
 </head>
 <body data-page="event">
 
@@ -511,6 +511,6 @@
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260608"></script>
   <script src="alerts.js?v=20260608"></script>
-  <script src="event.js?v=20260615"></script>
+  <script src="event.js?v=20260616"></script>
 </body>
 </html>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -265,13 +265,12 @@
         `<td class="num">${num(r.listings_count)}</td>` +
         `<td class="num">${num(r.tickets_count)}</td>` +
         '</tr>').join('');
-      const spark = sgSparkline(rows.map(r => +r.allin_median).filter(v => Number.isFinite(v)));
       priceSection =
         `<section id="kpi-grid">${kpiHtml}</section>` +
         '<section id="sg-price-history">' +
           '<div class="panel-title row"><span>SEATGEEK PRICE HISTORY — daily all-in (wc_price_daily)</span>' +
           `<span class="muted small">${rows.length} days · sg_event_id ${sgId}</span></div>` +
-          spark +
+          '<div id="wcChartHost" class="wc-chart"></div>' +
           '<table class="wc-daily"><thead><tr><th>Date</th><th class="num">Get-in</th><th class="num">Median</th>' +
           '<th class="num">P90</th><th class="num">Listings</th><th class="num">Tickets</th></tr></thead>' +
           `<tbody>${tableRows}</tbody></table>` +
@@ -279,16 +278,69 @@
     }
 
     pane.innerHTML = priceSection +
+      '<section id="wc-markets"><div class="panel-title row"><span>MARKETS — cross-source (via AQ hub)</span>' +
+        '<span class="muted small" id="wcMktMeta">loading…</span></div><div id="wcMktBody"><div class="empty">loading…</div></div>' +
+        '<div class="muted small" style="margin-top:6px">SeatGeek is live; StubHub / VividSeats / Ticketmaster fill in as their pulls land. ' +
+        'GameTime needs discovery; seat map / EVO aren\'t available for SeatGeek-native events.</div></section>' +
       '<section id="sg-listings-inline"><div class="panel-title row"><span>CURRENT SG LISTINGS — cheapest all-in (deduped, last 7d)</span>' +
         '<span class="muted small" id="sgLstMeta">loading…</span></div><div id="sgLstBody"><div class="empty">loading…</div></div></section>' +
       '<section id="sg-sales-inline"><div class="panel-title row"><span>RECENT SG SALES — last 90d (deduped)</span>' +
-        '<span class="muted small" id="sgSlsMeta">loading…</span></div><div id="sgSlsBody"><div class="empty">loading…</div></div></section>' +
-      '<section id="other-markets"><div class="panel-title">OTHER MARKETS — via AQ hub</div>' +
-        '<div class="muted small">StubHub + VividSeats collection is being enabled for World Cup matches (listings appear here as they\'re pulled). ' +
-        'Ticketmaster + GameTime use slug-based URLs and require discovery. Seat map / EVO aren\'t available — these events aren\'t in the TEvo market.</div></section>';
+        '<span class="muted small" id="sgSlsMeta">loading…</span></div><div id="sgSlsBody"><div class="empty">loading…</div></div></section>';
 
+    if (rows.length) renderWcChart('wcChartHost', rows);
+    loadWcMarkets(sgId).catch(e => console.error('[wc markets]', e));
     loadSgListingsInline(sgId).catch(e => console.error('[sg listings]', e));
     loadSgSalesInline(sgId).catch(e => console.error('[sg sales]', e));
+  }
+
+  // Real uPlot price chart for the WC page (get-in / median / p90 daily series).
+  function renderWcChart(hostId, rows) {
+    const host = document.getElementById(hostId);
+    if (!host || typeof uPlot === 'undefined' || !rows || rows.length < 2) return;
+    const asc = rows.slice().sort((a, b) => (a.snapshot_date < b.snapshot_date ? -1 : 1));
+    const xs = asc.map(r => Math.floor(new Date(r.snapshot_date + 'T00:00:00Z').getTime() / 1000));
+    const col = k => asc.map(r => (r[k] != null ? +r[k] : null));
+    const data = [xs, col('allin_min'), col('allin_median'), col('allin_p90')];
+    const width = () => Math.max(320, host.clientWidth || 800);
+    const opts = {
+      width: width(), height: 240,
+      scales: { x: { time: true } },
+      series: [
+        {},
+        { label: 'Get-in', stroke: '#5ab0ff', width: 2 },
+        { label: 'Median', stroke: '#46d39a', width: 2 },
+        { label: 'P90', stroke: '#e0a23c', width: 1 },
+      ],
+    };
+    host.innerHTML = '';
+    const u = new uPlot(opts, data, host);
+    if (!host._wcResize) {
+      host._wcResize = true;
+      window.addEventListener('resize', () => u.setSize({ width: width(), height: 240 }));
+    }
+  }
+
+  // Cross-source markets summary (SeatGeek live + StubHub/VividSeats/Ticketmaster
+  // as their data lands), resolved through the AQ hub by get_wc_markets.
+  async function loadWcMarkets(sgId) {
+    const Auth = window.TerminalAuth;
+    const body = document.getElementById('wcMktBody'), meta = document.getElementById('wcMktMeta');
+    if (!body || !Auth || !Auth.client) return;
+    const res = await Auth.client.rpc('get_wc_markets', { p_sg_event_id: sgId });
+    if (res.error) { body.innerHTML = `<div class="empty">${escapeHtml(res.error.message)}</div>`; if (meta) meta.textContent = ''; return; }
+    const rows = res.data || [];
+    if (!rows.length) { body.innerHTML = '<div class="empty">No market data yet — pulls in progress.</div>'; if (meta) meta.textContent = ''; return; }
+    if (meta) meta.textContent = `${rows.length} source${rows.length > 1 ? 's' : ''}`;
+    const money = v => (v == null ? '—' : '$' + T.fmtNum(Math.round(+v)));
+    const trs = rows.map(r => '<tr>' +
+      `<td><strong>${escapeHtml(r.source)}</strong></td>` +
+      `<td class="num">${money(r.getin)}</td>` +
+      `<td class="num">${money(r.median)}</td>` +
+      `<td class="num">${r.listings != null ? T.fmtNum(r.listings) : '—'}</td>` +
+      `<td class="muted small">${r.last_pull ? escapeHtml(T.fmtDate(r.last_pull)) : '—'}</td>` +
+      '</tr>').join('');
+    body.innerHTML = '<table><thead><tr><th>Source</th><th class="num">Get-in</th><th class="num">Median</th>' +
+      '<th class="num">Listings</th><th>Last pull</th></tr></thead><tbody>' + trs + '</tbody></table>';
   }
 
   async function loadSgListingsInline(sgId) {

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -108,8 +108,9 @@ main.wrap {
   color: var(--muted);
   background: var(--panel-2);
 }
-/* SeatGeek-mode event page — median-price sparkline */
+/* SeatGeek-mode event page — price chart + sparkline */
 .sg-spark { display: block; width: 100%; height: 72px; color: var(--accent); margin: 8px 0 12px; }
+.wc-chart { width: 100%; min-height: 240px; margin: 8px 0 12px; }
 table.wc-daily { width: 100%; }
 
 /* Source badge — marks a SeatGeek-native watchlist row (now links to SG mode) */

--- a/supabase/migrations/20260616180000_wc_all_platforms.sql
+++ b/supabase/migrations/20260616180000_wc_all_platforms.sql
@@ -1,0 +1,105 @@
+-- Migration 20260616180000 · lane:D0 (author) → A1 (apply) · writes:ticketsdata_event_xref (seed TM for WC), get_wc_markets · reads:aq_event_map, sg_events_canonical, seatgeek_listings_snapshots, ticketsdata_listings_snapshots · pre:20260615140000_wc_enable_sh_vd_collection · auth:operator-requested 2026-06-16 ("match wc games across all platforms and track them all")
+--
+-- D0 — extend World Cup collection to Ticketmaster + add a cross-source markets
+-- RPC for the terminal event page.
+--
+-- (1) TM seed: the TM /fetch URL is derivable from the hub's native id —
+--     ticketsdata.com fetches by marketplace URL, and TM's canonical event URL
+--     is https://www.ticketmaster.com/event/<HEX> where HEX = upper(to_hex(id))
+--     (verified: every existing TM event_url ends in exactly that hex). So seed
+--     TM xref rows from aq_event_map.tm_event_id; the active td_enqueue_peak_tm +
+--     drains then collect them (budget-gated). Best-effort: if TD won't resolve
+--     the slug-less URL it simply yields no rows (no harm). GameTime stays the
+--     one gap — its URL is pure slug with no id form, so it needs td_gt_discover
+--     (performer-matched) which is a separate follow-up.
+--
+-- (2) get_wc_markets(p_sg_event_id): resolves the event through the AQ hub and
+--     returns the latest per-source summary (get-in / median / listings) across
+--     SeatGeek (live snapshots) + StubHub/VividSeats/Ticketmaster (TD raw
+--     snapshots, latest pull per platform). Powers the WC event page's
+--     cross-source panel. Email-gated, anon revoked.
+
+-- ============================================================================
+-- 1. Seed Ticketmaster collection for World Cup
+-- ============================================================================
+WITH wc AS (
+  SELECT DISTINCT a.aq_short_event_id, a.tm_event_id
+  FROM public.sg_events_canonical c
+  JOIN public.aq_event_map a ON a.sg_event_id = c.sg_event_id
+  WHERE c.sg_event_name ILIKE '%world cup - match%' AND a.tm_event_id IS NOT NULL
+)
+INSERT INTO public.ticketsdata_event_xref
+  (event_id, platform, aq_short_event_id, event_url, active, always_on, match_method, created_at, updated_at)
+SELECT tm_event_id, 'TM', aq_short_event_id,
+       'https://www.ticketmaster.com/event/' || upper(to_hex(tm_event_id)),
+       true, false, 'hub_seed_wc', now(), now()
+FROM wc
+ON CONFLICT (event_id, platform) DO UPDATE
+  SET active = true, event_url = EXCLUDED.event_url,
+      aq_short_event_id = COALESCE(public.ticketsdata_event_xref.aq_short_event_id, EXCLUDED.aq_short_event_id),
+      updated_at = now();
+
+-- ============================================================================
+-- 2. Cross-source markets summary, resolved through the AQ hub
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_wc_markets(p_sg_event_id bigint)
+RETURNS TABLE(source text, getin numeric, median numeric, listings integer, last_pull timestamptz)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $func$
+#variable_conflict use_column
+DECLARE
+  v_email text := coalesce(auth.jwt()->>'email', '');
+  v_sh bigint; v_vd bigint; v_tm bigint;
+BEGIN
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE='42501';
+  END IF;
+  SELECT a.sh_event_id, a.vivid_event_id, a.tm_event_id
+    INTO v_sh, v_vd, v_tm
+  FROM public.aq_event_map a WHERE a.sg_event_id = p_sg_event_id LIMIT 1;
+
+  RETURN QUERY
+  WITH sg_mx AS (
+    SELECT max(s.captured_at) AS mc FROM public.seatgeek_listings_snapshots s WHERE s.sg_event_id = p_sg_event_id
+  ),
+  sg AS (
+    SELECT 'SeatGeek'::text AS source,
+           min(s.retail_price_all_in) AS getin,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY s.retail_price_all_in) AS median,
+           count(*)::int AS listings, max(s.captured_at) AS last_pull
+    FROM public.seatgeek_listings_snapshots s, sg_mx
+    WHERE s.sg_event_id = p_sg_event_id AND sg_mx.mc IS NOT NULL
+      AND s.captured_at >= sg_mx.mc - interval '6 hours' AND s.retail_price_all_in > 0
+  ),
+  td_mx AS (
+    SELECT t.event_id, t.platform, max(t.captured_at) AS mc
+    FROM public.ticketsdata_listings_snapshots t
+    WHERE (t.event_id = v_sh AND t.platform = 'SH')
+       OR (t.event_id = v_vd AND t.platform = 'VD')
+       OR (t.event_id = v_tm AND t.platform = 'TM')
+    GROUP BY t.event_id, t.platform
+  ),
+  td AS (
+    SELECT CASE t.platform WHEN 'SH' THEN 'StubHub' WHEN 'VD' THEN 'VividSeats'
+                           WHEN 'TM' THEN 'Ticketmaster' ELSE t.platform END AS source,
+           min(t.price_with_fees) AS getin,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY t.price_with_fees) AS median,
+           count(*)::int AS listings, max(t.captured_at) AS last_pull
+    FROM public.ticketsdata_listings_snapshots t
+    JOIN td_mx m ON m.event_id = t.event_id AND m.platform = t.platform
+                AND t.captured_at >= m.mc - interval '6 hours'
+    WHERE coalesce(t.is_parking, false) = false AND t.price_with_fees > 0
+    GROUP BY t.platform
+  )
+  SELECT u.source, u.getin, u.median, u.listings, u.last_pull FROM (
+    SELECT source, round(getin)::numeric AS getin, round(median)::numeric AS median, listings, last_pull FROM sg WHERE listings > 0
+    UNION ALL
+    SELECT source, round(getin)::numeric AS getin, round(median)::numeric AS median, listings, last_pull FROM td
+  ) u
+  ORDER BY u.getin NULLS LAST;
+END;
+$func$;
+
+REVOKE ALL ON FUNCTION public.get_wc_markets(bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_wc_markets(bigint) TO authenticated;

--- a/supabase/migrations/20260616181000_wc_listings_catchup.sql
+++ b/supabase/migrations/20260616181000_wc_listings_catchup.sql
@@ -1,0 +1,69 @@
+-- Migration 20260616181000 · lane:D0 (author) → A1 (apply) · writes:sg_force_track_listings_tick, cron(sg_wc_listings_catchup) · reads:sg_event_priority_state · pre:20260616180000_wc_all_platforms · auth:operator-requested 2026-06-16 ("track them all" — keep World Cup SeatGeek data fresh)
+--
+-- D0 — dedicated, paced SeatGeek catch-up poller for the force-tracked World Cup
+-- events. WHY: the owned poller (sg_listings_poll_owned_1min) orders by tightest
+-- cadence-band first, so far-horizon WC events sort last and never get reached
+-- before p_max is hit — they sat ~2 weeks stale despite force_track=true. This
+-- tick is SCOPED to force_track=true events only (the operator-requested WC set),
+-- so it does NOT reverse the June-8 owned-focus directive globally; it just keeps
+-- the explicitly-tracked set fresh. Rate-aware (honors the live ratelimit-remaining
+-- header, same guard as sg_listings_poll_tick) and bounded (p_max), so it shares
+-- the SG token politely; the clock advances only on a fired request and the
+-- pipeline is strand-safe (a 429 leaves last_fired old → retried next tick).
+
+CREATE OR REPLACE FUNCTION public.sg_force_track_listings_tick(
+  p_max integer DEFAULT 6,
+  p_min_remaining integer DEFAULT 4,
+  p_repoll_min integer DEFAULT 30)
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_token text := public.get_app_secret('SEATGEEK_API_TOKEN');
+  v_remaining int; r RECORD; v_req bigint; v_now timestamptz := clock_timestamp(); v_count int := 0;
+BEGIN
+  IF NOT public.cron_should_fire('sg_wc_listings_catchup') THEN RETURN 0; END IF;
+  IF v_token IS NULL OR v_token = '' THEN RETURN 0; END IF;
+
+  -- Rate-aware: back off if the freshest budget reading is low (same guard as the
+  -- main poller). A stale reading (>10s) is ignored so we don't deadlock.
+  SELECT (h.headers->>'ratelimit-remaining')::int INTO v_remaining
+  FROM public.sg_broker_pending p JOIN net._http_response h ON h.id = p.request_id
+  WHERE h.headers ? 'ratelimit-remaining' AND h.created > v_now - interval '10 seconds'
+  ORDER BY h.id DESC LIMIT 1;
+  IF v_remaining IS NOT NULL AND v_remaining < p_min_remaining THEN RETURN 0; END IF;
+
+  FOR r IN
+    SELECT s.sg_event_id
+    FROM public.sg_event_priority_state s
+    WHERE s.force_track = true
+      AND s.tier <> 'SKIP'
+      AND s.sg_datetime_utc > v_now - interval '6 hours'
+      AND ( s.last_fired_listings_at IS NULL
+            OR s.last_fired_listings_at < v_now - make_interval(mins => p_repoll_min) )
+    ORDER BY s.last_fired_listings_at ASC NULLS FIRST, s.sg_datetime_utc ASC
+    LIMIT p_max
+  LOOP
+    SELECT net.http_get(
+      url := 'https://brokerdata.seatgeek.com/listings?token=' || v_token || '&event_id=' || r.sg_event_id::text,
+      timeout_milliseconds := 30000) INTO v_req;
+    INSERT INTO public.sg_broker_pending(sg_event_id, scope, request_id, fired_at)
+      VALUES (r.sg_event_id, 'listings', v_req, v_now);
+    UPDATE public.sg_event_priority_state
+      SET last_fired_listings_at = v_now, listings_polls_today = listings_polls_today + 1
+      WHERE sg_event_id = r.sg_event_id;
+    v_count := v_count + 1;
+  END LOOP;
+  RETURN v_count;
+END;
+$func$;
+
+REVOKE ALL ON FUNCTION public.sg_force_track_listings_tick(integer, integer, integer) FROM PUBLIC, anon;
+
+-- Cron: every 2 min, ≤6 events/tick → the ~87 force-tracked WC events refresh on a
+-- ~30-min rolling cadence (existing sg_priority_listings_process_5min drains the
+-- responses into seatgeek_listings_snapshots).
+DO $$ BEGIN PERFORM cron.unschedule('sg_wc_listings_catchup'); EXCEPTION WHEN OTHERS THEN NULL; END $$;
+SELECT cron.schedule('sg_wc_listings_catchup', '*/2 * * * *',
+  $cron$ SELECT public.sg_force_track_listings_tick(6, 4, 30); $cron$);


### PR DESCRIPTION
## What

(1) Match + track World Cup across **all platforms the AQ hub maps**, and (2) **fix the terminal view** so the WC event page has a real chart + cross-source markets instead of a bare overview.

## Tracking — all platforms
The AQ hub already maps each WC match to SeatGeek/StubHub/VividSeats/Ticketmaster. Collection status after this PR:
- **SeatGeek** ✅ (force-tracked; see fresh-data fix below)
- **StubHub + VividSeats** ✅ (seeded earlier, deterministic URLs)
- **Ticketmaster** ✅ **new** — `event_url` derived from the hub's `tm_event_id` as `ticketmaster.com/event/<hex>` (verified every existing TM URL ends in exactly `upper(to_hex(id))`). Best-effort: if TD won't resolve the slug-less URL it just yields no rows.
- **GameTime** ⏳ — pure slug URL, no derivable form → needs `td_gt_discover` (performer-matched). Tracked as the one remaining follow-up.

## Fresh-data fix (the real blocker behind "track them all")
WC data sat ~2 weeks stale because far-horizon events lose the cadence-priority race in the owned poller. New **`sg_force_track_listings_tick` + `*/2` cron `sg_wc_listings_catchup`**: a dedicated, **rate-aware, bounded** poller scoped to the `force_track=true` WC set (≤6/tick, honors `ratelimit-remaining`, strand-safe). Refreshes the ~87 events on a ~30-min rolling cadence. **Does not** reverse the June-8 owned-focus directive globally — it's scoped to the explicitly-tracked set.

## Terminal view
- **Real uPlot price chart** (get-in / median / p90 daily series) replacing the sparkline.
- **Cross-source MARKETS panel** via `get_wc_markets(p_sg_event_id)` — latest get-in/median/listings per source, resolved through the AQ hub (SeatGeek live + SH/VD/TM from `ticketsdata_listings_snapshots` as they land).
- Honest notes on the page for what can't apply (seat map / EVO).

## Validation (applied to prod)
- `get_wc_markets` returns SeatGeek row (others fill in as TD pulls land); TM seed inserted; catch-up tick fired 6 and the `*/2` cron is scheduled.
- `node --check` passes on `event.js`. All string fields escaped before innerHTML.

https://claude.ai/code/session_01NhfzSnHiScaRpaXyHDaTmZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhfzSnHiScaRpaXyHDaTmZ)_