### PR TITLE
refactor(a1): lift clean_opt_url + tevo_runtime_to_http to core/helpers (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,6 +228,8 @@ from core.broker_helpers import bulk_performer_assets as _bulk_performer_assets 
 from core.broker_helpers import bulk_event_context as _bulk_event_context  # noqa: E402
 from core.movers import compute_movers as _compute_movers  # noqa: E402
 from core.search import search_sql_only as _search_sql_only  # noqa: E402
+from core.helpers import clean_opt_url as _clean_opt_url  # noqa: E402
+from core.helpers import tevo_runtime_to_http as _tevo_runtime_to_http  # noqa: E402
 
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
@@ -4389,21 +4391,8 @@ def _is_tbd(name: str | None) -> bool:
     )
 
 
-def _clean_opt_url(v) -> str | None:
-    """Coerce sentinel non-URLs to real None.
-
-    `v_event_seating_chart` (and occasionally TEvo's inline config) carry the
-    literal string "null" / "None" / "" for an absent seat-map URL. Passed
-    through verbatim, the frontend treats the truthy string "null" as a URL
-    and renders a broken <img> whose src resolves to /store/event/null. Coerce
-    those sentinels to None so the no-chart placeholder path is taken.
-    """
-    if v is None:
-        return None
-    s = str(v).strip()
-    if s.lower() in ("null", "none", ""):
-        return None
-    return v
+# _clean_opt_url + _tevo_runtime_to_http (+ _TEVO_STATUS_RE) -> core/helpers.py
+# (BR-CODE-1 shared event/listings layer). Imported (aliased) near the top.
 
 
 def _search_cache_get(key: str) -> dict | None:
@@ -5600,29 +5589,9 @@ def _fetch_owned_ticket_groups(
     return groups, "live"
 
 
-# Map an EvoClient RuntimeError to a semantically correct HTTP status.
-# evo_client raises RuntimeError("TEvo API returned <code>") for a non-2xx
-# upstream response, or "TEvo API returned no response" for a connection/
-# timeout/DNS failure. A 400/404 from TEvo means the event id doesn't
-# resolve → that's a client-facing 404 (Not Found), NOT a gateway error.
-# Everything else (5xx, no-response) is a genuine upstream failure → 502;
-# 429/503 surface as 503 so callers/crawlers back off ("try again") rather
-# than treating it as a hard gateway break. Never echoes upstream body/URL —
-# only the mapped status + a caller-supplied generic detail reach the client
-# (the evo_client already scrubbed everything but the status into the message).
-_TEVO_STATUS_RE = re.compile(r"\b(\d{3})\b")
-
-
-def _tevo_runtime_to_http(
-    e: Exception, *, not_found_detail: str, failure_detail: str
-) -> HTTPException:
-    m = _TEVO_STATUS_RE.search(str(e))
-    upstream = int(m.group(1)) if m else None
-    if upstream in (400, 404):
-        return HTTPException(404, not_found_detail)
-    if upstream in (429, 503):
-        return HTTPException(503, failure_detail)
-    return HTTPException(502, failure_detail)
+# _tevo_runtime_to_http (maps an EvoClient RuntimeError to a 404/503/502) +
+# _TEVO_STATUS_RE moved to core/helpers.py (BR-CODE-1 shared event/listings
+# layer). Imported (aliased) near the top of this module.
 
 
 def _resolve_event_with_filters(event_id: int, filters: dict, include_inactive: bool = False) -> dict:

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import re
 from datetime import datetime
 
+from fastapi import HTTPException
+
 
 def listings_cadence_seconds(occurs_at_local: str | None) -> int:
     """Mirror collect-listings cron windows: closer events poll faster."""
@@ -151,3 +153,39 @@ def classify_world_cup(event_name: str | None,
     if not event_name:
         return False
     return bool(_WORLD_CUP_RE.search(event_name))
+
+
+def clean_opt_url(v) -> str | None:
+    """Coerce sentinel non-URLs to real None.
+
+    `v_event_seating_chart` (and occasionally TEvo's inline config) carry the
+    literal string "null" / "None" / "" for an absent seat-map URL. Passed
+    through verbatim, the frontend treats the truthy string "null" as a URL
+    and renders a broken <img> whose src resolves to /store/event/null. Coerce
+    those sentinels to None so the no-chart placeholder path is taken.
+    """
+    if v is None:
+        return None
+    s = str(v).strip()
+    if s.lower() in ("null", "none", ""):
+        return None
+    return v
+
+
+# A 3-digit run in a TEvo client exception message — used to recover the
+# upstream HTTP status so the route can map it to the right downstream code.
+_TEVO_STATUS_RE = re.compile(r"\b(\d{3})\b")
+
+
+def tevo_runtime_to_http(
+    e: Exception, *, not_found_detail: str, failure_detail: str
+) -> HTTPException:
+    """Map a TEvo client runtime error to the right HTTPException: upstream
+    400/404 -> 404 (event gone), 429/503 -> 503 (retryable), else 502."""
+    m = _TEVO_STATUS_RE.search(str(e))
+    upstream = int(m.group(1)) if m else None
+    if upstream in (400, 404):
+        return HTTPException(404, not_found_detail)
+    if upstream in (429, 503):
+        return HTTPException(503, failure_detail)
+    return HTTPException(502, failure_detail)

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from core.helpers import (  # noqa: E402
     classify_playoff, delta, listings_cadence_seconds,
     or_ilike_clause, is_speculative_event_name, classify_world_cup,
+    clean_opt_url, tevo_runtime_to_http,
 )
 from core.broker_helpers import bulk_performer_assets, bulk_event_context  # noqa: E402
 
@@ -212,3 +213,38 @@ def test_classify_world_cup_name_regex_fallback():
     assert classify_world_cup("World Cup Group Stage - Match 12") is True
     assert classify_world_cup("Knicks vs Celtics") is False
     assert classify_world_cup(None) is False
+
+
+# ---------- clean_opt_url ----------
+
+def test_clean_opt_url_coerces_sentinels():
+    for sentinel in ("null", "None", "  NULL ", "", "  "):
+        assert clean_opt_url(sentinel) is None
+    assert clean_opt_url(None) is None
+
+
+def test_clean_opt_url_passes_real_urls():
+    assert clean_opt_url("https://x/chart.png") == "https://x/chart.png"
+
+
+# ---------- tevo_runtime_to_http ----------
+
+def test_tevo_runtime_to_http_status_mapping():
+    mk = lambda e: tevo_runtime_to_http(e, not_found_detail="nf", failure_detail="fail")
+    # 400/404 -> 404
+    assert mk(RuntimeError("TEvo API returned 404")).status_code == 404
+    assert mk(RuntimeError("TEvo API returned 400")).status_code == 404
+    # 429/503 -> 503 (retryable)
+    assert mk(RuntimeError("TEvo API returned 429")).status_code == 503
+    assert mk(RuntimeError("TEvo API returned 503")).status_code == 503
+    # other 5xx -> 502
+    assert mk(RuntimeError("TEvo API returned 500")).status_code == 502
+    # no status in message (connection/DNS) -> 502
+    assert mk(RuntimeError("TEvo API returned no response")).status_code == 502
+
+
+def test_tevo_runtime_to_http_carries_details():
+    nf = tevo_runtime_to_http(RuntimeError("404"), not_found_detail="gone", failure_detail="oops")
+    assert nf.detail == "gone"
+    fail = tevo_runtime_to_http(RuntimeError("500"), not_found_detail="gone", failure_detail="oops")
+    assert fail.detail == "oops"


### PR DESCRIPTION
## BR-CODE-1 — shared event/listings layer, slice 1

Groundwork for eventually extracting `_resolve_event_with_filters`: lift the pure, widely-shared leaf helpers into `core/` first (the same de-coupling strategy that worked for the movers engine).

### Extracted (both pure)
- `clean_opt_url` — coerce `"null"` / `"none"` / `""` sentinel URLs → `None` (4 call sites across the event-detail/store surface)
- `tevo_runtime_to_http` (+ `_TEVO_STATUS_RE`) — map an `EvoClient` RuntimeError to 404/503/502 by upstream status (needs only `re` + `fastapi.HTTPException`, now imported by `core/helpers`)

### Wiring
- `app.py` imports them aliased to the historical `_`-prefixed names, so all call sites + the existing `test_store_events` `app_module._clean_opt_url` access keep resolving.

### Tests
- 4 new unit tests in `tests/test_core_helpers.py`: `clean_opt_url` sentinel coercion; `tevo_runtime_to_http` status mapping (404/503/502) + detail passthrough.

### Result
- `app.py` 6812 → **6781 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_