### PR TITLE
refactor(a1): lift _csv + _normalize_filters to core/helpers (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -230,6 +230,7 @@ from core.movers import compute_movers as _compute_movers  # noqa: E402
 from core.search import search_sql_only as _search_sql_only  # noqa: E402
 from core.helpers import clean_opt_url as _clean_opt_url  # noqa: E402
 from core.helpers import tevo_runtime_to_http as _tevo_runtime_to_http  # noqa: E402
+from core.helpers import normalize_filters as _normalize_filters  # noqa: E402
 
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
@@ -5241,8 +5242,8 @@ def _section_sort_key(s: str) -> tuple:
     return (1, int(digits) if digits else 0, s.lower())
 
 
-def _csv(v: str | None) -> list[str]:
-    return [s.strip() for s in (v or "").split(",") if s.strip()]
+# _csv + _normalize_filters -> core/helpers.py (BR-CODE-1 shared event/listings
+# layer); imported (aliased) near the top of this module.
 
 
 def _build_zone_resolver(performer_id: int | None, venue_id: int | None):
@@ -5278,37 +5279,7 @@ def _build_zone_resolver(performer_id: int | None, venue_id: int | None):
     return resolve
 
 
-def _normalize_filters(raw: dict | None) -> dict:
-    """Coerce a free-form filter dict (URL params or share_links.filters JSON)
-    into the canonical shape the resolver expects. Drops empty values."""
-    raw = raw or {}
-    def _maybe_csv(v):
-        if v is None:
-            return []
-        if isinstance(v, list):
-            return [str(x).strip() for x in v if str(x).strip()]
-        return _csv(str(v))
-    def _maybe_num(v):
-        if v is None or v == "":
-            return None
-        try:
-            return float(v)
-        except (TypeError, ValueError):
-            return None
-    def _maybe_int(v):
-        if v is None or v == "":
-            return None
-        try:
-            return int(v)
-        except (TypeError, ValueError):
-            return None
-    return {
-        "section": _maybe_csv(raw.get("section")),
-        "zones": _maybe_csv(raw.get("zones")),
-        "min_price": _maybe_num(raw.get("min_price")),
-        "max_price": _maybe_num(raw.get("max_price")),
-        "min_qty": _maybe_int(raw.get("min_qty")),
-    }
+# _normalize_filters -> core/helpers.py (BR-CODE-1); imported (aliased) at top.
 
 
 def _fire_canonical_refresh(event_id: int, ev: dict) -> None:

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -189,3 +189,41 @@ def tevo_runtime_to_http(
     if upstream in (429, 503):
         return HTTPException(503, failure_detail)
     return HTTPException(502, failure_detail)
+
+
+def csv_list(v: str | None) -> list[str]:
+    """Split a comma-separated string into a trimmed, empties-dropped list."""
+    return [s.strip() for s in (v or "").split(",") if s.strip()]
+
+
+def normalize_filters(raw: dict | None) -> dict:
+    """Coerce a free-form filter dict (URL params or share_links.filters JSON)
+    into the canonical shape the resolver expects. Drops empty values."""
+    raw = raw or {}
+    def _maybe_csv(v):
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return [str(x).strip() for x in v if str(x).strip()]
+        return csv_list(str(v))
+    def _maybe_num(v):
+        if v is None or v == "":
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+    def _maybe_int(v):
+        if v is None or v == "":
+            return None
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+    return {
+        "section": _maybe_csv(raw.get("section")),
+        "zones": _maybe_csv(raw.get("zones")),
+        "min_price": _maybe_num(raw.get("min_price")),
+        "max_price": _maybe_num(raw.get("max_price")),
+        "min_qty": _maybe_int(raw.get("min_qty")),
+    }

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -248,3 +248,36 @@ def test_tevo_runtime_to_http_carries_details():
     assert nf.detail == "gone"
     fail = tevo_runtime_to_http(RuntimeError("500"), not_found_detail="gone", failure_detail="oops")
     assert fail.detail == "oops"
+
+
+# ---------- csv_list + normalize_filters ----------
+
+def test_csv_list_trims_and_drops_empties():
+    from core.helpers import csv_list
+    assert csv_list("a, b ,,c") == ["a", "b", "c"]
+    assert csv_list(None) == []
+    assert csv_list("") == []
+
+
+def test_normalize_filters_canonical_shape():
+    from core.helpers import normalize_filters
+    out = normalize_filters({
+        "section": "100, 200",
+        "zones": ["Lower", " ", "Club"],
+        "min_price": "50", "max_price": "", "min_qty": "2",
+    })
+    assert out == {
+        "section": ["100", "200"],
+        "zones": ["Lower", "Club"],
+        "min_price": 50.0, "max_price": None, "min_qty": 2,
+    }
+
+
+def test_normalize_filters_empty_and_bad_values():
+    from core.helpers import normalize_filters
+    out = normalize_filters(None)
+    assert out == {"section": [], "zones": [], "min_price": None,
+                   "max_price": None, "min_qty": None}
+    # non-numeric price / qty coerce to None, not raise
+    bad = normalize_filters({"min_price": "abc", "min_qty": "x"})
+    assert bad["min_price"] is None and bad["min_qty"] is None


### PR DESCRIPTION
## BR-CODE-1 — shared event/listings layer, slice 2

Moves the filter-normalization helpers out of `app.py` into `core/helpers.py`.

### Extracted (both pure)
- `csv_list` (was `_csv`) — trimmed comma-split, empties dropped
- `normalize_filters` — coerce a free-form filter dict (URL params / `share_links` JSON) into the resolver's canonical shape (its `_maybe_csv`/`_maybe_num`/`_maybe_int` are nested-local, so they travel with it)

### Note on `_csv`
`_csv`'s only caller was `_normalize_filters` (the earlier ref-count was inflated by the `_maybe_csv` substring). Once both move, `app.py` no longer needs `_csv`, so the alias import is **dropped rather than left dead**. `app.py` imports `normalize_filters` aliased to `_normalize_filters`; its 2 call sites are unchanged.

### Tests
- 3 new unit tests: `csv_list` trim/empties; `normalize_filters` canonical shape + bad/empty-value coercion to `None`.

### Result
- `app.py` 6781 → **6752 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_