### PR TITLE
ci(d4): run exos migrations + SQL test suite on a real Postgres

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,18 @@
 name: tests
 
 # CI gate — runs on every PR + push to main.
-# Jobs: pytest (backend) · typescript (D4 bridge type-check + build) · mypy (Python types)
+# Jobs: pytest (backend) · typescript (D4 bridge type-check + build) · mypy
+#       (Python types) · exos-migrations (apply migrations + run the exos SQL
+#       test suite against a real Postgres).
 #
 # A1 must NOT merge to main until all jobs are green.
 # Render auto-deploys on push to main — green CI is the implicit deploy gate.
 #
 # Added 2026-05-15 (pytest). TypeScript + mypy added 2026-05-26.
+# exos-migrations added 2026-06-16 — migrations were never executed in CI, so
+# SQL bugs (reserved-word OUT params, column ambiguity, int casts, the voucher
+# bypass-at-fulfillment) only surfaced via a local harness. This job runs
+# tests/exos/run.sh (apply all migrations + PART A/B assertions) automatically.
 
 on:
   pull_request:
@@ -98,3 +104,38 @@ jobs:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
         run: npm run build
+
+  exos-migrations:
+    name: exos migration suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Real Postgres so the migrations actually EXECUTE (CI never did this before).
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      # Drives tests/exos/run.sh (it reads PGHOST/PGPORT/PGUSER; psql reads PGPASSWORD).
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure psql client
+        run: psql --version || (sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client)
+
+      - name: Apply migrations + run exos test suite
+        # run.sh: create a throwaway DB, load the harness prereq, apply every
+        # exos migration in order, then run PART A (each function) + PART B
+        # (end-to-end). Any failed migration or ASSERT exits non-zero → red.
+        run: bash tests/exos/run.sh exos_ci


### PR DESCRIPTION
## What

Backend/CI hardening (your pick: *Migrations in CI*). Until now CI ran pytest/tsc/mypy but **never executed a migration** — so every SQL bug in the recent Exos work (reserved-word OUT params, column ambiguity, `bigint→int` cast, the voucher bypass-at-fulfillment) surfaced *only* via my local Postgres harness. This makes that automatic.

Adds an **`exos-migrations`** job to `.github/workflows/tests.yml`:
- spins up a `postgres:16` service container,
- runs the committed `tests/exos/run.sh`: loads the self-contained harness prereq (roles, `extensions`+pgcrypto, `auth` shim), applies all **8** Exos feature migrations in order, then runs **PART A** (each function/trigger asserted) + **PART B** (end-to-end lifecycle),
- any failed migration or assertion → red CI.

## Notes
- Injection-safe: no `github.event.*` interpolation in `run:` steps; least-privilege token (`contents: read`) unchanged.
- Verified locally on Postgres 16 (PART A + PART B green). The real proof is this PR's own `exos migration suite` check.
- Self-contained harness, so when a *new* Exos migration is added it must also be appended to `run.sh`'s list (documented in the test header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXXdwKPrGmLniwu4DdDmPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXXdwKPrGmLniwu4DdDmPQ)_