### PR TITLE
test(a1): broker route coverage — by-league + section-metrics (BR-CODE-3)

### DIFF
--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -190,3 +190,80 @@ def test_cadences_sections_and_listings_cadence(client, monkeypatch):
     assert body["sections"]["overview"]["cadence_seconds"] == 3600
     assert body["sections"]["overview"]["last_pull_at"] == "2026-05-10T00:00:00Z"
     assert body["sections"]["espn_injuries"]["cadence_seconds"] == 600
+
+
+# ---------- /api/broker/performers/by-league/{league} ----------
+
+def test_by_league_empty_returns_zero_count(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(rpc_data={"get_performers_by_league": []}))
+    body = client.get("/api/broker/performers/by-league/NBA").json()
+    assert body == {
+        "league": "NBA", "count": 0, "performers": [],
+        "_inactive_filter_applied": False, "_include_inactive_param": False,
+    }
+
+
+def test_by_league_maps_rows_and_computes_delta_pct(client, monkeypatch):
+    row = {
+        "performer_id": 16303, "performer_name": "New York Knicks", "league": "NBA",
+        "home_venue_id": 99, "home_venue_name": "MSG",
+        "home_events": 5, "home_market_med": 150, "home_owned_med": 140,
+        "home_market_tix": 200, "home_owned_tix": 50,
+        "home_prev_market_med": 120, "home_prev_owned_med": 130,
+        "road_events": 3, "road_market_med": 200, "road_market_tix": 80,
+        "road_prev_market_med": 200,
+    }
+    fake = FakeSupabase(rpc_data={"get_performers_by_league": [row]})
+    _use_db(monkeypatch, fake)
+    body = client.get("/api/broker/performers/by-league/NBA").json()
+    assert body["count"] == 1
+    p = body["performers"][0]
+    assert p["performer_name"] == "New York Knicks"
+    # (150-120)/120*100 = 25.0 ; (140-130)/130*100 = 7.69 (rounded)
+    assert p["home"]["delta_market_pct"] == 25.0
+    assert p["home"]["delta_owned_pct"] == 7.69
+    # flat market => 0.0, not None
+    assert p["road"]["delta_market_pct"] == 0.0
+    # missing prev (road_prev_owned_med absent) => None
+    assert p["road"]["delta_owned_pct"] is None
+    # tix/events default to 0 when absent
+    assert p["road"]["owned_tix"] == 0
+    assert fake.rpc_calls[0] == ("get_performers_by_league", {"p_league": "NBA"})
+
+
+# ---------- /api/broker/event/{id}/section-metrics ----------
+
+def test_section_metrics_empty(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(table_data={"section_metrics": []}))
+    body = client.get("/api/broker/event/1/section-metrics").json()
+    assert body["sections"] == []
+    assert body["last_pull_at"] is None
+    # no events row => occurs_at_local None => 24h default cadence
+    assert body["cadence_seconds"] == 60 * 60 * 24
+
+
+def test_section_metrics_groups_deltas_and_sorts(client, monkeypatch):
+    rows = [
+        {"captured_at": "2026-05-10T12:00:00Z", "section": "104", "is_ancillary": False,
+         "tickets_count": 50, "groups_count": 10, "retail_min": 100,
+         "retail_median": 150, "retail_mean": 160, "retail_max": 300},
+        {"captured_at": "2026-05-09T12:00:00Z", "section": "104", "is_ancillary": False,
+         "tickets_count": 40, "groups_count": 8, "retail_min": 90,
+         "retail_median": 140, "retail_mean": 150, "retail_max": 280},
+        {"captured_at": "2026-05-10T11:00:00Z", "section": "Parking", "is_ancillary": True,
+         "tickets_count": 5, "groups_count": 2, "retail_min": 20,
+         "retail_median": 25, "retail_mean": 25, "retail_max": 30},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={"section_metrics": rows}))
+    body = client.get("/api/broker/event/1/section-metrics").json()
+    secs = body["sections"]
+    # non-ancillary "104" sorts before ancillary "Parking"
+    assert [s["section"] for s in secs] == ["104", "Parking"]
+    # 104 has a prior snapshot -> delta computed (50 vs 40 = up)
+    assert secs[0]["metrics"]["tickets_count"]["v"] == 50
+    assert secs[0]["metrics"]["tickets_count"]["delta"]["dir"] == "up"
+    # Parking has only one snapshot -> delta None
+    assert secs[1]["is_ancillary"] is True
+    assert secs[1]["metrics"]["tickets_count"]["delta"] is None
+    # latest captured_at across sections
+    assert body["last_pull_at"] == "2026-05-10T12:00:00Z"


### PR DESCRIPTION
## BR-CODE-3 — broker route coverage (by-league + section-metrics)

Additive coverage on the existing `FakeSupabase` harness (**no `app.py` change** — zero conflict with the active store session). Adds 4 tests for two previously-untested read-only broker routes.

### `/api/broker/performers/by-league/{league}`
- empty league → count 0 + the `_inactive_filter_applied` / `_include_inactive` passthrough flags
- populated → row mapping + `_delta_pct` math (25.0 / 7.69 / flat **0.0** / missing-prev **None**), 0-defaults, and the `get_performers_by_league` RPC arg

### `/api/broker/event/{id}/section-metrics`
- empty → `[]` + `None` last_pull + 24h default cadence (no events row)
- populated → per-section grouping, latest-two delta, non-ancillary-first sort, and `last_pull_at` = max `captured_at`

### Note: BR-CODE-2 dropped (with reason)
While picking this up I assessed **BR-CODE-2** (`BaseReadOnlyClient` guard dedup) and **dropped it**: the RULE-2 static check (`check_readonly.check_guard_tokens`) requires `_assert_readonly_method` / `ALLOWED_HTTP_METHODS` / `frozenset({"GET"})` tokens **in each client file**, and `test_readonly_guards` requires each client's **own** error class. The per-client duplication is deliberate defense-in-depth and is mechanically enforced — it can't be hoisted into a base without weakening RULE-2 (a security-CRIT change). The only dedupable part is per-client HTTP plumbing (HMAC vs token vs the SeatData POST carve-out), which is low-benefit/high-risk across 9 security-critical files.

### Result
- +4 tests (426 passing). Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_