### PR TITLE
refactor(a1): extract _bulk_performer_assets + _classify_playoff to core (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,6 +229,12 @@ from core.config import (  # noqa: E402
 # `core.auth.AUTH_DISABLED`.
 from core.auth import require_auth, AUTH_DISABLED, _is_production  # noqa: E402
 
+# Helpers moved to core/ (BR-CODE-1 helper pass). Aliased to the historical
+# `_`-prefixed names so every call site + the route tests' monkeypatch
+# (app._bulk_performer_assets) keep resolving the app-module binding.
+from core.helpers import classify_playoff as _classify_playoff, _PLAYOFF_SPECIFIC_RE  # noqa: E402
+from core.broker_helpers import bulk_performer_assets as _bulk_performer_assets  # noqa: E402
+
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
 
@@ -1321,66 +1327,9 @@ def broker_tours_near(
     return _discover_payload(home_lat, home_lon, within_mi, days, min_shows, concerts_only)
 
 
-def _bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
-    """Fetch performer_metadata for many performer_ids at once. Returns map
-    {performer_id: {logo_default_url, color_primary, ...}}. Used by event
-    overview to attach home + away logos in a single roundtrip."""
-    if not performer_ids:
-        return {}
-    rows = (db.table("performer_metadata")
-              .select("performer_id, name, espn_team_id, espn_league, "
-                      "color_primary, color_alternate, logo_default_url, logo_dark_url")
-              .in_("performer_id", performer_ids)
-              .execute()).data or []
-    return {int(r["performer_id"]): r for r in rows}
-
-
-# Playoff-specific phrases we recognize in event names. Order matters: more
-# specific labels (NBA Finals) are tried before generic round indicators so
-# the badge surfaces "NBA Finals" instead of "Playoffs" when both match.
-_PLAYOFF_SPECIFIC_RE = re.compile(
-    r"\b("
-    r"NBA\s+Finals|"
-    r"NBA\s+(?:Eastern|Western)\s+Conference\s+(?:Semi)?Finals|"
-    r"NHL\s+Stanley\s+Cup\s+Finals|"
-    r"NHL\s+(?:Eastern|Western)\s+Conference\s+(?:Semi)?Finals|"
-    r"Stanley\s+Cup(?:\s+Finals?)?|"
-    r"World\s+Series|"
-    r"Super\s+Bowl(?:\s+L[IVX]+)?|"
-    r"MLS\s+Cup|"
-    r"NCAA\s+(?:Final\s+Four|National\s+Championship)|"
-    r"College\s+Football\s+Playoff(?:\s+National\s+Championship)?"
-    r")\b",
-    re.IGNORECASE,
-)
-_PLAYOFF_GENERIC_RE = re.compile(
-    r"\((?:Game\s+\d+|Round\s+\d+)|"           # parenthetical TEvo markers
-    r"\b(?:Playoffs?|Postseason|Wild\s+Card|"
-    r"Conference\s+Finals?|Conference\s+Semifinals?|"
-    r"Division\s+Series)\b",
-    re.IGNORECASE,
-)
-
-
-def _classify_playoff(event_name: str | None) -> dict | None:
-    """Return a playoff badge dict for the event name, or None.
-
-    Two-tier:
-      - specific  match (e.g. "NBA Finals") → that phrase is the label
-      - generic   match (e.g. "Round 3", "(Game 7,") → label = "Playoffs"
-
-    Falls back to None when nothing matches. Case-insensitive throughout.
-    """
-    if not event_name:
-        return None
-    m = _PLAYOFF_SPECIFIC_RE.search(event_name)
-    if m:
-        # Normalize whitespace so multi-word matches print cleanly.
-        label = re.sub(r"\s+", " ", m.group(1)).strip()
-        return {"label": label, "kind": "specific"}
-    if _PLAYOFF_GENERIC_RE.search(event_name):
-        return {"label": "Playoffs", "kind": "generic"}
-    return None
+# _bulk_performer_assets -> core/broker_helpers.py and _classify_playoff (+ its
+# _PLAYOFF_*_RE) -> core/helpers.py (BR-CODE-1 helper pass). Imported (aliased)
+# at the top of this module; call sites unchanged.
 
 
 # Marquee competitions — events that aren't playoffs but carry their own

--- a/core/broker_helpers.py
+++ b/core/broker_helpers.py
@@ -1,0 +1,22 @@
+"""DB-touching broker helpers shared by app.py + routers/* (BR-CODE-1 helper pass).
+
+Unlike core/helpers.py (pure), these take a live supabase `db` client as their
+first argument and issue read-only queries. They hold no module state and import
+nothing from app.py (one-directional: app.py/routers -> core, never reverse), so
+they're safe to move out of the monolith incrementally. Moved verbatim from app.py.
+"""
+from __future__ import annotations
+
+
+def bulk_performer_assets(db, performer_ids: list[int]) -> dict[int, dict]:
+    """Fetch performer_metadata for many performer_ids at once. Returns map
+    {performer_id: {logo_default_url, color_primary, ...}}. Used by event
+    overview to attach home + away logos in a single roundtrip."""
+    if not performer_ids:
+        return {}
+    rows = (db.table("performer_metadata")
+              .select("performer_id, name, espn_team_id, espn_league, "
+                      "color_primary, color_alternate, logo_default_url, logo_dark_url")
+              .in_("performer_id", performer_ids)
+              .execute()).data or []
+    return {int(r["performer_id"]): r for r in rows}

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -6,6 +6,7 @@ core, never reverse). Moved verbatim from app.py.
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime
 
 
@@ -44,3 +45,51 @@ def delta(curr, prev):
     pct = (diff / p * 100) if p != 0 else None
     return {"abs": round(diff, 2), "pct": round(pct, 2) if pct is not None else None,
             "dir": "up" if diff > 0 else "down"}
+
+
+# Playoff-specific phrases we recognize in event names. Order matters: more
+# specific labels (NBA Finals) are tried before generic round indicators so
+# the badge surfaces "NBA Finals" instead of "Playoffs" when both match.
+_PLAYOFF_SPECIFIC_RE = re.compile(
+    r"\b("
+    r"NBA\s+Finals|"
+    r"NBA\s+(?:Eastern|Western)\s+Conference\s+(?:Semi)?Finals|"
+    r"NHL\s+Stanley\s+Cup\s+Finals|"
+    r"NHL\s+(?:Eastern|Western)\s+Conference\s+(?:Semi)?Finals|"
+    r"Stanley\s+Cup(?:\s+Finals?)?|"
+    r"World\s+Series|"
+    r"Super\s+Bowl(?:\s+L[IVX]+)?|"
+    r"MLS\s+Cup|"
+    r"NCAA\s+(?:Final\s+Four|National\s+Championship)|"
+    r"College\s+Football\s+Playoff(?:\s+National\s+Championship)?"
+    r")\b",
+    re.IGNORECASE,
+)
+_PLAYOFF_GENERIC_RE = re.compile(
+    r"\((?:Game\s+\d+|Round\s+\d+)|"           # parenthetical TEvo markers
+    r"\b(?:Playoffs?|Postseason|Wild\s+Card|"
+    r"Conference\s+Finals?|Conference\s+Semifinals?|"
+    r"Division\s+Series)\b",
+    re.IGNORECASE,
+)
+
+
+def classify_playoff(event_name: str | None) -> dict | None:
+    """Return a playoff badge dict for the event name, or None.
+
+    Two-tier:
+      - specific  match (e.g. "NBA Finals") → that phrase is the label
+      - generic   match (e.g. "Round 3", "(Game 7,") → label = "Playoffs"
+
+    Falls back to None when nothing matches. Case-insensitive throughout.
+    """
+    if not event_name:
+        return None
+    m = _PLAYOFF_SPECIFIC_RE.search(event_name)
+    if m:
+        # Normalize whitespace so multi-word matches print cleanly.
+        label = re.sub(r"\s+", " ", m.group(1)).strip()
+        return {"label": label, "kind": "specific"}
+    if _PLAYOFF_GENERIC_RE.search(event_name):
+        return {"label": "Playoffs", "kind": "generic"}
+    return None

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -1,0 +1,103 @@
+"""Unit tests for the extracted core helpers (BR-CODE-1 helper pass).
+
+These cover the functions moved out of app.py into core/ so the monolith
+decomposition is regression-guarded at the unit level (no FastAPI / DB needed):
+  - core.helpers.classify_playoff        (pure: event name -> badge dict | None)
+  - core.helpers.listings_cadence_seconds / delta (pure)
+  - core.broker_helpers.bulk_performer_assets (one in_() table read, fake db)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from core.helpers import classify_playoff, delta, listings_cadence_seconds  # noqa: E402
+from core.broker_helpers import bulk_performer_assets  # noqa: E402
+
+
+# ---------- classify_playoff ----------
+
+def test_classify_playoff_specific_beats_generic():
+    # "NBA Finals" is a specific phrase -> that exact label, kind=specific,
+    # even though "Playoffs"-class generic markers could also be present.
+    out = classify_playoff("New York Knicks vs Boston Celtics - NBA Finals (Game 7)")
+    assert out == {"label": "NBA Finals", "kind": "specific"}
+
+
+def test_classify_playoff_generic_marker():
+    # A parenthetical "(Game 3" round marker with no specific phrase -> Playoffs.
+    out = classify_playoff("Yankees vs Red Sox (Game 3, If Necessary)")
+    assert out == {"label": "Playoffs", "kind": "generic"}
+
+
+def test_classify_playoff_none_for_regular_season():
+    assert classify_playoff("Knicks vs Celtics") is None
+    assert classify_playoff("") is None
+    assert classify_playoff(None) is None
+
+
+def test_classify_playoff_whitespace_normalized():
+    # Multi-space match collapses to single spaces in the label.
+    out = classify_playoff("Final:  NHL   Stanley  Cup  Finals")
+    assert out["kind"] == "specific"
+    assert "  " not in out["label"]
+
+
+# ---------- listings_cadence_seconds + delta (pure, re-cover post-move) ----------
+
+def test_listings_cadence_buckets():
+    assert listings_cadence_seconds(None) == 60 * 60 * 24
+    assert listings_cadence_seconds("not-a-date") == 60 * 60  # parse fail -> 60m
+
+
+def test_delta_directions():
+    assert delta(150, 120)["dir"] == "up"
+    assert delta(100, 120)["dir"] == "down"
+    assert delta(100, 100) == {"abs": 0, "pct": 0, "dir": "flat"}
+    assert delta(None, 5) is None
+
+
+# ---------- bulk_performer_assets ----------
+
+class _FakeChain:
+    def __init__(self, data):
+        self._data = data
+    def select(self, *_a, **_k):
+        return self
+    def in_(self, *_a, **_k):
+        return self
+    def execute(self):
+        return type("_R", (), {"data": self._data})()
+
+
+class _FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+        self.tables_touched = []
+    def table(self, name):
+        self.tables_touched.append(name)
+        return _FakeChain(self._rows)
+
+
+def test_bulk_performer_assets_empty_ids_skips_db():
+    db = _FakeDB([{"performer_id": 1}])
+    assert bulk_performer_assets(db, []) == {}
+    # no query issued for an empty id list
+    assert db.tables_touched == []
+
+
+def test_bulk_performer_assets_maps_by_int_id():
+    rows = [
+        {"performer_id": 16303, "name": "Knicks", "logo_default_url": "x.png"},
+        {"performer_id": "18", "name": "Celtics", "logo_default_url": "y.png"},
+    ]
+    db = _FakeDB(rows)
+    out = bulk_performer_assets(db, [16303, 18])
+    assert db.tables_touched == ["performer_metadata"]
+    # keys coerced to int (handles string performer_id rows from the DB)
+    assert set(out) == {16303, 18}
+    assert out[16303]["name"] == "Knicks"
+    assert out[18]["logo_default_url"] == "y.png"


### PR DESCRIPTION
## BR-CODE-1 — next app.py decomposition slice

Moves two more helpers out of the monolith behind unchanged call sites (strangler pattern).

### Extracted
- **`core/broker_helpers.py`** (new) — `bulk_performer_assets(db, ids)`, the db-touching `performer_metadata` bulk read used by 7 broker/store routes.
- **`core/helpers.py`** — `classify_playoff(name)` + the `_PLAYOFF_*_RE` regexes (pure, no DB).

### Wiring
- `app.py` imports both **aliased to the historical `_`-prefixed names**, so all call sites and the route tests' monkeypatch (`app._bulk_performer_assets`) keep resolving the app-module binding.
- `_PLAYOFF_SPECIFIC_RE` is re-imported because 3 other `app.py` functions reference it directly; `_PLAYOFF_GENERIC_RE` is only used inside `classify_playoff` so it stays in `core` only.

### Tests
- New `tests/test_core_helpers.py` — 8 unit tests (no DB/FastAPI): `classify_playoff` (specific-beats-generic / generic / none / whitespace), `bulk_performer_assets` (empty-skips-db + int-key mapping), plus re-coverage of `delta`/`listings_cadence_seconds`.

### Result
- `app.py` 8143 → 8092 LOC.
- Full route + core + security suites green (**359 passed**; the only local failures are env-only missing deps — `bs4` / `supabase.Client` — which CI provides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_