### PR TITLE
refactor(a1): lift human bot-gate token helpers to core/auth (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,6 +173,14 @@ from core.config import (  # noqa: E402
 # (one-directional import). The security tests force the gate ON by patching
 # `core.auth.AUTH_DISABLED`.
 from core.auth import require_auth, AUTH_DISABLED, _is_production  # noqa: E402
+# Human bot-gate cookie helpers -> core/auth.py (BR-CODE-1 config/auth seam),
+# aliased to their historical `_`-prefixed names so consumers keep resolving.
+from core.auth import (  # noqa: E402
+    issue_human_token as _issue_human_token,
+    valid_human_token as _valid_human_token,
+    HUMAN_COOKIE_NAME as _HUMAN_COOKIE_NAME,
+    HUMAN_TTL_SECONDS as _HUMAN_TTL_SECONDS,
+)
 
 # Helpers moved to core/ (BR-CODE-1 helper pass). Aliased to the historical
 # `_`-prefixed names so every call site + the route tests' monkeypatch
@@ -211,35 +219,9 @@ from core.helpers import flatten_order_items as _flatten_order_items  # noqa: E4
 # (storefront-mode flags + reCAPTCHA config moved to core/config.py — imported
 # at the top of this bootstrap block, BR-CODE-1 core extraction.)
 
-# HMAC key for the signed human-session cookie. Prefer a stable secret so the
-# cookie survives restarts; fall back to a per-process random (cookies simply
-# re-issue on the next interaction after a restart — fine for a demo).
-_HUMAN_COOKIE_SECRET = (
-    os.environ.get("SESSION_SIGNING_SECRET") or CRON_SECRET or secrets.token_hex(32)
-).encode()
-_HUMAN_COOKIE_NAME = "vp_human"
-_HUMAN_TTL_SECONDS = 1800  # 30 min
-
-
-def _issue_human_token(ttl: int = _HUMAN_TTL_SECONDS) -> str:
-    """Mint a signed, expiring opaque token: '<exp>.<hex-hmac>'."""
-    exp = int(time.time()) + ttl
-    sig = hmac.new(_HUMAN_COOKIE_SECRET, str(exp).encode(), "sha256").hexdigest()
-    return f"{exp}.{sig}"
-
-
-def _valid_human_token(tok: str | None) -> bool:
-    if not tok or "." not in tok:
-        return False
-    exp_s, _, sig = tok.partition(".")
-    try:
-        exp = int(exp_s)
-    except ValueError:
-        return False
-    if exp < int(time.time()):
-        return False
-    expected = hmac.new(_HUMAN_COOKIE_SECRET, exp_s.encode(), "sha256").hexdigest()
-    return hmac.compare_digest(sig, expected)
+# _HUMAN_COOKIE_SECRET + _HUMAN_COOKIE_NAME + _HUMAN_TTL_SECONDS +
+# _issue_human_token + _valid_human_token -> core/auth.py (BR-CODE-1 config/auth
+# seam). Imported (aliased) near the top of this module.
 
 
 def _verify_recaptcha(token: str | None, expected_action: str, remote_ip: str | None) -> bool:

--- a/core/auth.py
+++ b/core/auth.py
@@ -15,13 +15,16 @@ One-directional import: core.auth -> core.config; never imports app.py.
 """
 from __future__ import annotations
 
+import hmac
 import logging
 import os
+import secrets
+import time
 
 import requests
 from fastapi import Header, HTTPException
 
-from core.config import ALLOWED_EMAIL_DOMAIN, SUPABASE_ANON_KEY, SUPABASE_URL
+from core.config import ALLOWED_EMAIL_DOMAIN, CRON_SECRET, SUPABASE_ANON_KEY, SUPABASE_URL
 
 # AUTH_DISABLED is a local-dev kill switch. To prevent a misconfig from
 # accidentally opening the whole API, it ONLY takes effect when:
@@ -91,3 +94,38 @@ def require_auth(authorization: str | None = Header(None)):
     if not email.endswith("@" + ALLOWED_EMAIL_DOMAIN.lower()):
         raise HTTPException(403, f"access restricted to @{ALLOWED_EMAIL_DOMAIN}")
     return user
+
+
+# ---------- "human" cookie — lightweight signed bot-gate token ----------
+# A signed, expiring opaque token proving a request cleared the bot gate
+# (honeypot / rate-limit / reCAPTCHA). HMAC over the expiry; no PII. The secret
+# prefers an explicit SESSION_SIGNING_SECRET, falls back to CRON_SECRET, then a
+# per-process random (so a restart just re-issues on next interaction — fine for
+# a demo).
+_HUMAN_COOKIE_SECRET = (
+    os.environ.get("SESSION_SIGNING_SECRET") or CRON_SECRET or secrets.token_hex(32)
+).encode()
+HUMAN_COOKIE_NAME = "vp_human"
+HUMAN_TTL_SECONDS = 1800  # 30 min
+
+
+def issue_human_token(ttl: int = HUMAN_TTL_SECONDS) -> str:
+    """Mint a signed, expiring opaque token: '<exp>.<hex-hmac>'."""
+    exp = int(time.time()) + ttl
+    sig = hmac.new(_HUMAN_COOKIE_SECRET, str(exp).encode(), "sha256").hexdigest()
+    return f"{exp}.{sig}"
+
+
+def valid_human_token(tok: str | None) -> bool:
+    """True iff `tok` is a non-expired token whose HMAC verifies."""
+    if not tok or "." not in tok:
+        return False
+    exp_s, _, sig = tok.partition(".")
+    try:
+        exp = int(exp_s)
+    except ValueError:
+        return False
+    if exp < int(time.time()):
+        return False
+    expected = hmac.new(_HUMAN_COOKIE_SECRET, exp_s.encode(), "sha256").hexdigest()
+    return hmac.compare_digest(sig, expected)

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -1,0 +1,47 @@
+"""Unit tests for the bot-gate token helpers moved into core/auth (BR-CODE-1).
+
+These were untested while inline in app.py. core.auth imports cleanly without
+live env (core.config env reads have defaults), so the HMAC round-trip is now
+covered directly.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from core.auth import issue_human_token, valid_human_token  # noqa: E402
+
+
+def test_human_token_roundtrip():
+    assert valid_human_token(issue_human_token()) is True
+
+
+def test_human_token_rejects_empty_and_malformed():
+    assert valid_human_token(None) is False
+    assert valid_human_token("") is False
+    assert valid_human_token("no-dot") is False
+    assert valid_human_token("notanint.deadbeef") is False
+
+
+def test_human_token_rejects_expired():
+    # ttl in the past -> exp < now -> invalid
+    assert valid_human_token(issue_human_token(ttl=-10)) is False
+
+
+def test_human_token_rejects_tampered_signature():
+    tok = issue_human_token()
+    exp_s, _, _sig = tok.partition(".")
+    forged = f"{exp_s}.{'0' * 64}"
+    assert valid_human_token(forged) is False
+
+
+def test_human_token_rejects_extended_expiry_with_old_sig():
+    # bump the expiry but keep the old signature -> HMAC mismatch -> invalid
+    tok = issue_human_token()
+    _exp_s, _, sig = tok.partition(".")
+    forged = f"{int(time.time()) + 99999}.{sig}"
+    assert valid_human_token(forged) is False


### PR DESCRIPTION
## BR-CODE-1 — config/auth seam, slice 2

Moves the signed **"human" bot-gate cookie** helpers out of `app.py` into `core/auth.py` (the security-pinned auth module, which already imports from `core.config`).

### Extracted
- `_HUMAN_COOKIE_SECRET` (private; `SESSION_SIGNING_SECRET` → `CRON_SECRET` → per-process random)
- `HUMAN_COOKIE_NAME` / `HUMAN_TTL_SECONDS`
- `issue_human_token` / `valid_human_token` (HMAC-SHA256 over the expiry, constant-time compare)

The secret is used only by the two functions, so it travels with them; `app.py` no longer references it. Adds `hmac`/`secrets`/`time` + `CRON_SECRET` imports to `core/auth`.

### Wiring
`app.py` imports the two functions + two constants aliased to their historical `_`-prefixed names; both consumers (the bot-gate check + the `Set-Cookie` route) are unchanged.

### Tests
New `tests/test_core_auth.py` (5 tests) — **these helpers were previously untested**: HMAC round-trip, malformed/empty reject, expiry reject, tampered-signature reject, and extended-expiry-with-old-signature reject.

### Result
- `app.py` 6648 → **6630 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_