### PR TITLE
test(a1): broker route coverage — event orders roll-up (BR-CODE-3)

### DIFF
--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -386,3 +386,33 @@ def test_tours_near_passes_params_to_discovery(client, monkeypatch):
     assert body == {"ok": True, "performers": []}
     assert captured == {"home_lat": 40.75, "home_lon": -73.99, "within_mi": 100.0,
                         "days": 60, "min_shows": 3, "concerts_only": True}
+
+
+# ---------- /api/broker/event/{id}/orders ----------
+
+def test_orders_empty_returns_null_summary(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(table_data={"evo_order_items": []}))
+    body = client.get("/api/broker/event/1/orders").json()
+    assert body == {"event_id": 1, "items": [], "orders": [], "summary": None}
+
+
+def test_orders_rolls_up_state_counts_and_sold(client, monkeypatch):
+    items = [
+        {"evo_order_id": 10, "evo_item_id": 1, "quantity": 2, "price": 100},  # accepted
+        {"evo_order_id": 11, "evo_item_id": 2, "quantity": 1, "price": 50},   # pending
+    ]
+    orders = [
+        {"evo_order_id": 10, "state": "accepted", "evo_updated_at": "2026-05-10T12:00:00Z"},
+        {"evo_order_id": 11, "state": "pending", "evo_updated_at": "2026-05-09T12:00:00Z"},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={
+        "evo_order_items": items, "evo_orders": orders,
+    }))
+    body = client.get("/api/broker/event/1/orders").json()
+    s = body["summary"]
+    assert s["total_items"] == 2
+    assert s["by_state"] == {"accepted": 1, "pending": 1}
+    # only accepted/completed items count toward sold totals
+    assert s["tickets_sold"] == 2
+    assert s["gross_sold"] == 200.0       # 100 * 2
+    assert s["last_update_at"] == "2026-05-10T12:00:00Z"


### PR DESCRIPTION
## BR-CODE-3 — event orders roll-up coverage

Additive coverage (**no `app.py` change**). 2 tests for `/api/broker/event/{id}/orders` (reads persisted `evo_orders`/`evo_order_items` — no TEvo call):
- empty items → null summary, empty `items`/`orders`
- populated → `by_state` item counts, **accepted/completed-only** `tickets_sold` + `gross_sold` (200.0), and `last_update_at` = max `evo_updated_at`

### Result
- +2 tests (439 passing). `/api/broker/*` coverage now spans 9 routes on the shared `FakeSupabase` harness. Full suite green aside from the known env-only deps (`supabase.Client`, `pyo3` crypto) that CI provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114LxeiwxvGv6fSQguNgu2N)_