### PR TITLE
fix(store): allow maps CDN in middleware connect-src so seat map renders

### DIFF
--- a/app.py
+++ b/app.py
@@ -596,7 +596,15 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "script-src 'self'; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data: https:; "
-        "connect-src 'self' https://*.supabase.co; "
+        # maps.ticketevolution.com: the Tevomaps seat-map library fetches the
+        # venue map.svg via connect (fetch/XHR), so it must be in connect-src.
+        # The per-page <meta> CSP already allows it, but browsers enforce the
+        # INTERSECTION of meta + this header — without it here the SVG fetch is
+        # blocked and the storefront seat map renders blank. (The D0 terminal is
+        # served from a static CDN that doesn't run this middleware, so only its
+        # permissive meta CSP applied — which is why the terminal map worked and
+        # the storefront map didn't.)
+        "connect-src 'self' https://*.supabase.co https://maps.ticketevolution.com; "
         "frame-ancestors 'none'; "
         "base-uri 'self'; "
         "form-action 'self'"
@@ -610,7 +618,7 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "script-src 'self' https://www.google.com https://www.gstatic.com; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data: https:; "
-        "connect-src 'self' https://www.google.com https://*.supabase.co; "
+        "connect-src 'self' https://www.google.com https://*.supabase.co https://maps.ticketevolution.com; "
         "frame-src https://www.google.com; "
         "frame-ancestors 'none'; "
         "base-uri 'self'; "


### PR DESCRIPTION
## Root cause (confirmed via browser console)

The storefront seat map rendered blank on every event. The browser console showed:

```
Fetch API cannot load https://maps.ticketevolution.com/5725/53/map.svg.
Refused to connect because it violates the document's Content Security Policy.
connect-src 'self' https://*.supabase.co
```

The Tevomaps library inlines the venue `map.svg` via `fetch` (governed by `connect-src`). The storefront enforces **two** CSPs:
- `event.html`'s `<meta>` CSP — *does* allow `maps.ticketevolution.com`
- the FastAPI security-headers **middleware response header** — did **not**

Browsers enforce the **intersection**, so the stricter header blocked the SVG fetch. The D0 terminal map works because it's served from a static CDN that doesn't run this middleware — only its permissive meta CSP applied. That's why every prior CSS/timing fix had no effect: the request never left the browser.

## Fix

Add `https://maps.ticketevolution.com` to `connect-src` in the middleware CSP (both `_CSP` and the reCAPTCHA `_CSP_RECAPTCHA` variant). `img-src` already allowed `https:`; only `connect-src` was missing.

## Verification

Confirmed the blocking directive directly from the live page's console. Can't render the map in this environment (maps CDN + storefront host are egress-blocked, no browser), so please confirm on-device after deploy. `app.py` parses; the existing CSP header test (`frame-ancestors`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzTbrZ7VycRxXDdovcoh1d)_