### PR TITLE
feat(store): Google-style search landing + unified performer/player results

### DIFF
--- a/static/store/index.html
+++ b/static/store/index.html
@@ -26,157 +26,55 @@
   <link rel="stylesheet" href="/static/store/style.css" />
 </head>
 <body data-page="catalog">
-  <header class="topbar">
-    <a class="brand" href="/store">VibePass</a>
-    <nav class="topnav" aria-label="Primary">
-      <a href="#concierge">Concierge</a>
-      <a href="#how">How it works</a>
-      <a href="/store/discover">Discover tours</a>
-    </nav>
-    <a class="topcta" href="#concierge">Talk to a specialist</a>
-  </header>
-
-  <main class="wrap">
-    <section class="hero hero-concierge">
-      <p class="hero-eyebrow">Private ticket concierge</p>
-      <h1>The best seats, already in hand.</h1>
-      <p class="sub">Tell us where you want to be. We hold the inventory, price it all-in,
-        and get it to you before the gates open — no daisy chains, no surprises.</p>
-      <form id="searchForm" class="search" role="search">
-        <label for="q" class="sr-only">Search events, performers, or venues</label>
+  <main class="wrap search-shell" id="searchShell">
+    <!-- Google-style centered search home. The whole landing IS the search.
+         Results (grid) only appear after a search or via a deep link
+         (?performer_id= / ?venue_id=) — wired in store.js. -->
+    <section class="search-home" id="searchHome">
+      <a class="brand-mark" href="/store">VibePass</a>
+      <p class="brand-tagline">The best seats, already in hand.</p>
+      <form id="searchForm" class="gsearch" role="search">
+        <span class="gsearch-ic" aria-hidden="true">⚲</span>
+        <label for="q" class="sr-only">Search teams, players, artists, or venues</label>
         <input
           id="q"
           type="search"
-          placeholder="artist · team · venue · city"
+          placeholder="Search a team, player, artist, or venue…"
           autocomplete="off"
           autofocus
-          aria-label="Search events, performers, or venues"
+          aria-label="Search teams, players, artists, or venues"
           aria-autocomplete="list"
           aria-controls="searchSuggest"
         />
-        <button type="submit">Search</button>
         <div id="searchSuggest" class="search-suggest" hidden role="listbox"></div>
       </form>
-      <nav class="hero-chips" aria-label="Quick links">
-        <a class="chip chip-gold" href="#conciergeRail">Premium seats</a>
-        <a class="chip" href="#moversSections">Trending now</a>
-        <a class="chip" href="#grid">Browse all events</a>
-        <a class="chip" href="#concierge">Premium &amp; VIP</a>
-      </nav>
-    </section>
-
-    <!-- Trust / guarantee strip. The promises that matter at checkout. -->
-    <section class="trust" aria-label="Our guarantee">
-      <div class="trust-item">
-        <span class="trust-ic" aria-hidden="true">✦</span>
-        <span class="trust-h">All-in pricing</span>
-        <span class="trust-s">The price you see is the price you pay.</span>
-      </div>
-      <div class="trust-item">
-        <span class="trust-ic" aria-hidden="true">✦</span>
-        <span class="trust-h">100% authentic, guaranteed</span>
-        <span class="trust-s">Every seat verified, every order backed.</span>
-      </div>
-      <div class="trust-item">
-        <span class="trust-ic" aria-hidden="true">✦</span>
-        <span class="trust-h">In hand before the gates</span>
-        <span class="trust-s">Delivered ahead of the event, every time.</span>
-      </div>
-      <div class="trust-item">
-        <span class="trust-ic" aria-hidden="true">✦</span>
-        <span class="trust-h">Cancelled? Fully refunded</span>
-        <span class="trust-s">If the event is called off, you're covered.</span>
+      <div class="gsearch-actions">
+        <button type="submit" form="searchForm" class="gbtn">Search</button>
+        <button type="button" id="browseAll" class="gbtn">Browse all events</button>
       </div>
     </section>
 
-    <section id="results" class="results" aria-live="polite">
-      <!-- Filter banner — shown when opened via a ?performer_id= / ?venue_id= link. -->
+    <!-- Results — hidden on the bare home view; revealed on search or a
+         performer/venue deep link. -->
+    <section id="results" class="results" aria-live="polite" hidden>
       <div id="catalogFilterBanner" class="banner" hidden></div>
-      <!-- Concierge rail — premium top-band EVO seats (/api/store/concierge).
-           EVO inventory only; no SeatGeek data. Hidden when empty. -->
-      <div id="conciergeRail" class="movers-sections" hidden></div>
-      <!-- Themed curated rails (/api/store/movers): Featured, moving fast, etc. -->
-      <div id="moversSections" class="movers-sections" hidden></div>
-      <div id="status" class="status" aria-live="polite">Curating your events…</div>
+      <div id="status" class="status" aria-live="polite" hidden></div>
       <h2 id="gridHeading" class="grid-heading" hidden>All events</h2>
       <div id="grid" class="grid" hidden></div>
       <div id="empty" class="empty" hidden>
-        No events match. Try a broader search, or clear the box to see everything we hold.
+        No events match. Try a broader search, or clear the box to start over.
       </div>
-    </section>
-
-    <!-- White-glove concierge services. This is where we go past a broker grid. -->
-    <section id="concierge" class="concierge" aria-label="Concierge services">
-      <p class="section-eyebrow">White-glove service</p>
-      <h2 class="section-title">A specialist on every order.</h2>
-      <div class="concierge-grid">
-        <article class="svc">
-          <span class="svc-ic" aria-hidden="true">☎</span>
-          <h3>Talk to a specialist</h3>
-          <p>Real people who know the rooms. Tell us the occasion and we'll find the seat that fits it.</p>
-        </article>
-        <article class="svc">
-          <span class="svc-ic" aria-hidden="true">★</span>
-          <h3>Premium &amp; VIP access</h3>
-          <p>Club level, courtside, suites, and hospitality — including doors most resale sites never see.</p>
-        </article>
-        <article class="svc">
-          <span class="svc-ic" aria-hidden="true">◎</span>
-          <h3>Sightline guidance</h3>
-          <p>We map the view before you buy, so you know exactly what you're paying for in every section.</p>
-        </article>
-        <article class="svc">
-          <span class="svc-ic" aria-hidden="true">✈</span>
-          <h3>Flexible delivery</h3>
-          <p>Mobile transfer, e-delivery, or local pickup — in hand and ready well before the event.</p>
-        </article>
-      </div>
-    </section>
-
-    <!-- How it works — three calm steps. -->
-    <section id="how" class="how" aria-label="How it works">
-      <p class="section-eyebrow">How it works</p>
-      <h2 class="section-title">Three steps to your seat.</h2>
-      <ol class="how-steps">
-        <li class="step">
-          <span class="step-n">1</span>
-          <h3>Tell us where</h3>
-          <p>Search an event, or message a specialist with the vibe you're after.</p>
-        </li>
-        <li class="step">
-          <span class="step-n">2</span>
-          <h3>We hand-pick the seats</h3>
-          <p>From inventory we hold directly — verified, all-in priced, no daisy chains.</p>
-        </li>
-        <li class="step">
-          <span class="step-n">3</span>
-          <h3>Show up and enjoy</h3>
-          <p>Tickets delivered before the gates. We're on call right through the event.</p>
-        </li>
-      </ol>
     </section>
   </main>
 
-  <footer class="foot foot-rich">
-    <div class="foot-cols">
-      <div class="foot-brand">
-        <a class="brand" href="/store">VibePass</a>
-        <p class="foot-tag">Your private ticket concierge. Direct inventory, transparent pricing,
-          white-glove service.</p>
-      </div>
-      <nav class="foot-nav" aria-label="Footer">
-        <a href="#concierge">Concierge</a>
-        <a href="#how">How it works</a>
-        <a href="/store/discover">Discover tours</a>
-        <a href="/store/about">About</a>
-        <a href="/store/privacy">Privacy</a>
-        <a href="/store/terms">Terms</a>
-      </nav>
-    </div>
-    <div class="foot-base">
-      <span class="badge mvp">MVP · browse only · no real purchases</span>
-      <span class="foot-meta">&copy; 2026 VibePass &middot; MVP preview</span>
-    </div>
+  <footer class="foot foot-min">
+    <span class="badge mvp">MVP · browse only · no real purchases</span>
+    <nav class="foot-nav-min" aria-label="Footer">
+      <a href="/store/discover">Discover tours</a>
+      <a href="/store/about">About</a>
+      <a href="/store/privacy">Privacy</a>
+      <a href="/store/terms">Terms</a>
+    </nav>
   </footer>
 
   <script src="/static/store/store.js" defer></script>

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -895,35 +895,22 @@
     }
   }
 
-  // Render suggestion dropdown body. Sections, in priority order:
-  //   Players — sports search: a matched athlete + their team's upcoming
-  //     events (e.g. "messi" → Inter Miami CF games). Shown first.
-  //   Events you can buy now (we_own=true) — top priority among plain events
-  //   Other events (we_own=false) — surfaced but flagged as "browse"
-  //   Performers + venues — bottom, clickable filter pivots
+  // Render suggestion dropdown body. Sections, in order:
+  //   EVO events — "tickets you can buy" (we_own) then "more events" (browse)
+  //   Players (ESPN) — a matched athlete + their team's upcoming events
+  //   Performers + venues — clickable filter pivots (performer → their events
+  //     in the grid; e.g. "Pearl Jam" → concerts)
   function renderSuggest(host, payload) {
     if (!host) return;
     host.replaceChildren();
-    const players = (payload && payload.players) || [];
     const events = (payload && payload.events) || [];
+    const players = (payload && payload.players) || [];
     const performers = (payload && payload.performers) || [];
     const venues = (payload && payload.venues) || [];
 
-    if (!players.length && !events.length && !performers.length && !venues.length) {
+    if (!events.length && !players.length && !performers.length && !venues.length) {
       host.hidden = true;
       return;
-    }
-
-    if (players.length) {
-      host.append(suggestHeader("Players"));
-      players.forEach((pl) => {
-        host.append(suggestPlayerRow(pl));
-        (pl.events || []).forEach((e) => {
-          const row = suggestEventRow(e, !!e.we_own);
-          row.classList.add("under-player");
-          host.append(row);
-        });
-      });
     }
 
     const buyable = events.filter((e) => e.we_own);
@@ -936,6 +923,17 @@
     if (browseOnly.length) {
       host.append(suggestHeader("More events"));
       browseOnly.forEach((e) => host.append(suggestEventRow(e, false)));
+    }
+    if (players.length) {
+      host.append(suggestHeader("Players"));
+      players.forEach((pl) => {
+        host.append(suggestPlayerRow(pl));
+        (pl.events || []).forEach((e) => {
+          const row = suggestEventRow(e, !!e.we_own);
+          row.classList.add("under-player");
+          host.append(row);
+        });
+      });
     }
     if (performers.length) {
       host.append(suggestHeader("Performers"));

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -366,6 +366,29 @@
     let suggestTimer = null;
     let suggestSeq = 0;
 
+    // Google-style landing: the page starts as just the centered search box
+    // (#searchHome) and the results grid (#results) is hidden. A search or a
+    // performer/venue deep link flips into "results mode" — the brand shrinks
+    // to the top and the grid appears. body.mode-results drives the CSS.
+    const results = $("#results");
+    const browseAll = $("#browseAll");
+    let inResultsMode = false;
+    function enterResultsMode() {
+      if (inResultsMode) return;
+      inResultsMode = true;
+      document.body.classList.add("mode-results");
+      if (results) results.hidden = false;
+    }
+    function exitResultsMode() {
+      inResultsMode = false;
+      document.body.classList.remove("mode-results");
+      if (results) results.hidden = true;
+      if (grid) { grid.replaceChildren(); grid.hidden = true; }
+      if (gridHeading) gridHeading.hidden = true;
+      if (empty) empty.hidden = true;
+      if (status) status.hidden = true;
+    }
+
     let allEvents = [];
     // loadComplete gates filter() so the user can't trigger a misleading
     // "No events match" empty state by typing in the search box while the
@@ -551,12 +574,14 @@
       e.preventDefault();
       const q = (input.value || "").trim();
       hideSuggest();
-      // Empty submit → revert to the home view (full catalog).
+      // Empty submit → back to the centered Google-style search home.
       if (!q) {
         userHasSearched = false;
-        render(allEvents, "all");
+        exitResultsMode();
+        input.focus();
         return;
       }
+      enterResultsMode();
       // Backend search — hits /api/store/search for the FULL result set,
       // not just the in-memory home payload. Click-Search previously called
       // filter(q) which ran an in-memory scan over the 60 events that
@@ -572,7 +597,10 @@
     // Local in-memory filter on the already-loaded catalog AND a debounced
     // call to /api/store/search for live suggestions (TEvo + our SQL).
     input.addEventListener("input", () => {
-      filter(input.value);
+      // Only the loaded results grid filters in-memory as you type. On the
+      // centered home there is no grid yet — typing just drives the
+      // autocomplete dropdown (Google-style).
+      if (inResultsMode && loadComplete) filter(input.value);
       scheduleSuggest(input.value);
     });
 
@@ -775,27 +803,23 @@
           status.append(msg, retry);
         });
     }
-    loadCatalog();
-
-    // NYC themed sliders — only shown on the bare /store view (no performer
-    // or venue filter). Server returns 4 keyed arrays (moving_fast,
-    // price_drops, climbing, specials) and each becomes its own horizontal
-    // slider. Empty sections are hidden. days=90 to give the 3mo horizon
-    // enough pool depth for each section's filter.
-    if (!performerId && !venueId) {
-      // Concierge rail — premium top-band EVO seats (leads the curated rails).
-      const cHost = $("#conciergeRail");
-      if (cHost) {
-        api("/api/store/concierge?days=60&limit=18")
-          .then((res) => renderConcierge(cHost, res))
-          .catch(() => { cHost.hidden = true; });
+    if (isHomeView) {
+      // Google-style landing: the page IS the search. No auto catalog load,
+      // no curated rails. The grid loads only on an explicit search (submit)
+      // or via the "Browse all events" affordance.
+      if (browseAll) {
+        browseAll.addEventListener("click", () => {
+          userHasSearched = false;
+          enterResultsMode();
+          if (gridHeading) gridHeading.textContent = "All events";
+          loadCatalog();
+        });
       }
-      const host = $("#moversSections");
-      if (host) {
-        api("/api/store/movers?city=NYC&days=90")
-          .then((res) => renderMoversSections(host, res))
-          .catch(() => { host.hidden = true; });
-      }
+    } else {
+      // Deep link (?performer_id= / ?venue_id=, e.g. from a player result) →
+      // straight into results with that filter applied.
+      enterResultsMode();
+      loadCatalog();
     }
 
     // ----- Live search suggestions dropdown -----

--- a/static/store/style.css
+++ b/static/store/style.css
@@ -197,6 +197,107 @@ a { color: inherit; }
   font-size: 13px;
 }
 .suggest-row.under-player .suggest-row-name { font-size: 13px; font-weight: 500; }
+
+/* ===================== Google-style search landing ===================== */
+.search-shell {
+  min-height: calc(100vh - 56px);
+  display: flex;
+  flex-direction: column;
+}
+.search-home {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 18px;
+  padding: 8vh 20px 4vh;
+  transition: padding .2s ease;
+}
+.brand-mark {
+  font-size: clamp(40px, 8vw, 76px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--accent);
+  text-decoration: none;
+  line-height: 1;
+}
+.brand-tagline { color: var(--muted); margin: 0; font-size: 15px; }
+.gsearch {
+  position: relative;          /* anchor for .search-suggest dropdown */
+  display: flex;
+  align-items: center;
+  width: min(620px, 92vw);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 18px;
+  transition: border-color .15s, box-shadow .15s;
+}
+.gsearch:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(255,92,42,0.15);
+}
+.gsearch-ic { color: var(--muted); font-size: 18px; margin-right: 10px; }
+.gsearch input {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--text);
+  font-size: 17px;
+  padding: 12px 0;
+}
+.gsearch input::placeholder { color: var(--muted); }
+.gsearch .search-suggest { border-radius: 16px; text-align: left; }
+.gsearch-actions { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+.gbtn {
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 9px 18px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background .15s, border-color .15s;
+}
+.gbtn:hover { background: var(--panel); border-color: var(--accent); }
+
+/* Results mode — brand shrinks to a top bar, the grid appears below. */
+body.mode-results .search-home {
+  flex: 0 0 auto;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+}
+body.mode-results .brand-mark { font-size: 26px; }
+body.mode-results .brand-tagline { display: none; }
+body.mode-results .gsearch { width: min(520px, 60vw); }
+body.mode-results .gsearch-actions { margin-left: auto; }
+body.mode-results #results {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+/* Minimal footer */
+.foot-min {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 10px;
+  padding: 14px 20px; border-top: 1px solid var(--line);
+  color: var(--muted); font-size: 13px;
+}
+.foot-nav-min { display: flex; gap: 16px; flex-wrap: wrap; }
+.foot-nav-min a { color: var(--muted); text-decoration: none; }
+.foot-nav-min a:hover { color: var(--text); }
 .suggest-status {
   /* Loading + error states inside the dropdown — same height/position as
      a hit row so the dropdown doesn't jump-resize when results land. */

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -130,48 +130,43 @@
       renderResults(d);
     }
 
+    // Render a performer/player head row + its nested upcoming-event rows.
+    // Unifies how a player (ESPN → team) and a performer (Pearl Jam, a team)
+    // present: a clickable head linking to the performer page, with the
+    // entity's next events listed beneath. `sub` = "#23 · F" for a player;
+    // `inj` = an injury badge. Events array is {tevo_event_id,name,venue_name,
+    // occurs_at_local}.
+    function pushPerformerRows(parts, perfId, title, metaText, sub, inj, events) {
+      const headHref = perfId != null ? `performer.html?performer=${perfId}` : '#';
+      flat.push({ href: headHref, label: title, kind: 'performer' });
+      parts.push(`<a class="ts-row ts-player-head" href="${headHref}" data-kind="performer">
+          <span class="ts-name">${escapeHtml(title || '(unknown)')}${sub ? ` <span class="ts-sub">${escapeHtml(sub)}</span>` : ''}${inj || ''}</span>
+          <span class="ts-meta">${escapeHtml(metaText || '')}</span>
+        </a>`);
+      (events || []).forEach(e => {
+        const href = `event.html?event=${e.tevo_event_id}`;
+        const meta = [e.venue_name, fmtDateShort(e.occurs_at_local)].filter(Boolean).join(' · ');
+        flat.push({ href, label: e.name, kind: 'event' });
+        parts.push(`<a class="ts-row ts-player-event" href="${href}" data-kind="event">
+            <span class="ts-name">${escapeHtml(e.name || '(unnamed)')}</span>
+            <span class="ts-meta">${escapeHtml(meta)}</span>
+          </a>`);
+      });
+    }
+
     function renderResults(d) {
-      const players = d.players     || [];
       const evs     = d.events      || [];
+      const players = d.players     || [];
       const perfs   = d.performers  || [];
       const vens    = d.venues      || [];
       const mkt     = d.marketplace || [];
       flat = [];
-      if (!players.length && !evs.length && !perfs.length && !vens.length && !mkt.length) {
+      if (!evs.length && !players.length && !perfs.length && !vens.length && !mkt.length) {
         sugg.innerHTML = `<div class="ts-empty">no matches for &ldquo;${escapeHtml(d.q || '')}&rdquo;</div>`;
         return;
       }
       const parts = [];
-      // PLAYERS — ESPN athlete → mapped TEvo team performer → upcoming events.
-      // The headline sports-search feature: typing a player name surfaces their
-      // team and the team's next games. Player head links to the performer page;
-      // each nested event row links to that event's page.
-      if (players.length) {
-        parts.push('<div class="ts-section"><div class="ts-section-lbl">PLAYERS</div>');
-        players.forEach(pl => {
-          const teamHref = pl.tevo_performer_id != null
-            ? `performer.html?performer=${pl.tevo_performer_id}` : '#';
-          const bits = [pl.jersey ? '#' + pl.jersey : '', pl.position_abbr].filter(Boolean).join(' · ');
-          const teamMeta = [pl.team_name, pl.espn_league].filter(Boolean).join(' · ');
-          const inj = pl.latest_injury && pl.latest_injury.status
-            ? `<span class="ts-inj">${escapeHtml(pl.latest_injury.status)}</span>` : '';
-          flat.push({ href: teamHref, label: pl.full_name, kind: 'player' });
-          parts.push(`<a class="ts-row ts-player-head" href="${teamHref}" data-kind="player">
-              <span class="ts-name">${escapeHtml(pl.full_name || '(unknown)')}${bits ? ` <span class="ts-sub">${escapeHtml(bits)}</span>` : ''}${inj}</span>
-              <span class="ts-meta">${escapeHtml(teamMeta)}</span>
-            </a>`);
-          (pl.events || []).forEach(e => {
-            const href = `event.html?event=${e.tevo_event_id}`;
-            const meta = [e.venue_name, fmtDateShort(e.occurs_at_local)].filter(Boolean).join(' · ');
-            flat.push({ href, label: e.name, kind: 'event' });
-            parts.push(`<a class="ts-row ts-player-event" href="${href}" data-kind="event">
-                <span class="ts-name">${escapeHtml(e.name || '(unnamed)')}</span>
-                <span class="ts-meta">${escapeHtml(meta)}</span>
-              </a>`);
-          });
-        });
-        parts.push('</div>');
-      }
+      // EVO — events from our ticketing catalog (direct event-name matches).
       if (evs.length) {
         parts.push('<div class="ts-section"><div class="ts-section-lbl">EVENTS</div>');
         evs.forEach(e => {
@@ -185,15 +180,24 @@
         });
         parts.push('</div>');
       }
+      // ESPN — athlete → mapped TEvo team performer → that team's next games.
+      if (players.length) {
+        parts.push('<div class="ts-section"><div class="ts-section-lbl">PLAYERS</div>');
+        players.forEach(pl => {
+          const sub = [pl.jersey ? '#' + pl.jersey : '', pl.position_abbr].filter(Boolean).join(' · ');
+          const meta = [pl.team_name, pl.espn_league].filter(Boolean).join(' · ');
+          const inj = pl.latest_injury && pl.latest_injury.status
+            ? `<span class="ts-inj">${escapeHtml(pl.latest_injury.status)}</span>` : '';
+          pushPerformerRows(parts, pl.tevo_performer_id, pl.full_name, meta, sub, inj, pl.events);
+        });
+        parts.push('</div>');
+      }
+      // PERFORMERS — TEvo performers (Pearl Jam, teams) with their next events.
+      // Same shape as players: "Pearl Jam" → concerts, like "Lakers" → games.
       if (perfs.length) {
         parts.push('<div class="ts-section"><div class="ts-section-lbl">PERFORMERS</div>');
         perfs.forEach(p => {
-          const href = `performer.html?performer=${p.tevo_performer_id}`;
-          flat.push({ href, label: p.performer_name, kind: 'performer' });
-          parts.push(`<a class="ts-row" href="${href}" data-kind="performer">
-              <span class="ts-name">${escapeHtml(p.performer_name || '(unnamed)')}</span>
-              <span class="ts-meta">${escapeHtml(p.category || '')}</span>
-            </a>`);
+          pushPerformerRows(parts, p.tevo_performer_id, p.performer_name, p.category, '', '', p.events);
         });
         parts.push('</div>');
       }
@@ -215,9 +219,8 @@
         // track locally yet. No internal page to link to — open the buy URL.
         parts.push('<div class="ts-section"><div class="ts-section-lbl">MARKETPLACE</div>');
         mkt.forEach(m => {
-          // Scheme-validate the third-party URL: TicketsData supplies
-          // event_url verbatim — only http(s) may reach an href (blocks
-          // javascript:/data: if the feed is ever compromised).
+          // Scheme-validate the third-party URL: only http(s) may reach an href
+          // (blocks javascript:/data: if the feed is ever compromised).
           const href = /^https?:\/\//i.test(m.event_url || '') ? m.event_url : '#';
           const meta = [m.platform, m.venue_name, fmtDateShort(m.event_date)].filter(Boolean).join(' · ');
           flat.push({ href, label: m.event_name, kind: 'marketplace' });

--- a/supabase/migrations/20260617150000_terminal_search_performer_events.sql
+++ b/supabase/migrations/20260617150000_terminal_search_performer_events.sql
@@ -1,0 +1,154 @@
+-- Migration 20260617150000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): terminal_search() (v4 — performers now carry upcoming events) ·
+--   reads: events, aq_performer_map, aq_venue_map, v_td_unmatched_discovered_events,
+--          sports_player_search() ·
+--   pre: 20260617120000 (terminal_search v3 + sports_player_search)
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1).
+--
+-- WHY ───────────────────────────────────────────────────────────────────────
+-- Unify how a PERFORMER and a PLAYER present in search: each should show its
+-- upcoming events inline. Searching "Pearl Jam" should show Pearl Jam concerts
+-- the same way searching a team (or a player → team) shows that team's games.
+--
+-- v3 already returns a `players` section (athlete → team performer → events).
+-- This adds the symmetric piece: the `performers` section now carries an
+-- `events` array per performer (up to 3 upcoming, via primary_performer_id OR
+-- performer_ids[]). All other sections (events/venues/marketplace) unchanged.
+--
+-- NOTE (national teams / multi-team players): a player → *national team* link
+-- (e.g. Messi → Argentina) is NOT yet possible from our data — ESPN carries no
+-- nationality on the athlete, the "Argentina Mens National Soccer" performer
+-- has a NULL tevo_performer_id, and we hold no upcoming Argentina-soccer events.
+-- That needs a curated athlete→national-team map + performer mapping + event
+-- ingest — tracked as a follow-up. sports_player_search already returns ALL
+-- ESPN teams per athlete, so it lights up automatically once that data lands.
+--
+-- IDEMPOTENT: CREATE OR REPLACE (same (text,integer) signature). Re-runnable.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.terminal_search(
+  p_q     text,
+  p_limit integer DEFAULT 6
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $func$
+DECLARE
+  v_email   text;
+  v_q       text;
+  v_pat     text;
+  v_now_s   text;
+  v_cap     integer;
+  v_evs     jsonb;
+  v_perfs   jsonb;
+  v_vens    jsonb;
+  v_mkt     jsonb;
+  v_players jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  v_q   := trim(coalesce(p_q, ''));
+  v_cap := greatest(1, least(coalesce(p_limit, 6), 20));
+  IF length(v_q) < 2 THEN
+    RETURN jsonb_build_object('q', v_q, 'players', '[]'::jsonb, 'events', '[]'::jsonb,
+                              'performers', '[]'::jsonb, 'venues', '[]'::jsonb,
+                              'marketplace', '[]'::jsonb);
+  END IF;
+  v_pat   := '%' || v_q || '%';
+  v_now_s := to_char(now() - interval '6 hours', 'YYYY-MM-DD"T"HH24:MI:SS');
+
+  -- PLAYERS — shared resolver (ESPN athlete → team performer → upcoming events)
+  v_players := public.sports_player_search(v_q, v_cap);
+
+  -- EVENTS (catalog, upcoming) — direct event-name matches.
+  SELECT coalesce(jsonb_agg(to_jsonb(e) ORDER BY e.match_len, e.occurs_at_local), '[]'::jsonb)
+  INTO v_evs
+  FROM (
+    SELECT id AS tevo_event_id, name, venue_name, occurs_at_local,
+           primary_performer_name, length(name) AS match_len
+    FROM public.events
+    WHERE name ILIKE v_pat
+      AND occurs_at_local >= v_now_s
+      AND coalesce(state, '') <> 'past'
+    ORDER BY length(name) ASC, occurs_at_local ASC
+    LIMIT v_cap
+  ) e;
+
+  -- PERFORMERS — now each carries up to 3 upcoming events (Pearl Jam→concerts,
+  -- a team→games), mirroring the players section.
+  SELECT coalesce(jsonb_agg(to_jsonb(p) ORDER BY p.match_len, p.performer_name), '[]'::jsonb)
+  INTO v_perfs
+  FROM (
+    SELECT pp.tevo_performer_id, pp.performer_short_id, pp.performer_name, pp.category, pp.match_len,
+      (SELECT coalesce(jsonb_agg(ev ORDER BY ev.occurs_at_local), '[]'::jsonb)
+         FROM (
+           SELECT e.id AS tevo_event_id, e.name, e.venue_name, e.occurs_at_local
+           FROM public.events e
+           WHERE (e.primary_performer_id = pp.tevo_performer_id
+                  OR pp.tevo_performer_id = ANY (e.performer_ids))
+             AND coalesce(e.state, '') <> 'past'
+             AND e.occurs_at_local >= v_now_s
+           ORDER BY e.occurs_at_local ASC
+           LIMIT 3
+         ) ev) AS events
+    FROM (
+      SELECT DISTINCT ON (m2.tevo_performer_id)
+        m2.tevo_performer_id, m2.performer_short_id, m2.performer_name, m2.category,
+        length(m2.performer_name) AS match_len
+      FROM public.aq_performer_map m2
+      WHERE m2.tevo_performer_id IS NOT NULL
+        AND ( m2.performer_name ILIKE v_pat
+              OR EXISTS (SELECT 1 FROM unnest(coalesce(m2.aliases, ARRAY[]::text[])) AS a(alias)
+                         WHERE a.alias ILIKE v_pat) )
+      ORDER BY m2.tevo_performer_id, length(m2.performer_name) ASC
+      LIMIT v_cap
+    ) pp
+  ) p;
+
+  -- VENUES
+  SELECT coalesce(jsonb_agg(to_jsonb(v) ORDER BY v.match_len, v.venue_name), '[]'::jsonb)
+  INTO v_vens
+  FROM (
+    SELECT DISTINCT ON (m3.tevo_venue_id)
+      m3.tevo_venue_id, m3.venue_short_id, m3.venue_name, m3.city, m3.state,
+      length(m3.venue_name) AS match_len
+    FROM public.aq_venue_map m3
+    WHERE m3.tevo_venue_id IS NOT NULL
+      AND (m3.venue_name ILIKE v_pat OR m3.city ILIKE v_pat)
+    ORDER BY m3.tevo_venue_id, length(m3.venue_name) ASC
+    LIMIT v_cap
+  ) v;
+
+  -- MARKETPLACE (TicketsData /events discoveries we don't track locally)
+  SELECT coalesce(jsonb_agg(to_jsonb(k) ORDER BY k.event_date), '[]'::jsonb)
+  INTO v_mkt
+  FROM (
+    SELECT DISTINCT ON (lower(event_name), event_date, platform)
+      platform, td_event_id, event_url, event_name, event_date, venue_name, city
+    FROM public.v_td_unmatched_discovered_events
+    WHERE (event_name ILIKE v_pat OR performer_label ILIKE v_pat OR venue_name ILIKE v_pat)
+    ORDER BY lower(event_name), event_date, platform
+    LIMIT v_cap
+  ) k;
+
+  RETURN jsonb_build_object(
+    'q', v_q, 'limit', v_cap,
+    'players', v_players,
+    'events', v_evs, 'performers', v_perfs, 'venues', v_vens,
+    'marketplace', v_mkt
+  );
+END $func$;
+
+REVOKE ALL ON FUNCTION public.terminal_search(text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.terminal_search(text, integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.terminal_search(text, integer) IS
+  'D0 terminal search — players (sports_player_search) / events / performers '
+  '(now with inline upcoming events) / venues / marketplace. Email-gated. '
+  'v4 mig 20260617150000.';


### PR DESCRIPTION
## What
Two related search improvements on the storefront + terminal.

### 1. Google-style storefront landing
The store front page is now a clean, centered Google-style search — the landing *is* the search box. Marketing rails/sections removed from the bare home view; a search (or **Browse all events**, or a `?performer_id=`/`?venue_id=` deep link) flips into "results mode" and renders the grid. (`index.html`, `store.js`, `style.css`.)

### 2. Unified performer + player results (link players → teams, searchable)
Searching a **performer** and searching a **player** now read alike — each entity shows its upcoming events inline:
- **Performers** (Pearl Jam, a team) → their next events. *(migration v4 adds inline events to the performers bucket — validated: "yankees" → New York Yankees → 91 upcoming events.)*
- **Players** (ESPN) → their mapped **team** + that team's next games (Messi → Inter Miami CF, LeBron → Lakers). Shared head+nested-events renderer in `nav.js`.
- **All buckets kept**: events / players / performers / venues / marketplace.

**Migrations (author-only, NOT YET APPLIED):**
- `20260617120000` — `sports_player_search()` (shared public resolver) + `terminal_search` v3 players section. *(also on `main` via #567; re-listed here as the branch was cut before that merge)*
- `20260617150000` — `terminal_search` v4: performers carry inline upcoming events.

## Known data gap (flagged, not a bug)
Player → **national team** (e.g. Messi → Argentina) isn't possible from current data: ESPN carries no nationality on the athlete, the "Argentina Mens National Soccer" performer has a NULL `tevo_performer_id`, and we hold no upcoming Argentina-soccer events. `sports_player_search` already returns *all* ESPN teams per athlete, so this lights up automatically once a curated athlete→national-team map + performer mapping + event ingest land (follow-up).

## Notes
- Touches D1's lane (`static/store/*`) + D0 (`static/terminal/*`) — operator-directed.
- All dynamic HTML stays escaped (`escapeHtml`). JS syntax-checked; both migrations compile (validated in rolled-back transactions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvjBqisCLa2XZZcsjrS1wb