### PR TITLE
feat(retail-chat): cheap in-process cost guard (kill switch + daily caps)

### DIFF
--- a/app.py
+++ b/app.py
@@ -8284,6 +8284,61 @@ def store_reserve(request: Request, payload: dict = Body(...), authorization: st
 _RETAIL_CHAT_MAX_TURNS = 24
 _RETAIL_CHAT_MAX_CHARS = 4000
 
+# ---------- Cost guard (cheap, in-process) ----------
+#
+# A zero-infra backstop on top of the edge function's per-IP/minute limit. It
+# refuses BEFORE any LLM/TEvo spend, so a runaway client can't run up a bill.
+# Tunables (all env, hot-set without code):
+#   RETAIL_CHAT_ENABLED      "false" → kill switch: both endpoints 503 instantly.
+#   RETAIL_CHAT_DAILY_MAX    global LLM-bound requests/UTC-day across surfaces
+#                            (0 = unlimited). Default 1000.
+#   RETAIL_CHAT_IP_DAILY_MAX per-IP requests/UTC-day on the PUBLIC store
+#                            (0 = unlimited). Default 40.
+# Cheap-to-test: set the caps low (e.g. =20) while testing so you cannot burn
+# cost, then raise them — or flip RETAIL_CHAT_ENABLED=false to spend nothing.
+#
+# Caveat: counters are per-process and reset on restart/redeploy; this is a
+# cost CEILING, not exact metering. The durable per-IP/min limit lives in the
+# edge function (check_chat_rate_limit). Promote to a DB counter later if a
+# multi-instance, restart-proof quota is needed.
+_RETAIL_CHAT_ENABLED = os.environ.get("RETAIL_CHAT_ENABLED", "true").lower() != "false"
+try:
+    _RETAIL_CHAT_DAILY_MAX = int(os.environ.get("RETAIL_CHAT_DAILY_MAX", "1000"))
+except ValueError:
+    _RETAIL_CHAT_DAILY_MAX = 1000
+try:
+    _RETAIL_CHAT_IP_DAILY_MAX = int(os.environ.get("RETAIL_CHAT_IP_DAILY_MAX", "40"))
+except ValueError:
+    _RETAIL_CHAT_IP_DAILY_MAX = 40
+
+_retail_chat_lock = threading.Lock()
+_retail_chat_usage: dict = {"day": None, "total": 0, "by_ip": {}}
+
+
+def _retail_chat_budget_check(ip: str, public: bool) -> None:
+    """Raise 503/429 when over the cheap in-process cost budget, BEFORE we
+    forward to the (paid) edge function. Counts a request only once it passes —
+    malformed/over-budget calls never consume the LLM. `public` (the storefront)
+    also bears the per-IP daily cap; the email-gated terminal does not."""
+    if not _RETAIL_CHAT_ENABLED:
+        raise HTTPException(503, "chat is temporarily disabled")
+    today = datetime.now(timezone.utc).date().isoformat()
+    with _retail_chat_lock:
+        if _retail_chat_usage["day"] != today:
+            _retail_chat_usage["day"] = today
+            _retail_chat_usage["total"] = 0
+            _retail_chat_usage["by_ip"] = {}
+        if _RETAIL_CHAT_DAILY_MAX and _retail_chat_usage["total"] >= _RETAIL_CHAT_DAILY_MAX:
+            raise HTTPException(429, "the assistant has hit today's usage cap — please try again tomorrow")
+        if public and _RETAIL_CHAT_IP_DAILY_MAX:
+            used = _retail_chat_usage["by_ip"].get(ip, 0)
+            if used >= _RETAIL_CHAT_IP_DAILY_MAX:
+                raise HTTPException(429, "you've reached today's message limit — please try again tomorrow")
+        _retail_chat_usage["total"] += 1
+        if public:
+            _retail_chat_usage["by_ip"][ip] = _retail_chat_usage["by_ip"].get(ip, 0) + 1
+
+
 
 def _client_ip(request: Request) -> str:
     """Best-effort real client IP behind the Render/Railway proxy. Forwarded
@@ -8361,7 +8416,9 @@ def _proxy_retail_chat(history: list[dict], scope: str, client_ip: str) -> JSONR
 def retail_chat_terminal(request: Request, payload: dict = Body(...), _=Depends(require_auth)):
     """Operator-facing retail chat (email-gated). scope=all → full market."""
     history = _sanitize_chat_history(payload)
-    return _proxy_retail_chat(history, "all", _client_ip(request))
+    ip = _client_ip(request)
+    _retail_chat_budget_check(ip, public=False)
+    return _proxy_retail_chat(history, "all", ip)
 
 
 @app.post("/api/store/retail-chat")
@@ -8369,7 +8426,9 @@ def retail_chat_store(request: Request, payload: dict = Body(...)):
     """Public storefront retail chat. scope=owned → hard-locked to our owned
     EVO inventory (enforced server-side; the consumer cannot widen it)."""
     history = _sanitize_chat_history(payload)
-    return _proxy_retail_chat(history, "owned", _client_ip(request))
+    ip = _client_ip(request)
+    _retail_chat_budget_check(ip, public=True)
+    return _proxy_retail_chat(history, "owned", ip)
 
 
 @app.api_route("/store/chat", methods=["GET", "HEAD"])

--- a/tests/test_retail_chat.py
+++ b/tests/test_retail_chat.py
@@ -63,6 +63,17 @@ def capture_post(monkeypatch):
     return calls
 
 
+@pytest.fixture(autouse=True)
+def reset_budget(monkeypatch):
+    """Isolate the in-process cost-guard counters between tests + restore the
+    default (high) caps so unrelated tests aren't throttled."""
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_ENABLED", True)
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_DAILY_MAX", 1000)
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_IP_DAILY_MAX", 40)
+    app_module._retail_chat_usage.update({"day": None, "total": 0, "by_ip": {}})
+    yield
+
+
 # ---------- scope is server-set ----------
 
 def test_terminal_forwards_scope_all(capture_post):
@@ -135,3 +146,41 @@ def test_upstream_status_passthrough(monkeypatch):
     r = client.post("/api/store/retail-chat", json={"message": "hi"})
     assert r.status_code == 429
     assert "error" in r.json()
+
+
+# ---------- cost guard ----------
+
+def test_kill_switch_spends_nothing(monkeypatch, capture_post):
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_ENABLED", False)
+    r = client.post("/api/store/retail-chat", json={"message": "hi"})
+    assert r.status_code == 503
+    assert capture_post == []  # never forwarded → no LLM cost
+
+
+def test_store_per_ip_daily_cap(capture_post, monkeypatch):
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_IP_DAILY_MAX", 2)
+    h = {"x-forwarded-for": "198.51.100.5"}
+    assert client.post("/api/store/retail-chat", json={"message": "a"}, headers=h).status_code == 200
+    assert client.post("/api/store/retail-chat", json={"message": "b"}, headers=h).status_code == 200
+    assert client.post("/api/store/retail-chat", json={"message": "c"}, headers=h).status_code == 429
+    assert len(capture_post) == 2  # the capped 3rd never reached the LLM
+
+
+def test_terminal_exempt_from_per_ip_cap(capture_post, monkeypatch):
+    """The email-gated terminal isn't subject to the public per-IP cap."""
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_IP_DAILY_MAX", 1)
+    h = {"x-forwarded-for": "198.51.100.9"}
+    assert client.post("/api/retail-chat", json={"message": "a"}, headers=h).status_code == 200
+    assert client.post("/api/retail-chat", json={"message": "b"}, headers=h).status_code == 200
+    assert len(capture_post) == 2
+
+
+def test_global_daily_cap(capture_post, monkeypatch):
+    monkeypatch.setattr(app_module, "_RETAIL_CHAT_DAILY_MAX", 2)
+    codes = [
+        client.post("/api/store/retail-chat", json={"message": "x"},
+                    headers={"x-forwarded-for": f"203.0.113.{i}"}).status_code
+        for i in range(1, 4)
+    ]
+    assert codes == [200, 200, 429]
+    assert len(capture_post) == 2


### PR DESCRIPTION
## What

A **cheap, zero-infra cost guard** in front of the retail-chat proxy so a runaway or abusive client can't run up an LLM/TEvo bill. It refuses **before** forwarding to the paid edge function — a blocked request spends nothing.

Follow-up to #583.

## Knobs (all env, hot-set — no edge-fn redeploy)

| Env | Effect | Default |
|---|---|---|
| `RETAIL_CHAT_ENABLED=false` | **Kill switch** — both endpoints 503 instantly | on |
| `RETAIL_CHAT_DAILY_MAX` | Global LLM-bound requests / UTC-day across both surfaces (0 = unlimited) | 1000 |
| `RETAIL_CHAT_IP_DAILY_MAX` | Per-IP / UTC-day on the **public** store (0 = unlimited) | 40 |

**Cheap to test:** set the caps low (e.g. `=20`) while testing so you physically can't burn cost, then raise them — or flip `RETAIL_CHAT_ENABLED=false` to spend nothing at all.

## Behavior
- Refusal happens **before** the proxy forwards upstream → no LLM/TEvo spend on blocked calls.
- The **email-gated terminal** bears only the global cap + kill switch; the **public storefront** also bears the per-IP cap.
- This sits **on top of** the edge function's existing durable per-IP/minute limit (`check_chat_rate_limit`, 6/min).

## Caveat (called out in code)
Counters are **per-process** and reset on restart/redeploy — a cost **ceiling**, not exact metering. The single `vibepass-storefront-test` instance makes this fine as a backstop; promote to a DB counter later if a multi-instance, restart-proof quota is ever needed.

## Tests
`tests/test_retail_chat.py` adds: kill switch spends nothing, per-IP store cap, terminal exemption from the per-IP cap, and the global daily cap — each asserting the blocked request **never reaches the LLM**. RULE-2 read-only scan passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZbTiiK9JETy18nYbnWf1D)_