### PR TITLE
feat(d0): flag owned-ticket holdings on the AXS events tab

### DIFF
--- a/routers/axs.py
+++ b/routers/axs.py
@@ -46,9 +46,25 @@ def build_axs_router(get_require_sb: Callable[[], Callable], require_auth: Calla
             ).data or []
             snaps = {r["id"]: r for r in rows}
 
+        # Owned-inventory peg: which mapped events do WE hold tickets for. Batch
+        # the canonical latest_event_metrics view (keyed on tevo event_id, one
+        # latest row per event) over the mapped ids — owned_tickets_count is the
+        # broker-pool truth (is_owned/brokerage 1768 rolled up by the collector).
+        tevo_ids = [e["tevo_event_id"] for e in evs if e.get("tevo_event_id")]
+        owned: dict = {}
+        if tevo_ids:
+            mrows = (
+                db.table("latest_event_metrics")
+                .select("event_id,owned_tickets_count,owned_groups_count,owned_share")
+                .in_("event_id", tevo_ids).execute()
+            ).data or []
+            owned = {r["event_id"]: r for r in mrows}
+
         out = []
         for e in evs:
             s = snaps.get(e.get("last_snapshot_id")) or {}
+            m = owned.get(e.get("tevo_event_id")) or {}
+            owned_tix = m.get("owned_tickets_count")
             out.append({
                 "axs_event_id": e.get("axs_event_id"),
                 "event_url": e.get("event_url"),
@@ -56,6 +72,10 @@ def build_axs_router(get_require_sb: Callable[[], Callable], require_auth: Calla
                 "tevo_venue_id": e.get("tevo_venue_id"),
                 "active": e.get("active"),
                 "linked": e.get("tevo_event_id") is not None,
+                "we_own": bool(owned_tix and owned_tix > 0),
+                "owned_tickets": owned_tix,
+                "owned_groups": m.get("owned_groups_count"),
+                "owned_share": m.get("owned_share"),
                 "last_pulled_at": e.get("last_pulled_at"),
                 "captured_at": s.get("captured_at"),
                 "event_name": s.get("event_name"),
@@ -76,6 +96,7 @@ def build_axs_router(get_require_sb: Callable[[], Callable], require_auth: Calla
             "count": len(out),
             "linked": sum(1 for e in out if e["linked"]),
             "pulled": sum(1 for e in out if e["captured_at"]),
+            "owned": sum(1 for e in out if e["we_own"]),
             "events": out,
         }
 

--- a/static/terminal/axs.html
+++ b/static/terminal/axs.html
@@ -52,6 +52,11 @@
           <button class="ctrl-btn"           data-axs-active="0">All</button>
         </div>
         <div class="ctrl-group">
+          <span class="ctrl-lbl">HOLDINGS</span>
+          <button class="ctrl-btn is-active" data-axs-owned="0">All</button>
+          <button class="ctrl-btn"           data-axs-owned="1">We hold</button>
+        </div>
+        <div class="ctrl-group">
           <span class="ctrl-lbl">FILTER</span>
           <input type="search" id="axsFilter" class="ctrl-input"
                  placeholder="event / venue…" autocomplete="off" spellcheck="false" />
@@ -68,6 +73,6 @@
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620"></script>
-  <script src="axs.js?v=20260620"></script>
+  <script src="axs.js?v=20260620b"></script>
 </body>
 </html>

--- a/static/terminal/axs.js
+++ b/static/terminal/axs.js
@@ -18,7 +18,7 @@
   'use strict';
   const T = window.Terminal;
 
-  const state = { active: true, filter: '' };
+  const state = { active: true, ownedOnly: false, filter: '' };
   let _rows = [];  // last fetched events, for client-side filtering
 
   function init() {
@@ -39,6 +39,15 @@
         document.querySelectorAll('[data-axs-active]').forEach(b => b.classList.remove('is-active'));
         btn.classList.add('is-active');
         refreshAxsEvents();
+      });
+    });
+    // Holdings filter is purely client-side over the already-fetched rows.
+    document.querySelectorAll('[data-axs-owned]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        state.ownedOnly = btn.dataset.axsOwned === '1';
+        document.querySelectorAll('[data-axs-owned]').forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        renderTable();
       });
     });
     const filterEl = document.getElementById('axsFilter');
@@ -75,7 +84,8 @@
       summaryEl.innerHTML = _rows.length
         ? `<span class="badge">${data.count} tracked</span> ` +
           `<span class="badge">${data.linked} mapped → TEvo</span> ` +
-          `<span class="badge">${data.pulled} pulled</span>`
+          `<span class="badge">${data.pulled} pulled</span> ` +
+          `<span class="badge pos">${data.owned || 0} we hold tickets</span>`
         : '';
     }
     renderTable();
@@ -87,6 +97,9 @@
     if (!body) return;
 
     let rows = _rows;
+    if (state.ownedOnly) {
+      rows = rows.filter(r => r.we_own);
+    }
     if (state.filter) {
       rows = rows.filter(r =>
         (r.event_name || '').toLowerCase().includes(state.filter) ||
@@ -133,6 +146,7 @@
         <th class="num" title="Sections with availability">Sec</th>
         <th class="num" title="Primary box-office seats">Prim</th>
         <th class="num" title="AXS Marketplace resale seats">Resale</th>
+        <th class="num" title="Tickets WE hold for this event (S4K owned inventory, latest_event_metrics)">Owned</th>
         <th class="num" title="Last AXS pull">Pulled</th>
         <th>Links</th>
       </tr></thead>
@@ -150,6 +164,15 @@
         : escapeHtml(name);
       const onsale = r.onsale_now ? ' <span class="badge pos" title="On sale now">on sale</span>' : '';
       const unmapped = r.tevo_event_id ? '' : ' <span class="badge muted" title="Not yet mapped to a canonical TEvo event">unmapped</span>';
+      // We-hold-tickets flag: S4K owned inventory for the mapped TEvo event.
+      const sharePct = (r.owned_share != null && Number.isFinite(+r.owned_share))
+        ? ` · ${(+r.owned_share * 100).toFixed(0)}% of mkt` : '';
+      const hold = r.we_own
+        ? ` <span class="badge pos" title="We hold ${T.fmtNum(r.owned_tickets)} ticket(s)${sharePct}">HOLD</span>`
+        : '';
+      const ownedCell = r.we_own
+        ? `<span class="pos">${T.fmtNum(r.owned_tickets)}</span>`
+        : (r.linked ? '<span class="muted">0</span>' : '<span class="muted small">—</span>');
 
       const band = (r.price_min != null && r.price_max != null)
         ? `${cur}${T.fmtNum(Math.round(r.price_min))}–${cur}${T.fmtNum(Math.round(r.price_max))}`
@@ -162,7 +185,7 @@
       if (r.tevo_event_id) links.push(`<a href="event.html?event=${r.tevo_event_id}">EVENT</a>`);
 
       tr.innerHTML = `
-        <td>${nameCell}${onsale}${unmapped}</td>
+        <td>${nameCell}${hold}${onsale}${unmapped}</td>
         <td>${escapeHtml(r.venue_name || '—')}</td>
         <td class="num">${r.occurs_at_local ? T.temporalChipHtml(r.occurs_at_local) : '<span class="muted small">—</span>'}</td>
         <td class="num">${r.getin != null ? cur + T.fmtNum(Math.round(r.getin)) : '—'}</td>
@@ -171,6 +194,7 @@
         <td class="num">${T.fmtNum(r.sections_count)}</td>
         <td class="num">${T.fmtNum(r.seats_primary)}</td>
         <td class="num">${T.fmtNum(r.seats_resale)}</td>
+        <td class="num">${ownedCell}</td>
         <td class="num muted small">${fmtDateShort(r.last_pulled_at)}</td>
         <td class="small">${links.join(' · ') || '—'}</td>`;
       tb.appendChild(tr);

--- a/tests/test_axs_routes.py
+++ b/tests/test_axs_routes.py
@@ -88,16 +88,22 @@ def test_axs_events_list(client, monkeypatch):
               "currency": "USD", "getin": 55, "price_min": 55, "price_max": 250,
               "listings_count": 120, "sections_count": 18, "offers_count": 3,
               "seats_primary": 100, "seats_resale": 20, "onsale_now": True}]
-    _db(monkeypatch, tables={"axs_events": evs, "axs_event_snapshots": snaps})
+    metrics = [{"event_id": 42, "owned_tickets_count": 8, "owned_groups_count": 2,
+                "owned_share": 0.25}]
+    _db(monkeypatch, tables={"axs_events": evs, "axs_event_snapshots": snaps,
+                             "latest_event_metrics": metrics})
     body = client.get("/api/axs/events").json()
     assert body["count"] == 2
     assert body["linked"] == 1
     assert body["pulled"] == 1
+    assert body["owned"] == 1
     a = next(e for e in body["events"] if e["axs_event_id"] == "ev-a")
     assert a["linked"] is True and a["event_name"] == "Show A"
     assert a["getin"] == 55 and a["seats_resale"] == 20
+    assert a["we_own"] is True and a["owned_tickets"] == 8 and a["owned_share"] == 0.25
     b = next(e for e in body["events"] if e["axs_event_id"] == "ev-b")
     assert b["linked"] is False and b["event_name"] is None and b["captured_at"] is None
+    assert b["we_own"] is False and b["owned_tickets"] is None
 
 
 def test_axs_event_unlinked(client, monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up to the AXS tab (#635): mark **which AXS-tracked events we hold tickets for**, so the operator can see at a glance where our box-office tracking overlaps our own inventory.

Uses the canonical owned-inventory peg — `latest_event_metrics.owned_tickets_count` (the S4K `is_owned` / brokerage-`1768` rollup the collector already computes), batch-joined over each AXS event's **mapped `tevo_event_id`**. No new derivation, no firehose scan.

## Changes

- **`routers/axs.py`** — `GET /api/axs/events` now batch-queries `latest_event_metrics` (`.in_("event_id", mapped_ids)`) and returns per event: `we_own`, `owned_tickets`, `owned_groups`, `owned_share`; plus an `owned` rollup count in the envelope.
- **`static/terminal/axs.js`** — new **Owned** column (ticket count, green when held; `0` for mapped-but-unheld; `—` for unmapped), a green **HOLD** badge on the event name (ticket count + % of market on hover), a **HOLDINGS: All / We hold** filter toggle, and a "N we hold tickets" summary chip.
- **`static/terminal/axs.html`** — HOLDINGS control group; `axs.js` cache-bust bump.
- **`tests/test_axs_routes.py`** — extended to assert `we_own` / `owned_tickets` / `owned_share` and the `owned` rollup (held + unmapped rows).

## Notes

- An event counts as "held" only when it's mapped to a canonical TEvo id **and** `owned_tickets_count > 0` — unmapped AXS rows show `—` (we can't peg inventory without the mapping).
- No DB migration — reads the existing `latest_event_metrics` view.

## Verification

- `pytest tests/test_axs_routes.py` → 6 passed
- `routers.axs` imports clean; `axs.js` passes `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWSCY48FdxWpPsnuxbK1L8)_