### PR TITLE
feat(d0): ESPN sports player search — D0 terminal + consumer store

### DIFF
--- a/app.py
+++ b/app.py
@@ -5654,6 +5654,84 @@ def _search_sql_only(db, q_norm: str, limit: int) -> dict:
     }
 
 
+def _search_players(db, q_norm: str, limit: int) -> list[dict]:
+    """Sports player search for the storefront. Resolves a player name to their
+    team + the team's upcoming events via the shared PUBLIC RPC
+    `sports_player_search` (mig 20260617120000), then enriches each event with
+    the same we_own/from_price tags as _search_sql_only so the dropdown can show
+    "tickets you can buy" under a player.
+
+    Public sports data only (rosters, team names, public listings) — the only
+    money shown is the consumer-facing from_price already on every event card.
+    Returns [] on any failure: the players block is additive and must never 500
+    the whole search.
+    """
+    try:
+        players = (db.rpc("sports_player_search",
+                          {"p_q": q_norm, "p_limit": limit}).execute().data) or []
+    except Exception as e:
+        print(f"_search_players rpc failed: {e}")
+        return []
+    if not players:
+        return []
+
+    # One batched tag lookup across every event id from every matched player.
+    all_ids = [
+        int(ev.get("tevo_event_id") or 0)
+        for pl in players for ev in (pl.get("events") or [])
+        if ev.get("tevo_event_id")
+    ]
+    metrics: dict[int, dict] = {}
+    inactive: set[int] = set()
+    if all_ids:
+        uniq = list(set(all_ids))
+        try:
+            rows = (db.table("latest_event_metrics")
+                      .select("event_id,owned_tickets_count,retail_min")
+                      .in_("event_id", uniq).execute().data) or []
+            metrics = {int(r["event_id"]): r for r in rows if r.get("event_id")}
+        except Exception:
+            metrics = {}
+        try:
+            lc = (db.table("event_lifecycle")
+                    .select("event_id,is_active")
+                    .in_("event_id", uniq).execute().data) or []
+            inactive = {int(r["event_id"]) for r in lc if not r.get("is_active")}
+        except Exception:
+            inactive = set()
+
+    out: list[dict] = []
+    for pl in players:
+        events_out = []
+        for ev in (pl.get("events") or []):
+            eid = int(ev.get("tevo_event_id") or 0)
+            if not eid or eid in inactive or _is_speculative_event_name(ev.get("name")):
+                continue
+            m = metrics.get(eid) or {}
+            events_out.append({
+                "id": eid,
+                "name": ev.get("name"),
+                "venue_name": ev.get("venue_name"),
+                "location": ev.get("venue_location"),
+                "occurs_at": ev.get("occurs_at_local"),
+                "we_own": bool(m.get("owned_tickets_count")),
+                "from_price": m.get("retail_min"),
+                "owned_tix": m.get("owned_tickets_count"),
+            })
+        out.append({
+            "performer_id": int(pl.get("tevo_performer_id") or 0),
+            "name": pl.get("full_name") or pl.get("display_name"),
+            "team_name": pl.get("team_name"),
+            "league": pl.get("espn_league"),
+            "position": pl.get("position_abbr"),
+            "jersey": pl.get("jersey"),
+            "status": pl.get("status"),
+            "headshot_url": pl.get("headshot_url"),
+            "events": events_out,
+        })
+    return out
+
+
 def _search_live(db, q_norm: str, limit: int) -> dict:
     """Live search: hits TEvo /v9/searches/suggestions, then cross-joins the
     returned event IDs against our SQL to tag we_own + from_price. Used in
@@ -5765,7 +5843,7 @@ def store_search(
     """
     q_norm = (q or "").strip()
     if not q_norm:
-        return {"q": "", "events": [], "performers": [], "venues": [],
+        return {"q": "", "players": [], "events": [], "performers": [], "venues": [],
                 "source": "empty", "latency_ms": 0}
 
     # Cap at 50; the upstream cap is 20, so anything past that just trims.
@@ -5792,6 +5870,11 @@ def store_search(
         payload = _search_sql_only(db, q_norm, lim)
     else:
         payload = _search_live(db, q_norm, lim)
+
+    # Sports player layer (mode-agnostic): "messi"/"lebron" → their team's
+    # upcoming events. Independent of the events/performers/venues path so it
+    # works under both SQL and live modes; cached as part of payload below.
+    payload["players"] = _search_players(db, q_norm, lim)
 
     elapsed_ms = int((time.time() - t0) * 1000)
     payload["q"] = q_norm

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -871,20 +871,35 @@
     }
   }
 
-  // Render suggestion dropdown body. Three sections:
-  //   Events you can buy now (we_own=true) — top priority, shown first
+  // Render suggestion dropdown body. Sections, in priority order:
+  //   Players — sports search: a matched athlete + their team's upcoming
+  //     events (e.g. "messi" → Inter Miami CF games). Shown first.
+  //   Events you can buy now (we_own=true) — top priority among plain events
   //   Other events (we_own=false) — surfaced but flagged as "browse"
   //   Performers + venues — bottom, clickable filter pivots
   function renderSuggest(host, payload) {
     if (!host) return;
     host.replaceChildren();
+    const players = (payload && payload.players) || [];
     const events = (payload && payload.events) || [];
     const performers = (payload && payload.performers) || [];
     const venues = (payload && payload.venues) || [];
 
-    if (!events.length && !performers.length && !venues.length) {
+    if (!players.length && !events.length && !performers.length && !venues.length) {
       host.hidden = true;
       return;
+    }
+
+    if (players.length) {
+      host.append(suggestHeader("Players"));
+      players.forEach((pl) => {
+        host.append(suggestPlayerRow(pl));
+        (pl.events || []).forEach((e) => {
+          const row = suggestEventRow(e, !!e.we_own);
+          row.classList.add("under-player");
+          host.append(row);
+        });
+      });
     }
 
     const buyable = events.filter((e) => e.we_own);
@@ -938,6 +953,25 @@
       price.textContent = `from ${fmtMoney(ev.from_price)}`;
       a.append(price);
     }
+    return a;
+  }
+
+  function suggestPlayerRow(pl) {
+    // Player → their team's performer filter page. The team's upcoming events
+    // render as nested rows beneath this one (see renderSuggest).
+    const a = document.createElement("a");
+    a.className = "suggest-row player";
+    a.href = `/store?performer_id=${Number(pl.performer_id) || 0}`;
+    a.setAttribute("role", "option");
+    const name = document.createElement("div");
+    name.className = "suggest-row-name";
+    name.textContent = pl.name || "";
+    a.append(name);
+    const meta = document.createElement("div");
+    meta.className = "suggest-row-meta";
+    const who = [pl.jersey ? `#${pl.jersey}` : "", pl.position].filter(Boolean).join(" ");
+    meta.textContent = [pl.team_name, pl.league, who].filter(Boolean).join(" · ");
+    a.append(meta);
     return a;
   }
 

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -190,6 +190,13 @@ a { color: inherit; }
   font-weight: 700;
   color: var(--accent-2);
 }
+/* Sports player row + its nested team-event rows */
+.suggest-row.player { border-left-color: var(--accent-2); }
+.suggest-row.under-player {
+  padding-left: 26px;
+  font-size: 13px;
+}
+.suggest-row.under-player .suggest-row-name { font-size: 13px; font-weight: 500; }
 .suggest-status {
   /* Loading + error states inside the dropdown — same height/position as
      a hit row so the dropdown doesn't jump-resize when results land. */

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -58,8 +58,9 @@
   // ---------- Global terminal search ----------
   //
   // Topbar search input, available on every terminal page (via nav.js).
-  // Calls `terminal_search` SECDEF RPC (mig 20260517230000) and renders a
-  // 3-section dropdown — Events / Performers / Venues.
+  // Calls `terminal_search` SECDEF RPC (mig 20260517230000, players added v3
+  // mig 20260617120000) and renders a dropdown — Players (sports: athlete →
+  // team → upcoming events) / Events / Performers / Venues / Marketplace.
   //
   // Keyboard: type-to-search (300ms debounce), ↑/↓ to navigate suggestions,
   // Enter to follow first/selected result, Esc closes. Click-outside closes.
@@ -71,7 +72,7 @@
     const wrap = document.createElement('div');
     wrap.className = 'term-search';
     wrap.innerHTML = `
-      <input type="search" class="term-search-input" placeholder="Search events / performers / venues…" autocomplete="off" spellcheck="false" />
+      <input type="search" class="term-search-input" placeholder="Search players / events / performers / venues…" autocomplete="off" spellcheck="false" />
       <div class="term-search-suggest" hidden></div>`;
     // Insert before version chip / auth ctrl / status. Use the .pagenav as
     // anchor — search slots immediately after the nav links.
@@ -130,16 +131,47 @@
     }
 
     function renderResults(d) {
-      const evs   = d.events      || [];
-      const perfs = d.performers  || [];
-      const vens  = d.venues      || [];
-      const mkt   = d.marketplace || [];
+      const players = d.players     || [];
+      const evs     = d.events      || [];
+      const perfs   = d.performers  || [];
+      const vens    = d.venues      || [];
+      const mkt     = d.marketplace || [];
       flat = [];
-      if (!evs.length && !perfs.length && !vens.length && !mkt.length) {
+      if (!players.length && !evs.length && !perfs.length && !vens.length && !mkt.length) {
         sugg.innerHTML = `<div class="ts-empty">no matches for &ldquo;${escapeHtml(d.q || '')}&rdquo;</div>`;
         return;
       }
       const parts = [];
+      // PLAYERS — ESPN athlete → mapped TEvo team performer → upcoming events.
+      // The headline sports-search feature: typing a player name surfaces their
+      // team and the team's next games. Player head links to the performer page;
+      // each nested event row links to that event's page.
+      if (players.length) {
+        parts.push('<div class="ts-section"><div class="ts-section-lbl">PLAYERS</div>');
+        players.forEach(pl => {
+          const teamHref = pl.tevo_performer_id != null
+            ? `performer.html?performer=${pl.tevo_performer_id}` : '#';
+          const bits = [pl.jersey ? '#' + pl.jersey : '', pl.position_abbr].filter(Boolean).join(' · ');
+          const teamMeta = [pl.team_name, pl.espn_league].filter(Boolean).join(' · ');
+          const inj = pl.latest_injury && pl.latest_injury.status
+            ? `<span class="ts-inj">${escapeHtml(pl.latest_injury.status)}</span>` : '';
+          flat.push({ href: teamHref, label: pl.full_name, kind: 'player' });
+          parts.push(`<a class="ts-row ts-player-head" href="${teamHref}" data-kind="player">
+              <span class="ts-name">${escapeHtml(pl.full_name || '(unknown)')}${bits ? ` <span class="ts-sub">${escapeHtml(bits)}</span>` : ''}${inj}</span>
+              <span class="ts-meta">${escapeHtml(teamMeta)}</span>
+            </a>`);
+          (pl.events || []).forEach(e => {
+            const href = `event.html?event=${e.tevo_event_id}`;
+            const meta = [e.venue_name, fmtDateShort(e.occurs_at_local)].filter(Boolean).join(' · ');
+            flat.push({ href, label: e.name, kind: 'event' });
+            parts.push(`<a class="ts-row ts-player-event" href="${href}" data-kind="event">
+                <span class="ts-name">${escapeHtml(e.name || '(unnamed)')}</span>
+                <span class="ts-meta">${escapeHtml(meta)}</span>
+              </a>`);
+          });
+        });
+        parts.push('</div>');
+      }
       if (evs.length) {
         parts.push('<div class="ts-section"><div class="ts-section-lbl">EVENTS</div>');
         evs.forEach(e => {

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1840,6 +1840,21 @@ body[data-page="login"] {
 }
 .ts-empty.err { color: var(--neg); }
 
+/* Player rows (sports search): athlete head + nested upcoming-event rows */
+.ts-player-head .ts-name { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.ts-sub { color: var(--muted); font-weight: 400; font-size: 10px; }
+.ts-inj {
+  color: var(--neg);
+  font-family: var(--mono); font-size: 9px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  border: 1px solid var(--neg); border-radius: 3px;
+  padding: 0 3px;
+}
+/* Indent a player's team events under the athlete head */
+.ts-player-event { padding-left: 22px; border-left: 2px solid var(--line-2); }
+.ts-player-event .ts-name { font-weight: 400; }
+.ts-player-event:hover, .ts-player-event.active { border-left-color: var(--accent); }
+
 /* ---------- Event redesign (post-PR #206) ---------- */
 
 /* Hero weather card — compact top-right of hero side-rail */

--- a/supabase/migrations/20260617120000_terminal_search_players.sql
+++ b/supabase/migrations/20260617120000_terminal_search_players.sql
@@ -1,0 +1,255 @@
+-- Migration 20260617120000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): terminal_search() (v3 — adds a 'players' section),
+--                 events_primary_performer_id_idx (new), events_performer_ids_gin (new) ·
+--   reads: espn_athletes, performer_espn_team_xref, espn_teams_canonical,
+--          espn_injuries_snapshots, aq_performer_map, events,
+--          aq_venue_map, v_td_unmatched_discovered_events ·
+--   pre: 20260609130000 (terminal_search v2 — events/performers/venues/marketplace)
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1). Validate on a
+--    Supabase branch (copy-on-write fork) before any prod apply.
+--
+-- WHY ───────────────────────────────────────────────────────────────────────
+-- Make the terminal search a *sports* search: typing a player's name ("messi",
+-- "lebron") should surface that player's TEAM and the team's upcoming event
+-- info — not just literal event/performer/venue name matches.
+--
+-- terminal_search v2 only matched on event / performer / venue NAMES, so a
+-- player name returned nothing (no event is literally named "LeBron"). This
+-- adds a 'players' section that layers in our ESPN athlete data:
+--
+--     espn_athletes (name)                       -- "LeBron James"
+--       → performer_espn_team_xref (team→tevo)   -- LA Lakers performer 16328
+--       → events (upcoming for that performer)   -- the team's games
+--
+-- and returns, per matched player: the athlete (position/jersey/status/headshot
+-- + latest injury) + their mapped TEvo team performer + up to 3 upcoming events.
+-- The frontend renders these as a PLAYERS section whose rows deep-link to the
+-- team's performer page and to each upcoming event page.
+--
+-- This composes with — does not replace — the existing API-search-fed sections:
+-- events/performers/venues come from our TEvo-search-populated catalog and the
+-- 'marketplace' section from TicketsData /events discovery (v2). Players is the
+-- ESPN layer that ties a person to the ticketed team event.
+--
+-- LANDMINES OBSERVED (PROJECT_BIBLE §3) ──────────────────────────────────────
+--   * espn_team_id COLLIDES across leagues (id "13" = NBA Lakers AND an MLB
+--     team). The legacy get_player_info()/team_xref join on espn_team_id ALONE,
+--     so they mis-label LeBron's team as "Texas Rangers". This RPC joins
+--     performer_espn_team_xref + espn_teams_canonical on (espn_team_id,
+--     espn_league) BOTH — verified league-correct (LeBron→Lakers, Messi→Inter
+--     Miami CF). latest_injury is likewise espn_league-scoped.
+--   * events.occurs_at_local is TEXT (offset-bearing) — compare against a
+--     formatted string cutoff, never a timestamptz (same fix as v2).
+--   * events link to a performer via primary_performer_id OR performer_ids[]
+--     (array) — both checked.
+--
+-- IDEMPOTENT: CREATE OR REPLACE (same (text,integer) signature → no new
+-- overload) + CREATE INDEX IF NOT EXISTS. Re-runnable.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Supporting indexes for the per-player upcoming-events lookup (events is small,
+-- ~9.4k rows, but these keep the lookup index-driven as the catalog grows).
+CREATE INDEX IF NOT EXISTS events_primary_performer_id_idx
+  ON public.events (primary_performer_id)
+  WHERE primary_performer_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS events_performer_ids_gin
+  ON public.events USING gin (performer_ids);
+
+
+CREATE OR REPLACE FUNCTION public.terminal_search(
+  p_q     text,
+  p_limit integer DEFAULT 6
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email   text;
+  v_q       text;
+  v_pat     text;
+  v_re      text;   -- regex-safe token for word-boundary (\m) ranking
+  v_now_s   text;   -- formatted "upcoming" cutoff (occurs_at_local is TEXT)
+  v_cap     integer;
+  v_evs     jsonb;
+  v_perfs   jsonb;
+  v_vens    jsonb;
+  v_mkt     jsonb;
+  v_players jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_q   := trim(coalesce(p_q, ''));
+  v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
+  IF length(v_q) < 2 THEN
+    RETURN jsonb_build_object('q', v_q, 'players', '[]'::jsonb, 'events', '[]'::jsonb,
+                              'performers', '[]'::jsonb, 'venues', '[]'::jsonb,
+                              'marketplace', '[]'::jsonb);
+  END IF;
+  v_pat   := '%' || v_q || '%';
+  -- strip regex metacharacters so the \m word-boundary match can't error / inject
+  v_re    := regexp_replace(v_q, '[^[:alnum:][:space:]]', '', 'g');
+  v_now_s := to_char(now() - interval '6 hours', 'YYYY-MM-DD"T"HH24:MI:SS');
+
+  -- ── PLAYERS (ESPN) — athlete → mapped TEvo team performer → upcoming events ──
+  WITH cand AS (
+    SELECT a.espn_athlete_id, a.full_name, a.display_name, a.position_abbr,
+           a.jersey, a.status, a.espn_league, a.espn_team_id, a.headshot_url,
+           a.last_seen_at,
+           CASE
+             WHEN lower(a.full_name) = lower(v_q) OR lower(a.display_name) = lower(v_q) THEN 100
+             -- whole-word hit (surname etc): "messi"→"Lionel Messi" beats "Messick"/"Messiah"
+             WHEN a.full_name ~* ('\m' || v_re || '\M') OR a.display_name ~* ('\m' || v_re || '\M') THEN 90
+             WHEN a.full_name ~* ('\m' || v_re) OR a.display_name ~* ('\m' || v_re) THEN 85
+             WHEN a.full_name ILIKE v_q || '%' OR a.display_name ILIKE v_q || '%' THEN 80
+             ELSE 60
+           END AS match_strength
+    FROM public.espn_athletes a
+    WHERE a.full_name ILIKE v_pat
+       OR a.display_name ILIKE v_pat
+       OR coalesce(a.short_name, '') ILIKE v_pat
+  ),
+  m AS (
+    SELECT DISTINCT ON (c.espn_athlete_id)
+      c.espn_athlete_id, c.full_name, c.display_name, c.position_abbr,
+      c.jersey, c.status, c.espn_league, c.headshot_url, c.last_seen_at,
+      c.match_strength,
+      ptx.tevo_performer_id,
+      -- league-scoped team name (NOT the collision-prone team_xref)
+      coalesce(tc.display_name,
+               (SELECT apm.performer_name FROM public.aq_performer_map apm
+                 WHERE apm.tevo_performer_id = ptx.tevo_performer_id LIMIT 1)) AS team_name,
+      (SELECT coalesce(jsonb_agg(ev ORDER BY ev.occurs_at_local), '[]'::jsonb)
+         FROM (
+           SELECT e.id AS tevo_event_id, e.name, e.venue_name, e.occurs_at_local
+           FROM public.events e
+           WHERE (e.primary_performer_id = ptx.tevo_performer_id
+                  OR ptx.tevo_performer_id = ANY (e.performer_ids))
+             AND coalesce(e.state, '') <> 'past'
+             AND e.occurs_at_local >= v_now_s
+           ORDER BY e.occurs_at_local ASC
+           LIMIT 3
+         ) ev) AS events,
+      EXISTS (
+        SELECT 1 FROM public.events e2
+        WHERE (e2.primary_performer_id = ptx.tevo_performer_id
+               OR ptx.tevo_performer_id = ANY (e2.performer_ids))
+          AND coalesce(e2.state, '') <> 'past'
+          AND e2.occurs_at_local >= v_now_s
+      ) AS has_events
+    FROM cand c
+    JOIN public.performer_espn_team_xref ptx
+      ON ptx.espn_team_id = c.espn_team_id AND ptx.espn_league = c.espn_league
+    LEFT JOIN public.espn_teams_canonical tc
+      ON tc.espn_team_id = c.espn_team_id AND tc.espn_league = c.espn_league
+    ORDER BY c.espn_athlete_id, c.match_strength DESC
+  )
+  SELECT coalesce(
+           jsonb_agg(
+             jsonb_build_object(
+               'espn_athlete_id',   q.espn_athlete_id,
+               'full_name',         q.full_name,
+               'display_name',      q.display_name,
+               'position_abbr',     q.position_abbr,
+               'jersey',            q.jersey,
+               'status',            q.status,
+               'espn_league',       q.espn_league,
+               'headshot_url',      q.headshot_url,
+               'tevo_performer_id', q.tevo_performer_id,
+               'team_name',         q.team_name,
+               'latest_injury', (
+                 SELECT jsonb_build_object('status', i.status,
+                                           'injury_type', i.injury_type,
+                                           'short_comment', i.short_comment)
+                 FROM public.espn_injuries_snapshots i
+                 WHERE i.athlete_id = q.espn_athlete_id
+                   AND i.espn_league = q.espn_league
+                 ORDER BY i.captured_at DESC LIMIT 1),
+               'events', q.events
+             )
+             ORDER BY q.has_events DESC, q.match_strength DESC, q.last_seen_at DESC
+           ), '[]'::jsonb)
+  INTO v_players
+  FROM (
+    SELECT * FROM m
+    ORDER BY m.has_events DESC, m.match_strength DESC, m.last_seen_at DESC
+    LIMIT v_cap
+  ) q;
+
+  -- ── EVENTS (catalog, upcoming) ──────────────────────────────────────────────
+  SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.match_len, e.occurs_at_local), '[]'::jsonb)
+  INTO v_evs
+  FROM (
+    SELECT id AS tevo_event_id, name, venue_name, occurs_at_local,
+           primary_performer_name, length(name) AS match_len
+    FROM public.events
+    WHERE name ILIKE v_pat
+      AND occurs_at_local >= v_now_s
+      AND coalesce(state, '') <> 'past'
+    ORDER BY length(name) ASC, occurs_at_local ASC
+    LIMIT v_cap
+  ) e;
+
+  -- ── PERFORMERS ──────────────────────────────────────────────────────────────
+  SELECT coalesce(jsonb_agg(to_jsonb(p) ORDER BY p.match_len, p.performer_name), '[]'::jsonb)
+  INTO v_perfs
+  FROM (
+    SELECT DISTINCT ON (m2.tevo_performer_id)
+      m2.tevo_performer_id, m2.performer_short_id, m2.performer_name, m2.category,
+      length(m2.performer_name) AS match_len
+    FROM public.aq_performer_map m2
+    WHERE m2.tevo_performer_id IS NOT NULL
+      AND ( m2.performer_name ILIKE v_pat
+            OR EXISTS (SELECT 1 FROM unnest(coalesce(m2.aliases, ARRAY[]::text[])) AS a(alias)
+                       WHERE a.alias ILIKE v_pat) )
+    ORDER BY m2.tevo_performer_id, length(m2.performer_name) ASC
+    LIMIT v_cap
+  ) p;
+
+  -- ── VENUES ──────────────────────────────────────────────────────────────────
+  SELECT coalesce(jsonb_agg(to_jsonb(v) ORDER BY v.match_len, v.venue_name), '[]'::jsonb)
+  INTO v_vens
+  FROM (
+    SELECT DISTINCT ON (m3.tevo_venue_id)
+      m3.tevo_venue_id, m3.venue_short_id, m3.venue_name, m3.city, m3.state,
+      length(m3.venue_name) AS match_len
+    FROM public.aq_venue_map m3
+    WHERE m3.tevo_venue_id IS NOT NULL
+      AND (m3.venue_name ILIKE v_pat OR m3.city ILIKE v_pat)
+    ORDER BY m3.tevo_venue_id, length(m3.venue_name) ASC
+    LIMIT v_cap
+  ) v;
+
+  -- ── MARKETPLACE (TicketsData /events discoveries we don't track locally) ─────
+  SELECT coalesce(jsonb_agg(to_jsonb(k) ORDER BY k.event_date), '[]'::jsonb)
+  INTO v_mkt
+  FROM (
+    SELECT DISTINCT ON (lower(event_name), event_date, platform)
+      platform, td_event_id, event_url, event_name, event_date, venue_name, city
+    FROM public.v_td_unmatched_discovered_events
+    WHERE (event_name ILIKE v_pat OR performer_label ILIKE v_pat OR venue_name ILIKE v_pat)
+    ORDER BY lower(event_name), event_date, platform
+    LIMIT v_cap
+  ) k;
+
+  RETURN jsonb_build_object(
+    'q', v_q, 'limit', v_cap,
+    'players', v_players,
+    'events', v_evs, 'performers', v_perfs, 'venues', v_vens,
+    'marketplace', v_mkt
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.terminal_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.terminal_search(text, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.terminal_search(text, integer) IS
+  'D0 terminal topbar search — players (ESPN athlete→team performer→upcoming '
+  'events) / events / performers / venues / marketplace (TicketsData-discovered). '
+  'Email-gated. Cap 20/section. v3 mig 20260617120000 (adds players section; '
+  'team mapping is league-scoped to avoid the espn_team_id cross-league collision).';

--- a/supabase/migrations/20260617120000_terminal_search_players.sql
+++ b/supabase/migrations/20260617120000_terminal_search_players.sql
@@ -1,5 +1,7 @@
 -- Migration 20260617120000 · lane:D0 (author) → A1 (apply) ·
---   writes (DDL): terminal_search() (v3 — adds a 'players' section),
+--   writes (DDL): sports_player_search() (new, public/ungated),
+--                 terminal_search() (v3 — adds a 'players' section, now via the
+--                 shared sports_player_search()),
 --                 events_primary_performer_id_idx (new), events_performer_ids_gin (new) ·
 --   reads: espn_athletes, performer_espn_team_xref, espn_teams_canonical,
 --          espn_injuries_snapshots, aq_performer_map, events,
@@ -11,27 +13,31 @@
 --    Supabase branch (copy-on-write fork) before any prod apply.
 --
 -- WHY ───────────────────────────────────────────────────────────────────────
--- Make the terminal search a *sports* search: typing a player's name ("messi",
--- "lebron") should surface that player's TEAM and the team's upcoming event
--- info — not just literal event/performer/venue name matches.
+-- Make our search a *sports* search on BOTH surfaces — the D0 terminal and the
+-- consumer store: typing a player's name ("messi", "lebron") should surface
+-- that player's TEAM and the team's upcoming event info — not just literal
+-- event/performer/venue name matches.
 --
--- terminal_search v2 only matched on event / performer / venue NAMES, so a
--- player name returned nothing (no event is literally named "LeBron"). This
--- adds a 'players' section that layers in our ESPN athlete data:
+-- The name→team→events resolution lives in ONE shared, public RPC,
+-- sports_player_search(), so both surfaces use identical matching + ranking:
 --
 --     espn_athletes (name)                       -- "LeBron James"
 --       → performer_espn_team_xref (team→tevo)   -- LA Lakers performer 16328
 --       → events (upcoming for that performer)   -- the team's games
 --
--- and returns, per matched player: the athlete (position/jersey/status/headshot
--- + latest injury) + their mapped TEvo team performer + up to 3 upcoming events.
--- The frontend renders these as a PLAYERS section whose rows deep-link to the
--- team's performer page and to each upcoming event page.
+-- and it returns, per matched player: the athlete (position/jersey/status/
+-- headshot + latest injury) + their mapped TEvo team performer + up to 3
+-- upcoming events (with venue + occurs_at so each surface can shape its own row
+-- — the store adds we_own/from_price tags on top; the terminal links to the
+-- event/performer pages).
 --
--- This composes with — does not replace — the existing API-search-fed sections:
--- events/performers/venues come from our TEvo-search-populated catalog and the
--- 'marketplace' section from TicketsData /events discovery (v2). Players is the
--- ESPN layer that ties a person to the ticketed team event.
+--   * D0 terminal  → terminal_search() (email-gated) calls sports_player_search
+--                    and returns it as the 'players' section alongside the
+--                    existing TEvo-catalog events/performers/venues + the
+--                    TicketsData 'marketplace' section.
+--   * Consumer store → /api/store/search calls sports_player_search directly
+--                    (it is PUBLIC — only public sports data, no broker
+--                    numbers) and enriches the events with we_own/from_price.
 --
 -- LANDMINES OBSERVED (PROJECT_BIBLE §3) ──────────────────────────────────────
 --   * espn_team_id COLLIDES across leagues (id "13" = NBA Lakers AND an MLB
@@ -41,12 +47,12 @@
 --     espn_league) BOTH — verified league-correct (LeBron→Lakers, Messi→Inter
 --     Miami CF). latest_injury is likewise espn_league-scoped.
 --   * events.occurs_at_local is TEXT (offset-bearing) — compare against a
---     formatted string cutoff, never a timestamptz (same fix as v2).
+--     formatted string cutoff, never a timestamptz.
 --   * events link to a performer via primary_performer_id OR performer_ids[]
 --     (array) — both checked.
 --
--- IDEMPOTENT: CREATE OR REPLACE (same (text,integer) signature → no new
--- overload) + CREATE INDEX IF NOT EXISTS. Re-runnable.
+-- IDEMPOTENT: CREATE OR REPLACE (same signatures → no new overload) +
+-- CREATE INDEX IF NOT EXISTS. Re-runnable.
 -- ─────────────────────────────────────────────────────────────────────────────
 
 -- Supporting indexes for the per-player upcoming-events lookup (events is small,
@@ -58,7 +64,14 @@ CREATE INDEX IF NOT EXISTS events_performer_ids_gin
   ON public.events USING gin (performer_ids);
 
 
-CREATE OR REPLACE FUNCTION public.terminal_search(
+-- ─────────────────────────────────────────────────────────────────────────────
+-- sports_player_search() — shared, PUBLIC athlete→team→upcoming-events resolver.
+-- Returns a JSONB ARRAY of matched players (NOT wrapped). Used by both
+-- terminal_search() (D0) and /api/store/search (consumer store). No email gate:
+-- it exposes only public sports data (rosters, team names, public event listings)
+-- — never broker prices/inventory.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.sports_player_search(
   p_q     text,
   p_limit integer DEFAULT 6
 )
@@ -67,36 +80,23 @@ LANGUAGE plpgsql STABLE SECURITY DEFINER
 SET search_path = public, extensions, pg_temp
 AS $func$
 DECLARE
-  v_email   text;
-  v_q       text;
-  v_pat     text;
-  v_re      text;   -- regex-safe token for word-boundary (\m) ranking
-  v_now_s   text;   -- formatted "upcoming" cutoff (occurs_at_local is TEXT)
-  v_cap     integer;
-  v_evs     jsonb;
-  v_perfs   jsonb;
-  v_vens    jsonb;
-  v_mkt     jsonb;
-  v_players jsonb;
+  v_q     text;
+  v_pat   text;
+  v_re    text;   -- regex-safe token for word-boundary (\m) ranking
+  v_now_s text;   -- formatted "upcoming" cutoff (occurs_at_local is TEXT)
+  v_cap   integer;
+  v_out   jsonb;
 BEGIN
-  v_email := coalesce(auth.jwt()->>'email', '');
-  IF v_email NOT LIKE '%@s4kent.com' THEN
-    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
-  END IF;
-
   v_q   := trim(coalesce(p_q, ''));
   v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
   IF length(v_q) < 2 THEN
-    RETURN jsonb_build_object('q', v_q, 'players', '[]'::jsonb, 'events', '[]'::jsonb,
-                              'performers', '[]'::jsonb, 'venues', '[]'::jsonb,
-                              'marketplace', '[]'::jsonb);
+    RETURN '[]'::jsonb;
   END IF;
   v_pat   := '%' || v_q || '%';
   -- strip regex metacharacters so the \m word-boundary match can't error / inject
   v_re    := regexp_replace(v_q, '[^[:alnum:][:space:]]', '', 'g');
   v_now_s := to_char(now() - interval '6 hours', 'YYYY-MM-DD"T"HH24:MI:SS');
 
-  -- ── PLAYERS (ESPN) — athlete → mapped TEvo team performer → upcoming events ──
   WITH cand AS (
     SELECT a.espn_athlete_id, a.full_name, a.display_name, a.position_abbr,
            a.jersey, a.status, a.espn_league, a.espn_team_id, a.headshot_url,
@@ -126,7 +126,7 @@ BEGIN
                  WHERE apm.tevo_performer_id = ptx.tevo_performer_id LIMIT 1)) AS team_name,
       (SELECT coalesce(jsonb_agg(ev ORDER BY ev.occurs_at_local), '[]'::jsonb)
          FROM (
-           SELECT e.id AS tevo_event_id, e.name, e.venue_name, e.occurs_at_local
+           SELECT e.id AS tevo_event_id, e.name, e.venue_name, e.venue_location, e.occurs_at_local
            FROM public.events e
            WHERE (e.primary_performer_id = ptx.tevo_performer_id
                   OR ptx.tevo_performer_id = ANY (e.performer_ids))
@@ -174,12 +174,67 @@ BEGIN
              )
              ORDER BY q.has_events DESC, q.match_strength DESC, q.last_seen_at DESC
            ), '[]'::jsonb)
-  INTO v_players
+  INTO v_out
   FROM (
     SELECT * FROM m
     ORDER BY m.has_events DESC, m.match_strength DESC, m.last_seen_at DESC
     LIMIT v_cap
   ) q;
+
+  RETURN v_out;
+END $func$;
+
+REVOKE ALL ON FUNCTION public.sports_player_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.sports_player_search(text, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.sports_player_search(text, integer) IS
+  'Shared PUBLIC sports search: athlete name → mapped TEvo team performer → up '
+  'to 3 upcoming events. Returns a JSONB array. League-scoped team mapping '
+  '(dodges the espn_team_id cross-league collision). Used by terminal_search '
+  '(D0) and /api/store/search (consumer store). mig 20260617120000.';
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- terminal_search() v3 — adds the 'players' section (via sports_player_search).
+-- Existing events/performers/venues/marketplace keys unchanged → forward-compat.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.terminal_search(
+  p_q     text,
+  p_limit integer DEFAULT 6
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email   text;
+  v_q       text;
+  v_pat     text;
+  v_now_s   text;
+  v_cap     integer;
+  v_evs     jsonb;
+  v_perfs   jsonb;
+  v_vens    jsonb;
+  v_mkt     jsonb;
+  v_players jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_q   := trim(coalesce(p_q, ''));
+  v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
+  IF length(v_q) < 2 THEN
+    RETURN jsonb_build_object('q', v_q, 'players', '[]'::jsonb, 'events', '[]'::jsonb,
+                              'performers', '[]'::jsonb, 'venues', '[]'::jsonb,
+                              'marketplace', '[]'::jsonb);
+  END IF;
+  v_pat   := '%' || v_q || '%';
+  v_now_s := to_char(now() - interval '6 hours', 'YYYY-MM-DD"T"HH24:MI:SS');
+
+  -- PLAYERS — shared resolver (ESPN athlete → team performer → upcoming events)
+  v_players := public.sports_player_search(v_q, v_cap);
 
   -- ── EVENTS (catalog, upcoming) ──────────────────────────────────────────────
   SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.match_len, e.occurs_at_local), '[]'::jsonb)
@@ -249,7 +304,6 @@ REVOKE ALL ON FUNCTION public.terminal_search(text, integer) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.terminal_search(text, integer) TO anon, authenticated;
 
 COMMENT ON FUNCTION public.terminal_search(text, integer) IS
-  'D0 terminal topbar search — players (ESPN athlete→team performer→upcoming '
-  'events) / events / performers / venues / marketplace (TicketsData-discovered). '
-  'Email-gated. Cap 20/section. v3 mig 20260617120000 (adds players section; '
-  'team mapping is league-scoped to avoid the espn_team_id cross-league collision).';
+  'D0 terminal topbar search — players (via sports_player_search) / events / '
+  'performers / venues / marketplace (TicketsData-discovered). Email-gated. '
+  'Cap 20/section. v3 mig 20260617120000 (adds players section).';


### PR DESCRIPTION
## What

Make the search a **sports search** on **both surfaces** — the D0 terminal and the consumer store: typing a player's name (`messi`, `lebron`) now surfaces that player's **team** and the team's **upcoming event info**, not just literal name matches.

The name→team→events resolution lives in **one shared, public RPC** so both surfaces match + rank identically:
```
espn_athletes (name)              →  "LeBron James" / "Lionel Messi"
  → performer_espn_team_xref      →  team → TEvo performer (Lakers 16328 / Inter Miami CF 72393)
  → events (upcoming; primary_performer_id OR performer_ids[])
```

## Changes

**`supabase/migrations/20260617120000_terminal_search_players.sql`** — *author-only, NOT YET APPLIED* (pending A1 review + explicit operator apply per `CLAUDE.md §1`).
- **NEW `sports_player_search(p_q, p_limit)`** — public/ungated SECDEF RPC returning a JSONB array of matched players (athlete + league-scoped team performer + up to 3 upcoming events with venue + `occurs_at`). Exposes only public sports data — no broker prices/inventory.
- **`terminal_search()` v3** now calls `sports_player_search` for its `players` section (single source of truth). All v2 keys (`events`/`performers`/`venues`/`marketplace`) unchanged → forward-compatible.
- **Cross-league collision dodged** (`PROJECT_BIBLE §3`): `espn_team_id` collides across leagues (id `13` = NBA Lakers *and* an MLB team), so the legacy `get_player_info()`/`team_xref` path mislabels LeBron's team as "Texas Rangers". This joins on **(espn_team_id, espn_league) both** — verified league-correct.
- Ranking adds a **whole-word tier** so `messi` ranks **Lionel Messi** above `Messick`/`Messiah`, then breaks ties by "team has upcoming events".
- Supporting indexes on `events(primary_performer_id)` + GIN `performer_ids`.

**D0 terminal** — `static/terminal/nav.js` + `style.css`: renders a `PLAYERS` section first; athlete row → performer page, nested rows → each event page.

**Consumer store** (`app.py` `/api/store/search`, `static/store/store.js` + `style.css`) — *D1's lane; operator-directed cross-lane work*:
- `_search_players()` calls the shared RPC, then enriches each event with `we_own`/`from_price` via the **same** `latest_event_metrics` + `event_lifecycle` + speculative-name pipeline as `_search_sql_only`. Fails soft (`[]`) — the players block can never 500 the whole search.
- `/api/store/search` returns a new `players` key (mode-agnostic: added after the sql/live path so both modes get it; cached as part of the payload).
- Suggest dropdown renders a **Players** section first: player row → team performer filter (`/store?performer_id=`), nested rows → the team's upcoming buyable events (reusing the existing `we_own`/`from_price` event row).

## Verification (read-only against prod, in rolled-back transactions)
| Query | Result |
|---|---|
| `sports_player_search('messi')` | **Lionel Messi → Inter Miami CF** (3 upcoming MLS games) ranked above Messick/Messiah |
| `sports_player_search('lebron')` | **LeBron James → Los Angeles Lakers** + upcoming game |
| both functions | compile clean; tx rolled back (no persisted change) |
| `app.py` | `py_compile` OK |

## Apply note
The migration is **not applied** — prod DDL needs explicit operator authorization and A1 is sole pusher to `main`. Both frontends degrade cleanly until the RPC is live (no `players` key → section simply absent).

## Side note (not in this PR)
The legacy `get_player_info()` still has the cross-league team-mislabel bug. Happy to open a follow-up to fix it the same way if it's consumed elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvjBqisCLa2XZZcsjrS1wb