### PR TITLE
refactor(a1): lift tour_dates + share_to_dict + flatten_order_items to core/helpers (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,6 +245,9 @@ from core.helpers import normalize_search_key as _normalize_search_key  # noqa: 
 from core.helpers import is_tbd as _is_tbd  # noqa: E402
 from core.helpers import section_sort_key as _section_sort_key  # noqa: E402
 from core.helpers import is_bowl_pattern_name as _is_bowl_pattern_name  # noqa: E402
+from core.helpers import tour_dates as _tour_dates  # noqa: E402
+from core.helpers import share_to_dict as _share_to_dict  # noqa: E402
+from core.helpers import flatten_order_items as _flatten_order_items  # noqa: E402
 
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
@@ -1184,12 +1187,7 @@ def broker_performer_trip_plan(
 
 
 # _clean_section -> core/helpers.py (BR-CODE-1); aliased at top.
-def _tour_dates(days: int):
-    from datetime import date, timedelta
-    start = date.today()
-    return start, start + timedelta(days=max(1, min(int(days), 730)))
-
-
+# _tour_dates -> core/helpers.py (BR-CODE-1 pure-helper pass); aliased at top.
 def _tour_package_payload(performer_id: int, home_lat: float, home_lon: float,
                           qty: int, budget_km: float, home_name: str, days: int,
                           budget_usd: float | None, side: str, clear_at: float,
@@ -3515,42 +3513,7 @@ def _flatten_order(order: dict) -> dict:
     }
 
 
-def _flatten_order_items(order: dict) -> list[dict]:
-    """Project order.items[] into evo_order_items schema, mapping event_id."""
-    out = []
-    for it in (order.get("items") or []):
-        tg = it.get("ticket_group") or {}
-        ev = tg.get("event") or {}
-        venue = ev.get("venue") or {}
-        out.append({
-            "evo_order_id":              _to_int_or_none(order.get("id")),
-            "evo_item_id":               _to_int_or_none(it.get("id")),
-            "quantity":                  _to_int_or_none(it.get("quantity")),
-            "price":                     _to_num_or_none(it.get("price")),
-            "ticket_group_id":           _to_int_or_none(tg.get("id")),
-            "ticket_group_remote_id":    tg.get("remote_id"),
-            "ticket_group_office_id":    _to_int_or_none(tg.get("office_id")),
-            "ticket_group_section":      tg.get("section"),
-            "ticket_group_row":          tg.get("row"),
-            "ticket_group_seats":        tg.get("seats") or [],
-            "ticket_group_quantity":     _to_int_or_none(tg.get("quantity")),
-            "ticket_group_retail_price": _to_num_or_none(tg.get("retail_price")),
-            "ticket_group_wholesale_price": _to_num_or_none(tg.get("wholesale_price")),
-            "ticket_group_external_notes": tg.get("external_notes"),
-            "event_id":                  _to_int_or_none(ev.get("id")),
-            "event_name":                ev.get("name"),
-            "occurs_at":                 _parse_iso_or_none(ev.get("occurs_at")),
-            "venue_id":                  _to_int_or_none(venue.get("id")),
-            "venue_name":                venue.get("name"),
-            "eticket_available":         it.get("eticket_available"),
-            "eticket_delivery":          it.get("eticket_delivery"),
-            "eticket_downloaded_at":     _parse_iso_or_none(it.get("eticket_downloaded_at")) or None,
-            "eticket_downloaded_by":     _to_int_or_none(it.get("eticket_downloaded_by")),
-            "raw":                       it,
-        })
-    return out
-
-
+# _flatten_order_items -> core/helpers.py (BR-CODE-1); aliased at top.
 @app.post("/api/admin/collect-orders")
 def collect_evo_orders(
     max_pages: int = 50,                   # 50 * 10 = 500 orders per tick
@@ -6228,33 +6191,7 @@ def store_terms_page():
 _SHARE_FILTER_KEYS = ("zones", "section", "min_price", "max_price", "min_qty")
 
 
-def _share_to_dict(row: dict) -> dict:
-    """Public-safe representation of a share_links row."""
-    if not row:
-        return {}
-    revoked = row.get("revoked_at")
-    expires = row.get("expires_at")
-    expired = False
-    if expires:
-        try:
-            expired = datetime.fromisoformat(str(expires).replace("Z", "+00:00")) <= datetime.now(timezone.utc)
-        except ValueError:
-            expired = False
-    return {
-        "id": row.get("id"),
-        "url": f"/s/{row.get('id')}",
-        "event_id": row.get("event_id"),
-        "filters": row.get("filters") or {},
-        "note": row.get("note"),
-        "created_at": row.get("created_at"),
-        "expires_at": expires,
-        "revoked_at": revoked,
-        "view_count": row.get("view_count") or 0,
-        "last_viewed_at": row.get("last_viewed_at"),
-        "active": (revoked is None) and (not expired),
-    }
-
-
+# _share_to_dict -> core/helpers.py (BR-CODE-1); aliased at top.
 @app.post("/api/store/share")
 def store_share_create(payload: dict = Body(...), user=Depends(require_auth)):
     """Create a revocable share link for one event with saved filters.

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import math
 import re
-from datetime import datetime
+from datetime import date, datetime, timedelta, timezone
 
 from fastapi import HTTPException
 
@@ -415,3 +415,74 @@ _CONSUMER_ZONE_NAME_RE = re.compile(
 def is_bowl_pattern_name(name: str | None) -> bool:
     """Whether a zone name matches the programmatic bowl-level pattern."""
     return bool(_CONSUMER_ZONE_NAME_RE.match((name or "").strip()))
+
+
+# ---- order / share-link projections + tour date window ----
+
+def tour_dates(days: int):
+    """Return (start_date, end_date) for a tour window, clamped to 1..730 days."""
+    start = date.today()
+    return start, start + timedelta(days=max(1, min(int(days), 730)))
+
+
+def share_to_dict(row: dict) -> dict:
+    """Public-safe representation of a share_links row."""
+    if not row:
+        return {}
+    revoked = row.get("revoked_at")
+    expires = row.get("expires_at")
+    expired = False
+    if expires:
+        try:
+            expired = datetime.fromisoformat(str(expires).replace("Z", "+00:00")) <= datetime.now(timezone.utc)
+        except ValueError:
+            expired = False
+    return {
+        "id": row.get("id"),
+        "url": f"/s/{row.get('id')}",
+        "event_id": row.get("event_id"),
+        "filters": row.get("filters") or {},
+        "note": row.get("note"),
+        "created_at": row.get("created_at"),
+        "expires_at": expires,
+        "revoked_at": revoked,
+        "view_count": row.get("view_count") or 0,
+        "last_viewed_at": row.get("last_viewed_at"),
+        "active": (revoked is None) and (not expired),
+    }
+
+
+def flatten_order_items(order: dict) -> list[dict]:
+    """Project order.items[] into evo_order_items schema, mapping event_id."""
+    out = []
+    for it in (order.get("items") or []):
+        tg = it.get("ticket_group") or {}
+        ev = tg.get("event") or {}
+        venue = ev.get("venue") or {}
+        out.append({
+            "evo_order_id":              to_int_or_none(order.get("id")),
+            "evo_item_id":               to_int_or_none(it.get("id")),
+            "quantity":                  to_int_or_none(it.get("quantity")),
+            "price":                     to_num_or_none(it.get("price")),
+            "ticket_group_id":           to_int_or_none(tg.get("id")),
+            "ticket_group_remote_id":    tg.get("remote_id"),
+            "ticket_group_office_id":    to_int_or_none(tg.get("office_id")),
+            "ticket_group_section":      tg.get("section"),
+            "ticket_group_row":          tg.get("row"),
+            "ticket_group_seats":        tg.get("seats") or [],
+            "ticket_group_quantity":     to_int_or_none(tg.get("quantity")),
+            "ticket_group_retail_price": to_num_or_none(tg.get("retail_price")),
+            "ticket_group_wholesale_price": to_num_or_none(tg.get("wholesale_price")),
+            "ticket_group_external_notes": tg.get("external_notes"),
+            "event_id":                  to_int_or_none(ev.get("id")),
+            "event_name":                ev.get("name"),
+            "occurs_at":                 parse_iso_or_none(ev.get("occurs_at")),
+            "venue_id":                  to_int_or_none(venue.get("id")),
+            "venue_name":                venue.get("name"),
+            "eticket_available":         it.get("eticket_available"),
+            "eticket_delivery":          it.get("eticket_delivery"),
+            "eticket_downloaded_at":     parse_iso_or_none(it.get("eticket_downloaded_at")) or None,
+            "eticket_downloaded_by":     to_int_or_none(it.get("eticket_downloaded_by")),
+            "raw":                       it,
+        })
+    return out

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -417,3 +417,57 @@ def test_is_bowl_pattern_name():
     assert is_bowl_pattern_name("Club (200s)") is True
     assert is_bowl_pattern_name("Section 104") is False
     assert is_bowl_pattern_name(None) is False
+
+
+# ---------- tour_dates / share_to_dict / flatten_order_items ----------
+
+def test_tour_dates_clamps_window():
+    from datetime import date
+    from core.helpers import tour_dates
+    start, end = tour_dates(30)
+    assert start == date.today()
+    assert (end - start).days == 30
+    # clamps: <1 -> 1, >730 -> 730
+    assert (tour_dates(0)[1] - tour_dates(0)[0]).days == 1
+    assert (tour_dates(9999)[1] - tour_dates(9999)[0]).days == 730
+
+
+def test_share_to_dict_active_and_url():
+    from core.helpers import share_to_dict
+    assert share_to_dict({}) == {}
+    out = share_to_dict({"id": "abc", "event_id": 5, "revoked_at": None, "expires_at": None})
+    assert out["url"] == "/s/abc"
+    assert out["active"] is True
+    assert out["view_count"] == 0          # default
+    assert out["filters"] == {}            # default
+
+
+def test_share_to_dict_inactive_when_revoked_or_expired():
+    from core.helpers import share_to_dict
+    assert share_to_dict({"id": "r", "revoked_at": "2026-01-01T00:00:00Z"})["active"] is False
+    assert share_to_dict({"id": "e", "expires_at": "2000-01-01T00:00:00Z"})["active"] is False
+
+
+def test_flatten_order_items_projects_and_coerces():
+    from core.helpers import flatten_order_items
+    order = {"id": "100", "items": [{
+        "id": "7", "quantity": "2", "price": "150.5",
+        "ticket_group": {"id": "9", "office_id": "42029", "section": "104",
+                         "event": {"id": "555", "name": "Knicks",
+                                   "occurs_at": "2026-05-01T00:00:00Z",
+                                   "venue": {"id": "12", "name": "MSG"}}},
+    }]}
+    rows = flatten_order_items(order)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["evo_order_id"] == 100 and r["evo_item_id"] == 7   # coerced to int
+    assert r["price"] == 150.5 and r["quantity"] == 2
+    assert r["event_id"] == 555 and r["venue_name"] == "MSG"
+    assert r["occurs_at"] == "2026-05-01T00:00:00+00:00"        # Z normalized
+    assert r["raw"] is order["items"][0]
+
+
+def test_flatten_order_items_empty():
+    from core.helpers import flatten_order_items
+    assert flatten_order_items({}) == []
+    assert flatten_order_items({"items": []}) == []


### PR DESCRIPTION
## BR-CODE-1 — pure-helper pass (projections + tour window)

Three more dependency-free utilities lifted from `app.py` into `core/helpers.py`.

### Extracted (all pure)
- `tour_dates` — `(start, end)` tour window clamped to 1..730 days
- `share_to_dict` — public-safe `share_links` row (computes `active` from `revoked_at` / `expires_at`)
- `flatten_order_items` — project `order.items[]` into the `evo_order_items` schema; its only deps (`to_int_or_none` / `to_num_or_none` / `parse_iso_or_none`) **already live in `core/helpers`**, so it calls them in-module

Adds `date`/`timedelta`/`timezone` to `core/helpers`' datetime import. `app.py` imports each aliased to its historical `_`-prefixed name; all 7 call sites unchanged.

### Tests
- 5 new unit tests: tour-window clamp; share active/url defaults + revoked/expired → inactive; order-item projection with int/num/iso coercion + `raw` passthrough; empty input.

### Result
- `app.py` 6607 → **6544 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_