### PR TITLE
refactor(a1): lift require_cron_or_auth to core/auth (BR-CODE-1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,6 @@ Optional:
 
 from __future__ import annotations
 
-import hmac
 import logging
 import math
 import os
@@ -173,6 +172,7 @@ from core.config import (  # noqa: E402
 # (one-directional import). The security tests force the gate ON by patching
 # `core.auth.AUTH_DISABLED`.
 from core.auth import require_auth, AUTH_DISABLED, _is_production  # noqa: E402
+from core.auth import require_cron_or_auth as _require_cron_or_auth  # noqa: E402
 # Human bot-gate cookie helpers -> core/auth.py (BR-CODE-1 config/auth seam),
 # aliased to their historical `_`-prefixed names so consumers keep resolving.
 from core.auth import (  # noqa: E402
@@ -3413,15 +3413,8 @@ def seatdata_auto_search(
 # CRON_SECRET is declared once at module top (line ~216) — no re-declaration.
 
 
-def _require_cron_or_auth(authorization: str | None, x_cron_secret: str | None):
-    """Allow either authenticated user OR matching X-Cron-Secret.
-
-    Fails closed if CRON_SECRET is not configured on the server — never
-    accepts an empty/placeholder secret.
-    """
-    if x_cron_secret and CRON_SECRET and hmac.compare_digest(x_cron_secret, CRON_SECRET):
-        return {"cron": True}
-    return require_auth(authorization)
+# _require_cron_or_auth -> core/auth.py (BR-CODE-1 config/auth seam). Imported
+# (aliased) near the top of this module.
 
 
 # _parse_iso_or_none + _to_int_or_none + _to_num_or_none -> core/helpers.py (BR-CODE-1); aliased at top.

--- a/core/auth.py
+++ b/core/auth.py
@@ -157,3 +157,14 @@ def verify_recaptcha(token: str | None, expected_action: str, remote_ip: str | N
     if action and expected_action and action != expected_action:
         return False
     return float(data.get("score") or 0.0) >= RECAPTCHA_MIN_SCORE
+
+
+def require_cron_or_auth(authorization: str | None, x_cron_secret: str | None):
+    """Allow either an authenticated user OR a matching X-Cron-Secret.
+
+    Fails closed if CRON_SECRET is not configured on the server — never
+    accepts an empty/placeholder secret.
+    """
+    if x_cron_secret and CRON_SECRET and hmac.compare_digest(x_cron_secret, CRON_SECRET):
+        return {"cron": True}
+    return require_auth(authorization)

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -55,3 +55,27 @@ def test_verify_recaptcha_missing_token_fails_closed():
     # before reaching here, so the dormant case never hits this function).
     assert verify_recaptcha(None, "submit", "1.2.3.4") is False
     assert verify_recaptcha("", "submit", None) is False
+
+
+from core.auth import require_cron_or_auth  # noqa: E402
+
+
+def test_require_cron_or_auth_accepts_matching_secret(monkeypatch):
+    import core.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "CRON_SECRET", "s3cr3t")
+    assert require_cron_or_auth(None, "s3cr3t") == {"cron": True}
+
+
+def test_require_cron_or_auth_falls_through_to_auth_when_secret_absent(monkeypatch):
+    import core.auth as auth_mod
+    # no server secret configured -> never accept a header secret; defer to auth.
+    monkeypatch.setattr(auth_mod, "CRON_SECRET", None)
+    monkeypatch.setattr(auth_mod, "AUTH_DISABLED", True)  # require_auth returns None
+    assert require_cron_or_auth(None, "anything") is None
+
+
+def test_require_cron_or_auth_wrong_secret_defers_to_auth(monkeypatch):
+    import core.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "CRON_SECRET", "s3cr3t")
+    monkeypatch.setattr(auth_mod, "AUTH_DISABLED", True)
+    assert require_cron_or_auth(None, "wrong") is None


### PR DESCRIPTION
## BR-CODE-1 — config/auth seam, slice 4

Moves the **cron-or-user gate** out of `app.py` into `core/auth.py`. Its three deps (`CRON_SECRET`, `hmac`, `require_auth`) **all already live there**, so the move is fully self-contained (`require_auth` is now an in-module call).

### Wiring
`app.py` imports it aliased to `_require_cron_or_auth`; all **4 call sites** unchanged. `hmac` was this function's last user in `app.py`, so the now-dead `import hmac` is dropped (`CRON_SECRET` stays — still used by the collect routes).

### Tests
Adds 3 unit tests — the **fail-closed-without-`CRON_SECRET`** contract was previously untested:
- matching secret → `{cron: True}`
- absent server secret never accepts a header secret → defers to auth
- wrong secret → defers to auth

### Result
- `app.py` 6609 → **6602 LOC**.
- Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_