### PR TITLE
fix(d4): convert manualChunks to function form for Vite 8 compat (unblocks #544)

### DIFF
--- a/d4_bridge/vite.config.ts
+++ b/d4_bridge/vite.config.ts
@@ -31,10 +31,20 @@ export default defineConfig(({ mode }) => {
       // entry chunk size considerably.
       rollupOptions: {
         output: {
-          manualChunks: {
-            stripe: ['@stripe/stripe-js'],
-            qr: ['html5-qrcode', 'qrcode.react'],
-            motion: ['motion'],
+          // Function form (not the Record<string, string[]> object form):
+          // Vite 8's bundled Rollup dropped the object overload from the
+          // OutputOptions type, so `tsc --noEmit` rejects it. The function
+          // form is accepted on both Vite 6 and 8 and is the forward-compatible
+          // way to express the same heavy-dep split.
+          manualChunks(id) {
+            if (id.includes('node_modules/@stripe/stripe-js/')) return 'stripe';
+            if (
+              id.includes('node_modules/html5-qrcode/') ||
+              id.includes('node_modules/qrcode.react/')
+            )
+              return 'qr';
+            if (id.includes('node_modules/motion/')) return 'motion';
+            return undefined;
           },
         },
       },


### PR DESCRIPTION
Unblocks the failing TypeScript check on dependabot PR #544 (bumps `d4_bridge` Vite 6 → 8).

## Problem

Vite 8's bundled Rollup dropped the `Record<string, string[]>` object overload from the `OutputOptions` type, so `d4_bridge`'s `tsc --noEmit` lint check fails on the object-form `manualChunks`:

```
vite.config.ts(6,29): error TS2769: No overload matches this call.
  ... manualChunks ... provides no match for the signature
  '(moduleId: string, meta) => string | void'
```

PR #544 can't go green until this is fixed on `main`.

## Fix

Rewrite `manualChunks` in the **function form** — same heavy-dep split (`stripe` / `qr` / `motion`), matched on `node_modules/<pkg>/` ids, with an explicit `return undefined` to satisfy `noImplicitReturns`. The function form is accepted on **both** Vite 6 and 8.

## Verification

Installed each version in `d4_bridge` and ran the exact CI check (`npm run lint`):

| Vite | `tsc --noEmit` |
|---|---|
| 8.0.16 (PR #544 target) | ✅ exit 0 |
| 6.4.2 (current `main` pin) | ✅ exit 0 |

Only `d4_bridge/vite.config.ts` changes; manifests are untouched (the version bump stays in #544's scope). Once this lands on `main`, #544 passes after a rebase.

## Lane note

Touches D4's surface (`d4_bridge/*`) — opened as **draft** for D4/D0 sign-off + A1 merge per `CLAUDE.md` push protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JceV1nscXTuzPBiEha5zL7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JceV1nscXTuzPBiEha5zL7)_