### PR TITLE
refactor(a1): lift storefront version/base-url derivation to core/config (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,60 +49,9 @@ STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
 # "not deployed" from the operator's perspective for hours after the
 # actual merge — see Round 4 of docs/d1-bot-continues-here audit.
 
-def _build_storefront_version() -> str:
-    """Short-SHA tag used in the `?v=<...>` query string on static asset
-    references inside the served HTML shells.
-
-    Resolution order:
-      1. RENDER_GIT_COMMIT       — auto-set by Render on every deploy.
-      2. RAILWAY_GIT_COMMIT_SHA  — auto-set by Railway on every deploy.
-      3. GIT_COMMIT              — set by some CI workflows; defensive fallback.
-      4. f"dev-{epoch}"          — local dev / unset prod; bumps per container
-         start so a fresh boot always re-fetches even if env wasn't wired.
-
-    Was returning hardcoded "dev" before; Railway audit 2026-05-16 found that
-    every Railway deploy served `?v=dev` (no RENDER_GIT_COMMIT, no GIT_COMMIT)
-    which defeated the cache-bust entirely. Adding Railway env + an epoch
-    fallback restores the invariant.
-    """
-    sha = (os.environ.get("RENDER_GIT_COMMIT")
-           or os.environ.get("RAILWAY_GIT_COMMIT_SHA")
-           or os.environ.get("GIT_COMMIT"))
-    if sha:
-        return sha[:7]
-    # Last-resort: per-container epoch so fresh boots always cache-bust.
-    return f"dev-{int(time.time())}"
-
-
-def _build_storefront_base_url() -> str:
-    """Absolute base URL used in OG share-card tags so previews
-    (iMessage/Slack/WhatsApp/Discord/Twitter) point at THIS deploy, not at
-    a hardcoded sibling deploy. Was hardcoded `vibepass-storefront-test.onrender.com`
-    in static/store/index.html (PR #166) so Railway-shared links previewed
-    the Render service.
-
-    Resolution order:
-      1. STOREFRONT_BASE_URL    — manual override (full URL with scheme).
-      2. RENDER_EXTERNAL_URL    — auto-set by Render to https://<service>.onrender.com.
-      3. RAILWAY_PUBLIC_DOMAIN  — auto-set by Railway to <env>.up.railway.app (no scheme).
-      4. Fallback hardcoded Render URL — preserves prior behavior on unconfigured
-         envs so nothing regresses.
-    """
-    override = os.environ.get("STOREFRONT_BASE_URL")
-    if override:
-        return override.rstrip("/")
-    render_url = os.environ.get("RENDER_EXTERNAL_URL")
-    if render_url:
-        return render_url.rstrip("/")
-    railway_dom = os.environ.get("RAILWAY_PUBLIC_DOMAIN")
-    if railway_dom:
-        dom = railway_dom.strip().removeprefix("https://").removeprefix("http://")
-        return f"https://{dom}"
-    return "https://vibepass-storefront-test.onrender.com"
-
-
-_STOREFRONT_VERSION = _build_storefront_version()
-_STOREFRONT_BASE_URL = _build_storefront_base_url()
+# _build_storefront_version + _build_storefront_base_url (+ the computed
+# _STOREFRONT_VERSION / _STOREFRONT_BASE_URL) -> core/config.py (BR-CODE-1
+# config seam). Imported (aliased) near the top of this module.
 _STOREFRONT_HTML_CACHE: dict[str, str] = {}
 
 
@@ -206,6 +155,16 @@ from core.config import (  # noqa: E402
     STOREFRONT_PREFER_INTERNAL_ZONES, STOREFRONT_RESERVE_REQUIRES_AUTH,
     STOREFRONT_CHECKOUT_DOMAIN, STOREFRONT_CHECKOUT_DISABLED,
     RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY, RECAPTCHA_MIN_SCORE, RECAPTCHA_ENABLED,
+)
+# Storefront deploy identity -> core/config.py (BR-CODE-1 config seam). Aliased
+# to the historical `_`-prefixed names so consumers + the test monkeypatch
+# (app._STOREFRONT_VERSION) + the direct test calls (app._build_storefront_version)
+# all keep resolving the app-module binding.
+from core.config import (  # noqa: E402
+    build_storefront_version as _build_storefront_version,
+    build_storefront_base_url as _build_storefront_base_url,
+    STOREFRONT_VERSION as _STOREFRONT_VERSION,
+    STOREFRONT_BASE_URL as _STOREFRONT_BASE_URL,
 )
 
 # Auth gate moved to core/auth.py (BR-CODE-1 core extraction): require_auth +

--- a/core/config.py
+++ b/core/config.py
@@ -11,6 +11,7 @@ monkeypatched there. Only the pure config values live here.
 from __future__ import annotations
 
 import os
+import time
 
 # ---------- Supabase + cross-cutting ----------
 SUPABASE_URL = os.environ.get("SUPABASE_URL")
@@ -72,3 +73,61 @@ if RECAPTCHA_ENABLED:
     print(f"reCAPTCHA v3 ENABLED — sitewide bot gate active (min score {RECAPTCHA_MIN_SCORE}).")
 else:
     print("reCAPTCHA v3 dormant (RECAPTCHA_SITE_KEY/RECAPTCHA_SECRET_KEY unset) — honeypot + rate limits still active.")
+
+
+# ---------- Storefront deploy identity (version tag + base URL) ----------
+
+def build_storefront_version() -> str:
+    """Short-SHA tag used in the `?v=<...>` query string on static asset
+    references inside the served HTML shells.
+
+    Resolution order:
+      1. RENDER_GIT_COMMIT       — auto-set by Render on every deploy.
+      2. RAILWAY_GIT_COMMIT_SHA  — auto-set by Railway on every deploy.
+      3. GIT_COMMIT              — set by some CI workflows; defensive fallback.
+      4. f"dev-{epoch}"          — local dev / unset prod; bumps per container
+         start so a fresh boot always re-fetches even if env wasn't wired.
+
+    Was returning hardcoded "dev" before; Railway audit 2026-05-16 found that
+    every Railway deploy served `?v=dev` (no RENDER_GIT_COMMIT, no GIT_COMMIT)
+    which defeated the cache-bust entirely. Adding Railway env + an epoch
+    fallback restores the invariant.
+    """
+    sha = (os.environ.get("RENDER_GIT_COMMIT")
+           or os.environ.get("RAILWAY_GIT_COMMIT_SHA")
+           or os.environ.get("GIT_COMMIT"))
+    if sha:
+        return sha[:7]
+    # Last-resort: per-container epoch so fresh boots always cache-bust.
+    return f"dev-{int(time.time())}"
+
+
+def build_storefront_base_url() -> str:
+    """Absolute base URL used in OG share-card tags so previews
+    (iMessage/Slack/WhatsApp/Discord/Twitter) point at THIS deploy, not at
+    a hardcoded sibling deploy. Was hardcoded `vibepass-storefront-test.onrender.com`
+    in static/store/index.html (PR #166) so Railway-shared links previewed
+    the Render service.
+
+    Resolution order:
+      1. STOREFRONT_BASE_URL    — manual override (full URL with scheme).
+      2. RENDER_EXTERNAL_URL    — auto-set by Render to https://<service>.onrender.com.
+      3. RAILWAY_PUBLIC_DOMAIN  — auto-set by Railway to <env>.up.railway.app (no scheme).
+      4. Fallback hardcoded Render URL — preserves prior behavior on unconfigured
+         envs so nothing regresses.
+    """
+    override = os.environ.get("STOREFRONT_BASE_URL")
+    if override:
+        return override.rstrip("/")
+    render_url = os.environ.get("RENDER_EXTERNAL_URL")
+    if render_url:
+        return render_url.rstrip("/")
+    railway_dom = os.environ.get("RAILWAY_PUBLIC_DOMAIN")
+    if railway_dom:
+        dom = railway_dom.strip().removeprefix("https://").removeprefix("http://")
+        return f"https://{dom}"
+    return "https://vibepass-storefront-test.onrender.com"
+
+
+STOREFRONT_VERSION = build_storefront_version()
+STOREFRONT_BASE_URL = build_storefront_base_url()


### PR DESCRIPTION
## BR-CODE-1 — config-coupled helper seam, slice 1

First slice of the config tier (now that the pure-leaf vein is exhausted). Moves the two **env-derived** storefront-identity builders out of `app.py` into `core/config.py` (which already owns env-derivation alongside `STOREFRONT_*` / `RECAPTCHA_*`).

### Extracted (read only `os.environ` + `time`)
- `build_storefront_version` — `?v=` cache-bust short-SHA (`RENDER_GIT_COMMIT` / `RAILWAY_GIT_COMMIT_SHA` / `GIT_COMMIT` → `dev-{epoch}` fallback)
- `build_storefront_base_url` — absolute OG-share base (`STOREFRONT_BASE_URL` / `RENDER_EXTERNAL_URL` / `RAILWAY_PUBLIC_DOMAIN` → hardcoded fallback)
- plus the two values they compute at import: `STOREFRONT_VERSION` / `STOREFRONT_BASE_URL`

### Wiring
`app.py` imports all four aliased to their historical `_`-prefixed names, so every consumer + test access keeps resolving:
- the **4 tests** that call `app._build_storefront_version()` directly,
- the `app._STOREFRONT_VERSION` **monkeypatch** (`test_store_home`),
- the `version_json` route assertion (`test_public_infra_routes`).

Adds `import time` to `core/config`.

### Result
- `app.py` 6689 → **6648 LOC**.
- Behavior already covered by the existing storefront-version tests (via the app alias) — no redundant core tests added. Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_