### PR TITLE
fix(store): seat-map host definite height so TEvo SVG renders

### DIFF
--- a/static/store/style.css
+++ b/static/store/style.css
@@ -496,13 +496,16 @@ a { color: inherit; }
    it mounts successfully store.js hides the static .map img above it. */
 .seatmap-host {
   width: 100%;
-  min-height: 320px;
+  /* Definite height (not just min-height): the TEvo SVG sizes to its container,
+     so without a resolved height it collapses to ~0 and the host renders as a
+     blank box. Mirrors the proven terminal pattern (static/terminal/style.css). */
+  height: 480px;
   border-radius: 6px;
   background: #f6f7f9;
   overflow: hidden;
   position: relative;
 }
-.seatmap-host svg { display: block; width: 100%; height: auto; }
+.seatmap-host svg { display: block; width: 100%; height: 100%; }
 /* TEvo injects its own controls/legend; keep them inside the rounded host. */
 .seatmap-host .legend,
 .seatmap-host .controls { font-size: 12px; }


### PR DESCRIPTION
## Problem

The storefront event-page seat map (`static/store/*`) rendered as a **blank box** — observed on *Matchroom Boxing – Xander Zayas vs Jaron Ennis* at Barclays Center (event 3349823, venue 27950, config 54743).

## Root cause

It was **not** a data, matching, or CSP problem — all verified healthy:
- Manifest cached, `has_map=true`, HTTP 200, 185 sections (fetched 2026-06-10).
- 60 of 61 listing section numbers overlap the manifest, so the matcher colors ~60 sections.
- `event.html` CSP `connect-src` already includes `https://maps.ticketevolution.com`.

The TEvo SVG sizes itself to its container. `.seatmap-host` had only `min-height: 320px` and the SVG used `height: auto`, so with no resolved parent height the map collapsed to ~0px tall — leaving only the host's `#f6f7f9` background visible (the blank box).

## Fix

Give `.seatmap-host` a **definite height** (`480px`) and the SVG `height: 100%`, matching the proven terminal pattern in `static/terminal/style.css` (`height: 560px` + `svg height: 100%`).

```diff
-  min-height: 320px;
+  height: 480px;
...
-.seatmap-host svg { display: block; width: 100%; height: auto; }
+.seatmap-host svg { display: block; width: 100%; height: 100%; }
```

## Verification

Visual rendering could not be confirmed in this environment — `maps.ticketevolution.com` is blocked by the egress allowlist and no browser is available. The fix is a 1:1 alignment with the working terminal seat map. **Please reload the storefront event page to confirm the map now paints.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzTbrZ7VycRxXDdovcoh1d)_