### PR TITLE
feat(d0): 25/page watchlist, exclude EVO-owned from Top-50, drop Movers + Owned panels

### DIFF
--- a/static/terminal/home.js
+++ b/static/terminal/home.js
@@ -1,50 +1,40 @@
 // D0 Terminal — Home page.
 //
-// Movers panel reads `event_movers_index` via Path-C RPCs (mig 20260527260000):
-//   get_event_movers_v2(source, window_days, category, limit)
-//   get_event_movers_index_summary(source, window_days)
-// Coverage band, full movers table (source / window / segment controls), and
-// owned-events list all derive from the v2 rows.
+// Three panels (operator directive 2026-06-17 — Movers + S4K-owned panels removed):
+//   • My watchlist — the user's own tracked events (event_watchlist_list RPC).
+//   • Coverage band — active-future-sports counts, derived from the cross-source
+//     mover index (get_event_movers_v2) which still drives the at-a-glance totals.
+//   • Top-50 chart — "SG SELLING, WE'RE NOT IN" (get_sg_market_chart RPC).
 //
-// Semantic shift from the prior /api/broker/movers?window_hours= path:
-//   • OLD: events that moved in the last N hours (rolling-window delta).
-//   • NEW: events currently in the mover index slot for an N-day horizon —
-//     populated by the cross-source mover compute (price_up / price_down /
-//     selling_fast / accumulating / value_gap / cross_gap categories).
-// Source toggle lets operator pin to a single platform or use the merged
-// composite. Owned/market deltas + SG sales / owned median / value cols
-// from the legacy panel are NOT in v2 — they render as "—" honest empty.
-// Top-50 chart fires its own RPC (get_sg_market_chart) — independent.
+// The full Movers cross-source table now lives only on its dedicated page
+// (movers.html); the home page keeps just the coverage roll-up it feeds.
 
 (function () {
   'use strict';
   const T = window.Terminal;
 
   const state = {
-    source: 'merged',         // 'merged' | 'evo' | 'sg' | 'td_sh' | 'td_gt' | 'td_vd'
-    windowDays: 7,            // 7 | 15 | 30 | 180 (rpc-supported buckets)
-    segment: 'all',           // 'all' | 'owned'
-    rows: [],
-    sortKey: 'delta_market_pct',
-    sortDir: 'desc',
-    gapMap: new Map(),        // event_id → [{ gap_type, detail, signal_score }]
+    // Coverage band reads the merged 7d mover index — the same default the
+    // dedicated Movers page opens with.
+    source: 'merged',
+    windowDays: 7,
     chartTab: 'top',          // 'top' (rank 1-50) | 'rest' (rank 51+)
   };
 
   async function init() {
     if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
-    wireMoversControls();
     // Watchlist is the first table — the user's own tracked events. Independent
-    // RPC, runs in parallel with movers/blind-spots.
+    // RPC, runs in parallel with the coverage roll-up / chart.
     loadWatchlist().catch(e => console.error('[watchlist]', e));
-    // Top-50 chart fires its own RPC, independent of movers — runs in parallel.
+    // Top-50 chart fires its own RPC — runs in parallel.
     wireChartTabs();
     renderMarketChart().catch(e => console.error('[sgChart]', e));
-    load();
+    // Coverage band counts (active future sports) from the mover index.
+    loadCoverage().catch(e => console.error('[coverage]', e));
   }
 
-  // ---------- Watchlist (first table; max 50/page, client-paged) ----------
-  const WL_PAGE_SIZE = 50;
+  // ---------- Watchlist (first table; max 25/page, client-paged) ----------
+  const WL_PAGE_SIZE = 25;
   let _wlItems = [];
   let _wlPage = 0;
   let _wlBasis = null;   // 'bell' (since today's 12:00 ET open) | '24h' — drives the Δ caption
@@ -219,129 +209,22 @@
       }));
   }
 
-  // ---------- Path-C v2 movers load ----------
-
-  async function load() {
-    T.setStatus(`Loading home · ${state.source} · ${state.windowDays}d…`);
-    const body = document.getElementById('moversBody');
-    if (body) body.innerHTML = '<div class="empty">loading…</div>';
-
-    const Auth = window.TerminalAuth;
-    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
-      T.setStatus('not signed in', 'err');
-      if (body) body.innerHTML = '<div class="empty">not signed in</div>';
-      return;
-    }
-
-    try {
-      const [eventsRes, summaryRes] = await Promise.all([
-        Auth.client.rpc('get_event_movers_v2', {
-          p_source:      state.source,
-          p_window_days: state.windowDays,
-          p_category:    null,   // all categories
-          p_limit:       200,
-        }),
-        Auth.client.rpc('get_event_movers_index_summary', {
-          p_source:      state.source,
-          p_window_days: state.windowDays,
-        }),
-      ]);
-      if (eventsRes.error)  throw new Error(eventsRes.error.message  || 'movers RPC error');
-      if (summaryRes.error) throw new Error(summaryRes.error.message || 'summary RPC error');
-
-      const rawRows = eventsRes.data  || [];
-      const summary = summaryRes.data || [];
-
-      // Reshape v2 columns to the legacy field aliases that renderMovers /
-      // renderCoverage / renderOwnedEvents consume. Fields not in v2 become null
-      // and render as "—".
-      state.rows = rawRows.map(reshapeV2Row);
-      state.gapMap = new Map();   // reset on each load
-
-      T.setStatus('Loaded', 'ok');
-      renderSummaryStrip(summary);
-      renderCoverage(state.rows);
-      renderMovers();
-      renderOwnedEvents(state.rows);
-      // Phase 2: batch-load gap alerts for all mover event_ids, then re-render
-      // so GapChips appear in the table without blocking the initial paint.
-      loadGapMap(state.rows).catch(e => console.error('[gapMap]', e));
-    } catch (e) {
-      T.setStatus(e.message, 'err');
-      if (body) body.innerHTML = '<div class="empty">' + escapeHtml(e.message) + '</div>';
-    }
-  }
-
-  // Map v2 RPC row → legacy field names used by the render functions.
-  function reshapeV2Row(r) {
-    return Object.assign({}, r, {
-      // v2 → legacy alias
-      name:             r.event_name || r.name || ('Event ' + r.event_id),
-      occurs_at_local:  r.occurs_at  || r.occurs_at_local,
-      cur_market_med:   r.cur_price  != null ? +r.cur_price  : null,
-      delta_market_pct: r.price_delta_pct != null ? +r.price_delta_pct : null,
-      cur_owned_tix:    r.cur_owned  != null ? +r.cur_owned  : 0,
-      // v2 lacks these — null renders as "—" in the table
-      cur_market_tix:   null,
-      cur_owned_med:    null,
-      sg_sales_window:  null,
-      delta_owned_pct:  null,
-      delta_market_val: null,
-      delta_owned_val:  null,
-      performer_name:   null,
-    });
-  }
-
-  // Summary strip above movers table — same shape as movers.html v2SummaryStrip.
-  function renderSummaryStrip(summary) {
-    const strip = document.getElementById('moversSummaryStrip');
-    if (!strip || !summary.length) { if (strip) strip.innerHTML = ''; return; }
-    strip.innerHTML = summary.map(s => {
-      const sz   = s.index_size || 0;
-      const cov  = s.data_coverage_pct != null ? ` · ${Math.round(s.data_coverage_pct)}% cov` : '';
-      const turn = (+s.entries_24h || 0) + (+s.exits_24h || 0);
-      const turnStr = turn ? ` · ${turn} Δ/24h` : '';
-      return `<span class="badge" title="source=${escapeHtml(s.source)} window=${s.window_days}d">${escapeHtml(s.source)}·${s.window_days}d·${escapeHtml(s.category || '')}: ${sz}${cov}${turnStr}</span>`;
-    }).join(' ');
-  }
-
-  // ---------- Phase 2: GapChip batch loader ----------
-  // discovery_gap_alerts has no RLS (relrowsecurity=false) — direct read OK.
-  // Queries all active gaps for the current mover rows in one round-trip, then
-  // re-renders the movers table so gap badges appear in event name cells.
-
-  async function loadGapMap(rows) {
-    if (!rows || !rows.length) return;
-    const Auth = window.TerminalAuth;
-    if (!Auth || !Auth.client) return;
-    const ids = [...new Set(rows.map(r => r.event_id).filter(Boolean))];
-    if (!ids.length) return;
-    const { data, error } = await Auth.client
-      .from('discovery_gap_alerts')
-      .select('event_id,gap_type,detail,signal_score')
-      .in('event_id', ids)
-      .is('resolved_at', null)
-      .order('signal_score', { ascending: false });
-    if (error || !data) return;
-    const m = new Map();
-    data.forEach(g => {
-      if (!m.has(g.event_id)) m.set(g.event_id, []);
-      m.get(g.event_id).push(g);
-    });
-    state.gapMap = m;
-    renderMovers();  // re-render now that gap badges are available
-  }
-
-  // Returns HTML for up to 2 gap chips for an event (compact — avoid badge overflow).
-  function gapBadgesHtml(eventId) {
-    const gaps = state.gapMap.get(eventId);
-    if (!gaps || !gaps.length) return '';
-    return gaps.slice(0, 2).map(g =>
-      `<span class="badge gap-chip" title="${escapeHtml(g.detail || '')}">${escapeHtml((g.gap_type || '').replace(/_/g, ' '))}</span>`
-    ).join(' ');
-  }
-
   // ---------- Coverage band ----------
+  // Counts active future events from the merged 7d mover index — the at-a-glance
+  // roll-up that headed the (now-removed) Movers panel.
+
+  async function loadCoverage() {
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) return;
+    const res = await Auth.client.rpc('get_event_movers_v2', {
+      p_source:      state.source,
+      p_window_days: state.windowDays,
+      p_category:    null,
+      p_limit:       200,
+    });
+    if (res.error) { console.error('[coverage] rpc', res.error); return; }
+    renderCoverage(res.data || []);
+  }
 
   function renderCoverage(rows) {
     const now = Date.now();
@@ -373,7 +256,9 @@
   //               + percent_rank(7d-MA sales median)        (0..2)
   //
   // High on EITHER axis charts; high on BOTH tops it. Eligibility:
-  // owned_count_last_7d = 0, future event, >= 2 days of sales in trailing 7d.
+  // SG owned_count_last_7d = 0 AND EVO owned_tickets_count = 0 (operator
+  // directive 2026-06-17 — exclude events where EVO holds owned tickets),
+  // future event, >= 2 days of sales in trailing 7d.
   // Each row carries prev_rank / peak_rank / days_on_chart for movement.
   // Two tabs: "Top 50" (rank 1-50) and "The Rest" (rank 51+, capped server-side).
 
@@ -506,124 +391,7 @@
     body.appendChild(tbl);
   }
 
-  // ---------- Full movers table (mirrors movers.html) ----------
-
-  function wireMoversControls() {
-    // Source toggle
-    document.querySelectorAll('[data-src]').forEach(btn => {
-      btn.addEventListener('click', () => {
-        document.querySelectorAll('[data-src]').forEach(b => b.classList.remove('is-active'));
-        btn.classList.add('is-active');
-        state.source = btn.dataset.src;
-        load();
-      });
-    });
-    // Window (days)
-    document.querySelectorAll('[data-wdays]').forEach(btn => {
-      btn.addEventListener('click', () => {
-        document.querySelectorAll('[data-wdays]').forEach(b => b.classList.remove('is-active'));
-        btn.classList.add('is-active');
-        state.windowDays = parseInt(btn.dataset.wdays, 10);
-        load();
-      });
-    });
-    // Segment
-    document.querySelectorAll('[data-segment]').forEach(btn => {
-      btn.addEventListener('click', () => {
-        document.querySelectorAll('[data-segment]').forEach(b => b.classList.remove('is-active'));
-        btn.classList.add('is-active');
-        state.segment = btn.dataset.segment;
-        renderMovers();
-      });
-    });
-  }
-
-  function renderMovers() {
-    const body = document.getElementById('moversBody');
-    if (!body) return;
-    const filtered = state.segment === 'owned'
-      ? state.rows.filter(r => (+r.cur_owned_tix || 0) > 0)
-      : state.rows;
-
-    const countEl = document.getElementById('moversCount');
-    if (countEl) countEl.textContent = filtered.length ? `${filtered.length} events` : '';
-
-    if (!filtered.length) {
-      body.innerHTML = '<div class="empty">no movers</div>';
-      return;
-    }
-
-    const sorted = [...filtered].sort((a, b) => {
-      const av = a[state.sortKey], bv = b[state.sortKey];
-      if (av === null || av === undefined) return 1;
-      if (bv === null || bv === undefined) return -1;
-      return state.sortDir === 'desc' ? bv - av : av - bv;
-    });
-
-    // v2 RPC cols available: event_name, occurs_at, cur_price (→ cur_market_med),
-    // price_delta_pct (→ delta_market_pct), cur_owned (→ cur_owned_tix), category,
-    // rank, signal_score, evo_median, sg_median, td_sh/gt/vd_median, *_spread.
-    // Legacy cols not in v2 (cur_market_tix, cur_owned_med, sg_sales_window,
-    // delta_owned_pct, delta_market_val, delta_owned_val) are dropped from the
-    // header to avoid a table of "—".
-    const cols = [
-      { key: null,               label: 'Event',      align: 'left' },
-      { key: null,               label: 'Category',   align: 'left' },
-      { key: null,               label: 'T-days',     align: 'num'  },
-      { key: 'cur_owned_tix',    label: 'Owned',      align: 'num'  },
-      { key: 'cur_market_med',   label: 'Cur $',      align: 'num'  },
-      { key: 'delta_market_pct', label: '%Δ',         align: 'num'  },
-      { key: 'signal_score',     label: 'Score',      align: 'num'  },
-      { key: 'rank',             label: 'Rank',       align: 'num'  },
-    ];
-
-    body.innerHTML = '';
-    const tbl = document.createElement('table');
-    tbl.className = 'movers-tbl';
-    const thead = document.createElement('thead');
-    const trh = document.createElement('tr');
-    cols.forEach(c => {
-      const th = document.createElement('th');
-      th.textContent = c.label;
-      if (c.align === 'num') th.classList.add('num');
-      if (c.key) {
-        th.classList.add('sortable');
-        th.dataset.sort = c.key;
-        if (state.sortKey === c.key) th.classList.add('is-sorted', state.sortDir);
-        th.addEventListener('click', () => {
-          if (state.sortKey === c.key) state.sortDir = state.sortDir === 'desc' ? 'asc' : 'desc';
-          else { state.sortKey = c.key; state.sortDir = 'desc'; }
-          renderMovers();
-        });
-      }
-      trh.appendChild(th);
-    });
-    thead.appendChild(trh);
-    tbl.appendChild(thead);
-
-    const tbody = document.createElement('tbody');
-    sorted.slice(0, 100).forEach(r => {
-      const tr = document.createElement('tr');
-      tr.classList.add('clickable');
-      tr.addEventListener('click', () => { window.location.href = 'event.html?event=' + r.event_id; });
-      const d = T.daysUntil(r.occurs_at_local || r.occurs_at);
-      const mDPct = r.delta_market_pct != null ? +r.delta_market_pct : NaN;
-      const ownedTix = +r.cur_owned_tix || 0;
-      const score = r.signal_score != null ? (+r.signal_score).toFixed(2) : '—';
-      tr.innerHTML = `
-        <td><a href="event.html?event=${r.event_id}" onclick="event.stopPropagation()">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a> ${T.temporalChipHtml(r.occurs_at_local || r.occurs_at)} ${gapBadgesHtml(r.event_id)}</td>
-        <td class="muted small">${escapeHtml((r.category || '—').replace(/_/g, ' '))}</td>
-        <td class="num">${d === null ? '—' : d}</td>
-        <td class="num ${ownedTix > 0 ? 'ours' : ''}">${T.fmtNum(ownedTix)}</td>
-        <td class="num">${r.cur_market_med != null ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>
-        <td class="num ${pctCls(mDPct)}">${Number.isFinite(mDPct) ? T.fmtPct(mDPct, 1) : '—'}</td>
-        <td class="num muted small">${score}</td>
-        <td class="num muted small">${r.rank != null ? r.rank : '—'}</td>`;
-      tbody.appendChild(tr);
-    });
-    tbl.appendChild(tbody);
-    body.appendChild(tbl);
-  }
+  // ---------- Util ----------
 
   function pctCls(v) {
     if (!Number.isFinite(v)) return '';
@@ -633,71 +401,6 @@
     if (!Number.isFinite(v)) return '—';
     return (v >= 0 ? '+' : '−') + '$' + T.fmtNum(Math.round(Math.abs(v)));
   }
-
-  // ---------- Owned events list (next 30d) ----------
-
-  function renderOwnedEvents(rows) {
-    const body = document.getElementById('ownedEventsBody');
-    const countEl = document.getElementById('ownedEventCount');
-    body.innerHTML = '';
-    const now = Date.now();
-    const day = 86400000;
-    const upcoming = rows.filter(r => {
-      if (!((+r.cur_owned_tix || 0) > 0)) return false;
-      const t = new Date(r.occurs_at_local || r.occurs_at).getTime();
-      if (!Number.isFinite(t)) return false;
-      const days = (t - now) / day;
-      return days >= -1 && days <= 30;
-    }).sort((a, b) => {
-      // Soonest-first by event date.
-      const ta = new Date(a.occurs_at_local || a.occurs_at).getTime();
-      const tb = new Date(b.occurs_at_local || b.occurs_at).getTime();
-      if (!Number.isFinite(ta)) return 1;
-      if (!Number.isFinite(tb)) return -1;
-      return ta - tb;
-    });
-
-    countEl.textContent = upcoming.length ? `${upcoming.length} events` : '';
-
-    if (!upcoming.length) {
-      body.innerHTML = '<div class="empty">no owned events in the next 30d</div>';
-      return;
-    }
-
-    // v2 RPC: cur_owned_med / delta_owned_val not available.
-    // Show qty + cur price (cur_market_med alias) + %Δ + mover chip.
-    const tbl = document.createElement('table');
-    tbl.innerHTML = `
-      <thead><tr>
-        <th>Event</th>
-        <th class="num">T-days</th>
-        <th class="num">Owned qty</th>
-        <th class="num">Cur $</th>
-        <th class="num">%Δ</th>
-        <th class="num">Category</th>
-      </tr></thead>
-      <tbody></tbody>
-    `;
-    const tb = tbl.querySelector('tbody');
-    upcoming.slice(0, 30).forEach(r => {
-      const ot = +r.cur_owned_tix || 0;
-      const d  = T.daysUntil(r.occurs_at_local || r.occurs_at);
-      const mDPct = r.delta_market_pct != null ? +r.delta_market_pct : NaN;
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td><a href="event.html?event=${r.event_id}">${escapeHtml(r.name || r.event_name || ('Event ' + r.event_id))}</a></td>
-        <td class="num">${d === null ? '—' : d}</td>
-        <td class="num ours">${T.fmtNum(ot)}</td>
-        <td class="num">${r.cur_market_med != null ? '$' + T.fmtNum(Math.round(+r.cur_market_med)) : '—'}</td>
-        <td class="num ${pctCls(mDPct)}">${Number.isFinite(mDPct) ? T.fmtPct(mDPct, 1) : '—'}</td>
-        <td class="muted small">${escapeHtml((r.category || '—').replace(/_/g, ' '))}</td>
-      `;
-      tb.appendChild(tr);
-    });
-    body.appendChild(tbl);
-  }
-
-  // ---------- Util ----------
 
   function setText(id, txt) {
     const el = document.getElementById(id);

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -56,45 +56,6 @@
       <div id="sgChartBody"><div class="empty">loading…</div></div>
     </section>
 
-    <section id="movers-panel">
-      <div class="panel-title row">
-        <span>MOVERS · CROSS-SOURCE INDEX</span>
-        <span class="muted small" id="moversCount"></span>
-      </div>
-      <div id="moversSummaryStrip" class="muted small" style="margin-bottom:6px"></div>
-      <div class="ctrl-row">
-        <div class="ctrl-group">
-          <span class="ctrl-lbl">SOURCE</span>
-          <button class="ctrl-btn is-active" data-src="merged">Merged</button>
-          <button class="ctrl-btn"           data-src="evo">EVO</button>
-          <button class="ctrl-btn"           data-src="sg">SG</button>
-          <button class="ctrl-btn"           data-src="td_sh">SH</button>
-          <button class="ctrl-btn"           data-src="td_gt">GT</button>
-          <button class="ctrl-btn"           data-src="td_vd">VD</button>
-        </div>
-        <div class="ctrl-group">
-          <span class="ctrl-lbl">WINDOW</span>
-          <button class="ctrl-btn is-active" data-wdays="7">7d</button>
-          <button class="ctrl-btn"           data-wdays="15">15d</button>
-          <button class="ctrl-btn"           data-wdays="30">30d</button>
-          <button class="ctrl-btn"           data-wdays="180">180d</button>
-        </div>
-        <div class="ctrl-group">
-          <span class="ctrl-lbl">SEGMENT</span>
-          <button class="ctrl-btn is-active" data-segment="all">All</button>
-          <button class="ctrl-btn"           data-segment="owned">Owned only</button>
-        </div>
-      </div>
-      <div id="moversBody"><div class="empty">loading…</div></div>
-    </section>
-
-    <section id="owned-events">
-      <div class="panel-title row">
-        <span>S4K-OWNED EVENTS — NEXT 30 DAYS</span>
-        <span class="muted small" id="ownedEventCount"></span>
-      </div>
-      <div id="ownedEventsBody"></div>
-    </section>
   </main>
 
   <script src="lib/supabase.js"></script>
@@ -102,6 +63,6 @@
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260608"></script>
-  <script src="home.js?v=20260615"></script>
+  <script src="home.js?v=20260617"></script>
 </body>
 </html>

--- a/supabase/migrations/20260617130000_sg_market_chart_exclude_evo_owned.sql
+++ b/supabase/migrations/20260617130000_sg_market_chart_exclude_evo_owned.sql
@@ -1,0 +1,176 @@
+-- Migration 20260617130000 · lane:D0 (author) → A1 (apply) ·
+--   writes (DDL): rebuild_sg_market_chart() (CREATE OR REPLACE — elig CTE now
+--                 also excludes events where EVO/TEvo holds owned tickets) ·
+--   reads: seatgeek_event_metrics, seatdata_sales_snapshots,
+--          sg_event_priority_state, latest_event_metrics ·
+--   pre: 20260608220000 (sg_market_chart blended + hybrid rank — latest body)
+--
+-- ## NOT YET APPLIED — author-only migration file.
+--    Pending A1 review + explicit operator apply (CLAUDE.md §1). Validate on a
+--    Supabase branch (copy-on-write fork) before any prod apply.
+--
+-- WHY (operator directive 2026-06-17) ───────────────────────────────────────
+-- The "TOP 50 — SG SELLING, WE'RE NOT IN" home chart (D0) is meant to surface
+-- only events we hold ZERO inventory in. Eligibility filtered on the SG-side
+-- ownership flag (sg_event_priority_state.owned_count_last_7d = 0) but NOT on
+-- the EVO/TEvo book — so an event we DO own in EVO (but not on SG) could still
+-- chart as a "we're not in" blind-spot. Operator: "exclude where EVO has owned
+-- tickets."
+--
+-- FIX: in the elig CTE, LEFT JOIN latest_event_metrics on the event's TEvo id
+-- and require coalesce(em.owned_tickets_count, 0) = 0. latest_event_metrics is
+-- the per-event TEvo rollup matview (mig 20260513001000) carrying
+-- owned_tickets_count / owned_groups_count. LEFT JOIN keeps SG-native events
+-- with no TEvo mapping (em row NULL → coalesce 0 → still eligible), so the
+-- World-Cup-style SG-only universe is unaffected; only events where EVO shows
+-- owned tickets drop out. Everything else in the rebuild is byte-identical to
+-- mig 20260608220000.
+--
+-- ROLLBACK: restore the mig 20260608220000 rebuild_sg_market_chart() body
+--   (drop the latest_event_metrics join + owned_tickets_count predicate).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.rebuild_sg_market_chart()
+RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $func$
+DECLARE
+  v_today date := (now() AT TIME ZONE 'UTC')::date;
+  v_prev  date;
+  v_count int := 0;
+BEGIN
+  SELECT max(chart_date) INTO v_prev
+  FROM public.sg_market_chart WHERE chart_date < v_today;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date = v_today;  -- idempotent re-run
+
+  WITH daily AS (
+    SELECT DISTINCT ON (sg_event_id, (captured_at AT TIME ZONE 'UTC')::date)
+      sg_event_id,
+      (captured_at AT TIME ZONE 'UTC')::date AS d,
+      sold_quantity, sold_price_median, sold_gross
+    FROM public.seatgeek_event_metrics
+    WHERE captured_at > now() - interval '7 days'
+      AND coalesce(sold_quantity, 0) > 0
+    ORDER BY sg_event_id, (captured_at AT TIME ZONE 'UTC')::date, captured_at DESC
+  ),
+  ma AS (
+    SELECT sg_event_id,
+      count(*)                        AS days_with_sales,
+      avg(sold_quantity)::numeric     AS ma7_volume,
+      avg(sold_price_median)::numeric AS ma7_median,
+      avg(sold_gross)::numeric        AS ma7_gross
+    FROM daily
+    GROUP BY sg_event_id
+  ),
+  -- SeatData sold comps: per-event/day count, gross (Σ price×qty), and median price.
+  sd_daily AS (
+    SELECT s.tevo_event_id,
+           (s.sale_timestamp AT TIME ZONE 'UTC')::date AS d,
+           count(*)                                                       AS cnt,
+           sum(coalesce(s.price,0) * greatest(coalesce(s.quantity,1),1))  AS daily_gross,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY s.price)           AS daily_median
+    FROM public.seatdata_sales_snapshots s
+    WHERE s.sale_timestamp > now() - interval '7 days'
+    GROUP BY s.tevo_event_id, (s.sale_timestamp AT TIME ZONE 'UTC')::date
+  ),
+  sd AS (
+    SELECT tevo_event_id,
+           sum(cnt)::int               AS sd_sales_7d,
+           avg(cnt)::numeric           AS sd_ma7_volume,
+           avg(daily_median)::numeric  AS sd_ma7_median,
+           avg(daily_gross)::numeric   AS sd_ma7_gross
+    FROM sd_daily
+    GROUP BY tevo_event_id
+  ),
+  elig AS (
+    SELECT m.sg_event_id, m.days_with_sales, m.ma7_volume, m.ma7_median, m.ma7_gross,
+           p.tevo_event_id, p.sg_event_name, p.sg_venue_name, p.sg_datetime_utc
+    FROM ma m
+    JOIN public.sg_event_priority_state p ON p.sg_event_id = m.sg_event_id
+    -- EVO/TEvo book for this event (NULL for SG-native events with no TEvo map).
+    LEFT JOIN public.latest_event_metrics em ON em.event_id = p.tevo_event_id
+    WHERE coalesce(p.owned_count_last_7d, 0) = 0   -- SG-side: we hold no inventory
+      AND coalesce(em.owned_tickets_count, 0) = 0  -- EVO-side: no owned tickets either
+      AND p.sg_datetime_utc > now()                -- future events only
+      AND m.days_with_sales >= 2                   -- real MA, not a one-off spike
+  ),
+  -- join SeatData and compute blended metrics BEFORE the blended percentile windows
+  joined AS (
+    SELECT e.*,
+      sd.sd_sales_7d,
+      sd.sd_ma7_volume,
+      sd.sd_ma7_median,
+      sd.sd_ma7_gross,
+      (e.ma7_volume + coalesce(sd.sd_ma7_volume, 0))            AS ma7_volume_blended,
+      (e.ma7_gross  + coalesce(sd.sd_ma7_gross,  0))            AS ma7_gross_blended,
+      ( (e.ma7_median * e.ma7_volume
+         + coalesce(sd.sd_ma7_median * sd.sd_ma7_volume, 0))
+        / NULLIF(e.ma7_volume + coalesce(sd.sd_ma7_volume, 0), 0)
+      )                                                          AS ma7_median_blended
+    FROM elig e
+    LEFT JOIN sd ON sd.tevo_event_id = e.tevo_event_id
+  ),
+  scored AS (
+    SELECT j.*,
+      (percent_rank() OVER (ORDER BY ma7_volume))::numeric          AS pct_volume,
+      (percent_rank() OVER (ORDER BY ma7_median))::numeric          AS pct_median,
+      (percent_rank() OVER (ORDER BY ma7_volume_blended))::numeric  AS bl_pct_volume,
+      (percent_rank() OVER (ORDER BY ma7_median_blended))::numeric  AS bl_pct_median
+    FROM joined j
+  ),
+  ranked AS (
+    SELECT s.*,
+      (pct_volume + pct_median)                            AS chart_score,
+      (bl_pct_volume + bl_pct_median)                      AS blended_score,
+      (coalesce(sd_sales_7d, 0) > 0)                       AS has_sd,
+      row_number() OVER (
+        ORDER BY
+          CASE WHEN coalesce(sd_sales_7d, 0) > 0
+               THEN (bl_pct_volume + bl_pct_median)
+               ELSE (pct_volume + pct_median)
+          END DESC,
+          ma7_gross_blended DESC NULLS LAST,
+          ma7_volume_blended DESC
+      ) AS rnk
+    FROM scored s
+  )
+  INSERT INTO public.sg_market_chart (
+    chart_date, sg_event_id, rank, chart_score, pct_volume, pct_median,
+    ma7_volume, ma7_median, ma7_gross, days_with_sales,
+    prev_rank, peak_rank, days_on_chart,
+    tevo_event_id, sg_event_name, sg_venue_name, sg_datetime_utc,
+    sd_ma7_gross, sd_sales_7d,
+    sd_ma7_volume, sd_ma7_median,
+    ma7_volume_blended, ma7_median_blended, ma7_gross_blended,
+    blended_score, score_basis)
+  SELECT
+    v_today, r.sg_event_id, r.rnk::int, round(r.chart_score, 4),
+    round(r.pct_volume, 4), round(r.pct_median, 4),
+    round(r.ma7_volume, 1), round(r.ma7_median, 2), round(r.ma7_gross, 2), r.days_with_sales,
+    prev.rank,
+    LEAST(r.rnk::int,
+          coalesce((SELECT min(h.rank) FROM public.sg_market_chart h
+                    WHERE h.sg_event_id = r.sg_event_id), r.rnk::int)),
+    CASE WHEN prev.rank IS NOT NULL THEN coalesce(prev.days_on_chart, 0) + 1 ELSE 1 END,
+    r.tevo_event_id, r.sg_event_name, r.sg_venue_name, r.sg_datetime_utc,
+    round(r.sd_ma7_gross, 2), r.sd_sales_7d,
+    round(r.sd_ma7_volume, 1), round(r.sd_ma7_median, 2),
+    round(r.ma7_volume_blended, 1), round(r.ma7_median_blended, 2), round(r.ma7_gross_blended, 2),
+    round(r.blended_score, 4),
+    CASE WHEN r.has_sd THEN 'blended' ELSE 'sg' END
+  FROM ranked r
+  LEFT JOIN public.sg_market_chart prev
+    ON prev.sg_event_id = r.sg_event_id AND prev.chart_date = v_prev;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+
+  DELETE FROM public.sg_market_chart WHERE chart_date < v_today - 90;
+
+  RETURN v_count;
+END $func$;
+
+-- Repopulate today's chart so the EVO-owned exclusion lands immediately on apply.
+-- (A1: run as part of the apply; safe/idempotent — DELETE+rebuild for v_today.)
+SELECT public.rebuild_sg_market_chart();


### PR DESCRIPTION
## D0 home page fixes

Operator directive (2026-06-17) — four changes to the D0 terminal home page.

### 1. Watchlist → 25 results per page
`WL_PAGE_SIZE` 50 → 25 in `static/terminal/home.js`. Client-side pager unchanged; the "showing N/page" caption follows automatically.

### 2. TOP 50 — SG SELLING, WE'RE NOT IN → exclude where EVO has owned tickets
The chart's eligibility only checked the **SG-side** ownership flag (`sg_event_priority_state.owned_count_last_7d = 0`), so an event we own in **EVO/TEvo** (but not on SG) could still chart as a "we're not in" blind-spot.

New migration `supabase/migrations/20260617130000_sg_market_chart_exclude_evo_owned.sql` recreates `rebuild_sg_market_chart()` with the `elig` CTE also requiring `coalesce(latest_event_metrics.owned_tickets_count, 0) = 0`. `LEFT JOIN` on the TEvo id keeps SG-native events (no TEvo map → NULL → still eligible) unaffected; only EVO-owned events drop out. Everything else in the rebuild is byte-identical to mig `20260608220000`.

> ⚠️ **Author-only migration** — NOT applied. Pending **A1** review + explicit operator apply per CLAUDE.md §1 (D-tier has no Supabase mutation authority). Validate on a Supabase branch before prod apply; the file ends with a `SELECT rebuild_sg_market_chart()` so today's chart repopulates on apply.

### 3. Remove "MOVERS · CROSS-SOURCE INDEX" panel
Removed from `index.html` and `home.js`. The full cross-source Movers table still lives on its dedicated page (`movers.html`) — only the home-page panel is dropped. The **Coverage band** (which previously piggy-backed on the movers fetch) is kept and now fed by a dedicated minimal `get_event_movers_v2` call (`loadCoverage`).

### 4. Remove "S4K-OWNED EVENTS — NEXT 30 DAYS" panel
Removed from `index.html` and `home.js` (section + `renderOwnedEvents`).

Also bumped the `home.js` cache-bust token (`?v=20260617`).

### Testing
- `tests/test_watchlist_metrics.py` — 7 passed, 4 skipped (no DB). The RPC↔FE metric-key contract still holds.
- `node --check static/terminal/home.js` — OK.
- Remaining suite failures are pre-existing, environment-only (`bs4`/`fastapi` not installed, `pyo3` runtime) in modules this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Vug4VFQBRQdfcmu34Bowt

---
_Generated by [Claude Code](https://claude.ai/code/session_018Vug4VFQBRQdfcmu34Bowt)_