### PR TITLE
refactor(a1): lift 6 pure utility helpers (coercion + geo) to core/helpers (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -232,6 +232,12 @@ from core.helpers import clean_opt_url as _clean_opt_url  # noqa: E402
 from core.helpers import tevo_runtime_to_http as _tevo_runtime_to_http  # noqa: E402
 from core.helpers import normalize_filters as _normalize_filters  # noqa: E402
 from core.helpers import ticket_group_to_listing as _ticket_group_to_listing  # noqa: E402
+from core.helpers import parse_iso_or_none as _parse_iso_or_none  # noqa: E402
+from core.helpers import to_int_or_none as _to_int_or_none  # noqa: E402
+from core.helpers import to_num_or_none as _to_num_or_none  # noqa: E402
+from core.helpers import haversine_miles as _haversine_miles  # noqa: E402
+from core.helpers import venue_tokens as _venue_tokens  # noqa: E402
+from core.helpers import venue_overlap as _venue_overlap  # noqa: E402
 
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
@@ -2403,27 +2409,7 @@ def admin_seed_home_venues(league: str, _=Depends(require_auth)):
 #
 # RULE 2 compliant — every TEvo call is GET via the read-only client.
 
-def _venue_tokens(name: str) -> set[str]:
-    """Crude venue-name token bag for fuzzy match. Strips 'Parking' suffix
-    so 'Citi Field Parking' matches 'Citi Field'."""
-    if not name:
-        return set()
-    n = name.lower().replace(" parking", "").replace("parking", "")
-    return {tok for tok in re.split(r"[^a-z0-9]+", n) if len(tok) >= 3}
-
-
-def _venue_overlap(a: str, b: str) -> float:
-    """Jaccard overlap between two venue names. 1.0 = identical, 0 = nothing
-    in common. ~0.5 typically indicates a real match (e.g. 'Daikin Park'
-    vs 'Daikin Park Houston')."""
-    ta, tb = _venue_tokens(a), _venue_tokens(b)
-    if not ta or not tb:
-        return 0.0
-    inter = ta & tb
-    union = ta | tb
-    return len(inter) / len(union) if union else 0.0
-
-
+# _venue_tokens + _venue_overlap -> core/helpers.py (BR-CODE-1 pure-utility pass); aliased at top.
 def _upsert_tevo_event_into_events(db, ev: dict) -> int | None:
     """Upsert a TEvo event-detail dict into our `events` table. Returns the
     event id if upserted, None otherwise."""
@@ -3497,34 +3483,7 @@ def _require_cron_or_auth(authorization: str | None, x_cron_secret: str | None):
     return require_auth(authorization)
 
 
-def _parse_iso_or_none(s):
-    if not s:
-        return None
-    try:
-        # TEvo emits 'Z' suffix; Python 3.11+ fromisoformat handles it
-        return s.replace("Z", "+00:00") if isinstance(s, str) and s.endswith("Z") else s
-    except Exception:
-        return None
-
-
-def _to_int_or_none(v):
-    if v is None or v == "":
-        return None
-    try:
-        return int(v)
-    except (TypeError, ValueError):
-        return None
-
-
-def _to_num_or_none(v):
-    if v is None or v == "":
-        return None
-    try:
-        return float(v)
-    except (TypeError, ValueError):
-        return None
-
-
+# _parse_iso_or_none + _to_int_or_none + _to_num_or_none -> core/helpers.py (BR-CODE-1); aliased at top.
 def _flatten_order(order: dict) -> dict:
     """Project a TEvo /v9/orders row to our evo_orders schema."""
     buyer = order.get("buyer") or {}
@@ -4190,16 +4149,7 @@ def store_events(
     return {"count": len(out), "events": out, "limit": cap, "offset": offset}
 
 
-def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Great-circle distance in miles between two (lat,lon) pairs."""
-    R_MI = 3958.7613  # Earth's mean radius in miles
-    lat1r, lat2r = math.radians(lat1), math.radians(lat2)
-    dlat = lat2r - lat1r
-    dlon = math.radians(lon2 - lon1)
-    a = math.sin(dlat / 2) ** 2 + math.cos(lat1r) * math.cos(lat2r) * math.sin(dlon / 2) ** 2
-    return 2 * R_MI * math.asin(math.sqrt(a))
-
-
+# _haversine_miles -> core/helpers.py (BR-CODE-1 pure-utility pass); aliased at top.
 def _attach_owned_metadata(
     db,
     candidate_ids: list[int],

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -6,6 +6,7 @@ core, never reverse). Moved verbatim from app.py.
 """
 from __future__ import annotations
 
+import math
 import re
 from datetime import datetime
 
@@ -248,3 +249,70 @@ def ticket_group_to_listing(tg: dict) -> dict:
         "view_type": tg.get("view_type"),
         "wheelchair": tg.get("wheelchair"),
     }
+
+
+# ---- numeric / date coercion (lenient: bad input -> None, never raises) ----
+
+def parse_iso_or_none(s):
+    """Normalize a TEvo ISO timestamp's 'Z' suffix to '+00:00' (Python 3.11+
+    fromisoformat handles the rest). Returns None for falsy/bad input."""
+    if not s:
+        return None
+    try:
+        # TEvo emits 'Z' suffix; Python 3.11+ fromisoformat handles it
+        return s.replace("Z", "+00:00") if isinstance(s, str) and s.endswith("Z") else s
+    except Exception:
+        return None
+
+
+def to_int_or_none(v):
+    """int(v) or None — empty/None/uncoercible -> None, never raises."""
+    if v is None or v == "":
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def to_num_or_none(v):
+    """float(v) or None — empty/None/uncoercible -> None, never raises."""
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---- geo / venue-name fuzzy matching ----
+
+def haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in miles between two (lat,lon) pairs."""
+    R_MI = 3958.7613  # Earth's mean radius in miles
+    lat1r, lat2r = math.radians(lat1), math.radians(lat2)
+    dlat = lat2r - lat1r
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1r) * math.cos(lat2r) * math.sin(dlon / 2) ** 2
+    return 2 * R_MI * math.asin(math.sqrt(a))
+
+
+def venue_tokens(name: str) -> set[str]:
+    """Crude venue-name token bag for fuzzy match. Strips 'Parking' suffix
+    so 'Citi Field Parking' matches 'Citi Field'."""
+    if not name:
+        return set()
+    n = name.lower().replace(" parking", "").replace("parking", "")
+    return {tok for tok in re.split(r"[^a-z0-9]+", n) if len(tok) >= 3}
+
+
+def venue_overlap(a: str, b: str) -> float:
+    """Jaccard overlap between two venue names. 1.0 = identical, 0 = nothing
+    in common. ~0.5 typically indicates a real match (e.g. 'Daikin Park'
+    vs 'Daikin Park Houston')."""
+    ta, tb = venue_tokens(a), venue_tokens(b)
+    if not ta or not tb:
+        return 0.0
+    inter = ta & tb
+    union = ta | tb
+    return len(inter) / len(union) if union else 0.0

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -310,3 +310,55 @@ def test_ticket_group_to_listing_defaults():
     assert out["type"] == "event"   # default
     assert out["splits"] == []      # default
     assert out["available_quantity"] is None
+
+
+# ---------- coercion: parse_iso_or_none / to_int_or_none / to_num_or_none ----------
+
+def test_to_int_or_none():
+    from core.helpers import to_int_or_none
+    assert to_int_or_none("42") == 42
+    assert to_int_or_none(7) == 7
+    assert to_int_or_none("") is None
+    assert to_int_or_none(None) is None
+    assert to_int_or_none("abc") is None
+
+
+def test_to_num_or_none():
+    from core.helpers import to_num_or_none
+    assert to_num_or_none("19.95") == 19.95
+    assert to_num_or_none("") is None
+    assert to_num_or_none("x") is None
+
+
+def test_parse_iso_or_none_z_suffix():
+    from core.helpers import parse_iso_or_none
+    assert parse_iso_or_none("2026-05-01T00:00:00Z") == "2026-05-01T00:00:00+00:00"
+    assert parse_iso_or_none("2026-05-01T00:00:00+00:00") == "2026-05-01T00:00:00+00:00"
+    assert parse_iso_or_none(None) is None
+    assert parse_iso_or_none("") is None
+
+
+# ---------- geo / venue matching ----------
+
+def test_haversine_miles_known_distance():
+    from core.helpers import haversine_miles
+    # NYC (Times Sq) -> LA (City Hall) is ~2450 mi; allow generous tolerance
+    d = haversine_miles(40.758, -73.985, 34.054, -118.243)
+    assert 2400 < d < 2500
+    # identical points -> 0
+    assert haversine_miles(40.0, -73.0, 40.0, -73.0) == 0
+
+
+def test_venue_tokens_strips_parking_and_short_tokens():
+    from core.helpers import venue_tokens
+    assert venue_tokens("Citi Field Parking") == {"citi", "field"}
+    assert venue_tokens("") == set()
+
+
+def test_venue_overlap_jaccard():
+    from core.helpers import venue_overlap
+    assert venue_overlap("Daikin Park", "Daikin Park") == 1.0
+    # "Daikin Park" {daikin,park} vs "Daikin Park Houston" {daikin,park,houston} = 2/3
+    assert abs(venue_overlap("Daikin Park", "Daikin Park Houston") - 2/3) < 1e-9
+    assert venue_overlap("Citi Field", "Yankee Stadium") == 0.0
+    assert venue_overlap("", "Citi Field") == 0.0


### PR DESCRIPTION
## BR-CODE-1 — pure-utility pass (coercion + geo)

Beyond the resolver cluster: a sweep of the *whole* file surfaced six dependency-free utility helpers still living in `app.py`. Lifts them into `core/helpers.py`.

### Extracted (all pure — `math`/`re`/stdlib only)
**Coercion** (lenient: bad input → `None`, never raises):
- `parse_iso_or_none` — normalize a TEvo `Z` suffix to `+00:00`
- `to_int_or_none` (15 call sites)
- `to_num_or_none` (12 call sites)

**Geo / venue-name fuzzy match:**
- `haversine_miles` — great-circle distance (used by tours-near)
- `venue_tokens` — token bag, strips `Parking`
- `venue_overlap` — Jaccard overlap (depends on `venue_tokens`, travels with it)

### Wiring
- `app.py` imports each aliased to its historical `_`-prefixed name; every call site is unchanged. Adds `import math` to `core/helpers`.

### Tests
- 6 new unit tests: int/num/iso coercion incl. bad-input→`None`; haversine NYC→LA distance + identical-point zero; venue token/parking strip + Jaccard ratios.

### Result
- `app.py` 6736 → **6686 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_