### PR TITLE
fix(skills): ship-a-migration links to inventory owner instead of stale counts

### DIFF
--- a/.claude-plugins/terminal2-governance/skills/ship-a-migration/SKILL.md
+++ b/.claude-plugins/terminal2-governance/skills/ship-a-migration/SKILL.md
@@ -23,7 +23,8 @@ The `/new-migration` command scaffolds the FILE; this skill is the whole lifecyc
 ## Process
 
 1. **Don't rebuild it.** Before designing anything, confirm it doesn't already exist —
-   132 tables / 152 views / 75+ crons are live. Grep `RESOURCES_BIBLE.md` for the keyword;
+   hundreds of tables / views / crons are live (`RESOURCES_BIBLE.md` owns the live inventory
+   + counts). Grep `RESOURCES_BIBLE.md` for the keyword;
    check `MIGRATION_CONVENTIONS.md §14` so you don't re-ship landmark work.
    `SELECT relname FROM pg_class JOIN pg_namespace n ON n.oid=relnamespace
     WHERE nspname='public' AND relkind IN ('r','v','m') AND relname ILIKE '%<kw>%';`
@@ -66,7 +67,7 @@ The `/new-migration` command scaffolds the FILE; this skill is the whole lifecyc
 | "…skip the sample test, the SQL looks right." | Column-name + null-key bugs (`occurs_at_local` is TEXT; `tevo_event_id` often NULL) only show on real rows. Step 3 is the cheapest place to catch them. |
 | "…apply now, it's a tiny change." | Apply is operator-gated **per call** regardless of size (CLAUDE.md §1). Tiny DDL still mutates prod. |
 | "…it's NOT VALID so the FK won't block inserts." | `NOT VALID` skips *existing* rows but still enforces every new INSERT. Drop it, don't mark it. |
-| "…I'll reuse this name, feels new." | 132 tables / 152 views exist; re-implementing `event_metrics`/`*_xref`/`v_event_*` is the #1 waste. Step 1 exists for this. |
+| "…I'll reuse this name, feels new." | The inventory is large (see `RESOURCES_BIBLE.md`); re-implementing `event_metrics`/`*_xref`/`v_event_*` is the #1 waste. Step 1 exists for this. |
 | "…verify later, apply succeeded." | "Applied" ≠ "correct." A function can return 20 and write 0 rows (clock_timestamp vs now() bug). Re-run the samples. |
 
 ## Red flags — stop if any are true


### PR DESCRIPTION
## What

Review + test pass over the merged 4-domain governance reorg + workflow-skills layer (PR #570/#571/#573). Surfaced and fixed one content bug in the new `ship-a-migration` skill.

The skill hardcoded **"132 tables / 152 views / 75+ crons are live"** (step 1) and **"132 tables / 152 views exist"** (rationalizations table). Two problems:
1. **Stale** — live DB has **209 tables / 178 views / 162 crons** (149 active), verified against project `hzrizjeaxlqcxfrtczpq`.
2. **Self-inconsistent** — the skills layer's own stated principle is *"procedures → skills, facts → bibles, link don't copy."* An inventory count is a fact owned by `RESOURCES_BIBLE.md`; the skill should point to it, not restate a number that drifts.

Fix replaces both hardcoded counts with a pointer to `RESOURCES_BIBLE.md` (the inventory owner).

## Test results (merged reorg state)

All green after syncing to `origin/main`:
- ✅ `bin/check-docs.sh` (docs-registry gate) — clean
- ✅ `scripts/check_readonly.py` (RULE-2 static audit) — no write paths; 9 client guards present
- ✅ `python3 -m pytest` — **310 passed, 16 skipped, 0 failed**
- ✅ Both governance hooks compile; `skill_router.py` functionally tested across all routes (migration-file edit → nudge, once-per-session dedupe, `apply_migration` → nudge, DDL `execute_sql` → nudge, read-only SELECT → silent, non-migration edit → silent, malformed stdin → silent rc0)

## Note (out of scope here)

The underlying inventory counts in `RESOURCES_BIBLE.md` itself are also stale (135/140/67 vs live 209/178/162), as are several other data-layer docs (MIGRATION_CONVENTIONS §14, CRON_HIERARCHY job counts, PROJECT_BIBLE §0 `aq_event_map` 7,271→8,241). The reorg addressed governance structure only; the data-drift sweep is tracked separately (KANBAN C1-OPS-2). This PR only fixes the freshly-introduced restatement inside the new skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HRSv8UrsxuKEfBg9CRe2S

---
_Generated by [Claude Code](https://claude.ai/code/session_015HRSv8UrsxuKEfBg9CRe2S)_