### PR TITLE
fix(store): follow-a-tour endpoint degrades gracefully instead of 500

### DIFF
--- a/app.py
+++ b/app.py
@@ -5070,10 +5070,31 @@ def store_performer_tour_package(
     returns the most stops that fit, cheapest seats per show, with the rest of the tour in
     all_stops (so the UI can offer 'add $X for one more'). Budget-first — no location needed.
     Shares the optimizer with the D0 route via `trip_planner`."""
-    return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km, home_name,
-                                 days, budget_usd, side, clear_at, away_margin,
-                                 section_like, prefer_owned, max_events=max_events,
-                                 start_date=start, end_date=end)
+    try:
+        return _tour_package_payload(performer_id, home_lat, home_lon, qty, budget_km, home_name,
+                                     days, budget_usd, side, clear_at, away_margin,
+                                     section_like, prefer_owned, max_events=max_events,
+                                     start_date=start, end_date=end)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        # Consumer-facing endpoint — never surface a raw 500. Log the full traceback
+        # (Render captures stdout) so a real failure is diagnosable, and return a clean
+        # "couldn't build" payload the FE already knows how to render (stops_available=0
+        # + unavailable flag → "try again" message), so a transient never breaks the page.
+        import traceback as _tb
+        print(f"[store_tour_package] performer={performer_id} qty={qty} side={side} "
+              f"budget_usd={budget_usd} failed: {exc!r}")
+        _tb.print_exc()
+        return JSONResponse(content={
+            "mode": "concert",
+            "qty_per_show": max(1, min(int(qty), 50)),
+            "stops_available": 0,
+            "package": {"legs": [], "count": 0, "cities": 0, "travel_km": 0,
+                        "fan_total": 0, "fan_total_bundled": 0},
+            "all_stops": [],
+            "unavailable": True,
+        })
 
 
 @app.get("/api/store/tours/multi")

--- a/static/store/store.js
+++ b/static/store/store.js
@@ -3063,9 +3063,11 @@
         });
       }
       if (!d.stops_available || !pk.count) {
-        $("ftStatus").textContent = isTeam
-          ? `No ${away ? "away" : "home"} games in range — try the other side.`
-          : "No routable tour right now — try a wider budget.";
+        $("ftStatus").textContent = d.unavailable
+          ? "We couldn't build your tour right now — please try again in a moment."
+          : (isTeam
+            ? `No ${away ? "away" : "home"} games in range — try the other side.`
+            : "No routable tour right now — try a wider budget.");
         $("ftResult").hidden = true;
         return;
       }

--- a/tests/test_store_tour_guard.py
+++ b/tests/test_store_tour_guard.py
@@ -1,0 +1,67 @@
+"""The store 'follow a tour' endpoint must never surface a raw 500.
+
+/api/store/performers/{id}/tour-package is consumer-facing. If the planner throws
+(transient DB blip, edge-case data, etc.) the route catches it, logs the traceback,
+and returns a clean stops_available=0 + unavailable=True payload the FE renders as
+"try again" — instead of a 500. Intentional HTTPExceptions still propagate.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("STOREFRONT_SQL_ONLY", "false")
+os.environ.setdefault("TEVO_API_TOKEN", "test-token")
+os.environ.setdefault("TEVO_API_SECRET", "test-secret")
+os.environ.setdefault("SUPABASE_URL", "http://localhost:54321")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
+os.environ.setdefault("AUTH_DISABLED", "true")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+fastapi = pytest.importorskip("fastapi")
+starlette_testclient = pytest.importorskip("fastapi.testclient")
+
+import app as app_module  # noqa: E402
+
+TestClient = starlette_testclient.TestClient
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+def test_planner_exception_degrades_gracefully(client, monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("planner exploded")
+    monkeypatch.setattr(app_module, "_tour_package_payload", boom)
+    r = client.get("/api/store/performers/72393/tour-package?qty=2&budget_usd=1500")
+    assert r.status_code == 200          # never a raw 500
+    body = r.json()
+    assert body["unavailable"] is True
+    assert body["stops_available"] == 0
+    assert body["package"]["count"] == 0
+
+
+def test_intentional_httpexception_still_propagates(client, monkeypatch):
+    from fastapi import HTTPException
+
+    def needs_db(*a, **k):
+        raise HTTPException(status_code=503, detail="db offline")
+    monkeypatch.setattr(app_module, "_tour_package_payload", needs_db)
+    r = client.get("/api/store/performers/72393/tour-package")
+    assert r.status_code == 503          # deliberate errors are not swallowed
+
+
+def test_happy_path_payload_passes_through(client, monkeypatch):
+    sentinel = {"mode": "team_away", "stops_available": 3,
+                "package": {"count": 3, "fan_total_bundled": 420}, "all_stops": []}
+    monkeypatch.setattr(app_module, "_tour_package_payload", lambda *a, **k: sentinel)
+    r = client.get("/api/store/performers/72393/tour-package?qty=2&max_events=3")
+    assert r.status_code == 200
+    assert r.json() == sentinel


### PR DESCRIPTION
## Why

You hit `Error: 500 performers/72393/tour-package` on the live store. I traced it:

- **The planner logic is correct.** I rebuilt the exact failing call (performer 72393 / Inter Miami CF) against **real production data** via a faithful fake-DB — it returns cleanly: **7 stops, $437.68**, mode `team_away`.
- **The queries are healthy** — the `listings_snapshots` fetch for those events runs in **149 ms** (index scan, 6,504 rows); all columns present; `splits` is `int4[]` so `.contains` is valid.

So the 500 was almost certainly the request landing **mid-redeploy** right after #561 merged. But a consumer-facing endpoint should never show a raw 500 regardless — this hardens it.

## What

- **`app.py`** — wrap `store_performer_tour_package`'s planner call:
  - Intentional `HTTPException`s still propagate (e.g. DB offline → 503).
  - Any *other* exception is logged with a full traceback (`[store_tour_package] …` + `traceback.print_exc()` → Render stdout, so a real failure stays diagnosable) and returns a clean `stops_available=0` + `unavailable=True` payload. Broker route untouched.
- **`static/store/store.js`** — when `unavailable=True`, the follow-a-tour page shows *"We couldn't build your tour right now — please try again in a moment."* instead of an error toast.
- **`tests/test_store_tour_guard.py`** — exception → graceful 200 (`unavailable:true`); deliberate `HTTPException` still propagates (503); happy-path payload passes through untouched.

## Testing
- `tests/test_store_tour_guard.py` — 3 passed
- `scripts/check_readonly.py` — RULE 2 clean
- Planner verified against real data (7 stops for the reported performer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6qoikEkdQCPjFsXJZwxTH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6qoikEkdQCPjFsXJZwxTH)_