### PR TITLE
refactor(a1): lift verify_recaptcha to core/auth (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,7 +154,7 @@ from core.config import (  # noqa: E402
     ALLOWED_EMAIL_DOMAIN, STOREFRONT_SQL_ONLY, STOREFRONT_SEARCH_SQL_ONLY,
     STOREFRONT_PREFER_INTERNAL_ZONES, STOREFRONT_RESERVE_REQUIRES_AUTH,
     STOREFRONT_CHECKOUT_DOMAIN, STOREFRONT_CHECKOUT_DISABLED,
-    RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY, RECAPTCHA_MIN_SCORE, RECAPTCHA_ENABLED,
+    RECAPTCHA_SITE_KEY, RECAPTCHA_ENABLED,
 )
 # Storefront deploy identity -> core/config.py (BR-CODE-1 config seam). Aliased
 # to the historical `_`-prefixed names so consumers + the test monkeypatch
@@ -178,6 +178,7 @@ from core.auth import require_auth, AUTH_DISABLED, _is_production  # noqa: E402
 from core.auth import (  # noqa: E402
     issue_human_token as _issue_human_token,
     valid_human_token as _valid_human_token,
+    verify_recaptcha as _verify_recaptcha,
     HUMAN_COOKIE_NAME as _HUMAN_COOKIE_NAME,
     HUMAN_TTL_SECONDS as _HUMAN_TTL_SECONDS,
 )
@@ -224,30 +225,8 @@ from core.helpers import flatten_order_items as _flatten_order_items  # noqa: E4
 # seam). Imported (aliased) near the top of this module.
 
 
-def _verify_recaptcha(token: str | None, expected_action: str, remote_ip: str | None) -> bool:
-    """Verify a reCAPTCHA v3 token with Google. Returns True when the gate is
-    dormant (no keys). Fails OPEN on a network/Google error (demo availability),
-    CLOSED on an explicit failure / low score / action mismatch."""
-    if not RECAPTCHA_ENABLED:
-        return True
-    if not token:
-        return False
-    try:
-        resp = requests.post(
-            "https://www.google.com/recaptcha/api/siteverify",
-            data={"secret": RECAPTCHA_SECRET_KEY, "response": token, "remoteip": remote_ip or ""},
-            timeout=5,
-        )
-        data = resp.json()
-    except Exception as e:  # noqa: BLE001 — network/parse: fail open so a Google blip can't break the demo
-        print(f"[recaptcha] verify call failed ({e!r}) — failing open")
-        return True
-    if not data.get("success"):
-        return False
-    action = data.get("action")
-    if action and expected_action and action != expected_action:
-        return False
-    return float(data.get("score") or 0.0) >= RECAPTCHA_MIN_SCORE
+# _verify_recaptcha -> core/auth.py (BR-CODE-1 config/auth seam; pairs with the
+# human-token bot gate). Imported (aliased) near the top of this module.
 
 
 def _require_human(request: Request, payload: dict | None = None):

--- a/core/auth.py
+++ b/core/auth.py
@@ -24,7 +24,10 @@ import time
 import requests
 from fastapi import Header, HTTPException
 
-from core.config import ALLOWED_EMAIL_DOMAIN, CRON_SECRET, SUPABASE_ANON_KEY, SUPABASE_URL
+from core.config import (
+    ALLOWED_EMAIL_DOMAIN, CRON_SECRET, SUPABASE_ANON_KEY, SUPABASE_URL,
+    RECAPTCHA_SECRET_KEY, RECAPTCHA_MIN_SCORE,
+)
 
 # AUTH_DISABLED is a local-dev kill switch. To prevent a misconfig from
 # accidentally opening the whole API, it ONLY takes effect when:
@@ -129,3 +132,28 @@ def valid_human_token(tok: str | None) -> bool:
         return False
     expected = hmac.new(_HUMAN_COOKIE_SECRET, exp_s.encode(), "sha256").hexdigest()
     return hmac.compare_digest(sig, expected)
+
+
+def verify_recaptcha(token: str | None, expected_action: str, remote_ip: str | None) -> bool:
+    """Verify a reCAPTCHA v3 token with Google. Callers gate on RECAPTCHA_ENABLED
+    before calling this (so the dormant case never reaches here). Fails OPEN on a
+    network/Google error (demo availability), CLOSED on a missing token / explicit
+    failure / low score / action mismatch."""
+    if not token:
+        return False
+    try:
+        resp = requests.post(
+            "https://www.google.com/recaptcha/api/siteverify",
+            data={"secret": RECAPTCHA_SECRET_KEY, "response": token, "remoteip": remote_ip or ""},
+            timeout=5,
+        )
+        data = resp.json()
+    except Exception as e:  # noqa: BLE001 — network/parse: fail open so a Google blip can't break the demo
+        print(f"[recaptcha] verify call failed ({e!r}) — failing open")
+        return True
+    if not data.get("success"):
+        return False
+    action = data.get("action")
+    if action and expected_action and action != expected_action:
+        return False
+    return float(data.get("score") or 0.0) >= RECAPTCHA_MIN_SCORE

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -45,3 +45,13 @@ def test_human_token_rejects_extended_expiry_with_old_sig():
     _exp_s, _, sig = tok.partition(".")
     forged = f"{int(time.time()) + 99999}.{sig}"
     assert valid_human_token(forged) is False
+
+
+from core.auth import verify_recaptcha  # noqa: E402
+
+
+def test_verify_recaptcha_missing_token_fails_closed():
+    # No token -> False without any network call (callers gate on RECAPTCHA_ENABLED
+    # before reaching here, so the dormant case never hits this function).
+    assert verify_recaptcha(None, "submit", "1.2.3.4") is False
+    assert verify_recaptcha("", "submit", None) is False


### PR DESCRIPTION
## BR-CODE-1 — config/auth seam, slice 3

Moves the **reCAPTCHA v3 verifier** out of `app.py` into `core/auth.py`, alongside the human-token bot gate it pairs with.

### Key change: removed a redundant (and post-move buggy) dormant check
The original `verify_recaptcha` opened with `if not RECAPTCHA_ENABLED: return True`. But **both call sites** — `_require_human` and the `/api/store/verify-human` route — already `return` on `not RECAPTCHA_ENABLED` *before* calling it, so the function is only ever reached when the gate is enabled. The check was redundant.

It also caused a **cross-module monkeypatch fragility**: the tests patch `app_module.RECAPTCHA_ENABLED` (which correctly controls the *route* gate), but the moved function would read `core.auth.RECAPTCHA_ENABLED` (unpatched=False) and wrongly short-circuit to `True` — surfaced as `test_reserve_blocked_without_human_when_gate_enabled` failing. Removing the redundant check fixes the test without changing its intent, and makes `verify_recaptcha` a clean pure-verify:
- missing token → `False` (no network)
- Google/network error → fail **open**
- success + score ≥ min + action match → verdict

### Wiring
`app.py` imports `verify_recaptcha` aliased to `_verify_recaptcha` (both call sites + the `app._verify_recaptcha` test monkeypatch keep resolving). `RECAPTCHA_SECRET_KEY` + `RECAPTCHA_MIN_SCORE` imports move from `app.py` to `core/auth` (now their only user); `app.py` keeps `RECAPTCHA_SITE_KEY` + `RECAPTCHA_ENABLED`.

### Tests
- `test_reserve_blocked_without_human_when_gate_enabled` now passes again.
- Added a no-token-fails-closed unit test (the live Google path stays untested by design).

### Result
- `app.py` 6630 → **6609 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_