### PR TITLE
ci(governance): add scheduled maintenance agent + 2026-06-19 maintenance plan

### DIFF
--- a/.claude-plugins/terminal2-governance/.claude-plugin/plugin.json
+++ b/.claude-plugins/terminal2-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal2-governance",
-  "description": "Terminal-2 governance enforcement: RULE 2 read-only audit + docs-registry gate as PostToolUse edit-time hooks; a PreToolUse skill_router surfaces workflow skills at trigger time; /rule2-audit + /new-migration commands and skills/ (ship-a-migration) encode the PROJECT_BIBLE §8 workflows. Versioned by commit SHA (no version field) so every merge to main is the latest.",
+  "description": "Terminal-2 governance enforcement: RULE 2 read-only audit + docs-registry gate as PostToolUse edit-time hooks; a PreToolUse skill_router surfaces workflow skills at trigger time; /rule2-audit + /new-migration commands and skills/ (ship-a-migration) encode the PROJECT_BIBLE §8 workflows; agents/ encodes the lanes (A1/B1/C1/D0) as real scoped subagents. Versioned by commit SHA (no version field) so every merge to main is the latest.",
   "author": {
     "name": "Terminal-2 operators",
     "email": "julian@s4kent.com"

--- a/.claude-plugins/terminal2-governance/agents/README.md
+++ b/.claude-plugins/terminal2-governance/agents/README.md
@@ -1,0 +1,57 @@
+# Lane agents — the bots, made real
+
+These are the Terminal-2 lanes encoded as **real, scoped Claude Code subagents**
+(not prose conventions a session adopts). Invoke one with the `Agent` tool, e.g.
+`subagent_type: b1-security` — or let a scheduled runner drive it (below).
+
+Each agent carries its lane's mandate, write surface, and **hard limits** from
+`BOT_HIERARCHY.md` + `CLAUDE.md`. The PostToolUse governance hooks (RULE-2 scanner,
+docs gate) still enforce the immutable limits regardless of which agent runs.
+
+## Roster
+
+| Agent (`subagent_type`) | Lane | Owns | Recurring runner? |
+|---|---|---|---|
+| `a1-data-plane` | A1 | DB · pipeline · crons · DB-security · AQ mapper | freshness/cron sweep (planned) |
+| `b1-git-code` | B1 | git history · code security · drift · tests · CI · deps | security sweep (planned) |
+| `c1-docs-coord` | C1 | bible set · registry · promotions · shared-resource register · drift | docs/drift sweep (planned) |
+| `d0-terminal` | D0 | broker terminal FE + `/api/broker/*` | none (interactive product work) |
+
+D1–D4 are PAUSED (add `d1-store` … `d4-exos` on reactivation, same pattern).
+
+## Autonomy matrix — what's autonomous vs operator-gated
+
+Default autonomy is **Tier 2: propose via draft PR**. Nothing below crosses an
+operator gate without a human. This is the lever for "reduce operator gating" —
+widen the *Autonomous* column deliberately, one row at a time, once trusted.
+
+| Action | Autonomous (Tier 2) | Operator-gated |
+|---|---|---|
+| Read / investigate / SELECT | ✅ any agent | — |
+| Author a migration FILE | ✅ A1 | — |
+| **Apply** a migration to prod | ❌ | ✅ A1 applies (CLAUDE.md §1) |
+| Open a DRAFT PR | ✅ any agent | — |
+| Merge a PR / push to main | ❌ | ✅ green-CI, per-task (humans for now) |
+| Auto-merge green lower-bound Dependabot | ❌ (Tier 3 upgrade) | ✅ flip when trusted |
+| Bump a dependency UPPER bound | ❌ | ✅ human verifies the major |
+| Change branch protection / rotate secrets / edit a guard | ❌ | ✅ operator only (CLAUDE.md §2) |
+| Edit another lane's surface | ❌ | coordinate via `bot_chat` / C1 |
+
+## Scheduled runners (automate hygiene)
+
+`.github/workflows/claude-maintenance.yml` is the **template** — a weekly,
+Tier-2, draft-PR-only Claude run. The Direction-B plan adds per-lane runners
+that drive a specific agent on a cron:
+
+- **`b1-security-sweep`** (weekly) → drives `b1-git-code`: secret-scan review, dependabot triage digest, CI-gate health, aging-PR flags.
+- **`a1-data-freshness`** (daily) → drives `a1-data-plane`: cron-failure / 429 / freshness / drift report (read-only; flags to `bot_chat`, never applies).
+- **`c1-docs-drift`** (weekly) → drives `c1-docs-coord`: registry + bible-vs-reality drift, `graph-drift.mjs` fold-in.
+
+Each runner: least-privilege perms, the credential-guard skip-if-unset step, and
+the same hard-limits prompt block. These are **operator-gated to add** because they
+need write permissions + the Claude credential secret — propose, don't self-enable.
+
+## Adding / changing an agent
+Edit the `*.md` here (frontmatter `name`/`description`/`tools` + the prompt body).
+Keep `tools` least-privilege; encode hard limits explicitly — the prompt is the
+real guardrail, tool-scoping is the second belt.

--- a/.claude-plugins/terminal2-governance/agents/a1-data-plane.md
+++ b/.claude-plugins/terminal2-governance/agents/a1-data-plane.md
@@ -1,0 +1,33 @@
+---
+name: a1-data-plane
+description: >-
+  A1 lane — the data plane. Use for Supabase tables/migrations/crons, the AQ
+  mapper + cross-source xref, the 9 read-only source clients, edge functions,
+  order ingestion, app.py data routes, and DB-layer security (RLS, SECURITY
+  DEFINER, the RULE-2 read-only lockdown). Authors migrations and investigates
+  data freshness / cron health. Does NOT apply migrations to prod (operator-gated).
+tools: Read, Grep, Glob, Bash, Write, Edit, mcp__Supabase__execute_sql, mcp__Supabase__list_tables, mcp__Supabase__list_migrations, mcp__Supabase__get_advisors, mcp__Supabase__get_logs, mcp__Supabase__list_extensions
+model: inherit
+---
+
+You are the **A1 / data-plane** agent for Terminal-2. Read `CLAUDE.md` and
+`PROJECT_BIBLE.md` (§0 AQ mapper, §3 column landmines) before any cross-source SQL.
+
+## Mandate
+Own upstream API → table → cron, and keep the DB safe + fresh:
+- Supabase tables / migrations / crons; the AQ mapper (`aq_event_map`) + cross-source xref.
+- The full ingest pipeline: the 9 read-only `*_client.py`, edge functions, order ingestion, `app.py` `/api/*` data routes.
+- DB-layer security: RLS coverage, SECDEF audits, the RULE-2 read-only upstream lockdown.
+- Monitor: cron `job_run_details`, `v_sg_broker_429_health` (>15%), table growth, data-source freshness, `migration_drift_check()`.
+
+## Writes
+Migration FILES in `supabase/migrations/` (scaffold via `/new-migration`); `supabase/functions/*`; the 9 `*_client.py`; `app.py` data routes; `requirements.txt`; `MIGRATION_CONVENTIONS.md`.
+
+## Hard limits (never cross — operator-gated per CLAUDE.md §1/§2)
+- **Do NOT apply migrations to prod** or run any `INSERT/UPDATE/DELETE/DDL` on prod. Read-only SQL (`SELECT`, `information_schema`, `pg_*`, `get_logs`, `get_advisors`) only.
+- **Do NOT touch upstream-write paths** — every `*_client.py` is GET-only by construction; never widen `ALLOWED_HTTP_METHODS` or add a write endpoint.
+- **Do NOT weaken RULE-2 guards** (`scripts/check_readonly.py`, `tests/test_readonly_guards.py`).
+- Cross-lane code (git history, docs structure, FE surfaces) → coordinate, don't write.
+
+## Output
+Author migration files + propose via draft PR; report findings (freshness/cron/drift) tersely. Applying to prod is a separate, operator-gated step — hand off with the exact `SELECT`-verified apply plan, never self-apply.

--- a/.claude-plugins/terminal2-governance/agents/b1-git-code.md
+++ b/.claude-plugins/terminal2-governance/agents/b1-git-code.md
@@ -1,0 +1,33 @@
+---
+name: b1-git-code
+description: >-
+  B1 lane — git + code health and code/git security. Use for secret-leak scans,
+  insecure-pattern review, git-history hygiene, drift prevention (main vs
+  deployed), code freshness, module compartmentalization / lane-boundary
+  enforcement, and test-suite + CI-gate health. Reports security findings;
+  does NOT make operator-gated security decisions (branch protection, secret rotation).
+tools: Read, Grep, Glob, Bash, Write, Edit
+model: inherit
+---
+
+You are the **B1 / git+code** agent for Terminal-2. Read `CLAUDE.md` first
+(immutable security + lockdown rules). DB-layer security (RLS/SECDEF/RULE-2) is
+A1's; you own code + git security.
+
+## Mandate
+- Git history hygiene; secret-leak scans (`secret-scan.yml`, `.gitleaks.toml`); insecure-pattern review.
+- Drift prevention (`main` vs deployed); code freshness; module compartmentalization / lane-boundary enforcement.
+- Test-suite health (`tests/`) + the CI gates (`tests.yml`, `check-docs.sh`, `forbidden-paths-check.yml`, `dependency-review.yml`, scorecard).
+- Dependency hygiene: triage Dependabot PRs (lower-bound only; never bump an upper bound without verifying the major).
+
+## Writes
+`KANBAN.md` security backlog; `docs/security-runbook-*.md`; `supabase/functions/_shared/cron-auth.ts`; CI workflow + `bin/`/`scripts/` guard code; cross-cutting code-security patches (coordinate via PR comment to the file's owner).
+
+## Hard limits (operator-gated — report, don't decide)
+- **Do NOT change branch protection, signing, SHA-pinning, or rotate/alter secrets.** Surface to the operator.
+- **Do NOT weaken any guard** (RULE-2 scanner/tests, docs gate, forbidden-paths, secret-scan allowlists beyond verified false-positives).
+- **Do NOT bump dependency UPPER bounds** without a human verifying the major.
+- DB-layer security findings → route to A1 (owns RLS/SECDEF/RULE-2).
+
+## Output
+Default to a draft PR for safe mechanical fixes + a terse findings report (severity-ordered, smallest fix per item). File security findings as `KANBAN.md` rows / `bot_chat` `flag`s. Run the sweeps (`bash bin/check-docs.sh`, `python scripts/check_readonly.py`, `pytest -q`) and report pass/fail with `file:line` evidence.

--- a/.claude-plugins/terminal2-governance/agents/c1-docs-coord.md
+++ b/.claude-plugins/terminal2-governance/agents/c1-docs-coord.md
@@ -1,0 +1,31 @@
+---
+name: c1-docs-coord
+description: >-
+  C1 lane — docs + coordination. Use for the main bible set + the closed doc
+  registry, doc-version/section-tag hygiene, the own-bible promotion gate,
+  bot_chat checkpoints, drift watch (main vs deployed, bibles vs reality), and
+  the shared cross-lane resource register (§5.5/§5.5b). Routes fixes to the
+  owning lane; does NOT write code, SQL, or FE surfaces.
+tools: Read, Grep, Glob, Bash, Write, Edit
+model: inherit
+---
+
+You are the **C1 / docs+coordination** agent for Terminal-2. The canonical doc
+set is CLOSED (README registry) — enforce it; never create a new root `.md`.
+
+## Mandate
+- The main bible set + closed registry + doc structure; doc-version lines + section tags (`README.md` *Doc-writing rules*).
+- The **promotion gate**: decide which facts graduate from a `<BOT>_BIBLE.md` into the main set (one fact, one home — move, never duplicate).
+- The **shared cross-lane resource register** (`BOT_HIERARCHY.md §5.5/§5.5b`): seat map, the shared API surface, `trip_planner`, order data (`unified_orders`), `static/_shared/`, the `*_public` boundary, the AQ hub. Review any change touching a shared resource for cross-consumer impact.
+- Drift watch: `migration_drift_check()`, `release_health_check()`; post checkpoints to `bot_chat`.
+
+## Writes (in lane)
+The main bible set + registry; `bot_chat` checkpoints/drift flags; `docs/c1_daily_checkpoint_runbook.md`. Dated snapshots → `bot_chat` or `docs/archive/YYYY-MM-DD-<topic>.md` — **never `docs/` root**.
+
+## Hard limits
+- **Do NOT create a new root or governance `.md`** (operator decision). Add the fact to its owner; link, don't duplicate.
+- **Do NOT write code / SQL / migrations / FE surfaces.** Route fixes: data→A1, code/security→B1, surface→the owning D-bot.
+- Keep `bash bin/check-docs.sh` green; every registry doc carries a `**Doc version:**` line.
+
+## Output
+Edit the owning doc in place (bump its version + tag the changed section); for drift, file a `bot_chat` flag + route to the owner. Default to a draft PR for doc changes.

--- a/.claude-plugins/terminal2-governance/agents/d0-terminal.md
+++ b/.claude-plugins/terminal2-governance/agents/d0-terminal.md
@@ -1,0 +1,30 @@
+---
+name: d0-terminal
+description: >-
+  D0 lane — the broker terminal frontend (PRIORITY surface). Use for
+  static/terminal/* + the terminal-side app.py /api/broker/* routes, the T.api()
+  data-fetch layer, per-page endpoint/RPC contracts, the seat-map overlay, and
+  UX/speed testing of the terminal. Free reign on its own HTML/JS; coordinates
+  on shared resources (seat map, /api/* surface, order views).
+tools: Read, Grep, Glob, Bash, Write, Edit
+model: inherit
+---
+
+You are the **D0 / terminal** agent for Terminal-2 — the priority active FE lane.
+Read `D0_BIBLE.md` (PART 1 is the full cold-start build manual) + `PROJECT_BIBLE.md §0/§3`.
+
+## Mandate
+- Broker terminal: `static/terminal/*` + terminal-side `app.py` `/api/broker/*` routes; the `T.api()` data-fetch architecture; per-page endpoint/RPC contracts; the Tevomaps seat-map overlay (`D0_BIBLE §B11`).
+- UX + speed testing of the terminal; owns its Render service (workspace-wide Render parity with A1).
+- Consume canonical data by `tevo_event_id`; resolve cross-source via the AQ hub — never hand-map by name/date.
+
+## Writes
+`static/terminal/*`; terminal-side `app.py` `/api/broker/*` routes; D0-facing read-only RPC *call sites* (the RPC bodies are A1's migrations).
+
+## Hard limits
+- **Free reign on D0 HTML/JS**, but **shared resources are C1-coordinated**: a seat-map or `/api/*` or order-view change must not break the store (D1) or the dashboard (D2). Coordinate before touching `static/_shared/`, the shared API surface, `trip_planner`, or `unified_orders`.
+- **No DB mutation / migration apply** (D-tier has zero DB-apply authority — file a migration + `bot_chat` to A1).
+- Stay in the terminal surface; D1–D4 surfaces are other lanes (and paused).
+
+## Output
+Build/iterate in lane; verify against the real terminal (run + check, don't assume). Every broker answer ends with a verified terminal link (check it resolves). Default to a draft PR.

--- a/.github/workflows/claude-maintenance.yml
+++ b/.github/workflows/claude-maintenance.yml
@@ -1,0 +1,133 @@
+# Claude Maintenance Agent — scheduled "background agent" (Tier 2: propose via draft PRs)
+#
+# WHAT THIS IS
+#   A recurring Claude Code run that performs the repo-maintenance loop described in
+#   docs/archive/2026-06-19-code-update-maintenance-plan.md. There is no always-on
+#   daemon in this stack — a "background agent" = this scheduled workflow.
+#
+# AUTONOMY (Tier 2 — operator-selected 2026-06-19)
+#   It REPORTS + PROPOSES. It opens DRAFT PRs for safe mechanical work and posts a
+#   summary. It does NOT merge, NOT force-push, NOT apply DB migrations, NOT make
+#   security decisions, NOT bump dependency UPPER bounds. Those stay operator-gated
+#   per CLAUDE.md §1/§2. Promote to "act" later by allowing dependabot auto-merge.
+#
+# SETUP (one secret — until then the job warns + skips, it does not fail red)
+#   Settings → Secrets and variables → Actions → New repository secret:
+#     ANTHROPIC_API_KEY   (or switch the auth line below to claude_code_oauth_token)
+#   Then enable: it runs weekly, or trigger manually via the Actions tab ("Run workflow").
+#   Disable: toggle the workflow off in the Actions tab, or delete this file.
+#
+# PERMISSIONS
+#   Default is read-only (top-level). The job elevates to contents/pull-requests/issues
+#   write so it can open draft PRs + comment. No other job in the repo gets these.
+
+name: Claude Maintenance
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"   # Mondays 08:00 UTC — weekly maintenance pass
+  workflow_dispatch:        # manual "Run workflow" button
+
+# Least-privilege default; the single job elevates only what it needs.
+permissions:
+  contents: read
+
+# Never run two maintenance passes at once (they'd open duplicate PRs).
+concurrency:
+  group: claude-maintenance
+  cancel-in-progress: false
+
+jobs:
+  maintenance:
+    name: Weekly maintenance pass
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write          # branch + commit for draft PRs
+      pull-requests: write      # open draft PRs, comment
+      issues: write             # post the summary
+    steps:
+      # Guard: if the Claude credential isn't wired yet, warn and skip cleanly
+      # so the weekly run doesn't show red before the operator adds the secret.
+      - name: Check credential is configured
+        id: cred
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Claude Maintenance skipped::ANTHROPIC_API_KEY secret not set. Add it in Settings → Secrets → Actions to enable the agent (see workflow header)."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.cred.outputs.configured == 'true'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0       # full history so drift/branch checks work
+
+      # The sweeps the agent runs are python (check_readonly.py) + node (graph-drift.mjs)
+      # + bash (check-docs.sh). Provision both runtimes up front.
+      - name: Set up Python
+        if: steps.cred.outputs.configured == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        if: steps.cred.outputs.configured == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Run Claude maintenance pass
+        if: steps.cred.outputs.configured == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # To use a Claude subscription instead, delete the line above and use:
+          #   claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: >-
+            --max-turns 40
+            --model claude-opus-4-8
+          prompt: |
+            You are the Terminal-2 weekly maintenance agent running headless in CI.
+            Authoritative plan: docs/archive/2026-06-19-code-update-maintenance-plan.md.
+            Governance you MUST obey: CLAUDE.md (read it first), PROJECT_BIBLE.md, README.md doc rules.
+
+            AUTONOMY = TIER 2 (propose, do not act). Allowed outputs this run:
+              - ONE summary comment (open or comment on a tracking GitHub issue titled
+                "Weekly maintenance — <YYYY-MM-DD>").
+              - DRAFT pull requests, branch name `claude/auto-maintenance-<YYYYMMDD>`, for
+                SAFE mechanical fixes only (doc/registry drift, a refreshed dated plan
+                snapshot, graph-drift fold-in). One concern per PR. Always draft.
+
+            HARD LIMITS — never cross (these would require an operator):
+              - Do NOT merge or close any PR. Do NOT enable auto-merge. Do NOT force-push.
+              - Do NOT push to main. Do NOT apply Supabase migrations or run any DB mutation.
+              - Do NOT change dependency UPPER bounds (requirements.txt) or edit a security
+                control (RULE-2 guards, RLS, branch protection, secrets). Report those instead.
+              - Do NOT edit another lane's surface beyond docs; if a fix needs code, file it
+                as a finding, don't write it.
+
+            DO THIS, IN ORDER:
+              1. Run the sweeps and capture pass/fail:
+                   bash bin/check-docs.sh
+                   python scripts/check_readonly.py
+                   node bin/graph-drift.mjs   (if present)
+                   pytest -q  (smoke; report failures, don't fix app code)
+              2. Review open Dependabot PRs: for each, note CI status + whether it is a
+                 LOWER-bound bump. Produce a "ready to merge (green + lower-bound)" digest —
+                 a recommendation list ONLY; you do not merge.
+              3. Flag any open PR with no activity for >7 days (aging) and list orphan
+                 `claude/*` / `a1/*` branches with no open PR (prune candidates for C1).
+              4. Cross-check docs/archive/2026-06-19-code-update-maintenance-plan.md against
+                 reality; if a fact drifted, open ONE draft PR with the correction.
+              5. Post the summary comment: sweep results, dependabot digest, aging PRs,
+                 orphan branches, any draft PRs you opened, and anything escalated to the
+                 operator. Keep it tight (tables, no preamble).
+
+            If nothing actionable, still post a one-line "all clear" summary (heartbeat —
+            a silent run is indistinguishable from a dead one). End your turn after posting.

--- a/docs/archive/2026-06-19-code-update-maintenance-plan.md
+++ b/docs/archive/2026-06-19-code-update-maintenance-plan.md
@@ -1,0 +1,151 @@
+# Code-Update & Maintenance Plan — 2026-06-19
+
+> **Status:** non-canonical durable artifact (per `CLAUDE.md §6` / README *Doc-writing rules* — a dated plan lives in `docs/archive/`, not the closed root registry). Living work items graduate to `KANBAN.md §🟢 OPEN WORK`; this file is the snapshot + cadence behind them.
+>
+> **Scope (operator-selected 2026-06-19):** dependency upgrades · tech-debt / KANBAN backlog · in-flight PR cleanup · CI / security hygiene.
+> **Lanes:** A1 (data plane) · B1 (git/code + security) · C1 (docs/coord) · D0–D4 (FE surfaces). Push to `main` per-task; prod-DB apply A1-centralized.
+
+---
+
+## 0. TL;DR — the five highest-leverage moves
+
+1. **Land the 4 dependency PRs in a controlled order** (cryptography #547 → anthropic #545 → fastapi #546 → npm #544), each on green CI. They are lower-bound bumps inside existing pins — low risk, but fastapi pulls Starlette.
+2. **Resolve the SEC-HIGH `CRON_SECRET` question (B1-NEXT-11)** — it is the only exploitable-class item open and is *operator-blocked*, not code-blocked. De-hardcode the 5 `collect-listings-*` cron bodies + confirm/rotate the edge-env secret.
+3. **Triage the 18 open PRs** — 5 are stale drafts (>1wk), 2 are C1 daily-checkpoint PRs that should close, 2 are exploratory POCs that should be labelled/parked. Cut the in-flight surface roughly in half.
+4. **Prune ~21 orphan branches** (C1-OPS-2) — no open PR, merged-or-abandoned; confirm-merged-then-delete.
+5. **Settle the Vite 6 → 8 question for `d4_bridge`** — PR #563 (manualChunks fn-form) + dependabot #544 (esbuild/vite/tsx) overlap; decide one target major and do it once.
+
+---
+
+## 1. Dependency upgrades
+
+### 1.1 Policy (unchanged — do not weaken)
+`requirements.txt` pins **compatible-release ranges** (`>=known-good,<next-major`). Dependabot may bump the **lower** bound; the **upper** bound is never bumped without a human verifying the major. Mirror this discipline for `d4_bridge` npm.
+
+### 1.2 Python (`requirements.txt`) — current state & open bumps
+
+| Package | Pin | Open PR | Notes / risk |
+|---|---|---|---|
+| `cryptography` | `>=48.0.0,<49` | **#547** | Security-relevant (Fernet barcode decrypt). Land **first**; clears GHSA-r6ph-v2qm-q3c2 lineage. Lazy-imported → low blast radius. |
+| `anthropic` | `>=0.107.1,<1.0` | **#545** | SDK only; no runtime call path on the hot ingest. Low risk. |
+| `fastapi` | `>=0.136.3,<0.137` | **#546** | **Pulls Starlette** — the one to watch. Run full `pytest` + a smoke of `/api/*` after. |
+| `uvicorn[standard]` | `>=0.49.0,<0.50` | — | current |
+| `requests` | `>=2.34.2,<3.0` | — | current |
+| `supabase` | `>=2.31.0,<3.0` | — | current |
+| `beautifulsoup4` | `>=4.15.0,<5.0` | — | current |
+| `defusedxml` | `>=0.7.1,<1.0` | — | current |
+| `tzdata` | `>=2026.2,<2027.0` | — | refresh yearly (IANA tz cutover) |
+
+**Order:** #547 → #545 → #546, each merged green before the next (avoid stacking a Starlette change under unrelated diffs).
+
+### 1.3 Node (`d4_bridge/package.json`) — needs a decision
+
+- **#544** (dependabot) bumps `esbuild`, `vite`, `tsx`. Manifest is on `vite ^6.2.0`.
+- **#563** adds a `manualChunks` **function form for Vite 8 compat** — implies a Vite 8 target is already in motion.
+- **Conflict to resolve:** pick ONE target major for Vite and land #563 + #544 together so the build config and the dep bump agree. Don't merge #544 onto a v6 config if #563 is moving to v8.
+- CI already type-checks + Vite-builds `d4_bridge` on every PR (`tests.yml` `typescript` job, Node 20), so a bad bump fails loudly. **Owner: D4, sign-off D0.**
+
+### 1.4 Edge functions (Deno)
+No `deno.json` / import-map pinning found under `supabase/functions/`. **Action (B1, low priority):** inventory edge-fn import URLs and pin versions; today they float. Pairs with B1-NEXT-3 (edge-fn auth inventory).
+
+### 1.5 Cadence
+- **Weekly:** review/merge open dependabot PRs (CI-green, lower-bound only).
+- **Monthly:** scan for new majors; file a verification row in KANBAN before touching any upper bound.
+- **Yearly:** `tzdata` refresh; re-baseline lower bounds to current known-good.
+
+---
+
+## 2. In-flight PR cleanup (snapshot from `KANBAN.md §🌿`, re-verify with `list_pull_requests`)
+
+18 open PRs. Recommended dispositions:
+
+| PR | Lane | Disposition |
+|---|---|---|
+| #570 | C1 | **Merged** (per recent git log #570) — drop from tracker. |
+| #568 | A1 | Review + land — `sweep_old_listings` by `captured_at` (retention). |
+| #564 | D4/B1 | Land — runs exos migrations + SQL tests on real Postgres (CI value). |
+| #563 | D4 | **Tie to §1.3** — land with the Vite-major decision + #544. |
+| #562 | B1 | Land — secret-scan allowlist false-positives (unblocks clean scans). |
+| #561 | D1 | D0 sign-off → land (seat-map render). |
+| #560 | D0 | Review + land (home movers default). |
+| #559 | A1/D0 | Review + land (pause non-AXS TD crons; cost). |
+| #547/#546/#545/#544 | B1-deps | **§1** — land in order. |
+| #543 | D4 | Stale draft — refresh or close (Firebase prune). |
+| #536 / #502 | C1 | Daily-checkpoint PRs — **close** (ephemeral; belongs in bot_chat, not a PR). |
+| #514 / #495 | explore | POCs — label `exploratory`, park or close; don't let them age silently. |
+| #506 | D0/ops | Decide: ship the Render→Actions deploy bridge or close. |
+| #505 | A1/D0 | Land — `seating_chart 'null'` poison fix (data quality). |
+
+**Orphan branches (C1-OPS-2):** ~21 `claude/*` + `a1/*` remotes with no open PR. Confirm-merged → delete; keep `release-please--*`, `dependabot/*`, `gh-pages`. One-time prune, then fold into the C1 drift sweep.
+
+**Hygiene rule going forward:** a PR open >7 days with no CI/▶ activity gets a disposition (refresh, convert to draft, or close). No silent aging.
+
+---
+
+## 3. Tech-debt / KANBAN backlog — prioritized
+
+Synthesized from `KANBAN.md §🟢 OPEN WORK`. **Severity order: SEC-HIGH → SEC-MED → SEC-LOW → OPS.** Operator-gated items can't be self-closed — they need a decision.
+
+### 3.1 SEC-HIGH (1) — do first
+- **B1-NEXT-11 — leaked/placeholder `CRON_SECRET`.** Operator-blocked. Two-part fix: (a) confirm the edge-env `CRON_SECRET` ≠ the placeholder literal (rotate if it is); (b) de-hardcode the 5 `collect-listings-*` cron bodies so the header isn't the placeholder. Then the history-rewrite-vs-accept call. **Owner: Operator + A1.**
+
+### 3.2 SEC-MED (defense-in-depth) — schedule across the month
+- **B1-NEXT-55** — systemic blanket `REVOKE … FROM anon, authenticated` on ~130 latent internal tables (RLS-off regression already fixed). *A1, gated DDL.*
+- **B1-NEXT-57** — append `_health_check_anon_exposed_relations()` + pgcrypto regex fix in the next coordinated `release_health_check` migration. *A1 apply-sequencing.*
+- **B1-NEXT-58 / -60** — document-or-revoke 3 ESPN anon-read tables; tighten `leads` `USING(true)` → email-claim (likely PII); apply `security_invoker`+email-gate on Tier-3 order/intel views. *D0/D1/D2 + B1.*
+- **B1-NEXT-63** — optional hardening: ISO `CHECK` on `events.occurs_at_local` or a `safe_occurs_tz()` wrapper (latent only; 0 live break). *A1.*
+- **B1-NEXT-31** — §6 body guard on 7 JWT-gated SECDEF RPCs — **blocked on B1 spec** (literal guard would brick anon/auth PostgREST callers). *Resolve spec first.*
+- **B1-NEXT-3 / -5** — edge-fn auth inventory doc; vault-orphan `release_health_check` row.
+
+### 3.3 SEC-LOW (hygiene) — batch quarterly
+- **B1-NEXT-10** — rename migration slot collisions (`…300000` ×3, etc.); risk-check applied-state first.
+- **B1-NEXT-4** — CodeQL / SAST evaluation decision doc.
+- **B1-NEXT-6** — quarterly egress-payload sweep (war-games W-3/W-4).
+- **B1-NEXT-62 / -64** — exos scan-attribution snapshot; governance audit-trail row.
+- **Operator-only:** B1-NEXT-15/16/17 (branch-protection `enforce_admins`, signatures, SHA-pinning), -18 (Actions secrets), -19/20 (Render ipAllowList / autoDeploy), -21 (Slack MCP).
+
+### 3.4 OPS (data-plane / product) — owner-scheduled
+- **A1-OPS-22** — `aq_event_map` dup consolidation: safe-class sweep **built, dry-run**, awaiting operator apply (235 clusters; 19 conflicting-sg cases handled per-case, never blind-merged).
+- **A1-OPS-21** — SG non-owned poller re-enable decision + listings retention halve drain.
+- **A1-OPS-24** — social-pulse → why_signals → alerts (exploring, operator-gated).
+- **A1-OPS-25** — AXS checkout/order-substitution automation **PARKED** (operator-gated, §2 security-CRIT).
+- **C1-OPS-1 / -2** — workflow-skills rollout backlog; 4-domain reorg follow-ups (own-bible CI wiring, drift sweep, orphan-branch prune).
+- **D0-PROD-8** — Trip Planner refinement backlog.
+
+---
+
+## 4. CI / security hygiene — recurring sweeps
+
+### 4.1 Existing gates (keep green; don't weaken)
+`.github/workflows/`: `tests.yml` (pytest + RULE-2 static audit + D4 tsc/Vite build + warn-only mypy) · `docs-registry-check.yml` · `forbidden-paths-check.yml` · `secret-scan.yml` · `dependency-review.yml` · `scorecard.yml` · `sync-check.yml` · `uptime-check.yml` · `pr-title-lint.yml` · `labeler.yml` · `release-please.yml`. Plus repo guards: `scripts/check_readonly.py` (RULE-2 static), `tests/test_readonly_guards.py` (RULE-2 runtime), `bin/check-docs.sh`, `bin/sync-check.sh`, `bin/graph-drift.mjs`.
+
+### 4.2 Recurring-sweep calendar
+
+| Cadence | Sweep | Owner | Reference |
+|---|---|---|---|
+| Hourly | bot_chat aging sweep (`:00` global, `:15` B1, `:45` D2) | each lane | `CLAUDE.md §5` |
+| Per-PR | RULE-2 static+runtime, docs gate, forbidden-paths, secret-scan, dep-review, tests | CI | `tests.yml` |
+| Weekly | Dependabot merge pass; PR-aging disposition (>7d) | B1 | §1.5 / §2 |
+| Monthly | New-major scan; RLS/grants spot-check; graph-drift fold-in (`graph-drift.mjs`) | B1/C1 | §1.5 / `PROJECT_BIBLE §8` |
+| Quarterly | §4 RPC-table drift (next ~2026-09); egress sweep (W-3/W-4); SAST decision; migration-slot cleanup | B1 | B1-NEXT-24/-6/-4/-10 |
+| Yearly | `tzdata` refresh; lower-bound re-baseline; secret rotation review | A1/B1 | §1.5 |
+
+### 4.3 Gaps to close
+- **mypy is warn-only** (`continue-on-error: true`). Track type-debt down, then flip to blocking. *B1.*
+- **Edge-fn deps unpinned** (§1.4). *B1.*
+- **No CodeQL/SAST** — B1-NEXT-4 decision pending.
+- **Branch protection soft** (enforce_admins / signatures / SHA-pinning off) — operator-gated B1-NEXT-15/16/17.
+
+---
+
+## 5. Execution sequence (suggested 2-week arc)
+
+1. **Day 1–2:** Land dep PRs in order (§1.2) + settle Vite major (§1.3). Close C1 checkpoint PRs #536/#502; label POCs #514/#495.
+2. **Day 3–4:** B1-NEXT-11 with operator (the only SEC-HIGH). Land #562 (secret-scan allowlist) to keep scans clean.
+3. **Day 5–7:** Orphan-branch prune (C1-OPS-2); PR-aging disposition pass on remaining drafts.
+4. **Week 2:** SEC-MED batch (B1-NEXT-55/57/58/60) as coordinated A1 migrations; operator applies A1-OPS-22 dry-run → execute.
+5. **Ongoing:** adopt the §4.2 calendar; first quarterly drift pass due ~2026-09.
+
+---
+
+*Owner of this artifact: whichever lane drives the sweep. Update the live rows in `KANBAN.md`; this file is the dated snapshot, not the ledger.*


### PR DESCRIPTION
Two related deliverables: the dated maintenance plan, and the automated agent that runs it.

## 1. `docs/archive/2026-06-19-code-update-maintenance-plan.md`

Non-canonical durable artifact per `CLAUDE.md §6` (a dated plan belongs in `docs/archive/`, not the closed root registry). Covers the four operator-selected scopes:
- **Dependency upgrades** — Python pins + open pip dependabot PRs (#547 cryptography → #545 anthropic → #546 fastapi/Starlette), npm #544, the Vite 6→8 decision (#563). Upper-bound-never-bumped policy preserved.
- **In-flight PR cleanup** — disposition for the 18 open PRs + the ~21 orphan-branch prune (C1-OPS-2).
- **Tech-debt / KANBAN backlog** — SEC-HIGH→MED→LOW→OPS prioritized; operator-gated items flagged (B1-NEXT-11 the only exploitable-class item).
- **CI / security hygiene** — the 11 workflows + repo guards, a recurring-sweep calendar, and gaps.

## 2. `.github/workflows/claude-maintenance.yml` — the "background agent"

A weekly (Mon 08:00 UTC) + manually-dispatchable Claude Code run that executes the plan's loop. **Tier 2 (propose, don't act):** reports findings and opens **draft PRs** for safe mechanical fixes. Hard limits baked into the prompt — never merges, force-pushes, applies DB migrations, edits security controls, or bumps dependency upper bounds (all operator-gated per `CLAUDE.md §1/§2`).

- Least-privilege: read-only default; the single job elevates to `contents`/`pull-requests`/`issues` write.
- **Setup = one secret.** Add `ANTHROPIC_API_KEY` (or switch the commented line to `claude_code_oauth_token`). Until then the job **warns + skips** — it never shows red pre-setup.
- PR author is an OWNER, so `forbidden-paths-check` passes on the `.github/` addition.

## Checks
- `bin/check-docs.sh` ✅ · workflow YAML validated ✅ · docs-only + CI-config; no app/SQL touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwfmkeFAJJ8fS138mHDmTd