### PR TITLE
refactor(a1): extract _search_sql_only to core/search.py (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -227,6 +227,7 @@ from core.helpers import (  # noqa: E402
 from core.broker_helpers import bulk_performer_assets as _bulk_performer_assets  # noqa: E402
 from core.broker_helpers import bulk_event_context as _bulk_event_context  # noqa: E402
 from core.movers import compute_movers as _compute_movers  # noqa: E402
+from core.search import search_sql_only as _search_sql_only  # noqa: E402
 
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
@@ -4352,14 +4353,8 @@ def _normalize_search_key(q: str) -> str:
 # PostgREST ILIKE pattern wildcards we need to escape so a user-supplied
 # query like "%" doesn't become a match-everything pattern. Backslash
 # escaped FIRST so we don't double-escape our own escapes.
-_ILIKE_WILDCARDS = ("\\", "%", "_")
-
-
-def _escape_ilike(s: str) -> str:
-    """Escape PostgREST ILIKE wildcards in a user-supplied substring."""
-    for ch in _ILIKE_WILDCARDS:
-        s = s.replace(ch, "\\" + ch)
-    return s
+# _ILIKE_WILDCARDS + _escape_ilike + _search_sql_only -> core/search.py
+# (BR-CODE-1). app.py imports search_sql_only (aliased) near the top.
 
 
 # Characters that, if present in an .or_() clause VALUE, force PostgREST to
@@ -4431,155 +4426,7 @@ def _search_cache_put(key: str, payload: dict) -> None:
         _search_cache.pop(oldest[0], None)
 
 
-def _search_sql_only(db, q_norm: str, limit: int) -> dict:
-    """SQL-only search: ILIKE across our `events` + `performer_metadata` for
-    queries when STOREFRONT_SQL_ONLY=true. Always hits Supabase, never TEvo.
-    Returns the same shape as the live path so the client is mode-agnostic.
-    """
-    today_iso = datetime.now(timezone.utc).date().isoformat()
-    # Strip characters that break PostgREST's or_() clause parser:
-    # commas (clause separator), periods (operator separator), parens
-    # (grouping). The replacement char is a space so multi-token queries
-    # still work via ILIKE's wildcard handling.
-    safe_q = re.sub(r"[,.()\"]", " ", q_norm).strip()
-    if not safe_q:
-        return {"events": [], "performers": [], "venues": [], "source": "sql"}
-    # Escape ILIKE wildcards (%, _, \) so a user-supplied "%" doesn't
-    # become a match-everything pattern. We wrap with our own %...%
-    # after the escape.
-    pattern = f"%{_escape_ilike(safe_q)}%"
-
-    # Events: search by event name, venue name, venue location, primary
-    # performer name. Limit to future + active so we don't surface ghosts.
-    # Uses _or_ilike_clause for defense-in-depth: today the pattern has
-    # been sanitized at line ~4467 so the legacy raw f-string would work,
-    # but if that sanitization ever loosens this site would re-introduce
-    # the PostgREST or-clause-separator bug that broke /api/store/movers.
-    try:
-        ev_rows = (db.table("events")
-                     .select("id,name,occurs_at_local,venue_name,venue_location,"
-                             "primary_performer_id,primary_performer_name")
-                     .gte("occurs_at_local", today_iso)
-                     .or_(",".join([
-                         _or_ilike_clause("name", pattern),
-                         _or_ilike_clause("venue_name", pattern),
-                         _or_ilike_clause("venue_location", pattern),
-                         _or_ilike_clause("primary_performer_name", pattern),
-                     ]))
-                     .order("occurs_at_local", desc=False)
-                     .limit(80)
-                     .execute().data) or []
-    except Exception as e:
-        print(f"search_sql_only events query failed: {e}")
-        ev_rows = []
-
-    # Tag with we_own + from_price via latest_event_metrics. Drop speculative
-    # names (CANCELLED / (If Necessary) / (Date TBD)) — consumer storefront
-    # should not surface playoff "may not happen" inventory.
-    ev_rows = [e for e in ev_rows if not _is_speculative_event_name(e.get("name"))]
-    if ev_rows:
-        ev_ids = [int(e["id"]) for e in ev_rows if e.get("id")]
-        metrics: dict[int, dict] = {}
-        if ev_ids:
-            try:
-                rows = (db.table("latest_event_metrics")
-                          .select("event_id,owned_tickets_count,owned_groups_count,retail_min")
-                          .in_("event_id", ev_ids).execute().data) or []
-                metrics = {int(r["event_id"]): r for r in rows if r.get("event_id")}
-            except Exception:
-                metrics = {}
-        # Drop inactive (ghost/cancelled) events.
-        try:
-            lc = (db.table("event_lifecycle")
-                    .select("event_id,is_active")
-                    .in_("event_id", ev_ids).execute().data) or []
-            inactive = {int(r["event_id"]) for r in lc if not r.get("is_active")}
-        except Exception:
-            inactive = set()
-        ev_rows = [e for e in ev_rows if int(e.get("id") or 0) not in inactive]
-    else:
-        metrics = {}
-
-    # Bias toward owned inventory: when a query like "aces" matches multiple
-    # teams (Reno Aces minor-league + Las Vegas Aces WNBA), the soonest event
-    # wins under the default occurs_at_local ASC sort even when we don't own
-    # any inventory for that team. Audit 2026-05-16 found "aces" returning
-    # Reno Aces first; we own Las Vegas Aces 5/17. Re-sort so events with
-    # owned inventory come first, soonest among them next.
-    ev_rows_sorted = sorted(
-        ev_rows,
-        key=lambda e: (
-            0 if (metrics.get(int(e.get("id") or 0)) or {}).get("owned_tickets_count") else 1,
-            e.get("occurs_at_local") or "9999-12-31",
-        ),
-    )
-
-    events_out = []
-    for e in ev_rows_sorted[:limit]:
-        eid = int(e.get("id") or 0)
-        m = metrics.get(eid) or {}
-        events_out.append({
-            "id": eid,
-            "name": e.get("name"),
-            "venue_name": e.get("venue_name"),
-            "location": e.get("venue_location"),
-            "occurs_at": e.get("occurs_at_local"),
-            "we_own": bool(m.get("owned_tickets_count")),
-            "from_price": m.get("retail_min"),
-            "owned_tix": m.get("owned_tickets_count"),
-        })
-
-    # Performers via performer_metadata name match.
-    try:
-        pf_rows = (db.table("performer_metadata")
-                     .select("performer_id,name,espn_league")
-                     .ilike("name", pattern)
-                     .limit(limit)
-                     .execute().data) or []
-    except Exception:
-        pf_rows = []
-    performers_out = [{
-        "id": int(p.get("performer_id") or 0),
-        "name": p.get("name"),
-        "league": p.get("espn_league"),
-    } for p in pf_rows if p.get("performer_id")]
-
-    # Venues — derive from events distinct venue rows for SQL-only mode.
-    # We don't have a public venues table; use distinct venue_name from
-    # upcoming events matching the query.
-    venues_out: list[dict] = []
-    try:
-        vn_rows = (db.table("events")
-                     .select("venue_id,venue_name,venue_location")
-                     .gte("occurs_at_local", today_iso)
-                     .or_(",".join([
-                         _or_ilike_clause("venue_name", pattern),
-                         _or_ilike_clause("venue_location", pattern),
-                     ]))
-                     .limit(40)
-                     .execute().data) or []
-        seen: set[int] = set()
-        for v in vn_rows:
-            vid = int(v.get("venue_id") or 0)
-            if vid in seen or not vid:
-                continue
-            seen.add(vid)
-            venues_out.append({
-                "id": vid,
-                "name": v.get("venue_name"),
-                "location": v.get("venue_location"),
-            })
-            if len(venues_out) >= limit:
-                break
-    except Exception:
-        pass
-
-    return {
-        "events": events_out,
-        "performers": performers_out,
-        "venues": venues_out,
-        "source": "sql",
-    }
+# _search_sql_only -> core/search.py (BR-CODE-1); imported (aliased) at top.
 
 
 def _search_players(db, q_norm: str, limit: int) -> list[dict]:

--- a/core/search.py
+++ b/core/search.py
@@ -1,0 +1,178 @@
+"""SQL-only storefront search — extracted from app.py (BR-CODE-1).
+
+`search_sql_only` is the STOREFRONT_SQL_ONLY search path: ILIKE across our own
+`events` + `performer_metadata` tables (never TEvo), returning the same shape as
+the live path so the client stays mode-agnostic. Self-contained: takes a live
+`db` client and depends outward only on core.helpers (one-directional: search ->
+core, never reverse). Moved verbatim from app.py.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from core.helpers import (
+    is_speculative_event_name as _is_speculative_event_name,
+    or_ilike_clause as _or_ilike_clause,
+)
+
+
+_ILIKE_WILDCARDS = ("\\", "%", "_")
+
+
+def _escape_ilike(s: str) -> str:
+    """Escape PostgREST ILIKE wildcards in a user-supplied substring."""
+    for ch in _ILIKE_WILDCARDS:
+        s = s.replace(ch, "\\" + ch)
+    return s
+
+
+def search_sql_only(db, q_norm: str, limit: int) -> dict:
+    """SQL-only search: ILIKE across our `events` + `performer_metadata` for
+    queries when STOREFRONT_SQL_ONLY=true. Always hits Supabase, never TEvo.
+    Returns the same shape as the live path so the client is mode-agnostic.
+    """
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    # Strip characters that break PostgREST's or_() clause parser:
+    # commas (clause separator), periods (operator separator), parens
+    # (grouping). The replacement char is a space so multi-token queries
+    # still work via ILIKE's wildcard handling.
+    safe_q = re.sub(r"[,.()\"]", " ", q_norm).strip()
+    if not safe_q:
+        return {"events": [], "performers": [], "venues": [], "source": "sql"}
+    # Escape ILIKE wildcards (%, _, \) so a user-supplied "%" doesn't
+    # become a match-everything pattern. We wrap with our own %...%
+    # after the escape.
+    pattern = f"%{_escape_ilike(safe_q)}%"
+
+    # Events: search by event name, venue name, venue location, primary
+    # performer name. Limit to future + active so we don't surface ghosts.
+    # Uses _or_ilike_clause for defense-in-depth: today the pattern has
+    # been sanitized at line ~4467 so the legacy raw f-string would work,
+    # but if that sanitization ever loosens this site would re-introduce
+    # the PostgREST or-clause-separator bug that broke /api/store/movers.
+    try:
+        ev_rows = (db.table("events")
+                     .select("id,name,occurs_at_local,venue_name,venue_location,"
+                             "primary_performer_id,primary_performer_name")
+                     .gte("occurs_at_local", today_iso)
+                     .or_(",".join([
+                         _or_ilike_clause("name", pattern),
+                         _or_ilike_clause("venue_name", pattern),
+                         _or_ilike_clause("venue_location", pattern),
+                         _or_ilike_clause("primary_performer_name", pattern),
+                     ]))
+                     .order("occurs_at_local", desc=False)
+                     .limit(80)
+                     .execute().data) or []
+    except Exception as e:
+        print(f"search_sql_only events query failed: {e}")
+        ev_rows = []
+
+    # Tag with we_own + from_price via latest_event_metrics. Drop speculative
+    # names (CANCELLED / (If Necessary) / (Date TBD)) — consumer storefront
+    # should not surface playoff "may not happen" inventory.
+    ev_rows = [e for e in ev_rows if not _is_speculative_event_name(e.get("name"))]
+    if ev_rows:
+        ev_ids = [int(e["id"]) for e in ev_rows if e.get("id")]
+        metrics: dict[int, dict] = {}
+        if ev_ids:
+            try:
+                rows = (db.table("latest_event_metrics")
+                          .select("event_id,owned_tickets_count,owned_groups_count,retail_min")
+                          .in_("event_id", ev_ids).execute().data) or []
+                metrics = {int(r["event_id"]): r for r in rows if r.get("event_id")}
+            except Exception:
+                metrics = {}
+        # Drop inactive (ghost/cancelled) events.
+        try:
+            lc = (db.table("event_lifecycle")
+                    .select("event_id,is_active")
+                    .in_("event_id", ev_ids).execute().data) or []
+            inactive = {int(r["event_id"]) for r in lc if not r.get("is_active")}
+        except Exception:
+            inactive = set()
+        ev_rows = [e for e in ev_rows if int(e.get("id") or 0) not in inactive]
+    else:
+        metrics = {}
+
+    # Bias toward owned inventory: when a query like "aces" matches multiple
+    # teams (Reno Aces minor-league + Las Vegas Aces WNBA), the soonest event
+    # wins under the default occurs_at_local ASC sort even when we don't own
+    # any inventory for that team. Audit 2026-05-16 found "aces" returning
+    # Reno Aces first; we own Las Vegas Aces 5/17. Re-sort so events with
+    # owned inventory come first, soonest among them next.
+    ev_rows_sorted = sorted(
+        ev_rows,
+        key=lambda e: (
+            0 if (metrics.get(int(e.get("id") or 0)) or {}).get("owned_tickets_count") else 1,
+            e.get("occurs_at_local") or "9999-12-31",
+        ),
+    )
+
+    events_out = []
+    for e in ev_rows_sorted[:limit]:
+        eid = int(e.get("id") or 0)
+        m = metrics.get(eid) or {}
+        events_out.append({
+            "id": eid,
+            "name": e.get("name"),
+            "venue_name": e.get("venue_name"),
+            "location": e.get("venue_location"),
+            "occurs_at": e.get("occurs_at_local"),
+            "we_own": bool(m.get("owned_tickets_count")),
+            "from_price": m.get("retail_min"),
+            "owned_tix": m.get("owned_tickets_count"),
+        })
+
+    # Performers via performer_metadata name match.
+    try:
+        pf_rows = (db.table("performer_metadata")
+                     .select("performer_id,name,espn_league")
+                     .ilike("name", pattern)
+                     .limit(limit)
+                     .execute().data) or []
+    except Exception:
+        pf_rows = []
+    performers_out = [{
+        "id": int(p.get("performer_id") or 0),
+        "name": p.get("name"),
+        "league": p.get("espn_league"),
+    } for p in pf_rows if p.get("performer_id")]
+
+    # Venues — derive from events distinct venue rows for SQL-only mode.
+    # We don't have a public venues table; use distinct venue_name from
+    # upcoming events matching the query.
+    venues_out: list[dict] = []
+    try:
+        vn_rows = (db.table("events")
+                     .select("venue_id,venue_name,venue_location")
+                     .gte("occurs_at_local", today_iso)
+                     .or_(",".join([
+                         _or_ilike_clause("venue_name", pattern),
+                         _or_ilike_clause("venue_location", pattern),
+                     ]))
+                     .limit(40)
+                     .execute().data) or []
+        seen: set[int] = set()
+        for v in vn_rows:
+            vid = int(v.get("venue_id") or 0)
+            if vid in seen or not vid:
+                continue
+            seen.add(vid)
+            venues_out.append({
+                "id": vid,
+                "name": v.get("venue_name"),
+                "location": v.get("venue_location"),
+            })
+            if len(venues_out) >= limit:
+                break
+    except Exception:
+        pass
+
+    return {
+        "events": events_out,
+        "performers": performers_out,
+        "venues": venues_out,
+        "source": "sql",
+    }

--- a/tests/test_core_search.py
+++ b/tests/test_core_search.py
@@ -1,0 +1,106 @@
+"""Unit tests for core.search (BR-CODE-1 extraction of the SQL-only search path).
+
+No live DB / FastAPI — drives search_sql_only against a tiny programmable fake
+that records the tables it touched and returns preloaded rows per table.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from core.search import _escape_ilike, search_sql_only  # noqa: E402
+
+
+# ---------- _escape_ilike ----------
+
+def test_escape_ilike_escapes_wildcards():
+    # %, _ and backslash are PostgREST ILIKE wildcards → must be backslash-escaped
+    # so a user-supplied "%" can't become a match-everything pattern.
+    assert _escape_ilike("50% off") == "50\\% off"
+    assert _escape_ilike("a_b") == "a\\_b"
+    assert _escape_ilike("c\\d") == "c\\\\d"
+
+
+def test_escape_ilike_plain_passthrough():
+    assert _escape_ilike("Knicks") == "Knicks"
+
+
+# ---------- search_sql_only ----------
+
+class _Chain:
+    def __init__(self, rows):
+        self._rows = rows
+    # every builder method returns self
+    def __getattr__(self, _name):
+        def _m(*_a, **_k):
+            return self
+        return _m
+    def execute(self):
+        return type("_R", (), {"data": self._rows})()
+
+
+class _DB:
+    def __init__(self, by_table):
+        self._by_table = by_table
+        self.touched: list[str] = []
+    def table(self, name):
+        self.touched.append(name)
+        return _Chain(self._by_table.get(name, []))
+
+
+def test_search_sql_only_blank_query_short_circuits():
+    db = _DB({})
+    out = search_sql_only(db, "  ,.()  ", 10)  # all stripped → empty
+    assert out == {"events": [], "performers": [], "venues": [], "source": "sql"}
+    assert db.touched == []  # never hit the DB
+
+
+def test_search_sql_only_shape_and_owned_bias():
+    # Two events match; only the second is owned. Owned must sort first even
+    # though the unowned one is sooner.
+    db = _DB({
+        "events": [
+            {"id": 1, "name": "Reno Aces", "occurs_at_local": "2026-05-01",
+             "venue_name": "Greater Nevada", "venue_location": "Reno, NV"},
+            {"id": 2, "name": "Las Vegas Aces", "occurs_at_local": "2026-05-17",
+             "venue_name": "Michelob Arena", "venue_location": "Las Vegas, NV"},
+        ],
+        "latest_event_metrics": [
+            {"event_id": 2, "owned_tickets_count": 12, "retail_min": 95},
+        ],
+        "event_lifecycle": [
+            {"event_id": 1, "is_active": True},
+            {"event_id": 2, "is_active": True},
+        ],
+        "performer_metadata": [
+            {"performer_id": 50, "name": "Las Vegas Aces", "espn_league": "WNBA"},
+        ],
+    })
+    out = search_sql_only(db, "aces", 10)
+    assert out["source"] == "sql"
+    # owned (id 2) sorts ahead of unowned (id 1)
+    assert [e["id"] for e in out["events"]] == [2, 1]
+    assert out["events"][0]["we_own"] is True
+    assert out["events"][0]["from_price"] == 95
+    assert out["events"][1]["we_own"] is False
+    assert out["performers"][0]["league"] == "WNBA"
+
+
+def test_search_sql_only_drops_speculative_and_inactive():
+    db = _DB({
+        "events": [
+            {"id": 1, "name": "Knicks (If Necessary)", "occurs_at_local": "2026-05-01"},
+            {"id": 2, "name": "Knicks vs Celtics", "occurs_at_local": "2026-05-02"},
+            {"id": 3, "name": "Celtics game", "occurs_at_local": "2026-05-03"},
+        ],
+        "latest_event_metrics": [],
+        "event_lifecycle": [{"event_id": 3, "is_active": False}],  # 3 is a ghost
+    })
+    out = search_sql_only(db, "knicks", 10)
+    ids = [e["id"] for e in out["events"]]
+    assert 1 not in ids   # speculative "(If Necessary)" dropped
+    assert 3 not in ids   # inactive/ghost dropped
+    assert ids == [2]


### PR DESCRIPTION
## BR-CODE-1 — extract the SQL-only search path

Moves `_search_sql_only` out of `app.py` into a new `core/search.py`.

### Extracted
- `search_sql_only` (the entry) + its search-exclusive `_escape_ilike` helper and `_ILIKE_WILDCARDS` constant.
- Self-contained: takes a live `db` client, depends outward only on `core.helpers` (`is_speculative_event_name`, `or_ilike_clause`).

### Wiring
- `app.py` imports `search_sql_only` aliased to the historical `_search_sql_only`; the 3 call sites are unchanged.

### Tests
- New `tests/test_core_search.py` (5 unit tests, fake db): `_escape_ilike` wildcard escaping, blank-query short-circuit (asserts no DB hit), owned-inventory sort bias, and speculative/inactive-event dropping.

### Result
- `app.py` 6965 → **6812 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_