### PR TITLE
refactor(a1): lift _ticket_group_to_listing to core/helpers (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,6 +231,7 @@ from core.search import search_sql_only as _search_sql_only  # noqa: E402
 from core.helpers import clean_opt_url as _clean_opt_url  # noqa: E402
 from core.helpers import tevo_runtime_to_http as _tevo_runtime_to_http  # noqa: E402
 from core.helpers import normalize_filters as _normalize_filters  # noqa: E402
+from core.helpers import ticket_group_to_listing as _ticket_group_to_listing  # noqa: E402
 
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
@@ -3950,25 +3951,8 @@ def seatdata_sync_sales(
 # /v9/ticket_groups?owned=true for live inventory; the catalog page uses
 # event_metrics.owned_tickets_count > 0 to find events worth listing.
 
-def _ticket_group_to_listing(tg: dict) -> dict:
-    """Reduce a TEvo ticket_group payload to the public-safe fields a buyer
-    needs. Strips wholesale price, signature, office/brokerage attribution."""
-    return {
-        "id": tg.get("id"),
-        "section": tg.get("section"),
-        "row": tg.get("row"),
-        "available_quantity": tg.get("available_quantity") or tg.get("quantity"),
-        "splits": tg.get("splits") or [],
-        "retail_price": tg.get("retail_price"),
-        "format": tg.get("format"),
-        "type": tg.get("type") or "event",
-        "in_hand": tg.get("in_hand"),
-        "in_hand_on": tg.get("in_hand_on"),
-        "instant_delivery": tg.get("instant_delivery"),
-        "public_notes": tg.get("public_notes"),
-        "view_type": tg.get("view_type"),
-        "wheelchair": tg.get("wheelchair"),
-    }
+# _ticket_group_to_listing -> core/helpers.py (BR-CODE-1 shared event/listings
+# layer; pure dict reshape). Imported (aliased) near the top of this module.
 
 
 # Our TEvo brokerage's office id. Resolved via probe `/v9/orders` (probe v2,

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -227,3 +227,24 @@ def normalize_filters(raw: dict | None) -> dict:
         "max_price": _maybe_num(raw.get("max_price")),
         "min_qty": _maybe_int(raw.get("min_qty")),
     }
+
+
+def ticket_group_to_listing(tg: dict) -> dict:
+    """Reduce a TEvo ticket_group payload to the public-safe fields a buyer
+    needs. Strips wholesale price, signature, office/brokerage attribution."""
+    return {
+        "id": tg.get("id"),
+        "section": tg.get("section"),
+        "row": tg.get("row"),
+        "available_quantity": tg.get("available_quantity") or tg.get("quantity"),
+        "splits": tg.get("splits") or [],
+        "retail_price": tg.get("retail_price"),
+        "format": tg.get("format"),
+        "type": tg.get("type") or "event",
+        "in_hand": tg.get("in_hand"),
+        "in_hand_on": tg.get("in_hand_on"),
+        "instant_delivery": tg.get("instant_delivery"),
+        "public_notes": tg.get("public_notes"),
+        "view_type": tg.get("view_type"),
+        "wheelchair": tg.get("wheelchair"),
+    }

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -281,3 +281,32 @@ def test_normalize_filters_empty_and_bad_values():
     # non-numeric price / qty coerce to None, not raise
     bad = normalize_filters({"min_price": "abc", "min_qty": "x"})
     assert bad["min_price"] is None and bad["min_qty"] is None
+
+
+# ---------- ticket_group_to_listing ----------
+
+def test_ticket_group_to_listing_public_safe_projection():
+    from core.helpers import ticket_group_to_listing
+    tg = {
+        "id": 7, "section": "104", "row": "G", "quantity": 4,
+        "retail_price": 220, "wholesale_price": 150,   # wholesale must be dropped
+        "signature": "broker-sig", "office_id": 42029,  # attribution must be dropped
+        "in_hand": True, "public_notes": "aisle",
+    }
+    out = ticket_group_to_listing(tg)
+    # public-safe fields kept
+    assert out["id"] == 7 and out["section"] == "104" and out["retail_price"] == 220
+    # quantity falls back into available_quantity
+    assert out["available_quantity"] == 4
+    # wholesale / signature / office attribution never leak
+    assert "wholesale_price" not in out
+    assert "signature" not in out
+    assert "office_id" not in out
+
+
+def test_ticket_group_to_listing_defaults():
+    from core.helpers import ticket_group_to_listing
+    out = ticket_group_to_listing({})
+    assert out["type"] == "event"   # default
+    assert out["splits"] == []      # default
+    assert out["available_quantity"] is None


### PR DESCRIPTION
## BR-CODE-1 — shared event/listings layer, slice 3

Moves the public-safe ticket_group projection out of `app.py` into `core/helpers.py`.

### Extracted (pure)
- `ticket_group_to_listing` — reduce a TEvo ticket_group to buyer-safe fields (strips wholesale price, signature, office/brokerage attribution)

Pure dict reshape, **zero deps** — the `_OFFICE_ID` flag noted in the earlier survey was a false match against the adjacent `TEVO_OFFICE_ID` block, which this function does not use. `app.py` imports it aliased to `_ticket_group_to_listing`; its 2 call sites are unchanged.

### Tests
- 2 new unit tests: public-safe projection asserting `wholesale_price`/`signature`/`office_id` never leak + the `quantity → available_quantity` fallback; default `type`/`splits`.

### Result
- `app.py` 6752 → **6736 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_