### PR TITLE
feat(retail-chat): natural-language price/inventory chat (terminal + store)

### DIFF
--- a/app.py
+++ b/app.py
@@ -8265,6 +8265,120 @@ def store_reserve(request: Request, payload: dict = Body(...), authorization: st
     }
 
 
+# ---------- Retail chat (natural-language price/inventory assistant) ----------
+#
+# Thin proxy in front of the deployed `chat` Supabase edge function (the same
+# tool-using assistant behind the SMS/web bots). It already resolves events,
+# aggregates price zones, and filters owned-EVO listings by qty + budget
+# ("next Yankees home game with tickets under $5"). We proxy rather than let
+# the browser call the function directly so that (a) the LLM key stays on the
+# edge function, (b) the terminal call is email-gated, (c) the storefront call
+# is hard-locked to OWNED inventory, and (d) we avoid the function's
+# localhost-only CORS allowlist.
+#
+# scope discipline: the proxy sets `scope` server-side — the client cannot
+# choose it. Terminal → "all" (full market); storefront → "owned" (our owned
+# EVO inventory only). The edge function clamps include_all accordingly, so a
+# consumer can never widen the storefront beyond owned inventory.
+
+_RETAIL_CHAT_MAX_TURNS = 24
+_RETAIL_CHAT_MAX_CHARS = 4000
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort real client IP behind the Render/Railway proxy. Forwarded
+    to the edge function so its per-IP rate limit is per-user, not per-proxy."""
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    real = request.headers.get("x-real-ip")
+    if real:
+        return real.strip()
+    return (request.client.host if request.client else "") or "unknown"
+
+
+def _sanitize_chat_history(payload: dict) -> list[dict]:
+    """Validate + bound the client-supplied transcript before forwarding.
+    Accepts either {history:[{role,content}...]} or {message:"..."}."""
+    if not isinstance(payload, dict):
+        raise HTTPException(400, "expected a JSON object")
+    hist = payload.get("history")
+    if hist is None and payload.get("message"):
+        hist = [{"role": "user", "content": str(payload.get("message"))}]
+    if not isinstance(hist, list) or not hist:
+        raise HTTPException(400, "history or message required")
+    out: list[dict] = []
+    for item in hist[-_RETAIL_CHAT_MAX_TURNS:]:
+        if not isinstance(item, dict):
+            continue
+        role = item.get("role")
+        content = item.get("content")
+        if role not in ("user", "assistant") or not isinstance(content, str):
+            continue
+        content = content.strip()
+        if not content:
+            continue
+        out.append({"role": role, "content": content[:_RETAIL_CHAT_MAX_CHARS]})
+    if not out:
+        raise HTTPException(400, "no valid messages in history")
+    if out[-1]["role"] != "user":
+        raise HTTPException(400, "last message must be from the user")
+    return out
+
+
+def _proxy_retail_chat(history: list[dict], scope: str, client_ip: str) -> JSONResponse:
+    if not (SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY):
+        raise HTTPException(503, "chat service not configured")
+    url = f"{SUPABASE_URL.rstrip('/')}/functions/v1/chat"
+    headers = {
+        "Authorization": f"Bearer {SUPABASE_SERVICE_ROLE_KEY}",
+        "apikey": SUPABASE_ANON_KEY or SUPABASE_SERVICE_ROLE_KEY,
+        "Content-Type": "application/json",
+        "x-real-ip": client_ip,
+        "x-forwarded-for": client_ip,
+    }
+    try:
+        r = requests.post(
+            url,
+            headers=headers,
+            json={"history": history, "scope": "all" if scope == "all" else "owned"},
+            timeout=45,
+        )
+    except Exception as e:
+        logging.getLogger(__name__).error("retail-chat proxy upstream error: %s", e)
+        raise HTTPException(502, "chat service unreachable")
+    try:
+        body = r.json()
+    except Exception:
+        body = {"error": "assistant returned a malformed response"}
+    status = r.status_code if r.status_code >= 400 else 200
+    return JSONResponse(body, status_code=status)
+
+
+@app.post("/api/retail-chat")
+def retail_chat_terminal(request: Request, payload: dict = Body(...), _=Depends(require_auth)):
+    """Operator-facing retail chat (email-gated). scope=all → full market."""
+    history = _sanitize_chat_history(payload)
+    return _proxy_retail_chat(history, "all", _client_ip(request))
+
+
+@app.post("/api/store/retail-chat")
+def retail_chat_store(request: Request, payload: dict = Body(...)):
+    """Public storefront retail chat. scope=owned → hard-locked to our owned
+    EVO inventory (enforced server-side; the consumer cannot widen it)."""
+    history = _sanitize_chat_history(payload)
+    return _proxy_retail_chat(history, "owned", _client_ip(request))
+
+
+@app.api_route("/store/chat", methods=["GET", "HEAD"])
+def store_chat_page():
+    """Storefront concierge chat. Mounts the shared retail-chat widget
+    (static/shared/retail-chat-widget.js) against /api/store/retail-chat."""
+    return _render_storefront_page("chat.html")
+
+
 @app.api_route("/store", methods=["GET", "HEAD"])
 def store_index_page():
     return _render_storefront_page("index.html")

--- a/static/shared/retail-chat-widget.js
+++ b/static/shared/retail-chat-widget.js
@@ -1,0 +1,316 @@
+// Retail Chat Widget — shared, build-once chat panel for the retail
+// price/inventory assistant. Mounted on TWO surfaces:
+//   - D0 broker terminal (static/terminal/retail-chat.html) → /api/retail-chat
+//     (scope=all; the operator sees the full market)
+//   - Consumer storefront (static/store/chat.html)           → /api/store/retail-chat
+//     (scope=owned; hard-locked to our owned EVO inventory)
+//
+// Both endpoints proxy to the deployed `chat` edge function, which already
+// resolves events, aggregates price zones, and filters owned-EVO listings by
+// quantity + budget (e.g. "next Yankees home game with tickets under $5").
+//
+// CSP-safe by construction: this is an external same-origin script
+// (script-src 'self'); it POSTs only to a same-origin/allowlisted endpoint
+// (connect-src 'self'); its styles are injected as a single <style> block
+// (style-src 'self' 'unsafe-inline'). No inline handlers, no third-party hosts.
+//
+// Two ways to use it:
+//   (a) Declarative — drop a container with data-retail-chat and the widget
+//       auto-mounts on DOMContentLoaded reading its data-* attributes. Used by
+//       the storefront (no auth header needed).
+//   (b) Programmatic — window.RetailChat.mount({ container, endpoint,
+//       getAuthHeaders, cors, ... }). Used by the terminal to attach the
+//       Supabase bearer token.
+
+(function () {
+  'use strict';
+
+  var STYLE_ID = 'retail-chat-widget-styles';
+  // Keep transcripts bounded so a long session can't grow an unbounded
+  // request body (the server also caps this defensively).
+  var MAX_HISTORY = 24;
+  var MAX_CHARS = 4000;
+
+  var CSS = [
+    '.rchat{display:flex;flex-direction:column;min-height:0;height:100%;',
+    'background:var(--rchat-bg,#0f0f12);color:var(--rchat-text,#e7e7ea);',
+    "font-family:var(--rchat-sans,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif);",
+    'border:1px solid var(--rchat-line,#26262c);border-radius:10px;overflow:hidden}',
+    '.rchat__log{flex:1 1 auto;min-height:0;overflow-y:auto;padding:16px;',
+    'display:flex;flex-direction:column;gap:12px;scroll-behavior:smooth}',
+    '.rchat__msg{max-width:86%;padding:10px 13px;border-radius:12px;',
+    'line-height:1.45;font-size:14px;white-space:pre-wrap;word-wrap:break-word}',
+    '.rchat__msg--user{align-self:flex-end;background:var(--rchat-accent,#fbbf24);',
+    'color:#1a1a1a;border-bottom-right-radius:3px}',
+    '.rchat__msg--bot{align-self:flex-start;background:var(--rchat-panel,#1c1c22);',
+    'border:1px solid var(--rchat-line,#26262c);border-bottom-left-radius:3px}',
+    '.rchat__msg--err{align-self:flex-start;background:#2a1416;',
+    'border:1px solid #7f1d1d;color:#fca5a5}',
+    '.rchat__typing{align-self:flex-start;display:flex;gap:4px;padding:12px 14px}',
+    '.rchat__typing span{width:7px;height:7px;border-radius:50%;',
+    'background:var(--rchat-muted,#737380);animation:rchatBlink 1.2s infinite both}',
+    '.rchat__typing span:nth-child(2){animation-delay:.2s}',
+    '.rchat__typing span:nth-child(3){animation-delay:.4s}',
+    '@keyframes rchatBlink{0%,80%,100%{opacity:.25}40%{opacity:1}}',
+    '.rchat__examples{display:flex;flex-wrap:wrap;gap:7px;padding:0 16px 12px}',
+    '.rchat__chip{font-size:12.5px;padding:6px 11px;border-radius:999px;cursor:pointer;',
+    'background:transparent;color:var(--rchat-muted,#9b9ba6);',
+    'border:1px solid var(--rchat-line,#34343c)}',
+    '.rchat__chip:hover{color:var(--rchat-text,#e7e7ea);border-color:var(--rchat-accent,#fbbf24)}',
+    '.rchat__composer{display:flex;gap:8px;padding:12px;',
+    'border-top:1px solid var(--rchat-line,#26262c);background:var(--rchat-panel,#16161a)}',
+    '.rchat__input{flex:1 1 auto;resize:none;max-height:140px;min-height:42px;',
+    'background:var(--rchat-bg,#0f0f12);color:var(--rchat-text,#e7e7ea);',
+    'border:1px solid var(--rchat-line,#34343c);border-radius:8px;padding:11px 12px;',
+    'font:inherit;font-size:14px;line-height:1.4;outline:none}',
+    '.rchat__input:focus{border-color:var(--rchat-accent,#fbbf24)}',
+    '.rchat__send{flex:0 0 auto;align-self:flex-end;height:42px;padding:0 18px;',
+    'border:none;border-radius:8px;cursor:pointer;font:inherit;font-weight:600;',
+    'background:var(--rchat-accent,#fbbf24);color:#1a1a1a}',
+    '.rchat__send:disabled{opacity:.45;cursor:not-allowed}',
+    '.rchat__hint{font-size:11px;color:var(--rchat-muted,#737380);',
+    'padding:0 16px 10px;margin:0}'
+  ].join('');
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    var s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = CSS;
+    document.head.appendChild(s);
+  }
+
+  function el(tag, cls, text) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text;
+    return e;
+  }
+
+  function ChatWidget(opts) {
+    this.endpoint = opts.endpoint;
+    this.scope = opts.scope === 'all' ? 'all' : 'owned';
+    this.cors = !!opts.cors;
+    this.getAuthHeaders = typeof opts.getAuthHeaders === 'function' ? opts.getAuthHeaders : null;
+    this.examples = opts.examples || [];
+    this.placeholder = opts.placeholder || 'Ask about a game, price, or seats…';
+    this.greeting = opts.greeting || '';
+    this.hint = opts.hint || '';
+    this.history = [];
+    this.busy = false;
+    this._build(opts.container);
+  }
+
+  ChatWidget.prototype._build = function (container) {
+    container.classList.add('rchat');
+    container.innerHTML = '';
+
+    this.log = el('div', 'rchat__log');
+    this.log.setAttribute('role', 'log');
+    this.log.setAttribute('aria-live', 'polite');
+    container.appendChild(this.log);
+
+    if (this.greeting) this._append('bot', this.greeting);
+
+    if (this.examples.length) {
+      var chips = el('div', 'rchat__examples');
+      var self = this;
+      this.examples.forEach(function (ex) {
+        var c = el('button', 'rchat__chip', ex);
+        c.type = 'button';
+        c.addEventListener('click', function () {
+          self.input.value = ex;
+          self._send();
+        });
+        chips.appendChild(c);
+      });
+      this.examplesEl = chips;
+      container.appendChild(chips);
+    }
+
+    if (this.hint) {
+      container.appendChild(el('p', 'rchat__hint', this.hint));
+    }
+
+    var composer = el('div', 'rchat__composer');
+    this.input = el('textarea', 'rchat__input');
+    this.input.placeholder = this.placeholder;
+    this.input.rows = 1;
+    this.input.setAttribute('aria-label', 'Message');
+    this.send = el('button', 'rchat__send', 'Send');
+    this.send.type = 'button';
+    composer.appendChild(this.input);
+    composer.appendChild(this.send);
+    container.appendChild(composer);
+
+    var self = this;
+    this.send.addEventListener('click', function () { self._send(); });
+    this.input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        self._send();
+      }
+    });
+    // Auto-grow the textarea up to its max-height.
+    this.input.addEventListener('input', function () {
+      self.input.style.height = 'auto';
+      self.input.style.height = Math.min(self.input.scrollHeight, 140) + 'px';
+    });
+  };
+
+  ChatWidget.prototype._append = function (kind, text) {
+    var cls = kind === 'user' ? 'rchat__msg rchat__msg--user'
+            : kind === 'err' ? 'rchat__msg rchat__msg--err'
+            : 'rchat__msg rchat__msg--bot';
+    var node = el('div', cls, text);
+    this.log.appendChild(node);
+    this.log.scrollTop = this.log.scrollHeight;
+    return node;
+  };
+
+  ChatWidget.prototype._showTyping = function () {
+    var t = el('div', 'rchat__typing');
+    t.appendChild(el('span'));
+    t.appendChild(el('span'));
+    t.appendChild(el('span'));
+    this.log.appendChild(t);
+    this.log.scrollTop = this.log.scrollHeight;
+    this._typing = t;
+  };
+
+  ChatWidget.prototype._hideTyping = function () {
+    if (this._typing && this._typing.parentNode) this._typing.parentNode.removeChild(this._typing);
+    this._typing = null;
+  };
+
+  ChatWidget.prototype._setBusy = function (busy) {
+    this.busy = busy;
+    this.send.disabled = busy;
+    this.input.disabled = busy;
+  };
+
+  ChatWidget.prototype._send = function () {
+    if (this.busy) return;
+    var text = (this.input.value || '').trim();
+    if (!text) return;
+    if (text.length > MAX_CHARS) text = text.slice(0, MAX_CHARS);
+
+    // Once a conversation starts, the example chips are noise.
+    if (this.examplesEl && this.examplesEl.parentNode) {
+      this.examplesEl.parentNode.removeChild(this.examplesEl);
+      this.examplesEl = null;
+    }
+
+    this.input.value = '';
+    this.input.style.height = 'auto';
+    this._append('user', text);
+    this.history.push({ role: 'user', content: text });
+    if (this.history.length > MAX_HISTORY) this.history = this.history.slice(-MAX_HISTORY);
+
+    this._setBusy(true);
+    this._showTyping();
+    this._post();
+  };
+
+  ChatWidget.prototype._post = function () {
+    var self = this;
+    var headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
+    if (this.getAuthHeaders) {
+      try {
+        var auth = this.getAuthHeaders();
+        if (auth) for (var k in auth) if (Object.prototype.hasOwnProperty.call(auth, k)) headers[k] = auth[k];
+      } catch (_) { /* fall through unauthenticated; server will 401 */ }
+    }
+
+    fetch(this.endpoint, {
+      method: 'POST',
+      headers: headers,
+      credentials: this.cors ? 'omit' : 'same-origin',
+      mode: this.cors ? 'cors' : 'same-origin',
+      body: JSON.stringify({ history: this.history })
+    }).then(function (res) {
+      return res.json().catch(function () { return {}; }).then(function (body) {
+        return { status: res.status, body: body };
+      });
+    }).then(function (r) {
+      self._hideTyping();
+      self._setBusy(false);
+      if (r.status === 401 || r.status === 403) {
+        self._append('err', 'Your session expired — please sign in again.');
+        return;
+      }
+      if (r.status === 429) {
+        self._append('err', "You're sending messages a little fast — give it a few seconds and try again.");
+        return;
+      }
+      if (r.status >= 500 || !r.body || (!r.body.reply && r.body.error)) {
+        self._append('err', (r.body && r.body.error) ? String(r.body.error) : 'Something went wrong. Try again in a moment.');
+        return;
+      }
+      var reply = r.body.reply || 'Let me know what you’re looking for!';
+      self._append('bot', reply);
+      self.history.push({ role: 'assistant', content: reply });
+      if (self.history.length > MAX_HISTORY) self.history = self.history.slice(-MAX_HISTORY);
+      self.input.focus();
+    }).catch(function () {
+      self._hideTyping();
+      self._setBusy(false);
+      self._append('err', "Couldn't reach the assistant. Check your connection and try again.");
+    });
+  };
+
+  function resolveContainer(c) {
+    if (!c) return null;
+    if (typeof c === 'string') return document.querySelector(c);
+    return c;
+  }
+
+  var RetailChat = {
+    mount: function (opts) {
+      opts = opts || {};
+      var container = resolveContainer(opts.container);
+      if (!container) { console.warn('RetailChat.mount: container not found', opts.container); return null; }
+      if (!opts.endpoint) { console.warn('RetailChat.mount: endpoint required'); return null; }
+      injectStyles();
+      return new ChatWidget(Object.assign({}, opts, { container: container }));
+    }
+  };
+
+  // Declarative auto-mount: any [data-retail-chat] element with a
+  // data-endpoint is wired automatically (no auth header — the storefront's
+  // public path). Examples accept a JSON array or a |-separated list.
+  function autoMount() {
+    var nodes = document.querySelectorAll('[data-retail-chat]');
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (n.__rchatMounted) continue;
+      n.__rchatMounted = true;
+      var endpoint = n.getAttribute('data-endpoint');
+      if (!endpoint) continue;
+      var examples = [];
+      var raw = n.getAttribute('data-examples');
+      if (raw) {
+        try { examples = JSON.parse(raw); }
+        catch (_) { examples = raw.split('|').map(function (s) { return s.trim(); }).filter(Boolean); }
+      }
+      RetailChat.mount({
+        container: n,
+        endpoint: endpoint,
+        scope: n.getAttribute('data-scope') || 'owned',
+        cors: n.getAttribute('data-cors') === 'true',
+        greeting: n.getAttribute('data-greeting') || '',
+        placeholder: n.getAttribute('data-placeholder') || '',
+        hint: n.getAttribute('data-hint') || '',
+        examples: examples
+      });
+    }
+  }
+
+  window.RetailChat = RetailChat;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoMount);
+  } else {
+    autoMount();
+  }
+})();

--- a/static/store/chat.html
+++ b/static/store/chat.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0b0b0e" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="VibePass" />
+  <link rel="apple-touch-icon" href="/static/store/favicon.svg" />
+  <link rel="manifest" href="/static/store/manifest.json" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://www.google.com https://*.supabase.co; frame-src https://www.google.com; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>VibePass — ask the concierge</title>
+  <meta name="description" content="Ask our concierge about seats and prices in plain English — every answer comes from inventory we hold directly." />
+  <link rel="icon" type="image/svg+xml" href="/static/store/favicon.svg" />
+  <link rel="stylesheet" href="/static/store/style.css" />
+  <style>
+    body[data-page="chat"] { height:100vh; display:flex; flex-direction:column; overflow:hidden; }
+    main.wrap.chat-wrap { flex:1 1 auto; min-height:0; display:flex; flex-direction:column;
+      max-width:760px; margin:0 auto; width:100%; padding:18px 16px; }
+    .chat-hero { flex:0 0 auto; margin:0 0 14px; }
+    .chat-hero h1 { font-size:24px; margin:0 0 6px; }
+    .chat-hero p { color:#9b9ba6; margin:0; font-size:14px; }
+    #storeChat { flex:1 1 auto; min-height:0;
+      --rchat-bg:#0b0b0e; --rchat-panel:#15161b; --rchat-line:#26272e;
+      --rchat-text:#ececf1; --rchat-muted:#9b9ba6; --rchat-accent:#e8b84b; }
+  </style>
+</head>
+<body data-page="chat">
+  <header class="topbar">
+    <a class="brand" href="/store">VibePass</a>
+    <nav class="topnav" aria-label="Primary">
+      <a href="/store">Browse events</a>
+      <a href="/store/discover">Discover tours</a>
+    </nav>
+    <a class="topcta" href="/store">Back to store</a>
+  </header>
+
+  <main class="wrap chat-wrap">
+    <div class="chat-hero">
+      <h1>Ask the concierge</h1>
+      <p>Tell us a team, a date, or a budget. Every answer comes from seats we hold directly.</p>
+    </div>
+
+    <!-- Auto-mounted by /static/shared/retail-chat-widget.js. Public endpoint,
+         server-locked to scope=owned (our owned EVO inventory only). -->
+    <div
+      data-retail-chat
+      data-endpoint="/api/store/retail-chat"
+      data-scope="owned"
+      data-cors="false"
+      data-greeting="Hi! Tell me what you're after — a team, a date, or a budget. For example: “next Yankees home game with tickets under $50”."
+      data-placeholder="e.g. Knicks home game under $150 this month"
+      data-hint="Direct inventory · all-in pricing · in hand before the gates."
+      data-examples='["Next Yankees home game with tickets under $50","Knicks home game under $150 this month","Two seats together for a Lakers game","What do you have at MSG this weekend?"]'
+      id="storeChat"></div>
+  </main>
+
+  <script src="/static/shared/retail-chat-widget.js?v=20260619" defer></script>
+</body>
+</html>

--- a/static/store/index.html
+++ b/static/store/index.html
@@ -36,11 +36,11 @@
   <header class="topbar">
     <a class="brand" href="/store">VibePass</a>
     <nav class="topnav" aria-label="Primary">
-      <a href="#concierge">Concierge</a>
+      <a href="/store/chat">Ask the concierge</a>
       <a href="#how">How it works</a>
       <a href="/store/discover">Discover tours</a>
     </nav>
-    <a class="topcta" href="#concierge">Talk to a specialist</a>
+    <a class="topcta" href="/store/chat">Ask the concierge</a>
   </header>
 
   <main class="wrap">
@@ -65,7 +65,8 @@
         <div id="searchSuggest" class="search-suggest" hidden role="listbox"></div>
       </form>
       <nav class="hero-chips" aria-label="Quick links">
-        <a class="chip chip-gold" href="#conciergeRail">Premium seats</a>
+        <a class="chip chip-gold" href="/store/chat">Ask the concierge</a>
+        <a class="chip" href="#conciergeRail">Premium seats</a>
         <a class="chip" href="#moversSections">Trending now</a>
         <a class="chip" href="#grid">Browse all events</a>
         <a class="chip" href="#concierge">Premium &amp; VIP</a>

--- a/static/terminal/app.js
+++ b/static/terminal/app.js
@@ -251,6 +251,7 @@
   }
 
   window.Terminal = {
+    API_BASE,
     setStatus, getAuthHeader, api, getEventId,
     fmtDate, fmtNum, fmtPct, daysUntil, latestNonNull,
     temporalChipHtml,

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -22,6 +22,10 @@
     { id: 'venue',     label: 'VENUE',     href: 'venue.html' },
     { id: 'performer', label: 'PERFORMER', href: 'performer.html' },
     { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
+    // Retail chat — natural-language price/inventory lookups over the book
+    // (full market on the terminal; owned-EVO-only on the storefront). Talks
+    // to /api/retail-chat → the `chat` edge fn. Wired 2026-06-19.
+    { id: 'retail-chat', label: 'RETAIL CHAT', href: 'retail-chat.html' },
     // Discovery — TEvo blindspot (broker selling, we own 0) + returning
     // performers/venues. Companion to Movers; same nav grouping for the
     // "what to watch" surface. Wired 2026-05-19 (PR A1 blindspot stack).

--- a/static/terminal/retail-chat.html
+++ b/static/terminal/retail-chat.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0a0a0a" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
+  <link rel="apple-touch-icon" href="/favicon.svg" />
+  <link rel="manifest" href="/manifest.json" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Terminal — Retail Chat</title>
+  <link rel="stylesheet" href="style.css?v=20260615" />
+  <style>
+    /* Page layout: let the chat panel fill the viewport under the topbar. */
+    body[data-page="retail-chat"] { height:100vh; display:flex; flex-direction:column; overflow:hidden; }
+    main.wrap.retail-chat { flex:1 1 auto; min-height:0; display:flex; flex-direction:column; padding:12px 16px; }
+    .rc-intro { color:var(--muted,#737373); font-size:12px; margin:0 0 10px; }
+    .rc-intro b { color:var(--text,#e5e5e5); font-weight:600; }
+    #retailChat { flex:1 1 auto; min-height:0;
+      --rchat-bg:var(--bg,#0a0a0a); --rchat-panel:var(--panel,#141414);
+      --rchat-line:var(--line,#2a2a2a); --rchat-text:var(--text,#e5e5e5);
+      --rchat-muted:var(--muted,#737373); --rchat-accent:var(--accent,#fbbf24);
+      --rchat-sans:var(--sans); }
+  </style>
+</head>
+<body data-page="retail-chat">
+
+  <header class="topbar">
+    <span class="brand">TERMINAL · D0</span>
+    <span id="status" class="status">Loading…</span>
+  </header>
+
+  <main class="wrap retail-chat">
+    <p class="rc-intro">
+      <b>Retail chat</b> — ask about prices and availability in plain English.
+      This desk view spans the <b>full market</b> (all listings), not just owned inventory.
+    </p>
+    <div id="retailChat"></div>
+  </main>
+
+  <script src="lib/supabase.js"></script>
+  <!-- Cache-busting: bump ?v= on any first-party asset change. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260619"></script>
+  <script src="nav.js?v=20260619"></script>
+  <script src="/static/shared/retail-chat-widget.js?v=20260619"></script>
+  <script src="retail-chat.js?v=20260619"></script>
+</body>
+</html>

--- a/static/terminal/retail-chat.js
+++ b/static/terminal/retail-chat.js
@@ -1,0 +1,62 @@
+// D0 Terminal — Retail Chat page init.
+//
+// Wires the shared retail-chat widget to the email-gated terminal endpoint
+// (/api/retail-chat, scope=all → full market). The widget itself lives in
+// /static/shared/retail-chat-widget.js so the storefront reuses the same code;
+// this file only supplies the terminal's auth + topology wiring.
+
+(function () {
+  'use strict';
+
+  function boot() {
+    var T = window.Terminal || {};
+    // API_BASE points the call at the FastAPI shell even when this page is
+    // served from the static CDN topology (terminal-test). Same-origin → ''.
+    var base = (typeof T.API_BASE === 'string') ? T.API_BASE : '';
+
+    if (!window.RetailChat) {
+      var host = document.getElementById('retailChat');
+      if (host) host.textContent = 'Chat failed to load — please refresh.';
+      return;
+    }
+
+    window.RetailChat.mount({
+      container: '#retailChat',
+      endpoint: base + '/api/retail-chat',
+      scope: 'all',
+      cors: !!base,
+      getAuthHeaders: function () {
+        return (T.getAuthHeader && T.getAuthHeader()) || {};
+      },
+      greeting: "Hey — ask me about prices or availability. Try a team and a budget, "
+              + "like “next Yankees home game with tickets under $5”.",
+      placeholder: 'e.g. cheapest Knicks home game this month',
+      hint: 'Full-market view · grounded in live TEvo listings.',
+      examples: [
+        'Next Yankees home game with tickets under $5',
+        'Cheapest Knicks home game this month',
+        'Lakers tickets under $100 next week',
+        'What’s at MSG this weekend?'
+      ]
+    });
+
+    if (T.setStatus) T.setStatus('retail chat', 'ok');
+  }
+
+  function start() {
+    var Auth = window.TerminalAuth;
+    if (Auth && Auth.requireAuth) {
+      // requireAuth bounces to login if the session is missing; boot once it
+      // resolves (or on failure, so the page still renders an auth error).
+      Auth.requireAuth().then(boot).catch(boot);
+    } else {
+      boot();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -1,4 +1,11 @@
-// Supabase Edge Function: chat (v26)
+// Supabase Edge Function: chat (v27)
+//
+// v27: request-level `scope` ('all' | 'owned', default 'owned'), set ONLY by
+//   the trusted app.py proxy (never the browser). It clamps include_all in the
+//   zone/listing tools: 'owned' forces owned-EVO-only (the public storefront
+//   can never widen past our inventory); 'all' defaults to the full market
+//   (the email-gated terminal). Powers the in-app retail-chat surfaces
+//   (/api/retail-chat → all, /api/store/retail-chat → owned).
 //
 // v26: STRICT event_id whitelist + switch-confirmation protocol.
 //   - validateEventId now requires the id be present in the conversation's
@@ -233,7 +240,10 @@ async function cachedTicketGroups(db: any, evo: Evo, eventId: number): Promise<a
   return fresh;
 }
 
-type ValidateOpts = { approvedSet?: Set<number> | null; focusedId?: number | null; confirmSwitch?: boolean };
+// scope (request-level, server-set by the app.py proxy — NEVER the client):
+//   'owned' → owned EVO inventory only (storefront; include_all forced false)
+//   'all'   → full market (terminal; include_all defaults true)
+type ValidateOpts = { approvedSet?: Set<number> | null; focusedId?: number | null; confirmSwitch?: boolean; scope?: "all" | "owned" };
 async function validateEventId(db: any, evo: Evo | null, eventId: any, opts: ValidateOpts = {}): Promise<{ ok: true; id: number } | { ok: false; error: any }> {
   const id = Number(eventId);
   if (!Number.isFinite(id) || id < MIN_PLAUSIBLE_EVENT_ID) {
@@ -471,7 +481,9 @@ async function toolGetEventZones(evo: Evo | null, db: any, args: any, gate: Vali
 
   if (!evo) return { error: "ticket service unavailable" };
   try {
-    const includeAll = !!args.include_all;
+    // scope clamp: storefront ('owned') can NEVER widen past owned EVO; the
+    // terminal ('all') defaults to the full market unless explicitly narrowed.
+    const includeAll = gate.scope === "all" ? (args.include_all !== false) : false;
     const [r, ctx] = await Promise.all([ cachedTicketGroups(db, evo, v.id), getEventContext(db, evo, v.id) ]);
     trackEventForCron(db, evo, v.id);
     const groups = filterRetailGroups(r.ticket_groups ?? [], includeAll);
@@ -499,7 +511,9 @@ async function toolFindListings(evo: Evo | null, db: any, args: any, gate: Valid
 
   if (!evo) return { error: "ticket service unavailable" };
   try {
-    const includeAll = !!args.include_all;
+    // scope clamp: storefront ('owned') can NEVER widen past owned EVO; the
+    // terminal ('all') defaults to the full market unless explicitly narrowed.
+    const includeAll = gate.scope === "all" ? (args.include_all !== false) : false;
     const [r, ctx] = await Promise.all([ cachedTicketGroups(db, evo, v.id), args.zone ? getEventContext(db, evo, v.id) : Promise.resolve({ performer_id: null, venue_id: null, occurs_at_local: null }) ]);
     trackEventForCron(db, evo, v.id);
     let groups = filterRetailGroups(r.ticket_groups ?? [], includeAll);
@@ -543,7 +557,9 @@ async function toolFindBetterSeats(evo: Evo | null, db: any, args: any, gate: Va
 
   if (!evo) return { error: "ticket service unavailable" };
   try {
-    const includeAll = !!args.include_all;
+    // scope clamp: storefront ('owned') can NEVER widen past owned EVO; the
+    // terminal ('all') defaults to the full market unless explicitly narrowed.
+    const includeAll = gate.scope === "all" ? (args.include_all !== false) : false;
     const r = await cachedTicketGroups(db, evo, v.id);
     trackEventForCron(db, evo, v.id);
     let groups = filterRetailGroups(r.ticket_groups ?? [], includeAll);
@@ -714,7 +730,7 @@ function buildStickyContext(stickyIds: Set<number>): string {
   return ["=== STICKY_CONTEXT (event_ids surfaced earlier in this conversation) ===", `Valid event_ids you've already seen: ${[...stickyIds].sort((a,b)=>a-b).join(", ")}`, "Reuse these instead of guessing."].join("\n");
 }
 
-async function runLLMLoop(apiKey: string, history: any[], db: any, evo: Evo | null): Promise<{ reply: string; trace: any[]; entities: any; resolved_count: number; comprehensive_count: number }> {
+async function runLLMLoop(apiKey: string, history: any[], db: any, evo: Evo | null, scope: "all" | "owned" = "owned"): Promise<{ reply: string; trace: any[]; entities: any; resolved_count: number; comprehensive_count: number }> {
   const today = new Date();
   const todayStr = today.toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", timeZone: "America/New_York" });
   const lastUser = [...history].reverse().find((m) => m.role === "user" && typeof m.content === "string");
@@ -742,7 +758,7 @@ async function runLLMLoop(apiKey: string, history: any[], db: any, evo: Evo | nu
   const trace: any[] = [];
   // v26: build the per-conversation gate — approved set + currently focused id
   const focusedId = extractFocusedEventId(history);
-  const gate: ValidateOpts = { approvedSet: stickyIds, focusedId };
+  const gate: ValidateOpts = { approvedSet: stickyIds, focusedId, scope };
   for (let turn = 0; turn < MAX_TURNS; turn++) {
     const { status, body } = await llmCall(apiKey, sys, TOOLS, messages);
     if (status !== 200) {
@@ -785,6 +801,9 @@ Deno.serve(async (req) => {
   try { body = await req.json(); } catch (_) { return jsonResponse(req, { error: "expected JSON body" }, 400); }
   const history = Array.isArray(body?.history) ? body.history : (body?.message ? [{ role: "user", content: body.message }] : []);
   if (!history.length) return jsonResponse(req, { error: "history or message required" }, 400);
+  // scope is set by the trusted server proxy (app.py), not the browser.
+  // Default 'owned' so any unscoped/legacy caller stays locked to owned EVO.
+  const scope: "all" | "owned" = body?.scope === "all" ? "all" : "owned";
   const ip = (req.headers.get("x-real-ip") ?? req.headers.get("cf-connecting-ip") ?? (req.headers.get("x-forwarded-for") ?? "").split(",")[0].trim() ?? "unknown") || "unknown";
   // Rate limit hardened 2026-05-11: fail-closed on RPC error so an outage
   // doesn't let an attacker burn LLM cost. Limits tightened from 10/min to
@@ -800,8 +819,8 @@ Deno.serve(async (req) => {
   const lastText = typeof last?.content === "string" ? last.content : "";
   try { await db.from("bot_messages").insert({ channel: "web", direction: "in", phone: "anon-retail", body: lastText }); } catch (_) {}
   let result: { reply: string; trace: any[]; entities: any; resolved_count: number; comprehensive_count: number };
-  try { result = await runLLMLoop(apiKey, history, db, evo); }
+  try { result = await runLLMLoop(apiKey, history, db, evo, scope); }
   catch (e) { result = { reply: `sorry, something went wrong: ${(e as Error).message}`, trace: [], entities: null, resolved_count: 0, comprehensive_count: 0 }; }
-  try { await db.from("bot_messages").insert({ channel: "web", direction: "out", phone: "anon-retail", body: result.reply, meta: { trace: result.trace, entities: result.entities, model: LLM_MODEL, provider: LLM_PROVIDER, resolved_events_count: result.resolved_count, comprehensive_events_count: result.comprehensive_count } }); } catch (_) {}
+  try { await db.from("bot_messages").insert({ channel: "web", direction: "out", phone: "anon-retail", body: result.reply, meta: { trace: result.trace, entities: result.entities, model: LLM_MODEL, provider: LLM_PROVIDER, scope, resolved_events_count: result.resolved_count, comprehensive_events_count: result.comprehensive_count } }); } catch (_) {}
   return jsonResponse(req, { reply: result.reply });
 });

--- a/tests/test_retail_chat.py
+++ b/tests/test_retail_chat.py
@@ -1,0 +1,137 @@
+"""Tests for the retail-chat proxy endpoints (/api/retail-chat,
+/api/store/retail-chat).
+
+The endpoints forward a validated transcript to the deployed `chat` edge
+function with a SERVER-SET scope:
+  - /api/retail-chat        → scope='all'   (email-gated terminal, full market)
+  - /api/store/retail-chat  → scope='owned' (public storefront, owned EVO only)
+
+The security-critical property: the client cannot choose scope. A storefront
+caller that smuggles scope='all' in the body is still forwarded as 'owned'.
+
+No real HTTP call is made — requests.post is monkeypatched to capture what the
+proxy would send upstream.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---- Env setup BEFORE importing app (mirrors tests/test_store_events.py) ----
+os.environ.setdefault("STOREFRONT_SQL_ONLY", "false")
+os.environ.setdefault("TEVO_API_TOKEN", "test-token")
+os.environ.setdefault("TEVO_API_SECRET", "test-secret")
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
+os.environ.setdefault("AUTH_DISABLED", "true")  # don't gate the terminal route
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+fastapi = pytest.importorskip("fastapi")
+starlette_testclient = pytest.importorskip("fastapi.testclient")
+
+import app as app_module  # noqa: E402
+
+TestClient = starlette_testclient.TestClient
+client = TestClient(app_module.app)
+
+
+class _FakeResp:
+    def __init__(self, body, status=200):
+        self._body = body
+        self.status_code = status
+
+    def json(self):
+        return self._body
+
+
+@pytest.fixture
+def capture_post(monkeypatch):
+    """Capture the upstream request the proxy makes to the edge function."""
+    calls = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: A002
+        calls.append({"url": url, "headers": headers or {}, "json": json or {}})
+        return _FakeResp({"reply": "here you go"}, 200)
+
+    monkeypatch.setattr(app_module.requests, "post", fake_post)
+    return calls
+
+
+# ---------- scope is server-set ----------
+
+def test_terminal_forwards_scope_all(capture_post):
+    r = client.post("/api/retail-chat", json={"message": "next Yankees home game under $5"})
+    assert r.status_code == 200
+    assert r.json()["reply"] == "here you go"
+    assert len(capture_post) == 1
+    sent = capture_post[0]["json"]
+    assert sent["scope"] == "all"
+    assert sent["history"][-1] == {"role": "user", "content": "next Yankees home game under $5"}
+    assert capture_post[0]["url"].endswith("/functions/v1/chat")
+
+
+def test_store_forwards_scope_owned(capture_post):
+    r = client.post("/api/store/retail-chat", json={"message": "knicks tickets"})
+    assert r.status_code == 200
+    assert capture_post[0]["json"]["scope"] == "owned"
+
+
+def test_store_cannot_smuggle_scope_all(capture_post):
+    """A storefront client sending scope='all' is still forwarded as owned."""
+    r = client.post("/api/store/retail-chat",
+                    json={"message": "show me everything", "scope": "all"})
+    assert r.status_code == 200
+    assert capture_post[0]["json"]["scope"] == "owned"
+
+
+def test_client_ip_is_forwarded(capture_post):
+    client.post("/api/store/retail-chat",
+                json={"message": "hi"},
+                headers={"x-forwarded-for": "203.0.113.7, 10.0.0.1"})
+    hdrs = capture_post[0]["headers"]
+    assert hdrs["x-real-ip"] == "203.0.113.7"
+    assert hdrs["x-forwarded-for"] == "203.0.113.7"
+
+
+# ---------- transcript validation ----------
+
+def test_history_required(capture_post):
+    r = client.post("/api/store/retail-chat", json={})
+    assert r.status_code == 400
+    assert capture_post == []  # never reached upstream
+
+
+def test_last_message_must_be_user(capture_post):
+    r = client.post("/api/store/retail-chat", json={"history": [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]})
+    assert r.status_code == 400
+    assert capture_post == []
+
+
+def test_history_is_bounded_and_trimmed(capture_post):
+    long_msg = "x" * 9000
+    big = [{"role": "user", "content": f"m{i}"} for i in range(40)]
+    big.append({"role": "user", "content": long_msg})
+    r = client.post("/api/retail-chat", json={"history": big})
+    assert r.status_code == 200
+    sent = capture_post[0]["json"]["history"]
+    assert len(sent) <= app_module._RETAIL_CHAT_MAX_TURNS
+    assert len(sent[-1]["content"]) <= app_module._RETAIL_CHAT_MAX_CHARS
+
+
+def test_upstream_status_passthrough(monkeypatch):
+    """A 429 from the edge function is surfaced to the client unchanged."""
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: A002
+        return _FakeResp({"error": "rate limited"}, 429)
+    monkeypatch.setattr(app_module.requests, "post", fake_post)
+    r = client.post("/api/store/retail-chat", json={"message": "hi"})
+    assert r.status_code == 429
+    assert "error" in r.json()


### PR DESCRIPTION
## What

A **retail chat** that answers price & inventory questions in plain English — e.g. _"next Yankees home game with tickets under $5"_. It reuses the already-deployed `chat` edge function (event resolution, price-zone aggregation, owned‑EVO listing filters by quantity + budget); the only thing that was missing was a UI to reach it (the function's CORS is localhost-only) and a way to scope it per surface.

Per the operator decision: **both surfaces, but the terminal gets all data while the store only gets EVO‑owned**, wired by **proxying to the existing chat function**.

## How it fits together

**Shared widget (build once)** — `static/shared/retail-chat-widget.js`
A self-contained, CSP-safe chat panel (injects its own styles; no inline handlers; POSTs only to a same-origin endpoint). Auto-mounts from `data-*` attributes (store) or via `RetailChat.mount()` (terminal).

**Terminal** (`static/terminal/`)
- `retail-chat.html` + thin `retail-chat.js`, new **RETAIL CHAT** nav entry, `Terminal.API_BASE` exposed.
- Email-gated (`@s4kent.com`), **full-market** view.

**Store** (`static/store/`)
- `chat.html` served at `/store/chat`; entry links added to the storefront nav + hero.
- Public, **owned‑EVO only**.

**Backend** (`app.py`, D0 terminal routes)
- `POST /api/retail-chat` (`scope=all`, email-gated) and `POST /api/store/retail-chat` (`scope=owned`, public) proxy to `…/functions/v1/chat`, forwarding the real client IP so the function's per-IP rate limit is per-user.
- **Scope is server-set** — a storefront caller cannot widen past owned inventory. Transcript is validated + bounded before forwarding.

**Edge function** (`supabase/functions/chat/index.ts`, v27)
- New request-level `scope` (default `owned`) clamps `include_all` in the zone/listing tools: `owned` = owned EVO only; `all` = full market.

## Lockdown / lane notes
- Read-only preserved — `scripts/check_readonly.py` passes (no new write paths to any broker host); no DB migration, no price/inventory mutation.
- Stays in the D0 lane (terminal + storefront frontend, terminal `app.py` routes) + the chat edge function that backs the feature.

## ⚠️ One operator-gated step to fully activate
The proxy + both UIs work against the **currently deployed** `chat` (v28) today, where the store is owned‑by‑default and the terminal is owned‑by‑default. To activate the **terminal's full-market view** and the **storefront hard-clamp**, the `chat` edge function needs a **redeploy** (it writes `bot_messages`, so the deploy is operator-gated per `CLAUDE.md §1`). I did **not** deploy it — happy to, on your go, or hand to A1.

## Tests
`tests/test_retail_chat.py` — scope server-enforcement (incl. a store client cannot smuggle `scope=all`), client-IP forwarding, transcript validation, and upstream status passthrough. mypy is warn-only; the TS job only covers d4_bridge.

## Known limitation (v1)
The proxy returns only the assistant's text, so multi-turn event-id "stickiness" (the edge fn's structured tool-result memory) isn't reconstructed client-side. Single-turn queries like the example work end-to-end; deep multi-turn refinement degrades gracefully (the assistant re-asks). Can be upgraded later by echoing structured turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZbTiiK9JETy18nYbnWf1D)_