### PR TITLE
fix(sg-matcher): clean residual mis-binds + close the venue+date coincidence hole (A1-OPS-24 follow-up)

### DIFF
--- a/supabase/functions/sg-to-tevo-search-bridge/index.ts
+++ b/supabase/functions/sg-to-tevo-search-bridge/index.ts
@@ -185,9 +185,23 @@ Deno.serve(async (req) => {
       if (sc > bestScore) { bestScore = sc; best = ev; }
     }
 
-    if (!best || bestScore < minScore) {
+    // A1-OPS-24: reject a pure venue+date coincidence. A different show at the
+    // same venue/date scores ~74 on venue (+50) and same-date (+24) ALONE with
+    // zero name overlap, clearing minScore — that is how "Salsa Spectacular ..."
+    // bound to "Los Angeles Philharmonic ..." at the Hollywood Bowl. Require at
+    // least one shared MEANINGFUL name/team token, mirroring the DB-side
+    // aq_name_consistent guard. (teamA holds the full SG name for non-"at"/"vs"
+    // titles, so concerts still match a TEvo name that shares any real word.)
+    const NAME_STOP = new Set(["the","and","at","of","a","an","to","in","on","for","with","vs","de","el","la","los"]);
+    const bestNameTokens = best ? tokenSet(best.name ?? "") : new Set<string>();
+    const sgNameTokens = new Set<string>([...tokenSet(teamB), ...tokenSet(teamA)]);
+    let nameOverlap = 0;
+    for (const t of sgNameTokens) if (!NAME_STOP.has(t) && bestNameTokens.has(t)) nameOverlap++;
+
+    if (!best || bestScore < minScore || nameOverlap === 0) {
       noResults++;
-      if (!dryRun) await sb.from("sg_tevo_search_attempts").upsert({ sg_event_id: c.sg_event_id, attempted_at: new Date().toISOString(), result: "low_score", meta: { best_score: bestScore, best_id: best?.id, best_name: best?.name, top_n: events.length, owned: c.owned } }, { onConflict: "sg_event_id" });
+      const lowScoreReason = (best && bestScore >= minScore && nameOverlap === 0) ? "no_name_overlap" : "low_score";
+      if (!dryRun) await sb.from("sg_tevo_search_attempts").upsert({ sg_event_id: c.sg_event_id, attempted_at: new Date().toISOString(), result: lowScoreReason, meta: { best_score: bestScore, best_id: best?.id, best_name: best?.name, name_overlap: nameOverlap, top_n: events.length, owned: c.owned } }, { onConflict: "sg_event_id" });
       continue;
     }
 

--- a/supabase/migrations/20260619163000_td_match_sg_anchored_map_cron_50pct.sql
+++ b/supabase/migrations/20260619163000_td_match_sg_anchored_map_cron_50pct.sql
@@ -1,0 +1,122 @@
+-- Migration 20260619163000 · lane:A1 (operator-directed) ·
+--   writes (DDL): td_match_cron_budget_ok(), sg_match_map_tick(); cron 'sg-match-map-tick'
+--   reads: aq_event_map, sg_events_canonical, td_match_queue/_results, ticketsdata_credit_usage
+--   writes on run: td_match_queue (fires <=1 /match), td_match_results (drain), aq_event_map (COALESCE-fill)
+--   spends: TicketsData /match = 12 credits + 1 report per tick that FIRES (<=1 in flight at a time)
+--
+-- ## Applied to prod 2026-06-19 via MCP apply_migration (operator-directed). Idempotent.
+--
+-- Operator-directed 2026-06-19: "create a cron to map unmapped SeatGeek events,
+--   tie it against credits, and only use 50% for now."
+--
+-- WHY: /match is a SeatGeek-anchored cross-market resolver (proven 2026-06-19 —
+--   feeding seatgeek.com/e/events/<id> returns sh/vivid/tm/tp/gt matches at ~84-88
+--   'probable'; feeding StubHub/VividSeats bare URLs 500s "could not resolve
+--   performer cluster", and Ticketmaster/Gametime URLs 500 "unsupported
+--   marketplace"). This cron walks FUTURE SG-mapped aq rows missing their
+--   StubHub/VividSeats id, fires ONE /match per tick on the SeatGeek URL, and
+--   COALESCE-fills the result onto aq_event_map — consolidating the scattered
+--   platform ids behind the A1-OPS-22 dup problem.
+--
+-- RATE LIMIT: /match is serialized per account (429 "Too many match requests",
+--   retry_after 5s) and pg_net batches concurrent fires — so the tick fires at
+--   most ONE /match and only when nothing is already in flight. 10-min cadence
+--   keeps fires well outside the 5s window.
+--
+-- BUDGET (the "50%" cap): td_match_cron_budget_ok() = credits OK (td_budget_ok)
+--   AND monthly /match reports < 300 (half of the 600 automated cap; plan = 2,000/mo).
+--   When 300 is hit the cron idles until the next UTC month.
+
+-- 1) Budget gate — ties the cron to credits + the 50% report cap.
+CREATE OR REPLACE FUNCTION public.td_match_cron_budget_ok()
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public','pg_temp'
+AS $$
+  SELECT public.td_budget_ok() AND public.td_reports_this_month() < 300;  -- 300 = 50% of the 600 automated cap
+$$;
+REVOKE ALL ON FUNCTION public.td_match_cron_budget_ok() FROM anon, public;
+COMMENT ON FUNCTION public.td_match_cron_budget_ok() IS
+  'Gate for sg_match_map_tick: TD credit budget OK AND monthly /match reports < 300 (50% of the 600 automated cap). Operator-directed 2026-06-19.';
+
+-- 2) The per-tick worker: reap-stale -> drain -> fill -> fire ONE (serialized).
+CREATE OR REPLACE FUNCTION public.sg_match_map_tick()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public','extensions','pg_temp'
+AS $fn$
+DECLARE
+  v_drained int := 0;
+  v_fired   int := 0;
+  v_req bigint; v_url text; v_tevo bigint; v_aq text;
+  v_user text; v_pass text;
+BEGIN
+  -- (a) Reap stale in-flight rows (fired, no response after 30 min) to avoid deadlock.
+  UPDATE public.td_match_queue q
+  SET resolved_at = now(), status_code = -2, error_msg = 'timeout_no_response'
+  WHERE q.resolved_at IS NULL AND q.request_id IS NOT NULL
+    AND q.fired_at < now() - interval '30 minutes'
+    AND NOT EXISTS (SELECT 1 FROM net._http_response r WHERE r.id = q.request_id);
+
+  -- (b) Drain completed /match responses -> td_match_results, then COALESCE-fill NULLs.
+  v_drained := public.td_match_drain(50);
+  PERFORM 1 FROM public.td_match_apply(80, true);  -- NULL-fills only; CONFLICTs flagged, never overwritten
+
+  -- (c) Fire ONE new /match, only if budget OK AND nothing is currently in flight (429 guard).
+  IF public.td_match_cron_budget_ok()
+     AND NOT EXISTS (SELECT 1 FROM public.td_match_queue q
+                     WHERE q.request_id IS NOT NULL AND q.resolved_at IS NULL) THEN
+    SELECT a.tevo_event_id, a.aq_short_event_id, sgc.sg_url
+    INTO v_tevo, v_aq, v_url
+    FROM public.aq_event_map a
+    JOIN public.sg_events_canonical sgc
+      ON sgc.sg_event_id = a.sg_event_id AND sgc.sg_url IS NOT NULL
+    WHERE a.sg_event_id IS NOT NULL AND a.tevo_event_id IS NOT NULL
+      AND a.event_date > now()
+      AND (a.sh_event_id IS NULL OR a.vivid_event_id IS NULL)
+      AND NOT EXISTS (SELECT 1 FROM public.td_match_results mr
+                      WHERE mr.aq_short_event_id = a.aq_short_event_id
+                        AND mr.created_at > now() - interval '14 days')
+      AND NOT EXISTS (SELECT 1 FROM public.td_match_queue q
+                      WHERE q.aq_short_event_id = a.aq_short_event_id AND q.resolved_at IS NULL)
+    ORDER BY a.event_date   -- soonest unmapped first
+    LIMIT 1;
+
+    IF v_url IS NOT NULL THEN
+      v_user := public.get_app_secret('TICKETSDATA_USERNAME');
+      v_pass := public.get_app_secret('TICKETSDATA_PASSWORD');
+      IF v_user IS NOT NULL AND v_pass IS NOT NULL THEN
+        SELECT net.http_get(
+          url := 'https://ticketsdata.com/match',
+          params := jsonb_build_object('event_url', v_url, 'username', v_user, 'password', v_pass),
+          headers := '{}'::jsonb, timeout_milliseconds := 45000) INTO v_req;
+        INSERT INTO public.td_match_queue
+          (tevo_event_id, aq_short_event_id, seed_platform, seed_event_url, purpose, request_id)
+        VALUES (v_tevo, v_aq, 'SG', v_url, 'fill', v_req);
+        v_fired := 1;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'drained', v_drained,
+    'fired', v_fired,
+    'reports_used_month', public.td_reports_this_month(),
+    'budget_ok', public.td_match_cron_budget_ok());
+END $fn$;
+REVOKE ALL ON FUNCTION public.sg_match_map_tick() FROM anon, public;
+COMMENT ON FUNCTION public.sg_match_map_tick() IS
+  'Maps unmapped SeatGeek events via SG-anchored TicketsData /match: reap-stale -> drain -> COALESCE-fill -> fire ONE /match (serialized, budget-gated at 50%). Cron sg-match-map-tick every 10 min. Operator-directed 2026-06-19.';
+
+-- 3) Schedule: every 10 minutes, behind the repo cron policy gate.
+SELECT cron.unschedule('sg-match-map-tick')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'sg-match-map-tick');
+
+SELECT cron.schedule(
+  'sg-match-map-tick',
+  '*/10 * * * *',
+  $cronbody$
+    DO $b$ BEGIN
+      IF NOT public.cron_should_fire('sg-match-map-tick') THEN RETURN; END IF;
+      PERFORM public.sg_match_map_tick();
+    END $b$;
+  $cronbody$
+);

--- a/supabase/migrations/20260619170000_sg_match_map_prioritize_owned_axs.sql
+++ b/supabase/migrations/20260619170000_sg_match_map_prioritize_owned_axs.sql
@@ -1,0 +1,93 @@
+-- Migration 20260619170000 · lane:A1 (operator-directed) ·
+--   writes (DDL): CREATE OR REPLACE sg_match_map_tick() — target prioritization only
+--   ## Applied to prod 2026-06-19 via MCP (operator-directed). Idempotent.
+--
+-- Operator-directed 2026-06-19: "focus on owned events first and axs events first."
+-- Re-orders the sg_match_map_tick target pick so the SeatGeek->cross-market /match
+-- spend lands on the highest-value unmapped events first:
+--   1. OWNED events  (ticketsdata_event_xref.owned_tickets > 0 for the aq row)
+--   2. AXS events    (aq_event_map.axs_event_id IS NOT NULL)
+--   3. then most owned tickets, then soonest event_date.
+-- All other behaviour (reap-stale -> drain -> COALESCE-fill -> fire ONE, budget gate,
+-- 429 serialization) is unchanged from 20260619163000.
+--
+-- NOTE (2026-06-19 data check): SG-anchored /match needs a SeatGeek URL, so this
+-- priority only activates for owned/AXS events that have an sg_event_id+sg_url.
+-- Owned/AXS events lacking a SeatGeek anchor must be discovered on SeatGeek first
+-- (td_sg_discover / sg_to_tevo search bridge) before this cron can map them.
+
+CREATE OR REPLACE FUNCTION public.sg_match_map_tick()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public','extensions','pg_temp'
+AS $fn$
+DECLARE
+  v_drained int := 0;
+  v_fired   int := 0;
+  v_req bigint; v_url text; v_tevo bigint; v_aq text;
+  v_user text; v_pass text;
+BEGIN
+  -- (a) Reap stale in-flight rows (fired, no response after 30 min) to avoid deadlock.
+  UPDATE public.td_match_queue q
+  SET resolved_at = now(), status_code = -2, error_msg = 'timeout_no_response'
+  WHERE q.resolved_at IS NULL AND q.request_id IS NOT NULL
+    AND q.fired_at < now() - interval '30 minutes'
+    AND NOT EXISTS (SELECT 1 FROM net._http_response r WHERE r.id = q.request_id);
+
+  -- (b) Drain completed /match responses -> td_match_results, then COALESCE-fill NULLs.
+  v_drained := public.td_match_drain(50);
+  PERFORM 1 FROM public.td_match_apply(80, true);  -- NULL-fills only; CONFLICTs flagged, never overwritten
+
+  -- (c) Fire ONE new /match, only if budget OK AND nothing is currently in flight (429 guard).
+  IF public.td_match_cron_budget_ok()
+     AND NOT EXISTS (SELECT 1 FROM public.td_match_queue q
+                     WHERE q.request_id IS NOT NULL AND q.resolved_at IS NULL) THEN
+    SELECT a.tevo_event_id, a.aq_short_event_id, sgc.sg_url
+    INTO v_tevo, v_aq, v_url
+    FROM public.aq_event_map a
+    JOIN public.sg_events_canonical sgc
+      ON sgc.sg_event_id = a.sg_event_id AND sgc.sg_url IS NOT NULL
+    LEFT JOIN LATERAL (
+      SELECT COALESCE(SUM(x.owned_tickets), 0) AS owned_qty
+      FROM public.ticketsdata_event_xref x
+      WHERE x.aq_short_event_id = a.aq_short_event_id AND x.active
+    ) own ON true
+    WHERE a.sg_event_id IS NOT NULL AND a.tevo_event_id IS NOT NULL
+      AND a.event_date > now()
+      AND (a.sh_event_id IS NULL OR a.vivid_event_id IS NULL)
+      AND NOT EXISTS (SELECT 1 FROM public.td_match_results mr
+                      WHERE mr.aq_short_event_id = a.aq_short_event_id
+                        AND mr.created_at > now() - interval '14 days')
+      AND NOT EXISTS (SELECT 1 FROM public.td_match_queue q
+                      WHERE q.aq_short_event_id = a.aq_short_event_id AND q.resolved_at IS NULL)
+    ORDER BY
+      (own.owned_qty > 0)            DESC,   -- 1. owned events first
+      (a.axs_event_id IS NOT NULL)   DESC,   -- 2. then AXS events
+      own.owned_qty                  DESC,   -- 3. most owned tickets
+      a.event_date                   ASC     -- 4. soonest unmapped
+    LIMIT 1;
+
+    IF v_url IS NOT NULL THEN
+      v_user := public.get_app_secret('TICKETSDATA_USERNAME');
+      v_pass := public.get_app_secret('TICKETSDATA_PASSWORD');
+      IF v_user IS NOT NULL AND v_pass IS NOT NULL THEN
+        SELECT net.http_get(
+          url := 'https://ticketsdata.com/match',
+          params := jsonb_build_object('event_url', v_url, 'username', v_user, 'password', v_pass),
+          headers := '{}'::jsonb, timeout_milliseconds := 45000) INTO v_req;
+        INSERT INTO public.td_match_queue
+          (tevo_event_id, aq_short_event_id, seed_platform, seed_event_url, purpose, request_id)
+        VALUES (v_tevo, v_aq, 'SG', v_url, 'fill', v_req);
+        v_fired := 1;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'drained', v_drained,
+    'fired', v_fired,
+    'reports_used_month', public.td_reports_this_month(),
+    'budget_ok', public.td_match_cron_budget_ok());
+END $fn$;
+
+COMMENT ON FUNCTION public.sg_match_map_tick() IS
+  'Maps unmapped SeatGeek events via SG-anchored TicketsData /match: reap-stale -> drain -> COALESCE-fill -> fire ONE /match (serialized, budget-gated at 50%). Target priority: owned events -> AXS events -> most-owned -> soonest. Cron sg-match-map-tick every 10 min. Operator-directed 2026-06-19.';

--- a/supabase/migrations/20260619180000_disable_redundant_match_crons.sql
+++ b/supabase/migrations/20260619180000_disable_redundant_match_crons.sql
@@ -1,0 +1,34 @@
+-- Migration 20260619180000 · lane:A1 (operator-directed) ·
+--   writes: cron.job (active=false on 4 redundant matching crons)
+--   ## Applied to prod 2026-06-19 via MCP (operator-directed). Idempotent + reversible.
+--
+-- Operator-directed 2026-06-19: "look at the other matching crons and disable
+--   unnecessary or redundant ones."
+--
+-- Disabled (active=false; definitions retained for easy re-enable):
+--   • td_match_fill_enqueue          — BROKEN: td_match_enqueue('fill') seeds from
+--       ticketsdata_event_xref.event_url (StubHub/VividSeats/TM URLs), which /match
+--       rejects (500 "could not resolve performer cluster" / "unsupported marketplace");
+--       also fires 3 concurrently -> 429. Fully superseded by sg-match-map-tick, which
+--       seeds SeatGeek URLs (the only form /match resolves) and fires one-at-a-time.
+--   • td_match_drain                 — redundant: sg_match_map_tick() drains each cycle.
+--   • td_match_apply_cron            — redundant: sg_match_map_tick() applies (conf 80,
+--       superset of the cron's 90) every 10 min vs this one's 20.
+--   • auto_match_sg_canonical_v3_hourly — redundant: cross_source_match_tick() already
+--       calls auto_match_sg_canonical_v3() and runs twice/hr (:09,:39) vs this once/hr.
+--
+-- Net: sg-match-map-tick is the single owner of the TicketsData /match loop;
+--      cross_source_match_tick is the single owner of the SG-canonical v3 matcher.
+-- Reverse any of these with: SELECT cron.alter_job(jobid, active := true);
+
+DO $$
+DECLARE j bigint;
+BEGIN
+  FOR j IN
+    SELECT jobid FROM cron.job
+    WHERE jobname IN ('td_match_fill_enqueue','td_match_drain',
+                      'td_match_apply_cron','auto_match_sg_canonical_v3_hourly')
+  LOOP
+    PERFORM cron.alter_job(j, active := false);
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260619200000_sg_matcher_exact_date_guard.sql
+++ b/supabase/migrations/20260619200000_sg_matcher_exact_date_guard.sql
@@ -1,0 +1,216 @@
+-- ============================================================================
+-- Migration 20260619200000 — SG→TEvo matcher: exact-date guard (A1-OPS-24)
+--
+-- Lane:     xref+macro
+-- Touches:  sg_attempt_event_xref_v3 (W, fn), seatgeek_event_xref (W),
+--           sg_events_canonical (W), events (R), event_lifecycle (R)
+-- Pre-reqs: 20260608194500 (A1-OPS-23 name/league guard must exist),
+--           aq_name_consistent(), aq_league_consistent(), cross_source_venue_resolve()
+--
+-- BUG (event-mapping audit, 2026-06-19): sg_attempt_event_xref_v3 finds a TEvo
+-- candidate inside a ±24h window ordered by abs(time-diff). For a MULTI-DATE
+-- SERIES (same teams/performer at the same venue on consecutive days — MLB
+-- series, playoff rounds, Savannah Bananas residencies, multi-night theater),
+-- when the SAME-DATE TEvo event does not yet exist at match time (SG date stale/
+-- rescheduled, or TEvo not yet published), the window binds the ADJACENT-day
+-- sibling. The A1-OPS-23 name/league guard does NOT catch this — the opponent
+-- names ARE consistent; only the calendar date is wrong. And because the matcher
+-- early-returns an existing seatgeek_event_xref binding (before any guard runs),
+-- the wrong-day bind NEVER self-corrects once the real same-date event appears.
+--
+-- A read-only sweep of live bindings found 57 OFF-DATE rows. 35 carry the
+-- series signature (a same-venue, name-consistent sibling within ±3 days),
+-- including egregious mis-binds where the same teams meet again later in the
+-- season — e.g. "Tampa Bay Rays at New York Yankees" SG 2026-05-23 bound to the
+-- 2026-09-22 game (122 days off), and "St. Louis Cardinals at Cincinnati Reds"
+-- SG 2026-05-24 bound to 2026-08-17 (85 days off). The remaining 22 are lone
+-- single events off by ±1 local day with NO sibling — plausibly correct
+-- (timezone / TBD-placeholder boundary), so they are deliberately left alone.
+--
+-- FIX:
+--   (1) Same-date-first ordering: add a leading ORDER BY key that ranks a
+--       candidate on the SG event's own calendar date above any off-date
+--       candidate, regardless of the local-as-UTC vs real-UTC time arithmetic
+--       that abs(time-diff) is subject to.
+--   (2) Off-date SERIES reject: after candidate selection, if the chosen event
+--       is NOT on the SG event's date AND a same-venue, name-consistent sibling
+--       exists within ±3 days (the series signature), reject the bind (return
+--       NULL) and wait for the real same-date event. Permissive for lone events
+--       (no sibling) — the ±24h timezone fallback stands, so single-event
+--       off-by-one matches are unaffected.
+--   (3) One-time corrective sweep — UNBIND-ONLY. Delete the xref row + null
+--       sg_events_canonical for the 35 series-signature off-date binds, using
+--       the SAME self-selecting detector as the guard. The hourly
+--       auto_match_sg_canonical_v3 cron then re-evaluates each under the new
+--       guard: a clean same-date sibling -> re-mapped correctly; no same-date
+--       home -> left unmapped (never re-mislinked). Unbind-only is deliberate:
+--       the xref PK is tevo_event_id with ON CONFLICT DO UPDATE, so writing a
+--       re-map directly could STEAL an xref from a target already bound to its
+--       own (correct) SG event — observed for 2 of the 12 re-map targets
+--       (a doubleheader + a TBD playoff game). Letting the matcher re-bind
+--       avoids the steal.
+--
+-- ⚠️ NOT YET APPLIED — operator-gated (CLAUDE.md §1: CREATE OR REPLACE is DDL;
+--    the corrective sweep is UPDATE/DELETE on prod). Author-only commit. Apply
+--    via apply_migration after operator review of the dry-run in the PR.
+-- ============================================================================
+
+BEGIN;
+
+-- ── (1)+(2) Guard the matcher ──────────────────────────────────────────────
+-- Reproduces the live prod body (pg_get_functiondef 2026-06-19) verbatim, with
+-- only: a v_cand_date capture, the same-date-first ORDER BY key, and the
+-- off-date series reject added after the A1-OPS-23 name/league guard.
+CREATE OR REPLACE FUNCTION public.sg_attempt_event_xref_v3(p_sg_event_id bigint, p_sg_event_name text, p_sg_event_date date, p_sg_datetime_utc timestamp with time zone, p_sg_venue text, p_sg_venue_city text DEFAULT NULL::text, p_sg_venue_state text DEFAULT NULL::text, p_sg_category text DEFAULT NULL::text)
+ RETURNS bigint
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_tevo_event_id bigint;
+  v_tevo_name     text;
+  v_existing      bigint;
+  v_sg_team_a     text;
+  v_sg_team_b     text;
+  v_tevo_venue_id bigint;
+  v_cand_date     date;          -- A1-OPS-24: chosen candidate's local date for the exact-date guard
+BEGIN
+  IF p_sg_category IN ('Parking','parking')
+     OR coalesce(p_sg_venue,'') ILIKE '%parking%'
+     OR coalesce(p_sg_event_name,'') ILIKE '%parking%' THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT tevo_event_id INTO v_existing FROM public.seatgeek_event_xref WHERE sg_event_id = p_sg_event_id LIMIT 1;
+  IF v_existing IS NOT NULL THEN RETURN v_existing; END IF;
+
+  v_sg_team_a := trim(split_part(coalesce(p_sg_event_name,''), ' at ', 1));
+  v_sg_team_b := trim(split_part(coalesce(p_sg_event_name,''), ' at ', 2));
+  IF v_sg_team_b = '' THEN v_sg_team_b := v_sg_team_a; END IF;
+
+  v_tevo_venue_id := public.cross_source_venue_resolve(p_sg_venue, p_sg_venue_city, p_sg_venue_state);
+
+  SELECT e.id, e.name INTO v_tevo_event_id, v_tevo_name
+  FROM public.events e
+  LEFT JOIN public.event_lifecycle lc ON lc.event_id = e.id
+  WHERE
+    e.occurs_at_local::timestamptz BETWEEN
+      coalesce(p_sg_datetime_utc, p_sg_event_date::timestamptz) - interval '24 hours'
+      AND coalesce(p_sg_datetime_utc, p_sg_event_date::timestamptz) + interval '24 hours'
+    AND (
+      (v_tevo_venue_id IS NOT NULL AND e.venue_id = v_tevo_venue_id)
+      OR lower(trim(coalesce(e.venue_name,''))) = lower(trim(coalesce(p_sg_venue,'')))
+      OR lower(trim(coalesce(e.venue_name,''))) LIKE lower(trim(coalesce(p_sg_venue,''))) || '%'
+      OR lower(trim(coalesce(p_sg_venue,''))) LIKE lower(trim(coalesce(e.venue_name,''))) || '%'
+    )
+    AND (
+      (v_sg_team_b <> '' AND (
+        lower(coalesce(e.primary_performer_name,'')) LIKE '%' || lower(v_sg_team_b) || '%'
+        OR lower(coalesce(e.name,'')) LIKE '%' || lower(v_sg_team_b) || '%'))
+      OR
+      (v_sg_team_a <> '' AND (
+        lower(coalesce(e.primary_performer_name,'')) LIKE '%' || lower(v_sg_team_a) || '%'
+        OR lower(coalesce(e.name,'')) LIKE '%' || lower(v_sg_team_a) || '%'))
+    )
+  ORDER BY
+    -- A1-OPS-24: same-date candidates always outrank off-date ones (robust to the
+    -- local-as-UTC vs real-UTC skew that abs(time-diff) alone can be fooled by).
+    CASE WHEN e.occurs_at_local::date = coalesce(p_sg_event_date, p_sg_datetime_utc::date) THEN 0 ELSE 1 END,
+    abs(extract(epoch FROM (e.occurs_at_local::timestamptz - coalesce(p_sg_datetime_utc, p_sg_event_date::timestamptz)))),
+    CASE WHEN coalesce(lc.is_active, true) THEN 0 ELSE 1 END,
+    CASE WHEN v_tevo_venue_id IS NOT NULL AND e.venue_id = v_tevo_venue_id THEN 0 ELSE 1 END
+  LIMIT 1;
+
+  -- A1-OPS-23 ACCEPT GUARD (mirrors backfill_aq_maps; both guards permissive-by-default)
+  IF v_tevo_event_id IS NOT NULL
+     AND ( NOT public.aq_name_consistent(v_tevo_name, p_sg_event_name)
+           OR NOT public.aq_league_consistent(v_tevo_event_id, p_sg_category) ) THEN
+    v_tevo_event_id := NULL;
+  END IF;
+
+  -- A1-OPS-24 EXACT-DATE GUARD: the ±24h window can bind an adjacent-day game of
+  -- a multi-date series (same teams/venue on consecutive days). Because the
+  -- matcher early-returns an existing xref, such a wrong-day bind never
+  -- self-corrects. Reject an OFF-DATE candidate when a same-venue,
+  -- name-consistent SERIES sibling exists within ±3 days — wait unmapped for the
+  -- real same-date event rather than mis-bind the wrong game. Permissive for
+  -- lone events (no sibling): the ±24h timezone fallback stands.
+  IF v_tevo_event_id IS NOT NULL THEN
+    SELECT e.occurs_at_local::date INTO v_cand_date FROM public.events e WHERE e.id = v_tevo_event_id;
+    IF v_cand_date IS DISTINCT FROM p_sg_event_date
+       AND EXISTS (
+         SELECT 1 FROM public.events e2
+         WHERE e2.id <> v_tevo_event_id
+           AND ( (v_tevo_venue_id IS NOT NULL AND e2.venue_id = v_tevo_venue_id)
+                 OR lower(trim(coalesce(e2.venue_name,''))) = lower(trim(coalesce(p_sg_venue,''))) )
+           AND e2.occurs_at_local::date BETWEEN p_sg_event_date - 3 AND p_sg_event_date + 3
+           AND public.aq_name_consistent(e2.name, p_sg_event_name)
+       ) THEN
+      v_tevo_event_id := NULL;
+    END IF;
+  END IF;
+
+  IF v_tevo_event_id IS NOT NULL THEN
+    INSERT INTO public.seatgeek_event_xref (
+      tevo_event_id, sg_event_id, sg_event_name, sg_event_type,
+      sg_event_location, sg_start_data, match_method, match_confidence
+    ) VALUES (
+      v_tevo_event_id, p_sg_event_id, p_sg_event_name, p_sg_category,
+      p_sg_venue,
+      coalesce(p_sg_datetime_utc, make_timestamptz(
+        EXTRACT(YEAR FROM p_sg_event_date)::int,
+        EXTRACT(MONTH FROM p_sg_event_date)::int,
+        EXTRACT(DAY FROM p_sg_event_date)::int, 0, 0, 0, 'UTC')),
+      'matcher_v3_pm24h', 0.9
+    )
+    ON CONFLICT (tevo_event_id) DO UPDATE SET
+      sg_event_id = EXCLUDED.sg_event_id,
+      sg_event_name = EXCLUDED.sg_event_name,
+      sg_event_location = EXCLUDED.sg_event_location,
+      match_method = 'matcher_v3_pm24h',
+      matched_at = NOW();
+  END IF;
+  RETURN v_tevo_event_id;
+END $function$;
+
+-- ── (3) One-time corrective sweep — UNBIND-ONLY, self-selecting ─────────────
+-- Detector = the guard's own signature: OFF-DATE bind WITH a same-venue,
+-- name-consistent sibling within ±3 days. Delete the xref FIRST (the matcher
+-- early-returns on an existing xref), then null sg_events_canonical so the
+-- hourly cron re-binds under the new guard.
+DELETE FROM public.seatgeek_event_xref x
+USING public.sg_events_canonical sgc
+JOIN public.events e ON e.id = sgc.tevo_event_id
+WHERE x.sg_event_id = sgc.sg_event_id
+  AND sgc.tevo_event_id IS NOT NULL
+  AND e.occurs_at_local::date <> sgc.sg_event_date
+  AND EXISTS (
+    SELECT 1 FROM public.events e2
+    WHERE e2.id <> sgc.tevo_event_id
+      AND ( e2.venue_id = e.venue_id
+            OR lower(trim(coalesce(e2.venue_name,''))) = lower(trim(coalesce(sgc.sg_venue_name,''))) )
+      AND e2.occurs_at_local::date BETWEEN sgc.sg_event_date - 3 AND sgc.sg_event_date + 3
+      AND public.aq_name_consistent(e2.name, sgc.sg_event_name)
+  );
+
+UPDATE public.sg_events_canonical sgc
+SET tevo_event_id    = NULL,
+    match_method     = 'a1ops24_exactdate_unbind',
+    match_confidence = NULL,
+    matched_at       = NULL,
+    updated_at       = now()
+FROM public.events e
+WHERE e.id = sgc.tevo_event_id
+  AND sgc.tevo_event_id IS NOT NULL
+  AND e.occurs_at_local::date <> sgc.sg_event_date
+  AND EXISTS (
+    SELECT 1 FROM public.events e2
+    WHERE e2.id <> sgc.tevo_event_id
+      AND ( e2.venue_id = e.venue_id
+            OR lower(trim(coalesce(e2.venue_name,''))) = lower(trim(coalesce(sgc.sg_venue_name,''))) )
+      AND e2.occurs_at_local::date BETWEEN sgc.sg_event_date - 3 AND sgc.sg_event_date + 3
+      AND public.aq_name_consistent(e2.name, sgc.sg_event_name)
+  );
+
+COMMIT;

--- a/supabase/migrations/20260619200000_sg_matcher_exact_date_guard.sql
+++ b/supabase/migrations/20260619200000_sg_matcher_exact_date_guard.sql
@@ -50,9 +50,14 @@
 --       (a doubleheader + a TBD playoff game). Letting the matcher re-bind
 --       avoids the steal.
 --
--- ⚠️ NOT YET APPLIED — operator-gated (CLAUDE.md §1: CREATE OR REPLACE is DDL;
---    the corrective sweep is UPDATE/DELETE on prod). Author-only commit. Apply
---    via apply_migration after operator review of the dry-run in the PR.
+-- ✅ Applied to prod  Applied via MCP 2026-06-19 (operator-authorized, CLAUDE.md §1).
+--    Post-apply verified: guard_live=true; swept_unbound=35 (== pre-count);
+--    series_offdate_remaining=0; any_offdate_remaining=22 (lone ±1d events left
+--    untouched, by design); swept_xref_leftover=0. Re-binding of the clean
+--    same-date siblings is left to the hourly auto_match_sg_canonical_v3 cron
+--    (not run inline, to avoid broad side effects during apply). NOTE: applied
+--    without the outer BEGIN/COMMIT (apply_migration manages the transaction);
+--    the wrapper is retained below for documentation / db-reset fidelity.
 -- ============================================================================
 
 BEGIN;

--- a/supabase/migrations/20260619210000_sg_acl_stale_tbd_unbind.sql
+++ b/supabase/migrations/20260619210000_sg_acl_stale_tbd_unbind.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- Migration 20260619210000 — unbind stale mis-bound SG rows (A1-OPS-24 follow-up)
+--   Part A: 9 stale TBD off-date auto_canonical_loop bindings
+--   Part B: 2 cross-event name-inconsistent bindings (shared venue/date, wrong show)
+--
+-- Lane:     xref+macro
+-- Touches:  seatgeek_event_xref (W), sg_events_canonical (W), events (R)
+-- Pre-reqs: 20260619200000 (A1-OPS-24 exact-date guard — the v3 cron that
+--           re-evaluates these after unbind), aq_name_consistent()
+--
+-- FOLLOW-UP to A1-OPS-24 (#613). The exact-date sweep cleared 35 series
+-- mis-binds in the v3 matcher path. A residual 9 off-date bindings remained,
+-- all tagged match_method='auto_canonical_loop' — written by the LEGACY v1 loop
+-- auto_match_sg_canonical() (now UNSCHEDULED; no cron references it). These are
+-- NFL/NBA TBD-placeholder events (away side = "TBD"): at bind time the dates
+-- matched, then the SG-side date drifted to a default (e.g. 2026-08-11) while
+-- the binding persisted via the existing-xref early-return. Examples:
+--   • "NFL Preseason G1 - TBD at Philadelphia" SG 08-11 -> a Bengals game 08-28 (17d)
+--   • "NFL Preseason G2 - TBD at Las Vegas"     SG 08-18 -> a 49ers game   08-27 ( 9d)
+--   • "Oklahoma City Thunder at San Antonio Spurs" SG 05-20 -> 05-22 (2d, playoff)
+--
+-- The v1 binder is dead (its matcher even requires an exact date, so it cannot
+-- re-create these), so a one-time unbind is permanent. After clearing, the
+-- guarded hourly auto_match_sg_canonical_v3 cron re-maps each to the correct
+-- same-date event once the league finalizes the matchup; until then they sit
+-- unmapped — correct for a TBD placeholder.
+--
+-- Scope (Part A) is surgical: ONLY auto_canonical_loop rows whose bound TEvo date
+-- differs from the SG date. The 1,392 on-date auto_canonical_loop bindings are
+-- untouched.
+--
+-- Part B — cross-event name-inconsistent unbind. Two same-venue/same-date binds
+-- to a DIFFERENT show that the A1-OPS-23 name guard would reject but which slipped
+-- through guard-less binders (these are the exact examples cited in A1-OPS-23,
+-- recurred):
+--   • "TBD at Colorado Avalanche (NHL)" -> "TBD at Denver Nuggets (NBA)"  Ball Arena
+--     (auto_canonical_loop; v1 path, now dead — won't recur)
+--   • "Salsa Spectacular ..."           -> "Los Angeles Philharmonic ..."  Hollywood Bowl
+--     (tevo_search_owned_priority; this binder lacks a name guard — see KANBAN
+--      follow-up to port aq_name_consistent into the tevo_search binders; this
+--      unbind clears the live wrong-inventory display in the meantime)
+-- Detector is self-selecting (NOT aq_name_consistent) and permissive-by-default,
+-- so it only ever touches genuinely-inconsistent rows.
+--
+-- ✅ Applied to prod  Applied via MCP 2026-06-19 (operator-authorized, CLAUDE.md §1).
+--    Post-apply verified: Part A acl_offdate_remaining=0 (9 nulled), on_date count
+--    unchanged; Part B name_inconsistent_remaining=0 (2 nulled). NOTE: applied
+--    without the outer BEGIN/COMMIT (apply_migration manages the transaction).
+-- ============================================================================
+
+BEGIN;
+
+-- Delete the xref rows for the 9 stale off-date auto_canonical_loop bindings.
+DELETE FROM public.seatgeek_event_xref x
+USING public.sg_events_canonical sgc
+JOIN public.events e ON e.id = sgc.tevo_event_id
+WHERE x.sg_event_id = sgc.sg_event_id
+  AND sgc.match_method = 'auto_canonical_loop'
+  AND sgc.tevo_event_id IS NOT NULL
+  AND e.occurs_at_local::date <> sgc.sg_event_date;
+
+-- Null the canonical rows so the v3 cron re-evaluates them under the new guard.
+UPDATE public.sg_events_canonical sgc
+SET tevo_event_id    = NULL,
+    match_method     = 'a1ops24_acl_tbd_unbind',
+    match_confidence = NULL,
+    matched_at       = NULL,
+    updated_at       = now()
+FROM public.events e
+WHERE e.id = sgc.tevo_event_id
+  AND sgc.match_method = 'auto_canonical_loop'
+  AND sgc.tevo_event_id IS NOT NULL
+  AND e.occurs_at_local::date <> sgc.sg_event_date;
+
+-- ── Part B: cross-event name-inconsistent unbind (any binder) ───────────────
+DELETE FROM public.seatgeek_event_xref x
+USING public.sg_events_canonical sgc
+JOIN public.events e ON e.id = sgc.tevo_event_id
+WHERE x.sg_event_id = sgc.sg_event_id
+  AND sgc.tevo_event_id IS NOT NULL
+  AND NOT public.aq_name_consistent(e.name, sgc.sg_event_name);
+
+UPDATE public.sg_events_canonical sgc
+SET tevo_event_id    = NULL,
+    match_method     = 'a1ops24_nameguard_unbind',
+    match_confidence = NULL,
+    matched_at       = NULL,
+    updated_at       = now()
+FROM public.events e
+WHERE e.id = sgc.tevo_event_id
+  AND sgc.tevo_event_id IS NOT NULL
+  AND NOT public.aq_name_consistent(e.name, sgc.sg_event_name);
+
+COMMIT;


### PR DESCRIPTION
Follow-up to #613 (the v3 exact-date guard). After that shipped, a full-table audit found **11 residual mis-binds** from *other* binders, plus the **code hole** that keeps re-creating one class. This PR clears them and closes the hole.

## Migration `20260619210000` — clear residual mis-binds (✅ applied to prod, verified)

**Part A — 9 stale TBD off-date `auto_canonical_loop` rows.** Written by the **legacy v1 loop** (`auto_match_sg_canonical()`, now *unscheduled* — no cron references it). These are NFL/NBA **TBD-placeholder** events whose SG-side date drifted after binding (e.g. "TBD at Philadelphia" SG 08-11 → a Bengals game 08-28, 17 days off). The v1 binder is dead *and* requires an exact date, so the unbind is permanent. Scope is surgical — the 1,392 **on-date** `auto_canonical_loop` bindings are untouched.

**Part B — 2 cross-event name-inconsistent rows** (same venue/date, *different show*) — the exact examples cited in the A1-OPS-23 migration, recurred via guard-less binders:
- "TBD at **Colorado Avalanche** (NHL)" → "TBD at **Denver Nuggets** (NBA)" @ Ball Arena
- "**Salsa Spectacular** …" → "**Los Angeles Philharmonic** …" @ Hollywood Bowl (was showing 2,550 / 120 wrong listings)

Verified post-apply: `acl_offdate_remaining=0`, `name_inconsistent_remaining=0`, **`total_wrong_class_remaining=0`** across the whole table (no binding ≥2 days off or name-inconsistent remains).

## `sg-to-tevo-search-bridge` — name-overlap guard (⚠️ deploy operator-gated)

**Root cause of the Salsa recurrence:** the bridge accepts any candidate scoring `≥ minScore` (50). `score()` awards **venue +50** and **same-date +~24**, so a *different show* at the same venue/date binds at **~74 with zero name overlap**. Without a fix, unbinding Salsa is futile — the next run re-binds it.

**Fix:** require **≥1 shared meaningful (stopword-filtered) name/team token** before accepting, mirroring the DB-side `aq_name_consistent` guard. Logs `result='no_name_overlap'` for observability. `teamA` holds the full SG name for non-"at"/"vs" titles, so legitimate concerts still match a TEvo name sharing any real word; only pure venue+date coincidences are rejected.

> **Edge-function deploy is operator-gated** (`CLAUDE.md §1`). The code is committed; **deploy pending your approval**. Until deployed, the Part B unbind clears the live wrong-inventory display, but the bridge could re-create the Salsa bind on its next run — so deploy is the durable closure.

## Status
- Migration `20260619210000`: **applied + verified on prod**.
- Edge-function guard: **committed, not deployed** (awaiting operator go-ahead to `deploy_edge_function`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgDhimAdwVbbCjWCrrHWAc)_