### PR TITLE
feat(d0): add dedicated AXS events tab

### DIFF
--- a/routers/axs.py
+++ b/routers/axs.py
@@ -16,6 +16,69 @@ from fastapi import APIRouter, Depends
 def build_axs_router(get_require_sb: Callable[[], Callable], require_auth: Callable) -> APIRouter:
     router = APIRouter()
 
+    @router.get("/api/axs/events")
+    def axs_events(active: bool = True, limit: int = 500, _=Depends(require_auth)):
+        """All AXS events in the tracked registry (axs_events) enriched with each
+        event's latest snapshot summary (event/venue name, get-in, price band,
+        listing/section counts, primary/resale seats). `active=false` includes
+        retired rows. Service-role read (axs_* tables are RLS service-role-only),
+        so this is the only path the terminal's user-JWT client has to the set."""
+        limit = max(1, min(int(limit), 2000))
+        db = get_require_sb()()
+        q = (
+            db.table("axs_events")
+            .select("axs_event_id,event_url,tevo_event_id,tevo_venue_id,active,"
+                    "last_pulled_at,last_snapshot_id")
+        )
+        if active:
+            q = q.eq("active", True)
+        evs = (q.order("last_pulled_at", desc=True).limit(limit).execute()).data or []
+
+        snap_ids = [e["last_snapshot_id"] for e in evs if e.get("last_snapshot_id")]
+        snaps: dict = {}
+        if snap_ids:
+            rows = (
+                db.table("axs_event_snapshots")
+                .select("id,captured_at,event_name,venue_name,occurs_at_local,currency,"
+                        "price_min,price_max,getin,listings_count,sections_count,"
+                        "offers_count,seats_primary,seats_resale,onsale_now")
+                .in_("id", snap_ids).execute()
+            ).data or []
+            snaps = {r["id"]: r for r in rows}
+
+        out = []
+        for e in evs:
+            s = snaps.get(e.get("last_snapshot_id")) or {}
+            out.append({
+                "axs_event_id": e.get("axs_event_id"),
+                "event_url": e.get("event_url"),
+                "tevo_event_id": e.get("tevo_event_id"),
+                "tevo_venue_id": e.get("tevo_venue_id"),
+                "active": e.get("active"),
+                "linked": e.get("tevo_event_id") is not None,
+                "last_pulled_at": e.get("last_pulled_at"),
+                "captured_at": s.get("captured_at"),
+                "event_name": s.get("event_name"),
+                "venue_name": s.get("venue_name"),
+                "occurs_at_local": s.get("occurs_at_local"),
+                "currency": s.get("currency"),
+                "getin": s.get("getin"),
+                "price_min": s.get("price_min"),
+                "price_max": s.get("price_max"),
+                "listings_count": s.get("listings_count"),
+                "sections_count": s.get("sections_count"),
+                "offers_count": s.get("offers_count"),
+                "seats_primary": s.get("seats_primary"),
+                "seats_resale": s.get("seats_resale"),
+                "onsale_now": s.get("onsale_now"),
+            })
+        return {
+            "count": len(out),
+            "linked": sum(1 for e in out if e["linked"]),
+            "pulled": sum(1 for e in out if e["captured_at"]),
+            "events": out,
+        }
+
     @router.get("/api/axs/event/{event_id}")
     def axs_event(event_id: int, _=Depends(require_auth)):
         db = get_require_sb()()

--- a/static/terminal/axs.html
+++ b/static/terminal/axs.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0a0a0a" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
+  <link rel="apple-touch-icon" href="/favicon.svg" />
+  <link rel="manifest" href="/manifest.json" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Terminal — AXS Events</title>
+  <link rel="stylesheet" href="style.css?v=20260620" />
+</head>
+<body data-page="axs">
+
+  <header class="topbar">
+    <span class="brand">TERMINAL · D0</span>
+    <span id="status" class="status">Loading…</span>
+  </header>
+
+  <main class="wrap movers">
+
+    <!-- AXS tracked events — the full axs_events registry enriched with each
+         event's latest snapshot (event/venue, get-in, price band, listing /
+         section counts, primary vs resale seats). Backed by /api/axs/events
+         (service-role read; axs_* tables are RLS service-role-only, so the
+         backend is the only path the user-JWT client has to this set).
+         AXS is a PRIMARY box-office ticketer (not resale) — see CLAUDE/§3. -->
+    <section id="axs-events">
+      <div class="panel-title row">
+        <span>AXS EVENTS — TRACKED BOX OFFICE</span>
+        <span class="muted small" id="axsEventsCount"></span>
+      </div>
+      <div class="muted small" style="margin-bottom:8px">
+        Every event in the <code>axs_events</code> registry (sourced from the
+        AXS_RESALE workbook), drained into <code>axs_event_snapshots</code> via the
+        AXS <code>/fetch</code> pull (~40s + 1 credit each — not a firehose). Prices
+        are primary box-office get-in / band; <em>resale</em> seats are the AXS
+        Marketplace subset. Click an event to open its terminal page (when mapped to
+        a canonical TEvo id) or the live AXS listing.
+      </div>
+      <div class="ctrl-row">
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">SHOW</span>
+          <button class="ctrl-btn is-active" data-axs-active="1">Active</button>
+          <button class="ctrl-btn"           data-axs-active="0">All</button>
+        </div>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">FILTER</span>
+          <input type="search" id="axsFilter" class="ctrl-input"
+                 placeholder="event / venue…" autocomplete="off" spellcheck="false" />
+        </div>
+      </div>
+      <div id="axsEventsSummary" class="muted small" style="margin-bottom:6px"></div>
+      <div id="axsEventsBody"><div class="empty">loading…</div></div>
+    </section>
+
+  </main>
+
+  <script src="lib/supabase.js"></script>
+  <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
+  <script src="axs.js?v=20260620"></script>
+</body>
+</html>

--- a/static/terminal/axs.js
+++ b/static/terminal/axs.js
@@ -1,0 +1,211 @@
+// D0 Terminal — AXS Events page. Lists every event in the axs_events registry
+// (AXS = PRIMARY box-office ticketer, not resale) enriched with its latest
+// snapshot summary. Single panel, backed by the /api/axs/events route:
+//
+//   GET /api/axs/events?active=<0|1>
+//     -> { count, linked, pulled, events: [ {axs_event_id, event_url,
+//          tevo_event_id, linked, last_pulled_at, captured_at, event_name,
+//          venue_name, occurs_at_local, currency, getin, price_min, price_max,
+//          listings_count, sections_count, seats_primary, seats_resale,
+//          onsale_now, ...} ] }
+//
+// The axs_* tables are RLS service-role-only, so unlike the Supabase-client
+// panels (discovery/movers) this page goes through the backend (T.api) which
+// holds the service-role client. Prices are already dollars (snapshot columns
+// are normalized; the cents landmine is the raw payload only — CLAUDE §3).
+
+(function () {
+  'use strict';
+  const T = window.Terminal;
+
+  const state = { active: true, filter: '' };
+  let _rows = [];  // last fetched events, for client-side filtering
+
+  function init() {
+    wireControls();
+    refreshAxsEvents().catch(e => console.error('[axs]', e));
+    setStatus('');
+  }
+
+  function setStatus(s) {
+    const el = document.getElementById('status');
+    if (el) el.textContent = s;
+  }
+
+  function wireControls() {
+    document.querySelectorAll('[data-axs-active]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        state.active = btn.dataset.axsActive === '1';
+        document.querySelectorAll('[data-axs-active]').forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        refreshAxsEvents();
+      });
+    });
+    const filterEl = document.getElementById('axsFilter');
+    if (filterEl) {
+      let t = 0;
+      filterEl.addEventListener('input', () => {
+        clearTimeout(t);
+        t = setTimeout(() => {
+          state.filter = filterEl.value.trim().toLowerCase();
+          renderTable();
+        }, 150);
+      });
+    }
+  }
+
+  async function refreshAxsEvents() {
+    const body    = document.getElementById('axsEventsBody');
+    const countEl = document.getElementById('axsEventsCount');
+    if (!body) return;
+    body.innerHTML = '<div class="empty">loading…</div>';
+    if (countEl) countEl.textContent = '';
+
+    let data;
+    try {
+      data = await T.api(`/api/axs/events?active=${state.active ? 'true' : 'false'}`);
+    } catch (e) {
+      body.innerHTML = '<div class="empty">error: ' + escapeHtml(e.message) + '</div>';
+      return;
+    }
+
+    _rows = (data && data.events) || [];
+    const summaryEl = document.getElementById('axsEventsSummary');
+    if (summaryEl) {
+      summaryEl.innerHTML = _rows.length
+        ? `<span class="badge">${data.count} tracked</span> ` +
+          `<span class="badge">${data.linked} mapped → TEvo</span> ` +
+          `<span class="badge">${data.pulled} pulled</span>`
+        : '';
+    }
+    renderTable();
+  }
+
+  function renderTable() {
+    const body    = document.getElementById('axsEventsBody');
+    const countEl = document.getElementById('axsEventsCount');
+    if (!body) return;
+
+    let rows = _rows;
+    if (state.filter) {
+      rows = rows.filter(r =>
+        (r.event_name || '').toLowerCase().includes(state.filter) ||
+        (r.venue_name || '').toLowerCase().includes(state.filter) ||
+        String(r.axs_event_id || '').toLowerCase().includes(state.filter));
+    }
+
+    // Sort: events with a known date first (soonest upcoming), then undated /
+    // not-yet-pulled by most-recent pull.
+    rows = rows.slice().sort((a, b) => {
+      const da = a.occurs_at_local ? Date.parse(a.occurs_at_local) : NaN;
+      const db = b.occurs_at_local ? Date.parse(b.occurs_at_local) : NaN;
+      const va = Number.isFinite(da), vb = Number.isFinite(db);
+      if (va && vb) return da - db;
+      if (va) return -1;
+      if (vb) return 1;
+      return (Date.parse(b.last_pulled_at || 0) || 0) - (Date.parse(a.last_pulled_at || 0) || 0);
+    });
+
+    if (countEl) {
+      const total = _rows.length;
+      countEl.textContent = state.filter
+        ? `${rows.length} of ${total} event${total === 1 ? '' : 's'}`
+        : (total ? `${total} event${total === 1 ? '' : 's'}` : '');
+    }
+
+    if (!rows.length) {
+      body.innerHTML = _rows.length
+        ? '<div class="empty">no events match the filter</div>'
+        : '<div class="empty">no AXS events tracked yet</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.className = 'full-list-tbl';
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Event</th>
+        <th>Venue</th>
+        <th>Date</th>
+        <th class="num" title="Cheapest available primary box-office price">Get-in</th>
+        <th class="num" title="Primary price band (min–max)">Price band</th>
+        <th class="num" title="Total live listings">Listings</th>
+        <th class="num" title="Sections with availability">Sec</th>
+        <th class="num" title="Primary box-office seats">Prim</th>
+        <th class="num" title="AXS Marketplace resale seats">Resale</th>
+        <th class="num" title="Last AXS pull">Pulled</th>
+        <th>Links</th>
+      </tr></thead>
+      <tbody></tbody>`;
+    const tb = tbl.querySelector('tbody');
+
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const cur = curSymbol(r.currency);
+
+      // Event name → terminal event page when mapped, else plain text.
+      const name = r.event_name || `AXS ${escapeHtml(String(r.axs_event_id || '?'))}`;
+      const nameCell = r.tevo_event_id
+        ? `<a href="event.html?event=${r.tevo_event_id}">${escapeHtml(name)}</a>`
+        : escapeHtml(name);
+      const onsale = r.onsale_now ? ' <span class="badge pos" title="On sale now">on sale</span>' : '';
+      const unmapped = r.tevo_event_id ? '' : ' <span class="badge muted" title="Not yet mapped to a canonical TEvo event">unmapped</span>';
+
+      const band = (r.price_min != null && r.price_max != null)
+        ? `${cur}${T.fmtNum(Math.round(r.price_min))}–${cur}${T.fmtNum(Math.round(r.price_max))}`
+        : '—';
+
+      // External AXS listing link (scheme-validated) + terminal event link.
+      const axsHref = /^https?:\/\//i.test(r.event_url || '') ? r.event_url : null;
+      const links = [];
+      if (axsHref) links.push(`<a href="${escapeHtml(axsHref)}" target="_blank" rel="noopener">AXS ↗</a>`);
+      if (r.tevo_event_id) links.push(`<a href="event.html?event=${r.tevo_event_id}">EVENT</a>`);
+
+      tr.innerHTML = `
+        <td>${nameCell}${onsale}${unmapped}</td>
+        <td>${escapeHtml(r.venue_name || '—')}</td>
+        <td class="num">${r.occurs_at_local ? T.temporalChipHtml(r.occurs_at_local) : '<span class="muted small">—</span>'}</td>
+        <td class="num">${r.getin != null ? cur + T.fmtNum(Math.round(r.getin)) : '—'}</td>
+        <td class="num muted small">${band}</td>
+        <td class="num">${T.fmtNum(r.listings_count)}</td>
+        <td class="num">${T.fmtNum(r.sections_count)}</td>
+        <td class="num">${T.fmtNum(r.seats_primary)}</td>
+        <td class="num">${T.fmtNum(r.seats_resale)}</td>
+        <td class="num muted small">${fmtDateShort(r.last_pulled_at)}</td>
+        <td class="small">${links.join(' · ') || '—'}</td>`;
+      tb.appendChild(tr);
+    });
+
+    body.replaceChildren(tbl);
+  }
+
+  function curSymbol(c) {
+    if (!c || c === 'USD' || c === 'usd') return '$';
+    if (c === 'CAD') return 'C$';
+    if (c === 'GBP') return '£';
+    if (c === 'EUR') return '€';
+    return c + ' ';
+  }
+
+  function fmtDateShort(iso) {
+    if (!iso) return '—';
+    try {
+      return new Date(iso).toLocaleDateString(undefined, {
+        year: '2-digit', month: 'short', day: 'numeric',
+      });
+    } catch (_) { return '—'; }
+  }
+
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;',
+    }[c]));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/terminal/discovery.html
+++ b/static/terminal/discovery.html
@@ -166,7 +166,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="discovery.js?v=20260609"></script>
 </body>
 </html>

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -509,7 +509,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="alerts.js?v=20260608"></script>
   <script src="event.js?v=20260616"></script>
 </body>

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -101,7 +101,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="home.js?v=20260615"></script>
 </body>
 </html>

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -120,7 +120,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="movers.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -30,6 +30,10 @@
     // performers/venues. Companion to Movers; same nav grouping for the
     // "what to watch" surface. Wired 2026-05-19 (PR A1 blindspot stack).
     { id: 'discovery', label: 'DISCOVERY', href: 'discovery.html' },
+    // AXS — every event in the axs_events registry (PRIMARY box office) with
+    // its latest snapshot get-in / price band / listing depth. Backed by
+    // /api/axs/events (service-role read; axs_* tables are RLS-locked). 2026-06-20.
+    { id: 'axs',       label: 'AXS',       href: 'axs.html' },
     { id: 'orders',    label: 'ORDERS',    href: 'orders.html' },
   ];
 

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -117,7 +117,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="orders.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -234,7 +234,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="alerts.js?v=20260608"></script>
   <script src="performer.js?v=20260608"></script>
 </body>

--- a/static/terminal/retail-chat.html
+++ b/static/terminal/retail-chat.html
@@ -48,7 +48,7 @@
   <!-- Cache-busting: bump ?v= on any first-party asset change. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260619"></script>
-  <script src="nav.js?v=20260619"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="/static/shared/retail-chat-widget.js?v=20260619"></script>
   <script src="retail-chat.js?v=20260619"></script>
 </body>

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -649,6 +649,16 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
   color: #000;
   border-color: var(--accent);
 }
+.ctrl-input {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  color: var(--text);
+  font-family: var(--mono); font-size: 11px;
+  padding: 4px 10px;
+  min-width: 180px;
+}
+.ctrl-input::placeholder { color: var(--muted); }
+.ctrl-input:focus { outline: none; border-color: var(--accent); }
 .movers-tbl td a { color: var(--text); text-decoration: none; }
 .movers-tbl td a:hover { color: var(--accent); text-decoration: underline; }
 

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -175,7 +175,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
   <script src="alerts.js?v=20260608"></script>
   <script src="venue.js?v=20260608"></script>
 </body>

--- a/tests/test_axs_routes.py
+++ b/tests/test_axs_routes.py
@@ -40,6 +40,9 @@ class _Q:
     def eq(self, *a, **k):
         return self
 
+    def in_(self, *a, **k):
+        return self
+
     def order(self, *a, **k):
         return self
 
@@ -69,6 +72,32 @@ def client():
 
 def _db(monkeypatch, **kw):
     monkeypatch.setattr(app_module, "require_sb", lambda: _Sb(**kw))
+
+
+def test_axs_events_list(client, monkeypatch):
+    evs = [
+        {"axs_event_id": "ev-a", "event_url": "https://axs.com/a", "tevo_event_id": 42,
+         "tevo_venue_id": 7, "active": True, "last_pulled_at": "2026-06-19T00:00:00Z",
+         "last_snapshot_id": 100},
+        {"axs_event_id": "ev-b", "event_url": "https://axs.com/b", "tevo_event_id": None,
+         "tevo_venue_id": None, "active": True, "last_pulled_at": None,
+         "last_snapshot_id": None},
+    ]
+    snaps = [{"id": 100, "captured_at": "2026-06-19T00:00:00Z", "event_name": "Show A",
+              "venue_name": "Arena", "occurs_at_local": "2026-07-01T20:00:00-04:00",
+              "currency": "USD", "getin": 55, "price_min": 55, "price_max": 250,
+              "listings_count": 120, "sections_count": 18, "offers_count": 3,
+              "seats_primary": 100, "seats_resale": 20, "onsale_now": True}]
+    _db(monkeypatch, tables={"axs_events": evs, "axs_event_snapshots": snaps})
+    body = client.get("/api/axs/events").json()
+    assert body["count"] == 2
+    assert body["linked"] == 1
+    assert body["pulled"] == 1
+    a = next(e for e in body["events"] if e["axs_event_id"] == "ev-a")
+    assert a["linked"] is True and a["event_name"] == "Show A"
+    assert a["getin"] == 55 and a["seats_resale"] == 20
+    b = next(e for e in body["events"] if e["axs_event_id"] == "ev-b")
+    assert b["linked"] is False and b["event_name"] is None and b["captured_at"] is None
 
 
 def test_axs_event_unlinked(client, monkeypatch):


### PR DESCRIPTION
## Summary

Adds a dedicated **AXS** tab to the D0 terminal that lists **every event in the `axs_events` registry** (AXS = primary box office, not resale) with each event's latest snapshot rolled up: get-in, price band, listing/section counts, primary vs. resale seats, on-sale state, and links to the live AXS listing + the mapped terminal event page.

## Changes

- **`routers/axs.py`** — new `GET /api/axs/events?active=<true|false>` list endpoint. Reads the `axs_events` registry and joins each row's latest `axs_event_snapshots` (via `last_snapshot_id`) for the summary fields. Returns `{ count, linked, pulled, events[] }`. This goes through the backend's **service-role** client because the `axs_*` tables are RLS service-role-only — so unlike the Supabase-client panels (discovery/movers), the terminal's user-JWT client can only reach this set via the API.
- **`static/terminal/axs.html` + `axs.js`** — single-panel page: Active/All toggle, debounced client-side name/venue filter, date-sorted table (soonest upcoming first; unmapped rows badged). Prices render as dollars (the snapshot columns are already normalized; the cents landmine is the raw payload only — CLAUDE §3).
- **`nav.js`** — `AXS` link added between `DISCOVERY` and `ORDERS`; cache-bust token bumped across all terminal pages so the tab shows up everywhere.
- **`style.css`** — `.ctrl-input` for the filter box.
- **`tests/test_axs_routes.py`** — coverage for the list endpoint (mapped row with snapshot + unmapped/not-yet-pulled row). `6 passed`.

## Notes / coordination

- `routers/axs.py` is A1's data-route file; this additive read-only endpoint was made under the operator's direct routing of the task to D0. It mirrors the existing AXS read slice exactly (no AXS API calls, no mutations) and passes the RULE-2 readonly guard.
- No DB migration required — the endpoint reads existing tables/columns.

## Verification

- `pytest tests/test_axs_routes.py` → 6 passed
- `scripts/check_readonly.py` → RULE 2 clean
- `routers.axs` imports clean; `axs.js`/`nav.js` pass `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWSCY48FdxWpPsnuxbK1L8)_