### PR TITLE
style(d1): dark color-scheme for native storefront form controls

### DIFF
--- a/static/store/style.css
+++ b/static/store/style.css
@@ -18,6 +18,9 @@
   /* Editorial serif for display headings — system stack, no external font
      (CSP blocks remote font-src). Gives the concierge / luxury feel. */
   --display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, "Times New Roman", serif;
+  /* Render native controls (checkboxes, date/number pickers, <select> lists,
+     scrollbars) in dark mode so they match the theme instead of the OS default. */
+  color-scheme: dark;
 }
 
 * { box-sizing: border-box; }
@@ -32,6 +35,8 @@ body {
   min-height: 100dvh;
 }
 a { color: inherit; }
+/* Brand-tint the checked/active state of native form controls. */
+input, select, textarea { accent-color: var(--accent); }
 
 /* Screen-reader-only label utility. Visually hidden but exposed to
    assistive tech. Standard inert-block pattern (1×1 clip + non-wrap)


### PR DESCRIPTION
## Storefront native-control theming (D1)

Completes the storefront form-theming pass. After the discover/tour pages got explicit dark control styling (#642), the remaining gap was **native** controls — checkboxes, `<select>` dropdown lists, date/number pickers, scrollbars — which follow the **OS** color scheme, not the page. Most visible on the shares admin page, where the "show revoked & expired" checkbox rendered as a white box on the dark page.

### Change (one declaration, `static/store/style.css`)
- `color-scheme: dark` on `:root` → the browser renders native UI in dark mode.
- `accent-color: var(--accent)` on `input, select, textarea` → brand-tints checked/active states.

CSS only, no markup/JS change. Benefits every storefront page that uses a native control (shares checkbox, discover `<select>`, tour date/number pickers).

### Verification
Re-rendered `shares.html` via headless Chrome — the checkbox now renders dark/themed instead of white. Other pages unchanged.

### Scope
D1-lane file only (`static/store/style.css`). No cross-lane surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RE2Wq4XphUYwM15g1WDZPi

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE2Wq4XphUYwM15g1WDZPi)_