### PR TITLE
feat(d0): substitution checker (cost-aware row + section + terminal page)

### DIFF
--- a/core/substitutions.py
+++ b/core/substitutions.py
@@ -255,6 +255,7 @@ def find_row_substitutions(
             "unit_cost": unit_cost,
             "row_delta": row_delta,
             "ticket_group_id": gid,
+            "inv_source": c.get("inv_source"),
             "pnl_per_ticket": pnl_per_ticket,
             "pnl_total": pnl_total,
         }

--- a/core/substitutions.py
+++ b/core/substitutions.py
@@ -1,0 +1,222 @@
+"""Substitution checker — row-level matching (pure logic).
+
+When we double-sell or otherwise need to cover an owned ticket, we look for a
+substitute from our OWN inventory. A valid sub is, in priority order:
+
+  1. SAME section, SAME row  (a true like-for-like swap)
+  2. SAME section, BETTER row (an upgrade — the customer ends up closer in)
+
+"Better" means closer to the stage/field. By the usual venue convention a
+LOWER number is better (row 19 upgrades row 20) and an EARLIER letter is better
+(row A upgrades row B). This module implements ONLY the same-section row part;
+finding a better SECTION is a deliberate future phase (see KANBAN / the route
+docstring) and is out of scope here.
+
+Everything in this file is pure (no DB, no network) so it is cheap to unit-test
+exhaustively. The HTTP route in routers/broker.py feeds it the owned-listings
+snapshot and returns the structured result verbatim.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from core.helpers import clean_section
+
+# A row label is one of a few shapes. We only ever compare two rows when they
+# share a comparable KIND — comparing "A" against "12" is meaningless, so those
+# land in an "ambiguous" bucket for a human rather than a false upgrade claim.
+#
+#   numeric : "1", "2", "20"      -> rank = the integer (lower = better)
+#   alpha   : "A".."Z","AA","AB"  -> rank = spreadsheet-column index (A=1, lower = better)
+#   ga      : general admission    -> flat; any GA subs any GA, never an upgrade
+#   unknown : empty / mixed / weird -> only an exact string match qualifies
+# Match GA / GA1 / "General Admission" / "GEN ADM" but NOT words like "GATE":
+# the prefix must be followed by a space, a digit, or end-of-string.
+_GA_RE = re.compile(
+    r"^(GA|GEN(ERAL)?\.?\s*ADM(ISSION)?)(\s|\d|$)", re.IGNORECASE
+)
+_NUMERIC_RE = re.compile(r"^\d+$")
+_ALPHA_RE = re.compile(r"^[A-Za-z]{1,3}$")
+
+
+@dataclass(frozen=True)
+class RowRank:
+    """Parsed, comparable view of a raw row label.
+
+    `rank` is a sortable number where LOWER = a better (closer-in) seat, defined
+    only when `kind` is "numeric" or "alpha". `norm` is the normalized label used
+    for exact-match fallback on "unknown"/"ga" kinds.
+    """
+    kind: str          # "numeric" | "alpha" | "ga" | "unknown"
+    rank: int | None   # lower = better; None when not rank-comparable
+    raw: str | None
+    norm: str          # upper/trimmed label ("" when empty)
+
+
+def _alpha_to_rank(letters: str) -> int:
+    """Spreadsheet-column index: A=1, B=2, ... Z=26, AA=27, AB=28, ...
+
+    This keeps a strict monotonic order for BOTH common venue conventions —
+    sequential (A,B,...,Z,AA,AB) and doubled (AA,BB,CC) — since AA<AB<...<BB
+    holds either way. Absolute gaps may be off for doubled venues, but only the
+    ORDER matters for same/better comparison."""
+    acc = 0
+    for ch in letters.upper():
+        acc = acc * 26 + (ord(ch) - ord("A") + 1)
+    return acc
+
+
+def parse_row(row: str | None) -> RowRank:
+    """Parse a raw row label into a comparable RowRank. Never raises."""
+    norm = (row or "").strip().upper()
+    if not norm:
+        return RowRank("unknown", None, row, "")
+    if _GA_RE.match(norm):
+        return RowRank("ga", None, row, norm)
+    if _NUMERIC_RE.match(norm):
+        return RowRank("numeric", int(norm), row, norm)
+    if _ALPHA_RE.match(norm):
+        return RowRank("alpha", _alpha_to_rank(norm), row, norm)
+    return RowRank("unknown", None, row, norm)
+
+
+# Comparison verdicts.
+SAME = "same"
+UPGRADE = "upgrade"        # candidate row is BETTER (closer in) than target
+DOWNGRADE = "downgrade"    # candidate row is WORSE — never a valid sub
+INCOMPARABLE = "incomparable"  # kinds don't line up — needs a human
+
+
+def compare_rows(target: str | None, candidate: str | None) -> str:
+    """Compare a candidate row against the target row we need to cover.
+
+    Returns SAME / UPGRADE / DOWNGRADE / INCOMPARABLE. UPGRADE means the
+    candidate is a strictly better (closer-in) seat than the target.
+    """
+    t = parse_row(target)
+    c = parse_row(candidate)
+
+    # Rank-comparable kinds (numeric vs numeric, alpha vs alpha).
+    if t.kind == c.kind and t.kind in ("numeric", "alpha"):
+        if c.rank == t.rank:
+            return SAME
+        return UPGRADE if c.rank < t.rank else DOWNGRADE  # type: ignore[operator]
+
+    # GA is flat: a GA target is only ever swapped for another GA (a lateral
+    # same), never "upgraded". Treat GA-to-GA as SAME, anything else as
+    # incomparable.
+    if t.kind == "ga" or c.kind == "ga":
+        return SAME if (t.kind == "ga" and c.kind == "ga") else INCOMPARABLE
+
+    # Mixed/unknown kinds: only an exact normalized-label match is a safe sub.
+    if t.norm and c.norm and t.norm == c.norm:
+        return SAME
+    return INCOMPARABLE
+
+
+def _row_sort_key(verdict: str, cand: RowRank) -> tuple:
+    """Order substitutes best-first: upgrades before same-row, and within a
+    bucket the closer-in (lower rank) seat first. Ranks may be None for
+    exact-match SAME on unknown kinds — those sort last within their bucket."""
+    bucket = 0 if verdict == UPGRADE else 1  # upgrades first
+    rank = cand.rank if cand.rank is not None else 10**9
+    return (bucket, rank)
+
+
+def find_row_substitutions(
+    section: str | None,
+    row: str | None,
+    qty_needed: int,
+    candidates: list[dict],
+    *,
+    exclude_group_id=None,
+) -> dict:
+    """Find same-section, same-or-better-row substitutes from owned inventory.
+
+    Args:
+      section: the section of the ticket we need to cover.
+      row: the row of the ticket we need to cover.
+      qty_needed: how many seats we must replace; a candidate must have
+        `quantity >= qty_needed` to qualify.
+      candidates: owned listings. Each dict should carry at least
+        `section`, `row`, `quantity`; `tevo_ticket_group_id`/`id` and
+        `retail_price` are surfaced when present.
+      exclude_group_id: a ticket-group id to drop from the candidate pool
+        (e.g. the very listing that got double-sold).
+
+    Returns a dict:
+      {
+        "target": {"section","row","row_kind","quantity_needed"},
+        "subs":   [ {match_type, section, row, quantity, retail_price,
+                     ticket_group_id, row_delta}, ... ],   # best-first
+        "ambiguous": [ ... same shape, match_type="incomparable" ... ],
+        "counts": {"subs","ambiguous","scanned"},
+      }
+    """
+    target_section = clean_section(section)
+    target = parse_row(row)
+    qty_needed = max(1, int(qty_needed or 1))
+
+    subs: list[tuple[tuple, dict]] = []
+    ambiguous: list[dict] = []
+    scanned = 0
+
+    for c in candidates:
+        gid = c.get("tevo_ticket_group_id", c.get("id"))
+        if exclude_group_id is not None and gid is not None and gid == exclude_group_id:
+            continue
+        # Same-section only (row phase). Section normalization mirrors ingest.
+        if clean_section(c.get("section")) != target_section:
+            continue
+        scanned += 1
+        try:
+            qty = int(c.get("quantity") or 0)
+        except (TypeError, ValueError):
+            qty = 0
+        if qty < qty_needed:
+            continue
+
+        verdict = compare_rows(row, c.get("row"))
+        if verdict == DOWNGRADE:
+            continue
+
+        cand_rank = parse_row(c.get("row"))
+        row_delta = None
+        if (verdict in (SAME, UPGRADE)
+                and target.rank is not None and cand_rank.rank is not None):
+            # Positive = rows of improvement (target rank minus candidate rank).
+            row_delta = target.rank - cand_rank.rank
+
+        entry = {
+            "match_type": verdict,
+            "section": c.get("section"),
+            "row": c.get("row"),
+            "quantity": qty,
+            "retail_price": c.get("retail_price"),
+            "ticket_group_id": gid,
+            "row_delta": row_delta,
+        }
+        if verdict == INCOMPARABLE:
+            ambiguous.append(entry)
+        else:
+            subs.append((_row_sort_key(verdict, cand_rank), entry))
+
+    subs.sort(key=lambda x: x[0])
+    sub_entries = [e for _, e in subs]
+
+    return {
+        "target": {
+            "section": target_section,
+            "row": row,
+            "row_kind": target.kind,
+            "quantity_needed": qty_needed,
+        },
+        "subs": sub_entries,
+        "ambiguous": ambiguous,
+        "counts": {
+            "subs": len(sub_entries),
+            "ambiguous": len(ambiguous),
+            "scanned": scanned,
+        },
+    }

--- a/core/substitutions.py
+++ b/core/substitutions.py
@@ -128,13 +128,35 @@ def compare_rows(target: str | None, candidate: str | None) -> str:
     return INCOMPARABLE
 
 
-def _row_sort_key(verdict: str, cand: RowRank) -> tuple:
-    """Order substitutes best-first: upgrades before same-row, and within a
-    bucket the closer-in (lower rank) seat first. Ranks may be None for
-    exact-match SAME on unknown kinds — those sort last within their bucket."""
-    bucket = 0 if verdict == UPGRADE else 1  # upgrades first
-    rank = cand.rank if cand.rank is not None else 10**9
-    return (bucket, rank)
+_INF = float("inf")
+
+
+def _coerce_float(v) -> float | None:
+    """Best-effort numeric parse for cost/price fields ($, commas tolerated)."""
+    if v is None:
+        return None
+    if isinstance(v, (int, float)):
+        return float(v)
+    s = str(v).strip().replace("$", "").replace(",", "")
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _row_sort_key(unit_cost: float | None, over_delivery: int | None,
+                  qty: int) -> tuple:
+    """Cost-aware ordering. A valid sub must already be same-or-better row +
+    enough quantity; among those the cheapest is best, because over-delivering
+    a better seat than was sold is wasted money. Tiebreak by the SMALLEST
+    acceptable upgrade (closest to the row actually sold) then the smallest
+    lot (don't burn a big block to cover a few seats).
+
+    Missing cost sorts last (we can't prove it's cheap), and missing/unknown
+    over-delivery sorts after known ones."""
+    cost = unit_cost if unit_cost is not None else _INF
+    over = over_delivery if over_delivery is not None else 10**9
+    return (cost, over, qty)
 
 
 def find_row_substitutions(
@@ -144,32 +166,50 @@ def find_row_substitutions(
     candidates: list[dict],
     *,
     exclude_group_id=None,
+    revenue_per_ticket: float | None = None,
+    cost_fields: tuple[str, ...] = ("cost", "retail_price"),
 ) -> dict:
-    """Find same-section, same-or-better-row substitutes from owned inventory.
+    """Find same-section, same-or-better-row substitutes, ranked by COST.
 
     Args:
       section: the section of the ticket we need to cover.
       row: the row of the ticket we need to cover.
       qty_needed: how many seats we must replace; a candidate must have
         `quantity >= qty_needed` to qualify.
-      candidates: owned listings. Each dict should carry at least
-        `section`, `row`, `quantity`; `tevo_ticket_group_id`/`id` and
-        `retail_price` are surfaced when present.
-      exclude_group_id: a ticket-group id to drop from the candidate pool
-        (e.g. the very listing that got double-sold).
+      candidates: candidate listings (our owned inventory, or a market book to
+        buy into). Each dict should carry at least `section`, `row`,
+        `quantity`; `tevo_ticket_group_id`/`id` is surfaced when present, and a
+        unit cost is read from the first present of `cost_fields`.
+      exclude_group_id: a ticket-group id to drop (e.g. the listing that got
+        double-sold).
+      revenue_per_ticket: what we received per seat on the sale. When given,
+        each sub carries `pnl_per_ticket` / `pnl_total` (revenue − unit cost,
+        projected over qty_needed) so the loss/margin of covering is explicit.
+      cost_fields: ordered field names to read a unit cost from. Owned books
+        carry a real cost basis (`cost`); a market buy-in uses the ask
+        (`retail_price`).
 
-    Returns a dict:
+    Subs are ordered cheapest-first (then smallest acceptable upgrade, then
+    smallest lot). Returns:
       {
-        "target": {"section","row","row_kind","quantity_needed"},
-        "subs":   [ {match_type, section, row, quantity, retail_price,
-                     ticket_group_id, row_delta}, ... ],   # best-first
+        "target": {"section","row","row_kind","quantity_needed","revenue_per_ticket"},
+        "subs":   [ {match_type, section, row, quantity, unit_cost, row_delta,
+                     ticket_group_id, pnl_per_ticket, pnl_total}, ... ],
         "ambiguous": [ ... same shape, match_type="incomparable" ... ],
         "counts": {"subs","ambiguous","scanned"},
+        "best": <the cheapest sub or None>,
       }
     """
     target_section = clean_section(section)
     target = parse_row(row)
     qty_needed = max(1, int(qty_needed or 1))
+
+    def _unit_cost(c: dict) -> float | None:
+        for f in cost_fields:
+            v = _coerce_float(c.get(f))
+            if v is not None:
+                return v
+        return None
 
     subs: list[tuple[tuple, dict]] = []
     ambiguous: list[dict] = []
@@ -201,19 +241,30 @@ def find_row_substitutions(
             # Positive = rows of improvement (target rank minus candidate rank).
             row_delta = target.rank - cand_rank.rank
 
+        unit_cost = _unit_cost(c)
+        pnl_per_ticket = pnl_total = None
+        if revenue_per_ticket is not None and unit_cost is not None:
+            pnl_per_ticket = round(revenue_per_ticket - unit_cost, 2)
+            pnl_total = round(pnl_per_ticket * qty_needed, 2)
+
         entry = {
             "match_type": verdict,
             "section": c.get("section"),
             "row": c.get("row"),
             "quantity": qty,
-            "retail_price": c.get("retail_price"),
-            "ticket_group_id": gid,
+            "unit_cost": unit_cost,
             "row_delta": row_delta,
+            "ticket_group_id": gid,
+            "pnl_per_ticket": pnl_per_ticket,
+            "pnl_total": pnl_total,
         }
         if verdict == INCOMPARABLE:
             ambiguous.append(entry)
         else:
-            subs.append((_row_sort_key(verdict, cand_rank), entry))
+            # over_delivery = rows better than sold (0 for same row). Unknown
+            # when not rank-comparable (exact-match SAME on unknown kinds).
+            over = row_delta if row_delta is not None else None
+            subs.append((_row_sort_key(unit_cost, over, qty), entry))
 
     subs.sort(key=lambda x: x[0])
     sub_entries = [e for _, e in subs]
@@ -224,6 +275,7 @@ def find_row_substitutions(
             "row": row,
             "row_kind": target.kind,
             "quantity_needed": qty_needed,
+            "revenue_per_ticket": revenue_per_ticket,
         },
         "subs": sub_entries,
         "ambiguous": ambiguous,
@@ -232,4 +284,5 @@ def find_row_substitutions(
             "ambiguous": len(ambiguous),
             "scanned": scanned,
         },
+        "best": sub_entries[0] if sub_entries else None,
     }

--- a/core/substitutions.py
+++ b/core/substitutions.py
@@ -47,11 +47,19 @@ class RowRank:
     `rank` is a sortable number where LOWER = a better (closer-in) seat, defined
     only when `kind` is "numeric" or "alpha". `norm` is the normalized label used
     for exact-match fallback on "unknown"/"ga" kinds.
+
+    `alpha_width` is the letter count for alpha rows (1 for "A".."Z", 2 for
+    "AA".."ZZ", ...). It exists because the ordering of double-letter rows
+    relative to single-letter rows is VENUE-DEPENDENT: stadiums run A..Z then
+    AA (AA behind Z), while some theaters put AA/BB as premium rows IN FRONT of
+    A (AA ahead of Z). So two alpha rows are only safely comparable when their
+    widths match; cross-width pairs ("A" vs "AA") are deliberately incomparable.
     """
     kind: str          # "numeric" | "alpha" | "ga" | "unknown"
     rank: int | None   # lower = better; None when not rank-comparable
     raw: str | None
     norm: str          # upper/trimmed label ("" when empty)
+    alpha_width: int = 0  # letter count for alpha rows; 0 otherwise
 
 
 def _alpha_to_rank(letters: str) -> int:
@@ -77,7 +85,7 @@ def parse_row(row: str | None) -> RowRank:
     if _NUMERIC_RE.match(norm):
         return RowRank("numeric", int(norm), row, norm)
     if _ALPHA_RE.match(norm):
-        return RowRank("alpha", _alpha_to_rank(norm), row, norm)
+        return RowRank("alpha", _alpha_to_rank(norm), row, norm, alpha_width=len(norm))
     return RowRank("unknown", None, row, norm)
 
 
@@ -97,8 +105,13 @@ def compare_rows(target: str | None, candidate: str | None) -> str:
     t = parse_row(target)
     c = parse_row(candidate)
 
-    # Rank-comparable kinds (numeric vs numeric, alpha vs alpha).
+    # Rank-comparable kinds (numeric vs numeric, alpha vs alpha). Alpha rows
+    # only compare within the same letter-width — the AA-vs-Z direction is
+    # venue-specific (see RowRank.alpha_width), so cross-width pairs fall
+    # through to INCOMPARABLE for a human to judge.
     if t.kind == c.kind and t.kind in ("numeric", "alpha"):
+        if t.kind == "alpha" and t.alpha_width != c.alpha_width:
+            return INCOMPARABLE
         if c.rank == t.rank:
             return SAME
         return UPGRADE if c.rank < t.rank else DOWNGRADE  # type: ignore[operator]

--- a/core/substitutions.py
+++ b/core/substitutions.py
@@ -287,3 +287,112 @@ def find_row_substitutions(
         },
         "best": sub_entries[0] if sub_entries else None,
     }
+
+
+def _read_unit_cost(c: dict, cost_fields: tuple[str, ...]) -> float | None:
+    for f in cost_fields:
+        v = _coerce_float(c.get(f))
+        if v is not None:
+            return v
+    return None
+
+
+SECTION_UPGRADE = "section_upgrade"
+
+
+def find_section_substitutions(
+    section: str | None,
+    qty_needed: int,
+    candidates: list[dict],
+    section_quality: dict,
+    *,
+    exclude_group_id=None,
+    revenue_per_ticket: float | None = None,
+    cost_fields: tuple[str, ...] = ("cost", "retail_price"),
+) -> dict:
+    """Find BETTER-section substitutes — the fallback when no same-section row
+    sub works.
+
+    A "better section" is one whose market quality score is >= the sold
+    section's. `section_quality` maps a (cleaned) section label to a numeric
+    quality score where HIGHER = better; the caller supplies it, typically the
+    market `retail_median` per section (a pricier section is a better section).
+    The row WITHIN a better section need not beat the sold row — moving up a
+    section is itself the upgrade.
+
+    Ranked cheapest-first, then by the SMALLEST section over-upgrade (closest in
+    quality to what was sold, so we don't burn a premium section needlessly),
+    then the smallest lot. Same-section candidates are skipped (the row phase
+    owns those). Returns:
+      {
+        "sold_section", "sold_quality",
+        "section_subs": [ {match_type:"section_upgrade", to_section,
+                           section_quality, section_delta, row, quantity,
+                           unit_cost, ticket_group_id, inv_source,
+                           pnl_per_ticket, pnl_total}, ... ],
+        "best", "counts": {"section_subs","scanned"}, "note"?
+      }
+    """
+    sold = clean_section(section)
+    qty_needed = max(1, int(qty_needed or 1))
+    sold_q = _coerce_float(section_quality.get(sold))
+    if sold_q is None:
+        return {
+            "sold_section": sold, "sold_quality": None,
+            "section_subs": [], "best": None,
+            "counts": {"section_subs": 0, "scanned": 0},
+            "note": "no market quality signal for the sold section; cannot rank sections",
+        }
+
+    out: list[tuple[tuple, dict]] = []
+    scanned = 0
+    for c in candidates:
+        gid = c.get("tevo_ticket_group_id", c.get("id"))
+        if exclude_group_id is not None and gid is not None and gid == exclude_group_id:
+            continue
+        sec = clean_section(c.get("section"))
+        if sec is None or sec == sold:
+            continue  # same section is the row phase's job
+        q = _coerce_float(section_quality.get(sec))
+        if q is None or q < sold_q:
+            continue  # unknown or worse section — never a section upgrade
+        try:
+            qty = int(c.get("quantity") or 0)
+        except (TypeError, ValueError):
+            qty = 0
+        if qty < qty_needed:
+            continue
+        scanned += 1
+
+        unit_cost = _read_unit_cost(c, cost_fields)
+        pnl_per_ticket = pnl_total = None
+        if revenue_per_ticket is not None and unit_cost is not None:
+            pnl_per_ticket = round(revenue_per_ticket - unit_cost, 2)
+            pnl_total = round(pnl_per_ticket * qty_needed, 2)
+        section_delta = round(q - sold_q, 2)
+
+        entry = {
+            "match_type": SECTION_UPGRADE,
+            "to_section": sec,
+            "section_quality": q,
+            "section_delta": section_delta,
+            "row": c.get("row"),
+            "quantity": qty,
+            "unit_cost": unit_cost,
+            "ticket_group_id": gid,
+            "inv_source": c.get("inv_source"),
+            "pnl_per_ticket": pnl_per_ticket,
+            "pnl_total": pnl_total,
+        }
+        cost_key = unit_cost if unit_cost is not None else _INF
+        out.append(((cost_key, section_delta, qty), entry))
+
+    out.sort(key=lambda x: x[0])
+    section_subs = [e for _, e in out]
+    return {
+        "sold_section": sold,
+        "sold_quality": sold_q,
+        "section_subs": section_subs,
+        "best": section_subs[0] if section_subs else None,
+        "counts": {"section_subs": len(section_subs), "scanned": scanned},
+    }

--- a/core/substitutions.py
+++ b/core/substitutions.py
@@ -159,6 +159,18 @@ def _row_sort_key(unit_cost: float | None, over_delivery: int | None,
     return (cost, over, qty)
 
 
+def _landed(unit_cost: float | None, fee_pct: float, fee_flat: float) -> float | None:
+    """Landed per-ticket cost = ask + buy-in fees. For a market buy-in the ask
+    isn't what we actually pay — marketplace buyer fees (a % and/or a flat
+    per-ticket charge) push it up, so P&L must be computed on the landed cost.
+    Owned swaps pass fee_pct=fee_flat=0 (we already hold them — no purchase)."""
+    if unit_cost is None:
+        return None
+    if not fee_pct and not fee_flat:
+        return unit_cost
+    return round(unit_cost * (1 + (fee_pct or 0) / 100.0) + (fee_flat or 0), 2)
+
+
 def find_row_substitutions(
     section: str | None,
     row: str | None,
@@ -168,6 +180,8 @@ def find_row_substitutions(
     exclude_group_id=None,
     revenue_per_ticket: float | None = None,
     cost_fields: tuple[str, ...] = ("cost", "retail_price"),
+    fee_pct: float = 0.0,
+    fee_flat: float = 0.0,
 ) -> dict:
     """Find same-section, same-or-better-row substitutes, ranked by COST.
 
@@ -242,9 +256,10 @@ def find_row_substitutions(
             row_delta = target.rank - cand_rank.rank
 
         unit_cost = _unit_cost(c)
+        landed_cost = _landed(unit_cost, fee_pct, fee_flat)
         pnl_per_ticket = pnl_total = None
-        if revenue_per_ticket is not None and unit_cost is not None:
-            pnl_per_ticket = round(revenue_per_ticket - unit_cost, 2)
+        if revenue_per_ticket is not None and landed_cost is not None:
+            pnl_per_ticket = round(revenue_per_ticket - landed_cost, 2)
             pnl_total = round(pnl_per_ticket * qty_needed, 2)
 
         entry = {
@@ -253,6 +268,7 @@ def find_row_substitutions(
             "row": c.get("row"),
             "quantity": qty,
             "unit_cost": unit_cost,
+            "landed_cost": landed_cost,
             "row_delta": row_delta,
             "ticket_group_id": gid,
             "inv_source": c.get("inv_source"),
@@ -265,7 +281,7 @@ def find_row_substitutions(
             # over_delivery = rows better than sold (0 for same row). Unknown
             # when not rank-comparable (exact-match SAME on unknown kinds).
             over = row_delta if row_delta is not None else None
-            subs.append((_row_sort_key(unit_cost, over, qty), entry))
+            subs.append((_row_sort_key(landed_cost, over, qty), entry))
 
     subs.sort(key=lambda x: x[0])
     sub_entries = [e for _, e in subs]
@@ -309,6 +325,8 @@ def find_section_substitutions(
     exclude_group_id=None,
     revenue_per_ticket: float | None = None,
     cost_fields: tuple[str, ...] = ("cost", "retail_price"),
+    fee_pct: float = 0.0,
+    fee_flat: float = 0.0,
 ) -> dict:
     """Find BETTER-section substitutes — the fallback when no same-section row
     sub works.
@@ -365,9 +383,10 @@ def find_section_substitutions(
         scanned += 1
 
         unit_cost = _read_unit_cost(c, cost_fields)
+        landed_cost = _landed(unit_cost, fee_pct, fee_flat)
         pnl_per_ticket = pnl_total = None
-        if revenue_per_ticket is not None and unit_cost is not None:
-            pnl_per_ticket = round(revenue_per_ticket - unit_cost, 2)
+        if revenue_per_ticket is not None and landed_cost is not None:
+            pnl_per_ticket = round(revenue_per_ticket - landed_cost, 2)
             pnl_total = round(pnl_per_ticket * qty_needed, 2)
         section_delta = round(q - sold_q, 2)
 
@@ -379,12 +398,13 @@ def find_section_substitutions(
             "row": c.get("row"),
             "quantity": qty,
             "unit_cost": unit_cost,
+            "landed_cost": landed_cost,
             "ticket_group_id": gid,
             "inv_source": c.get("inv_source"),
             "pnl_per_ticket": pnl_per_ticket,
             "pnl_total": pnl_total,
         }
-        cost_key = unit_cost if unit_cost is not None else _INF
+        cost_key = landed_cost if landed_cost is not None else _INF
         out.append(((cost_key, section_delta, qty), entry))
 
     out.sort(key=lambda x: x[0])

--- a/docs/d0_terminal_build.md
+++ b/docs/d0_terminal_build.md
@@ -57,7 +57,7 @@ There are **two data paths** out of the browser:
 | `venue.js` | 509 | Venue index + detail + Market Carpet tab. |
 | `orders.js` | 50 | Doorway to the D2 orders dashboard (health ping only). |
 
-**HTML pages (8):** `index.html` (home), `event.html`, `movers.html`, `discovery.html`, `performer.html`, `venue.html`, `orders.html`, `login.html`.
+**HTML pages (9):** `index.html` (home), `event.html`, `movers.html`, `discovery.html`, `performer.html`, `venue.html`, `subs.html`, `orders.html`, `login.html`.
 Each sets `data-page` on `<body>` and loads the chain **`lib/supabase.js → auth.js → app.js → nav.js → <page>.js`**, with two exceptions:
 - `login.html` loads only `lib/supabase.js → auth.js → login.js` (no app.js/nav.js — you're not authed yet).
 - `event.html` additionally loads `lib/uplot.iife.min.js` + `lib/uplot.min.css` (charts) and `lib/tevomaps.bundle.js` (Seat Map, §B11).
@@ -98,6 +98,7 @@ Pages call `TerminalAuth.client.rpc('fn_name', {args})` or `.from('table').selec
 | **Discovery** (`discovery.html` / `discovery.js`) | C | `from('discovery_gap_alerts').select().is('resolved_at',null)` (`discovery.js:73-79`); rpc `get_blind_spots_tevo_selling` (`:260`), `get_returning_entities` (`:374`); enrich via `sg_events_canonical` + `events` | `discovery_gap_alerts`, `sg_events_canonical`, `events` |
 | **Performer** (`performer.html` / `performer.js`) | A + C | index rpc `get_broker_performer_index` (`:48`); detail `T.api('/api/broker/performer/{id}/assets')` + `T.api('/api/portfolio?performer_id={id}')` (`:111-112`); ESPN rpc `get_broker_performer_page({p_performer_id})` (`:355`); Market Carpet reads `event_listing_snapshot_daily`/`event_movers_index`/`discovery_gap_alerts` (`:491-508`) | `performer_metadata`, `entity_performer_map`, `espn_*`, portfolio |
 | **Venue** (`venue.html` / `venue.js`) | C | index rpc `get_broker_venue_index` (`:45`); detail rpc `get_broker_venue_page({p_venue_id})` — one round-trip for 4 tabs (`:108`); Market Carpet same 3 tables (`:332-349`) | `venue_assets`, `entity_venue_map` |
+| **Subs** (`subs.html` / `subs.js`) | A + C | `T.api('/api/broker/event/{id}/substitutions?section=&row=&quantity=&revenue=&source=&fee_pct=')` (`subs.js`); event-name typeahead rpc `terminal_search` | `listings_snapshots`, `seatgeek_seller_listings`, `section_metrics` (logic in `core/substitutions.py`) |
 | **Orders** (`orders.html` / `orders.js`) | — | health ping to `https://d2-orders-dashboard.onrender.com/healthz` (`orders.js:9,25`); **no broker API** | (D2 dashboard, separate service) |
 | **Login** (`login.html` / `login.js`) | C (auth) | Supabase Google OAuth via `TerminalAuth.signInWithGoogle`; no broker API | Supabase auth |
 | **(global)** `nav.js` | C | rpc `terminal_search({p_q, p_limit:6})` (`nav.js:115`) | `terminal_search` |

--- a/routers/broker.py
+++ b/routers/broker.py
@@ -103,25 +103,31 @@ def build_broker_router(
         section: str,
         row: str | None = None,
         quantity: int = 1,
+        revenue: float | None = None,
+        source: str = "owned",
         _=Depends(require_auth),
     ):
         """Substitution checker — ROW phase.
 
-        Given an owned ticket we need to cover (its section + row + quantity),
-        find same-section substitutes from OUR OWN inventory with the same or a
-        better (closer-in) row. Used when a listing is double-sold and we need
-        replacement seats we already hold.
+        Given a ticket we need to cover (its section + row + quantity), find
+        same-section substitutes with the same or a better (closer-in) row,
+        ranked CHEAPEST-FIRST — over-delivering a better seat than was sold is
+        wasted money, so the least-cost acceptable seat wins.
 
-        Source = the latest `listings_snapshots` snapshot for the event, filtered
-        to `is_owned=true` (our book). Matching/ranking is pure logic in
-        core.substitutions; "better SECTION" matching is a deliberate future
-        phase and is NOT attempted here.
+        `source` selects the candidate pool from the latest `listings_snapshots`
+        snapshot for the event:
+          owned  (default) our held inventory (is_owned=true) — a free swap
+          market the rest of the book — a buy-in when we hold no sub
+        `revenue` (total $ received for the sale) turns on per-sub P&L so the
+        loss/margin of each cover is explicit. Ranking/matching is pure logic in
+        core.substitutions; "better SECTION" matching is a deliberate future phase.
 
         Query params:
           section   (required) the section to cover
-          row       the row to cover (omit/empty => only same-section listings
-                    with a comparable row can ever qualify as "same")
+          row       the row to cover
           quantity  seats needed; a candidate must have quantity >= this (default 1)
+          revenue   total $ received on the sale (optional; enables P&L)
+          source    "owned" (default) | "market"
         """
         db = get_require_sb()()
         latest = (
@@ -129,22 +135,24 @@ def build_broker_router(
             .eq("event_id", event_id).order("captured_at", desc=True).limit(1)
             .execute().data or []
         )
+        qty = max(1, int(quantity or 1))
+        rev_per_ticket = (revenue / qty) if revenue is not None else None
         if not latest:
-            empty = find_row_substitutions(section, row, quantity, [])
-            empty["captured_at"] = None
-            empty["event_id"] = event_id
+            empty = find_row_substitutions(section, row, qty, [],
+                                           revenue_per_ticket=rev_per_ticket)
+            empty.update({"captured_at": None, "event_id": event_id, "source": source})
             return empty
         captured_at = latest[0]["captured_at"]
-        owned = (
+        q = (
             db.table("listings_snapshots")
             .select("tevo_ticket_group_id,section,row,quantity,retail_price,is_owned")
             .eq("event_id", event_id).eq("captured_at", captured_at)
-            .eq("is_owned", True)
-            .execute().data or []
+            .eq("is_owned", source == "owned")
         )
-        result = find_row_substitutions(section, row, quantity, owned)
-        result["captured_at"] = captured_at
-        result["event_id"] = event_id
+        pool = q.execute().data or []
+        result = find_row_substitutions(section, row, qty, pool,
+                                        revenue_per_ticket=rev_per_ticket)
+        result.update({"captured_at": captured_at, "event_id": event_id, "source": source})
         return result
 
     return router

--- a/routers/broker.py
+++ b/routers/broker.py
@@ -19,6 +19,7 @@ import requests
 from fastapi import APIRouter, Depends, HTTPException
 
 from core.helpers import listings_cadence_seconds
+from core.substitutions import find_row_substitutions
 
 
 def build_broker_router(
@@ -95,5 +96,55 @@ def build_broker_router(
                 "espn_team":       {"last_pull_at": last_team_at,     "cadence_seconds": 60 * 60 * 24},
             },
         }
+
+    @router.get("/api/broker/event/{event_id}/substitutions")
+    def broker_event_substitutions(
+        event_id: int,
+        section: str,
+        row: str | None = None,
+        quantity: int = 1,
+        _=Depends(require_auth),
+    ):
+        """Substitution checker — ROW phase.
+
+        Given an owned ticket we need to cover (its section + row + quantity),
+        find same-section substitutes from OUR OWN inventory with the same or a
+        better (closer-in) row. Used when a listing is double-sold and we need
+        replacement seats we already hold.
+
+        Source = the latest `listings_snapshots` snapshot for the event, filtered
+        to `is_owned=true` (our book). Matching/ranking is pure logic in
+        core.substitutions; "better SECTION" matching is a deliberate future
+        phase and is NOT attempted here.
+
+        Query params:
+          section   (required) the section to cover
+          row       the row to cover (omit/empty => only same-section listings
+                    with a comparable row can ever qualify as "same")
+          quantity  seats needed; a candidate must have quantity >= this (default 1)
+        """
+        db = get_require_sb()()
+        latest = (
+            db.table("listings_snapshots").select("captured_at")
+            .eq("event_id", event_id).order("captured_at", desc=True).limit(1)
+            .execute().data or []
+        )
+        if not latest:
+            empty = find_row_substitutions(section, row, quantity, [])
+            empty["captured_at"] = None
+            empty["event_id"] = event_id
+            return empty
+        captured_at = latest[0]["captured_at"]
+        owned = (
+            db.table("listings_snapshots")
+            .select("tevo_ticket_group_id,section,row,quantity,retail_price,is_owned")
+            .eq("event_id", event_id).eq("captured_at", captured_at)
+            .eq("is_owned", True)
+            .execute().data or []
+        )
+        result = find_row_substitutions(section, row, quantity, owned)
+        result["captured_at"] = captured_at
+        result["event_id"] = event_id
+        return result
 
     return router

--- a/routers/broker.py
+++ b/routers/broker.py
@@ -18,8 +18,8 @@ from typing import Callable
 import requests
 from fastapi import APIRouter, Depends, HTTPException
 
-from core.helpers import listings_cadence_seconds
-from core.substitutions import find_row_substitutions
+from core.helpers import clean_section, listings_cadence_seconds
+from core.substitutions import find_row_substitutions, find_section_substitutions
 
 
 def build_broker_router(
@@ -181,6 +181,25 @@ def build_broker_router(
 
         result = find_row_substitutions(section, row, qty, pool,
                                         revenue_per_ticket=rev_per_ticket)
+
+        # Better-SECTION fallback: rank sections by market quality (retail_median
+        # per section) and offer cheapest acceptable upgrades from the same pool.
+        sm = (
+            db.table("section_metrics")
+            .select("section,retail_median,is_ancillary,captured_at")
+            .eq("event_id", event_id).order("captured_at", desc=True)
+            .execute().data or []
+        )
+        section_quality: dict = {}
+        for r in sm:
+            if r.get("is_ancillary"):
+                continue  # parking/ancillary aren't seating upgrades
+            sec = clean_section(r.get("section"))
+            if sec and sec not in section_quality and r.get("retail_median") is not None:
+                section_quality[sec] = r.get("retail_median")  # latest wins (desc order)
+        result["section_subs"] = find_section_substitutions(
+            section, qty, pool, section_quality, revenue_per_ticket=rev_per_ticket)
+
         result.update({"captured_at": captured_at, "event_id": event_id, "source": source})
         return result
 

--- a/routers/broker.py
+++ b/routers/broker.py
@@ -114,10 +114,13 @@ def build_broker_router(
         ranked CHEAPEST-FIRST — over-delivering a better seat than was sold is
         wasted money, so the least-cost acceptable seat wins.
 
-        `source` selects the candidate pool from the latest `listings_snapshots`
-        snapshot for the event:
-          owned  (default) our held inventory (is_owned=true) — a free swap
-          market the rest of the book — a buy-in when we hold no sub
+        `source` selects the candidate pool:
+          owned  (default) our held inventory — the latest `listings_snapshots`
+                 `is_owned=true` rows (TEvo, cost≈list `retail_price`) MERGED
+                 with our SeatGeek SellerDirect book (`seatgeek_seller_listings`,
+                 real `cost` basis) — a free swap from stock we already hold
+          market the rest of the `listings_snapshots` book — a buy-in when we
+                 hold no sub
         `revenue` (total $ received for the sale) turns on per-sub P&L so the
         loss/margin of each cover is explicit. Ranking/matching is pure logic in
         core.substitutions; "better SECTION" matching is a deliberate future phase.
@@ -130,26 +133,52 @@ def build_broker_router(
           source    "owned" (default) | "market"
         """
         db = get_require_sb()()
+        qty = max(1, int(quantity or 1))
+        rev_per_ticket = (revenue / qty) if revenue is not None else None
+
         latest = (
             db.table("listings_snapshots").select("captured_at")
             .eq("event_id", event_id).order("captured_at", desc=True).limit(1)
             .execute().data or []
         )
-        qty = max(1, int(quantity or 1))
-        rev_per_ticket = (revenue / qty) if revenue is not None else None
-        if not latest:
-            empty = find_row_substitutions(section, row, qty, [],
-                                           revenue_per_ticket=rev_per_ticket)
-            empty.update({"captured_at": None, "event_id": event_id, "source": source})
-            return empty
-        captured_at = latest[0]["captured_at"]
-        q = (
-            db.table("listings_snapshots")
-            .select("tevo_ticket_group_id,section,row,quantity,retail_price,is_owned")
-            .eq("event_id", event_id).eq("captured_at", captured_at)
-            .eq("is_owned", source == "owned")
-        )
-        pool = q.execute().data or []
+        captured_at = latest[0]["captured_at"] if latest else None
+        pool: list[dict] = []
+        if captured_at is not None:
+            ls = (
+                db.table("listings_snapshots")
+                .select("tevo_ticket_group_id,section,row,quantity,retail_price,is_owned")
+                .eq("event_id", event_id).eq("captured_at", captured_at)
+                .eq("is_owned", source == "owned")
+                .execute().data or []
+            )
+            for r in ls:
+                r["inv_source"] = "tevo_owned" if source == "owned" else "tevo_market"
+            pool.extend(ls)
+
+        # Owned pool also spans our SeatGeek SellerDirect book (its own `cost`
+        # basis), so a sub we hold there isn't missed as a "buy-in".
+        if source == "owned":
+            seller_raw = (
+                db.table("seatgeek_seller_listings")
+                .select("seller_listing_id,section,row,quantity,cost,pulled_at")
+                .eq("tevo_event_id", event_id)
+                .execute().data or []
+            )
+            latest_seller: dict = {}
+            for r in seller_raw:
+                k = r.get("seller_listing_id")
+                if k not in latest_seller or (r.get("pulled_at") or "") > (latest_seller[k].get("pulled_at") or ""):
+                    latest_seller[k] = r
+            for r in latest_seller.values():
+                pool.append({
+                    "id": r.get("seller_listing_id"),
+                    "section": r.get("section"),
+                    "row": r.get("row"),
+                    "quantity": r.get("quantity"),
+                    "cost": r.get("cost"),
+                    "inv_source": "sg_seller",
+                })
+
         result = find_row_substitutions(section, row, qty, pool,
                                         revenue_per_ticket=rev_per_ticket)
         result.update({"captured_at": captured_at, "event_id": event_id, "source": source})

--- a/routers/broker.py
+++ b/routers/broker.py
@@ -105,6 +105,7 @@ def build_broker_router(
         quantity: int = 1,
         revenue: float | None = None,
         source: str = "owned",
+        fee_pct: float = 0.0,
         _=Depends(require_auth),
     ):
         """Substitution checker — ROW phase.
@@ -131,6 +132,9 @@ def build_broker_router(
           quantity  seats needed; a candidate must have quantity >= this (default 1)
           revenue   total $ received on the sale (optional; enables P&L)
           source    "owned" (default) | "market"
+          fee_pct   buy-in buyer-fee % applied to a market ask so P&L reflects
+                    landed cost (only used when source="market"; owned swaps
+                    are stock we already hold, no purchase fee)
         """
         db = get_require_sb()()
         qty = max(1, int(quantity or 1))
@@ -179,8 +183,12 @@ def build_broker_router(
                     "inv_source": "sg_seller",
                 })
 
+        # Buy-in fees only apply to a market purchase; an owned swap is stock we
+        # already hold (no fee).
+        eff_fee_pct = fee_pct if source == "market" else 0.0
         result = find_row_substitutions(section, row, qty, pool,
-                                        revenue_per_ticket=rev_per_ticket)
+                                        revenue_per_ticket=rev_per_ticket,
+                                        fee_pct=eff_fee_pct)
 
         # Better-SECTION fallback: rank sections by market quality (retail_median
         # per section) and offer cheapest acceptable upgrades from the same pool.
@@ -198,9 +206,11 @@ def build_broker_router(
             if sec and sec not in section_quality and r.get("retail_median") is not None:
                 section_quality[sec] = r.get("retail_median")  # latest wins (desc order)
         result["section_subs"] = find_section_substitutions(
-            section, qty, pool, section_quality, revenue_per_ticket=rev_per_ticket)
+            section, qty, pool, section_quality, revenue_per_ticket=rev_per_ticket,
+            fee_pct=eff_fee_pct)
 
-        result.update({"captured_at": captured_at, "event_id": event_id, "source": source})
+        result.update({"captured_at": captured_at, "event_id": event_id,
+                       "source": source, "fee_pct": eff_fee_pct})
         return result
 
     return router

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -511,6 +511,6 @@
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620"></script>
   <script src="alerts.js?v=20260608"></script>
-  <script src="event.js?v=20260616"></script>
+  <script src="event.js?v=20260620"></script>
 </body>
 </html>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -353,13 +353,22 @@
     if (meta) meta.textContent = rows.length ? `${rows.length} listings` : '';
     if (!rows.length) { body.innerHTML = '<div class="empty">No current SeatGeek listings.</div>'; return; }
     const money = v => (v == null ? '—' : '$' + T.fmtNum(Math.round(+v)));
+    // For an OURS row, link to the substitution checker pre-filled from the
+    // listing (event/section/row/qty) so a double-sell can be covered fast.
+    const eid = T.getEventId();
+    const subLink = (r) => {
+      if (!eid) return '';
+      const qs = `event=${eid}&section=${encodeURIComponent(r.section || '')}` +
+        `&row=${encodeURIComponent(r.row || '')}&quantity=${r.quantity || 1}`;
+      return ` <a class="sub-link" href="subs.html?${qs}" title="find substitutes">subs ↗</a>`;
+    };
     const trs = rows.map(r => '<tr>' +
       `<td>${escapeHtml(r.section || '—')}</td>` +
       `<td>${escapeHtml(r.row || '—')}</td>` +
       `<td class="num">${r.quantity != null ? T.fmtNum(r.quantity) : '—'}</td>` +
       `<td class="num">${money(r.retail_price_all_in)}</td>` +
       `<td class="num">${money(r.broadcast_price)}</td>` +
-      `<td>${r.is_broker_owned ? '<span class="badge">OURS</span>' : ''}</td>` +
+      `<td>${r.is_broker_owned ? '<span class="badge">OURS</span>' + subLink(r) : ''}</td>` +
       '</tr>').join('');
     body.innerHTML = '<table><thead><tr><th>Section</th><th>Row</th><th class="num">Qty</th>' +
       '<th class="num">All-in</th><th class="num">List</th><th></th></tr></thead><tbody>' + trs + '</tbody></table>';

--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -22,6 +22,10 @@
     { id: 'venue',     label: 'VENUE',     href: 'venue.html' },
     { id: 'performer', label: 'PERFORMER', href: 'performer.html' },
     { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
+    // Subs — substitution checker. Given a sold ticket (event/section/row/qty)
+    // find the cheapest acceptable cover: same-section same-or-better row, then
+    // a better-section fallback. Backed by /api/broker/event/{id}/substitutions.
+    { id: 'subs',      label: 'SUBS',      href: 'subs.html' },
     // Retail chat — natural-language price/inventory lookups over the book
     // (full market on the terminal; owned-EVO-only on the storefront). Talks
     // to /api/retail-chat → the `chat` edge fn. Wired 2026-06-19.

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -2210,3 +2210,34 @@ body[data-page="login"] {
   .src-link-row { margin-left: 0; }
   .wl-pager { flex-wrap: wrap; }
 }
+
+/* ===== Substitution checker (subs.html) ===== */
+.wrap.subs { display: flex; flex-direction: column; gap: 16px; }
+#subs-form-panel, #subs-results { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; }
+.subs-form { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-top: 12px; }
+.subs-field { display: flex; flex-direction: column; gap: 4px; flex: 1 1 130px; }
+.subs-field.narrow { flex: 0 1 90px; }
+.subs-field.submit { flex: 0 0 auto; }
+.subs-field label { font-size: 10px; letter-spacing: .05em; text-transform: uppercase; color: var(--muted); font-family: var(--mono); }
+.subs-field input, .subs-field select {
+  background: var(--bg); color: var(--text); border: 1px solid var(--line);
+  border-radius: 6px; padding: 8px 10px; font-family: var(--mono); font-size: 13px; width: 100%;
+}
+.subs-field input:focus, .subs-field select:focus { outline: none; border-color: var(--accent); }
+.subs-recap { font-family: var(--mono); font-size: 13px; margin-bottom: 12px; }
+.subs-recap .recap-line { margin-bottom: 2px; }
+.subs-best { margin-bottom: 16px; }
+.best-card {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  background: var(--shade); border: 1px solid var(--accent); border-radius: 6px; padding: 10px 12px; font-family: var(--mono); font-size: 13px;
+}
+.best-tag { font-size: 10px; font-weight: 700; letter-spacing: .08em; color: var(--accent); }
+.best-where { font-weight: 600; }
+.best-meta { color: var(--muted); font-size: 12px; }
+.best-none { color: var(--muted); font-family: var(--mono); font-size: 13px; padding: 8px 0; }
+.subs-table-wrap { overflow-x: auto; margin: 8px 0 16px; }
+.subs-table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 12px; }
+.subs-table th { text-align: left; color: var(--muted); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; font-size: 10px; padding: 6px 10px; border-bottom: 1px solid var(--line); }
+.subs-table td { padding: 6px 10px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+.subs-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+#subsAmbiguousWrap summary { cursor: pointer; font-family: var(--mono); font-size: 12px; color: var(--muted); padding: 6px 0; }

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -2241,3 +2241,19 @@ body[data-page="login"] {
 .subs-table td { padding: 6px 10px; border-bottom: 1px solid var(--line); white-space: nowrap; }
 .subs-table tbody tr:hover { background: rgba(255,255,255,0.02); }
 #subsAmbiguousWrap summary { cursor: pointer; font-family: var(--mono); font-size: 12px; color: var(--muted); padding: 6px 0; }
+.subs-field.event-search { position: relative; flex: 1 1 260px; }
+.subs-typeahead {
+  position: absolute; top: 100%; left: 0; right: 0; z-index: 30;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 6px;
+  margin-top: 4px; max-height: 320px; overflow-y: auto; box-shadow: 0 8px 24px rgba(0,0,0,.5);
+}
+.subs-typeahead .ta-row {
+  display: flex; flex-direction: column; gap: 2px; width: 100%; text-align: left;
+  background: none; border: none; border-bottom: 1px solid var(--line); cursor: pointer;
+  padding: 8px 10px; font-family: var(--mono); color: var(--text);
+}
+.subs-typeahead .ta-row:hover { background: var(--shade); }
+.subs-typeahead .ta-name { font-size: 12px; }
+.subs-typeahead .ta-meta { font-size: 10px; color: var(--muted); }
+.subs-typeahead .ta-empty { padding: 8px 10px; font-family: var(--mono); font-size: 11px; color: var(--muted); }
+.subs-typeahead .ta-empty.err { color: var(--neg); }

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -2257,3 +2257,5 @@ body[data-page="login"] {
 .subs-typeahead .ta-meta { font-size: 10px; color: var(--muted); }
 .subs-typeahead .ta-empty { padding: 8px 10px; font-family: var(--mono); font-size: 11px; color: var(--muted); }
 .subs-typeahead .ta-empty.err { color: var(--neg); }
+.sub-link { color: var(--accent); text-decoration: none; font-size: 10px; margin-left: 6px; font-family: var(--mono); }
+.sub-link:hover { text-decoration: underline; }

--- a/static/terminal/subs.html
+++ b/static/terminal/subs.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0a0a0a" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
+  <link rel="apple-touch-icon" href="/favicon.svg" />
+  <link rel="manifest" href="/manifest.json" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
+  <title>Terminal — Subs</title>
+  <link rel="stylesheet" href="style.css?v=20260620" />
+</head>
+<body data-page="subs">
+
+  <header class="topbar">
+    <span class="brand">TERMINAL · D0</span>
+    <span id="status" class="status">—</span>
+  </header>
+
+  <main class="wrap subs">
+    <section id="subs-form-panel">
+      <div class="panel-title">SUBSTITUTION CHECKER</div>
+      <p class="muted small">
+        Cover a sold / double-sold ticket from our own inventory. Finds the
+        <strong>cheapest acceptable</strong> sub — same section &amp; same-or-better row
+        first, then a better-section fallback. Enter the sold ticket below.
+      </p>
+      <form id="subsForm" class="subs-form" autocomplete="off">
+        <div class="subs-field">
+          <label for="subEvent">Event ID <span class="muted small">(tevo_event_id)</span></label>
+          <input id="subEvent" name="event" type="number" inputmode="numeric" min="1" placeholder="3100123" required />
+        </div>
+        <div class="subs-field">
+          <label for="subSection">Section</label>
+          <input id="subSection" name="section" type="text" placeholder="310" required />
+        </div>
+        <div class="subs-field">
+          <label for="subRow">Row</label>
+          <input id="subRow" name="row" type="text" placeholder="14" />
+        </div>
+        <div class="subs-field narrow">
+          <label for="subQty">Qty</label>
+          <input id="subQty" name="quantity" type="number" inputmode="numeric" min="1" value="1" />
+        </div>
+        <div class="subs-field narrow">
+          <label for="subRevenue">Revenue $ <span class="muted small">(total)</span></label>
+          <input id="subRevenue" name="revenue" type="number" inputmode="decimal" min="0" step="0.01" placeholder="67.12" />
+        </div>
+        <div class="subs-field narrow">
+          <label for="subSource">Pool</label>
+          <select id="subSource" name="source">
+            <option value="owned">Owned (free swap)</option>
+            <option value="market">Market (buy-in)</option>
+          </select>
+        </div>
+        <div class="subs-field submit">
+          <button type="submit" class="btn-primary" id="subsRun">Find subs</button>
+        </div>
+      </form>
+    </section>
+
+    <section id="subs-results" hidden>
+      <div id="subsRecap" class="subs-recap"></div>
+      <div id="subsBest" class="subs-best"></div>
+
+      <div class="panel-title row"><span>SAME-SECTION ROW SUBS</span><span id="subsRowCount" class="muted small"></span></div>
+      <div id="subsRowTable" class="subs-table-wrap"></div>
+
+      <div class="panel-title row"><span>BETTER-SECTION SUBS</span><span id="subsSecCount" class="muted small"></span></div>
+      <div id="subsSecTable" class="subs-table-wrap"></div>
+
+      <details id="subsAmbiguousWrap" hidden>
+        <summary>Ambiguous <span id="subsAmbCount" class="muted small"></span></summary>
+        <div id="subsAmbTable" class="subs-table-wrap"></div>
+        <p class="muted small">Row vs sold row not safely comparable (different kind, or venue-dependent letter rows). Eyeball before using.</p>
+      </details>
+    </section>
+  </main>
+
+  <script src="lib/supabase.js"></script>
+  <!-- Cache-busting: bump ?v=<date> on any first-party asset change. -->
+  <script src="auth.js?v=20260608"></script>
+  <script src="app.js?v=20260608"></script>
+  <script src="nav.js?v=20260620"></script>
+  <script src="subs.js?v=20260620"></script>
+</body>
+</html>

--- a/static/terminal/subs.html
+++ b/static/terminal/subs.html
@@ -33,8 +33,13 @@
         first, then a better-section fallback. Enter the sold ticket below.
       </p>
       <form id="subsForm" class="subs-form" autocomplete="off">
-        <div class="subs-field">
-          <label for="subEvent">Event ID <span class="muted small">(tevo_event_id)</span></label>
+        <div class="subs-field event-search">
+          <label for="subEventSearch">Event <span class="muted small">(search by name)</span></label>
+          <input id="subEventSearch" type="text" placeholder="Braves at Padres…" autocomplete="off" />
+          <div id="subEventResults" class="subs-typeahead" hidden></div>
+        </div>
+        <div class="subs-field narrow">
+          <label for="subEvent">Event ID</label>
           <input id="subEvent" name="event" type="number" inputmode="numeric" min="1" placeholder="3100123" required />
         </div>
         <div class="subs-field">
@@ -59,6 +64,10 @@
             <option value="owned">Owned (free swap)</option>
             <option value="market">Market (buy-in)</option>
           </select>
+        </div>
+        <div class="subs-field narrow" id="subFeeField" hidden>
+          <label for="subFee">Buy-in fee %</label>
+          <input id="subFee" name="fee_pct" type="number" inputmode="decimal" min="0" step="0.1" placeholder="0" />
         </div>
         <div class="subs-field submit">
           <button type="submit" class="btn-primary" id="subsRun">Find subs</button>

--- a/static/terminal/subs.js
+++ b/static/terminal/subs.js
@@ -18,7 +18,67 @@
   function init() {
     const form = document.getElementById('subsForm');
     if (form) form.addEventListener('submit', onSubmit);
+    wireEventSearch();
+    wireFeeToggle();
     prefillFromQuery();
+  }
+
+  // ---------- event-name search (typeahead → tevo_event_id) ----------
+
+  function wireEventSearch() {
+    const inp = document.getElementById('subEventSearch');
+    const box = document.getElementById('subEventResults');
+    if (!inp || !box) return;
+    let t = 0;
+    inp.addEventListener('input', () => {
+      clearTimeout(t);
+      const q = inp.value.trim();
+      if (q.length < 2) { box.hidden = true; box.innerHTML = ''; return; }
+      t = setTimeout(() => searchEvents(q), 250);
+    });
+    document.addEventListener('click', (e) => {
+      if (!box.contains(e.target) && e.target !== inp) box.hidden = true;
+    });
+  }
+
+  async function searchEvents(q) {
+    const box = document.getElementById('subEventResults');
+    const Auth = window.TerminalAuth;
+    if (!Auth || !Auth.client || !Auth.getAccessToken()) {
+      box.innerHTML = '<div class="ta-empty">search needs @s4kent.com sign-in</div>';
+      box.hidden = false; return;
+    }
+    box.innerHTML = '<div class="ta-empty">searching…</div>'; box.hidden = false;
+    try {
+      const res = await Auth.client.rpc('terminal_search', { p_q: q, p_limit: 8 });
+      if (res.error) { box.innerHTML = `<div class="ta-empty err">${esc(res.error.message || 'search error')}</div>`; return; }
+      const evs = (res.data && res.data.events) || [];
+      if (!evs.length) { box.innerHTML = '<div class="ta-empty">no events</div>'; return; }
+      box.innerHTML = evs.map(e => {
+        const meta = [e.venue_name, T.fmtDate(e.occurs_at_local)].filter(Boolean).join(' · ');
+        return `<button type="button" class="ta-row" data-eid="${esc(e.tevo_event_id)}" data-name="${esc(e.name || '')}">` +
+               `<span class="ta-name">${esc(e.name || '(unnamed)')}</span>` +
+               `<span class="ta-meta">${esc(meta)}</span></button>`;
+      }).join('');
+      box.querySelectorAll('.ta-row').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.getElementById('subEvent').value = btn.dataset.eid;
+          document.getElementById('subEventSearch').value = btn.dataset.name;
+          box.hidden = true;
+        });
+      });
+    } catch (err) {
+      box.innerHTML = `<div class="ta-empty err">${esc(String(err.message || err))}</div>`;
+    }
+  }
+
+  function wireFeeToggle() {
+    const src = document.getElementById('subSource');
+    const fee = document.getElementById('subFeeField');
+    if (!src || !fee) return;
+    const sync = () => { fee.hidden = src.value !== 'market'; };
+    src.addEventListener('change', sync);
+    sync();
   }
 
   function setStatus(s, cls) { T.setStatus(s, cls); }
@@ -53,6 +113,7 @@
       quantity: parseInt(val('subQty'), 10) || 1,
       revenue: val('subRevenue'),
       source: val('subSource') || 'owned',
+      fee_pct: val('subFee'),
     };
   }
 
@@ -67,6 +128,7 @@
     qs.set('quantity', String(f.quantity));
     if (f.revenue !== '') qs.set('revenue', f.revenue);
     qs.set('source', f.source);
+    if (f.source === 'market' && f.fee_pct !== '') qs.set('fee_pct', f.fee_pct);
 
     const btn = document.getElementById('subsRun');
     if (btn) btn.disabled = true;
@@ -134,7 +196,7 @@
     const cols = ['Row', 'Match', 'Δrow', 'Qty', 'Cost/tix', 'P&L total', 'Source'];
     const rows = subs.map(s => [
       esc(s.row), esc(s.match_type), s.row_delta != null ? `+${esc(s.row_delta)}` : '—',
-      esc(s.quantity), money(s.unit_cost), pnlCell(s.pnl_total), sourceBadge(s.inv_source),
+      esc(s.quantity), costDisp(s), pnlCell(s.pnl_total), sourceBadge(s.inv_source),
     ]);
     document.getElementById('subsRowTable').innerHTML =
       rows.length ? tableHtml(cols, rows) : emptyHtml('No same-section same-or-better-row sub.');
@@ -152,7 +214,7 @@
     const cols = ['To section', 'Δquality', 'Row', 'Qty', 'Cost/tix', 'P&L total', 'Source'];
     const rows = subs.map(s => [
       esc(s.to_section), s.section_delta != null ? `+${money(s.section_delta)}` : '—',
-      esc(s.row || '—'), esc(s.quantity), money(s.unit_cost), pnlCell(s.pnl_total), sourceBadge(s.inv_source),
+      esc(s.row || '—'), esc(s.quantity), costDisp(s), pnlCell(s.pnl_total), sourceBadge(s.inv_source),
     ]);
     document.getElementById('subsSecTable').innerHTML =
       rows.length ? tableHtml(cols, rows) : emptyHtml('No better-section sub in this pool.');
@@ -182,6 +244,16 @@
   function money(v) {
     if (v === null || v === undefined || v === '' || Number.isNaN(+v)) return '—';
     return '$' + Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  // Display cost = landed (ask + fees). Flag when fees moved it off the ask.
+  function costDisp(s) {
+    const landed = s.landed_cost, raw = s.unit_cost;
+    if (landed === null || landed === undefined) return money(raw);
+    if (raw !== null && raw !== undefined && Math.abs(+landed - +raw) > 0.005) {
+      return `<span title="ask ${esc(money(raw))} + fee">${money(landed)}*</span>`;
+    }
+    return money(landed);
   }
 
   function signedMoney(v) {

--- a/static/terminal/subs.js
+++ b/static/terminal/subs.js
@@ -1,0 +1,219 @@
+// D0 Terminal — Substitution checker. Enter a sold ticket (event / section /
+// row / qty) and find the cheapest acceptable cover from our inventory:
+// same-section same-or-better row first, then a better-section fallback.
+//
+//   GET /api/broker/event/{id}/substitutions
+//        ?section=&row=&quantity=&revenue=&source=owned|market
+//     -> { target, subs:[...], ambiguous:[...], section_subs:{...},
+//          best, counts, captured_at, source }
+//
+// Pure read-only; matching/ranking lives server-side in core.substitutions.
+// The page can be deep-linked with ?event=&section=&row=&quantity= (e.g. from
+// an order strip) and will auto-run when section is present.
+
+(function () {
+  'use strict';
+  const T = window.Terminal;
+
+  function init() {
+    const form = document.getElementById('subsForm');
+    if (form) form.addEventListener('submit', onSubmit);
+    prefillFromQuery();
+  }
+
+  function setStatus(s, cls) { T.setStatus(s, cls); }
+
+  function prefillFromQuery() {
+    const q = new URLSearchParams(location.search);
+    const map = { event: 'subEvent', section: 'subSection', row: 'subRow',
+                  quantity: 'subQty', revenue: 'subRevenue', source: 'subSource' };
+    let haveSection = false;
+    Object.entries(map).forEach(([k, id]) => {
+      const v = q.get(k);
+      if (v === null || v === '') return;
+      const el = document.getElementById(id);
+      if (el) { el.value = v; if (k === 'section') haveSection = true; }
+    });
+    // Auto-run when deep-linked with enough to search.
+    const ev = document.getElementById('subEvent').value;
+    if (ev && haveSection) run();
+  }
+
+  function onSubmit(e) {
+    e.preventDefault();
+    run();
+  }
+
+  function readForm() {
+    const val = (id) => (document.getElementById(id).value || '').trim();
+    return {
+      event: parseInt(val('subEvent'), 10),
+      section: val('subSection'),
+      row: val('subRow'),
+      quantity: parseInt(val('subQty'), 10) || 1,
+      revenue: val('subRevenue'),
+      source: val('subSource') || 'owned',
+    };
+  }
+
+  async function run() {
+    const f = readForm();
+    if (!Number.isFinite(f.event) || f.event <= 0) { setStatus('enter a valid event id', 'err'); return; }
+    if (!f.section) { setStatus('enter a section', 'err'); return; }
+
+    const qs = new URLSearchParams();
+    qs.set('section', f.section);
+    if (f.row) qs.set('row', f.row);
+    qs.set('quantity', String(f.quantity));
+    if (f.revenue !== '') qs.set('revenue', f.revenue);
+    qs.set('source', f.source);
+
+    const btn = document.getElementById('subsRun');
+    if (btn) btn.disabled = true;
+    setStatus('searching…');
+    try {
+      const data = await T.api(`/api/broker/event/${f.event}/substitutions?${qs.toString()}`);
+      render(data, f);
+      const n = (data.counts && data.counts.subs) || 0;
+      const sn = (data.section_subs && data.section_subs.counts && data.section_subs.counts.section_subs) || 0;
+      setStatus(`${n} row sub${n === 1 ? '' : 's'} · ${sn} section sub${sn === 1 ? '' : 's'}`, n + sn ? 'ok' : '');
+    } catch (err) {
+      console.error('[subs]', err);
+      setStatus(String(err.message || err), 'err');
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  // ---------- render ----------
+
+  function render(data, f) {
+    document.getElementById('subs-results').hidden = false;
+    renderRecap(data, f);
+    renderBest(data);
+    renderRowSubs(data);
+    renderSectionSubs(data);
+    renderAmbiguous(data);
+  }
+
+  function renderRecap(data, f) {
+    const t = data.target || {};
+    const poolLabel = data.source === 'market' ? 'market (buy-in)' : 'owned';
+    const rev = (t.revenue_per_ticket != null) ? ` · revenue ${money(t.revenue_per_ticket)}/tix` : '';
+    document.getElementById('subsRecap').innerHTML =
+      `<div class="recap-line">Cover <strong>${esc(f.quantity)}×</strong> ` +
+      `Section <strong>${esc(t.section || f.section)}</strong> ` +
+      `Row <strong>${esc(t.row || f.row || '—')}</strong>${rev}</div>` +
+      `<div class="muted small">pool: ${esc(poolLabel)} · snapshot: ${esc(T.fmtDate(data.captured_at))}` +
+      (data.captured_at ? '' : ' (no listings snapshot for this event)') + `</div>`;
+  }
+
+  function renderBest(data) {
+    const el = document.getElementById('subsBest');
+    const b = data.best || (data.section_subs && data.section_subs.best);
+    if (!b) {
+      el.innerHTML = `<div class="best-none">No acceptable sub found in the ${esc(data.source || 'owned')} pool.</div>`;
+      return;
+    }
+    const isSec = b.match_type === 'section_upgrade';
+    const where = isSec
+      ? `Section ${esc(b.to_section)} · Row ${esc(b.row || '—')}`
+      : `Row ${esc(b.row)} (${esc(b.match_type)}${b.row_delta != null ? `, +${esc(b.row_delta)} rows` : ''})`;
+    el.innerHTML =
+      `<div class="best-card">` +
+      `<span class="best-tag">BEST PICK</span> ` +
+      `<span class="best-where">${where}</span> ` +
+      `<span class="best-meta">${esc(b.quantity)} avail · cost ${money(b.unit_cost)}/tix · ${sourceBadge(b.inv_source)}</span>` +
+      pnlBadge(b.pnl_total, ' total') +
+      `</div>`;
+  }
+
+  function renderRowSubs(data) {
+    const subs = data.subs || [];
+    document.getElementById('subsRowCount').textContent = subs.length ? `${subs.length}` : '';
+    const cols = ['Row', 'Match', 'Δrow', 'Qty', 'Cost/tix', 'P&L total', 'Source'];
+    const rows = subs.map(s => [
+      esc(s.row), esc(s.match_type), s.row_delta != null ? `+${esc(s.row_delta)}` : '—',
+      esc(s.quantity), money(s.unit_cost), pnlCell(s.pnl_total), sourceBadge(s.inv_source),
+    ]);
+    document.getElementById('subsRowTable').innerHTML =
+      rows.length ? tableHtml(cols, rows) : emptyHtml('No same-section same-or-better-row sub.');
+  }
+
+  function renderSectionSubs(data) {
+    const ss = data.section_subs || {};
+    const subs = ss.section_subs || [];
+    document.getElementById('subsSecCount').textContent =
+      ss.sold_quality != null ? `sold-section median ${money(ss.sold_quality)}` : '';
+    if (ss.note) {
+      document.getElementById('subsSecTable').innerHTML = emptyHtml(esc(ss.note));
+      return;
+    }
+    const cols = ['To section', 'Δquality', 'Row', 'Qty', 'Cost/tix', 'P&L total', 'Source'];
+    const rows = subs.map(s => [
+      esc(s.to_section), s.section_delta != null ? `+${money(s.section_delta)}` : '—',
+      esc(s.row || '—'), esc(s.quantity), money(s.unit_cost), pnlCell(s.pnl_total), sourceBadge(s.inv_source),
+    ]);
+    document.getElementById('subsSecTable').innerHTML =
+      rows.length ? tableHtml(cols, rows) : emptyHtml('No better-section sub in this pool.');
+  }
+
+  function renderAmbiguous(data) {
+    const amb = data.ambiguous || [];
+    const wrap = document.getElementById('subsAmbiguousWrap');
+    wrap.hidden = amb.length === 0;
+    document.getElementById('subsAmbCount').textContent = amb.length ? `(${amb.length})` : '';
+    if (!amb.length) return;
+    const cols = ['Row', 'Qty', 'Cost/tix', 'Source'];
+    const rows = amb.map(s => [esc(s.row), esc(s.quantity), money(s.unit_cost), sourceBadge(s.inv_source)]);
+    document.getElementById('subsAmbTable').innerHTML = tableHtml(cols, rows);
+  }
+
+  // ---------- helpers ----------
+
+  function tableHtml(cols, rows) {
+    const head = cols.map(c => `<th>${esc(c)}</th>`).join('');
+    const body = rows.map(r => `<tr>${r.map(c => `<td>${c}</td>`).join('')}</tr>`).join('');
+    return `<table class="subs-table"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+  }
+
+  function emptyHtml(msg) { return `<div class="empty">${esc(msg)}</div>`; }
+
+  function money(v) {
+    if (v === null || v === undefined || v === '' || Number.isNaN(+v)) return '—';
+    return '$' + Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function signedMoney(v) {
+    const n = Number(v);
+    return (n >= 0 ? '+$' : '-$') + Math.abs(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function pnlCell(v) {
+    if (v === null || v === undefined || Number.isNaN(+v)) return '—';
+    return `<span class="${+v >= 0 ? 'pos' : 'neg'}">${signedMoney(v)}</span>`;
+  }
+
+  function pnlBadge(v, suffix) {
+    if (v === null || v === undefined || Number.isNaN(+v)) return '';
+    return ` <span class="badge ${+v >= 0 ? 'pos' : 'neg'}">${signedMoney(v)}${esc(suffix || '')}</span>`;
+  }
+
+  function sourceBadge(src) {
+    const label = { tevo_owned: 'TEvo', sg_seller: 'SG seller', tevo_market: 'market' }[src] || (src || '—');
+    return `<span class="badge muted" title="${esc(src || '')}">${esc(label)}</span>`;
+  }
+
+  function esc(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -508,6 +508,21 @@ def test_substitutions_section_fallback_offers_better_section(client, monkeypatc
     assert ss["sold_quality"] == 50
 
 
+def test_substitutions_market_fee_lands_cost(client, monkeypatch):
+    rows = [
+        {"tevo_ticket_group_id": "ask", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "310", "row": "14", "quantity": 4, "retail_price": 100, "is_owned": False},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={"listings_snapshots": rows}))
+    body = client.get("/api/broker/event/1/substitutions"
+                      "?section=310&row=14&quantity=4&revenue=400&source=market&fee_pct=25").json()
+    assert body["fee_pct"] == 25.0
+    b = body["best"]
+    assert b["unit_cost"] == 100      # raw ask
+    assert b["landed_cost"] == 125.0  # +25% buyer fee
+    assert b["pnl_per_ticket"] == round(100 - 125.0, 2)  # revenue 400/4=100/tix
+
+
 def test_substitutions_quantity_filter_and_ambiguous_bucket(client, monkeypatch):
     rows = [
         {"tevo_ticket_group_id": "toofew", "captured_at": "2026-05-10T12:00:00Z",

--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -456,6 +456,33 @@ def test_substitutions_finds_same_section_better_row(client, monkeypatch):
     assert body["counts"]["scanned"] == 3  # 3 in section 104
 
 
+def test_substitutions_owned_pool_merges_sg_seller_book(client, monkeypatch):
+    # TEvo owned holds only a pricey upgrade; our SG seller book holds a cheap
+    # same-row lot. The seller sub must win (cheapest) and be tagged sg_seller.
+    ls = [
+        {"tevo_ticket_group_id": "tevo_up", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "310", "row": "9", "quantity": 4, "retail_price": 281.05, "is_owned": True},
+    ]
+    seller = [
+        # older snapshot of the same listing — must be superseded by latest.
+        {"seller_listing_id": "SLR1", "section": "310", "row": "14", "quantity": 4,
+         "cost": 99.0, "pulled_at": "2026-05-09T00:00:00Z", "tevo_event_id": 3100123},
+        {"seller_listing_id": "SLR1", "section": "310", "row": "14", "quantity": 4,
+         "cost": 17.95, "pulled_at": "2026-05-10T00:00:00Z", "tevo_event_id": 3100123},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={
+        "listings_snapshots": ls, "seatgeek_seller_listings": seller,
+    }))
+    body = client.get("/api/broker/event/3100123/substitutions"
+                      "?section=310&row=14&quantity=4&revenue=67.12").json()
+    assert body["best"]["ticket_group_id"] == "SLR1"
+    assert body["best"]["inv_source"] == "sg_seller"
+    assert body["best"]["unit_cost"] == 17.95  # latest pulled_at wins over 99.0
+    assert body["best"]["match_type"] == "same"
+    # both lots qualify (seller same-row + TEvo upgrade), seller is cheaper.
+    assert [s["ticket_group_id"] for s in body["subs"]] == ["SLR1", "tevo_up"]
+
+
 def test_substitutions_quantity_filter_and_ambiguous_bucket(client, monkeypatch):
     rows = [
         {"tevo_ticket_group_id": "toofew", "captured_at": "2026-05-10T12:00:00Z",

--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -416,3 +416,51 @@ def test_orders_rolls_up_state_counts_and_sold(client, monkeypatch):
     assert s["tickets_sold"] == 2
     assert s["gross_sold"] == 200.0       # 100 * 2
     assert s["last_update_at"] == "2026-05-10T12:00:00Z"
+
+
+# ---------- /api/broker/event/{id}/substitutions (substitution checker, row phase) ----------
+
+def test_substitutions_empty_event_degrades_cleanly(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(table_data={"listings_snapshots": []}))
+    body = client.get("/api/broker/event/1/substitutions?section=104&row=12").json()
+    assert body["event_id"] == 1
+    assert body["captured_at"] is None
+    assert body["subs"] == [] and body["ambiguous"] == []
+    assert body["counts"]["scanned"] == 0
+
+
+def test_substitutions_finds_same_section_better_row(client, monkeypatch):
+    # All owned rows share one captured_at so the FakeSupabase "latest" probe
+    # and the row pull resolve to the same snapshot.
+    rows = [
+        {"tevo_ticket_group_id": "best", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "104", "row": "5", "quantity": 2, "retail_price": 400, "is_owned": True},
+        {"tevo_ticket_group_id": "same", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "104", "row": "12", "quantity": 2, "retail_price": 250, "is_owned": True},
+        {"tevo_ticket_group_id": "worse", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "104", "row": "20", "quantity": 2, "retail_price": 150, "is_owned": True},
+        {"tevo_ticket_group_id": "othersec", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "105", "row": "1", "quantity": 2, "retail_price": 900, "is_owned": True},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={"listings_snapshots": rows}))
+    body = client.get("/api/broker/event/1/substitutions?section=104&row=12&quantity=2").json()
+    assert body["captured_at"] == "2026-05-10T12:00:00Z"
+    # upgrade first, then same row; downgrade + other section excluded.
+    assert [s["ticket_group_id"] for s in body["subs"]] == ["best", "same"]
+    assert body["subs"][0]["match_type"] == "upgrade"
+    assert body["subs"][0]["row_delta"] == 7
+    assert body["counts"]["scanned"] == 3  # 3 in section 104
+
+
+def test_substitutions_quantity_filter_and_ambiguous_bucket(client, monkeypatch):
+    rows = [
+        {"tevo_ticket_group_id": "toofew", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "FLOOR", "row": "3", "quantity": 1, "retail_price": 100, "is_owned": True},
+        {"tevo_ticket_group_id": "alpha", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "FLOOR", "row": "A", "quantity": 4, "retail_price": 100, "is_owned": True},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={"listings_snapshots": rows}))
+    body = client.get("/api/broker/event/1/substitutions?section=FLOOR&row=5&quantity=2").json()
+    # numeric "3" would upgrade but lacks quantity; alpha "A" is incomparable.
+    assert body["subs"] == []
+    assert [s["ticket_group_id"] for s in body["ambiguous"]] == ["alpha"]

--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -483,6 +483,31 @@ def test_substitutions_owned_pool_merges_sg_seller_book(client, monkeypatch):
     assert [s["ticket_group_id"] for s in body["subs"]] == ["SLR1", "tevo_up"]
 
 
+def test_substitutions_section_fallback_offers_better_section(client, monkeypatch):
+    # No same-section (310) sub, but we own a better-section lot (108). The
+    # section phase should rank it by market quality (retail_median).
+    ls = [
+        {"tevo_ticket_group_id": "lower", "captured_at": "2026-05-10T12:00:00Z",
+         "section": "108", "row": "20", "quantity": 4, "retail_price": 180, "is_owned": True},
+    ]
+    section_metrics = [
+        {"section": "310", "retail_median": 50, "is_ancillary": False, "captured_at": "2026-05-10T12:00:00Z"},
+        {"section": "108", "retail_median": 200, "is_ancillary": False, "captured_at": "2026-05-10T12:00:00Z"},
+        {"section": "LOT A", "retail_median": 999, "is_ancillary": True, "captured_at": "2026-05-10T12:00:00Z"},
+    ]
+    _use_db(monkeypatch, FakeSupabase(table_data={
+        "listings_snapshots": ls, "section_metrics": section_metrics,
+    }))
+    body = client.get("/api/broker/event/1/substitutions"
+                      "?section=310&row=14&quantity=4&revenue=400").json()
+    assert body["subs"] == []  # nothing in-section
+    ss = body["section_subs"]
+    assert ss["best"]["to_section"] == "108"
+    assert ss["best"]["match_type"] == "section_upgrade"
+    assert ss["best"]["section_delta"] == 150  # 200 - 50
+    assert ss["sold_quality"] == 50
+
+
 def test_substitutions_quantity_filter_and_ambiguous_bucket(client, monkeypatch):
     rows = [
         {"tevo_ticket_group_id": "toofew", "captured_at": "2026-05-10T12:00:00Z",

--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -443,12 +443,16 @@ def test_substitutions_finds_same_section_better_row(client, monkeypatch):
          "section": "105", "row": "1", "quantity": 2, "retail_price": 900, "is_owned": True},
     ]
     _use_db(monkeypatch, FakeSupabase(table_data={"listings_snapshots": rows}))
-    body = client.get("/api/broker/event/1/substitutions?section=104&row=12&quantity=2").json()
+    body = client.get("/api/broker/event/1/substitutions?section=104&row=12&quantity=2&revenue=600").json()
     assert body["captured_at"] == "2026-05-10T12:00:00Z"
-    # upgrade first, then same row; downgrade + other section excluded.
-    assert [s["ticket_group_id"] for s in body["subs"]] == ["best", "same"]
-    assert body["subs"][0]["match_type"] == "upgrade"
-    assert body["subs"][0]["row_delta"] == 7
+    assert body["source"] == "owned"
+    # cheapest-first: same-row $250 outranks the $400 upgrade; downgrade +
+    # other section excluded.
+    assert [s["ticket_group_id"] for s in body["subs"]] == ["same", "best"]
+    assert body["best"]["ticket_group_id"] == "same"
+    # revenue 600 / qty 2 = 300/tix; same-row cost 250 -> +50/tix, +100 total.
+    assert body["best"]["pnl_per_ticket"] == 50.0
+    assert body["best"]["pnl_total"] == 100.0
     assert body["counts"]["scanned"] == 3  # 3 in section 104
 
 

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -15,9 +15,11 @@ from core.substitutions import (  # noqa: E402
     DOWNGRADE,
     INCOMPARABLE,
     SAME,
+    SECTION_UPGRADE,
     UPGRADE,
     compare_rows,
     find_row_substitutions,
+    find_section_substitutions,
     parse_row,
 )
 
@@ -197,3 +199,41 @@ def test_find_empty_candidates_is_clean():
     assert out["subs"] == [] and out["ambiguous"] == []
     assert out["counts"] == {"subs": 0, "ambiguous": 0, "scanned": 0}
     assert out["target"]["row_kind"] == "numeric"
+
+
+# ---------- find_section_substitutions (better-section phase) ----------
+
+def test_section_subs_only_better_or_equal_sections_cheapest_first():
+    # Sold section 310 (quality 50). 108 (quality 200) is better; 305 (quality
+    # 80) is better; 320 (quality 30) is WORSE -> excluded; 310 itself skipped.
+    quality = {"310": 50, "108": 200, "305": 80, "320": 30}
+    cands = [
+        _c("108", "20", quantity=4, gid="lower", price=180),
+        _c("305", "5", quantity=4, gid="mid", price=70),
+        _c("320", "1", quantity=4, gid="worse", price=10),  # better seat, worse section
+        _c("310", "1", quantity=4, gid="samesec", price=5),  # same section -> row phase
+    ]
+    out = find_section_substitutions("310", 4, cands, quality, revenue_per_ticket=100)
+    # cheapest acceptable better-section first: 305 ($70) before 108 ($180).
+    assert [s["ticket_group_id"] for s in out["section_subs"]] == ["mid", "lower"]
+    assert out["best"]["to_section"] == "305"
+    assert out["best"]["match_type"] == SECTION_UPGRADE
+    assert out["best"]["section_delta"] == 30  # 80 - 50
+    assert out["best"]["pnl_total"] == round((100 - 70) * 4, 2)
+    assert "worse" not in [s["ticket_group_id"] for s in out["section_subs"]]
+    assert "samesec" not in [s["ticket_group_id"] for s in out["section_subs"]]
+
+
+def test_section_subs_no_quality_for_sold_section_returns_note():
+    out = find_section_substitutions("999", 2, [_c("100", "1", gid="x")], {"100": 50})
+    assert out["section_subs"] == []
+    assert out["sold_quality"] is None
+    assert "note" in out
+
+
+def test_section_subs_unknown_candidate_section_excluded():
+    # Candidate section has no quality entry -> can't prove it's better -> skip.
+    quality = {"310": 50}
+    out = find_section_substitutions("310", 1, [_c("777", "1", gid="unk")], quality)
+    assert out["section_subs"] == []
+    assert out["counts"]["scanned"] == 0

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -1,0 +1,150 @@
+"""Unit tests for the substitution checker's pure row logic (core/substitutions).
+
+Row phase only: same-section, same-or-better row. No DB, no HTTP — these drive
+the pure functions directly so the matching/ranking rules are pinned down
+exhaustively. The route is covered separately in test_broker_routes.py.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from core.substitutions import (  # noqa: E402
+    DOWNGRADE,
+    INCOMPARABLE,
+    SAME,
+    UPGRADE,
+    compare_rows,
+    find_row_substitutions,
+    parse_row,
+)
+
+
+# ---------- parse_row ----------
+
+def test_parse_row_numeric():
+    r = parse_row("20")
+    assert r.kind == "numeric"
+    assert r.rank == 20
+
+
+def test_parse_row_alpha_single_and_double():
+    assert parse_row("A").kind == "alpha"
+    assert parse_row("A").rank == 1
+    assert parse_row("Z").rank == 26
+    # Spreadsheet-column ordering keeps AA after Z.
+    assert parse_row("AA").rank == 27
+    assert parse_row("AA").rank > parse_row("Z").rank
+
+
+def test_parse_row_ga_variants():
+    for label in ("GA", "ga", "General Admission", "GEN ADM", "GA1"):
+        assert parse_row(label).kind == "ga", label
+
+
+def test_parse_row_empty_and_mixed_are_unknown():
+    assert parse_row(None).kind == "unknown"
+    assert parse_row("   ").kind == "unknown"
+    assert parse_row("12B").kind == "unknown"  # mixed -> not safely rank-able
+
+
+# ---------- compare_rows ----------
+
+def test_compare_numeric_lower_is_upgrade():
+    assert compare_rows("20", "19") == UPGRADE   # 19 is closer in
+    assert compare_rows("20", "20") == SAME
+    assert compare_rows("20", "21") == DOWNGRADE
+
+
+def test_compare_alpha_earlier_is_upgrade():
+    assert compare_rows("C", "A") == UPGRADE
+    assert compare_rows("C", "C") == SAME
+    assert compare_rows("C", "D") == DOWNGRADE
+
+
+def test_compare_cross_kind_is_incomparable():
+    assert compare_rows("12", "A") == INCOMPARABLE
+    assert compare_rows("A", "12") == INCOMPARABLE
+
+
+def test_compare_ga_only_subs_ga():
+    assert compare_rows("GA", "GA") == SAME
+    assert compare_rows("GA", "5") == INCOMPARABLE
+    assert compare_rows("5", "GA") == INCOMPARABLE
+
+
+def test_compare_unknown_exact_match_is_same():
+    assert compare_rows("12B", "12B") == SAME
+    assert compare_rows("12B", "12C") == INCOMPARABLE
+
+
+# ---------- find_row_substitutions ----------
+
+def _c(section, row, quantity=2, gid=None, price=None):
+    return {
+        "tevo_ticket_group_id": gid,
+        "section": section,
+        "row": row,
+        "quantity": quantity,
+        "retail_price": price,
+    }
+
+
+def test_find_filters_to_same_section():
+    cands = [_c("104", "10", gid=1), _c("105", "5", gid=2)]
+    out = find_row_substitutions("104", "12", 1, cands)
+    assert [s["ticket_group_id"] for s in out["subs"]] == [1]
+    assert out["counts"]["scanned"] == 1  # other section never scanned
+
+
+def test_find_orders_upgrades_first_then_closer_in():
+    cands = [
+        _c("104", "12", gid="same"),   # SAME row
+        _c("104", "5", gid="best"),    # big upgrade
+        _c("104", "10", gid="mid"),    # smaller upgrade
+        _c("104", "20", gid="worse"),  # downgrade -> dropped
+    ]
+    out = find_row_substitutions("104", "12", 1, cands)
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["best", "mid", "same"]
+    assert all(s["ticket_group_id"] != "worse" for s in out["subs"])
+    # row_delta = how many rows closer (positive = better).
+    best = next(s for s in out["subs"] if s["ticket_group_id"] == "best")
+    assert best["row_delta"] == 7
+    same = next(s for s in out["subs"] if s["ticket_group_id"] == "same")
+    assert same["match_type"] == SAME and same["row_delta"] == 0
+
+
+def test_find_respects_quantity_needed():
+    cands = [_c("104", "5", quantity=1, gid="one"), _c("104", "6", quantity=4, gid="four")]
+    out = find_row_substitutions("104", "10", 2, cands)
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["four"]
+
+
+def test_find_excludes_self_group():
+    cands = [_c("104", "10", gid="self"), _c("104", "8", gid="other")]
+    out = find_row_substitutions("104", "10", 1, cands, exclude_group_id="self")
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["other"]
+
+
+def test_find_routes_cross_kind_to_ambiguous():
+    cands = [_c("FLOOR", "A", gid="alpha"), _c("FLOOR", "3", gid="num")]
+    out = find_row_substitutions("FLOOR", "5", 1, cands)
+    # target row "5" is numeric: "3" upgrades, "A" is incomparable -> ambiguous.
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["num"]
+    assert [s["ticket_group_id"] for s in out["ambiguous"]] == ["alpha"]
+    assert out["counts"]["ambiguous"] == 1
+
+
+def test_find_section_normalization_matches_whitespace():
+    cands = [_c("  104  ", "5", gid="pad")]
+    out = find_row_substitutions("104", "10", 1, cands)
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["pad"]
+
+
+def test_find_empty_candidates_is_clean():
+    out = find_row_substitutions("104", "10", 1, [])
+    assert out["subs"] == [] and out["ambiguous"] == []
+    assert out["counts"] == {"subs": 0, "ambiguous": 0, "scanned": 0}
+    assert out["target"]["row_kind"] == "numeric"

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -34,9 +34,12 @@ def test_parse_row_alpha_single_and_double():
     assert parse_row("A").kind == "alpha"
     assert parse_row("A").rank == 1
     assert parse_row("Z").rank == 26
-    # Spreadsheet-column ordering keeps AA after Z.
-    assert parse_row("AA").rank == 27
-    assert parse_row("AA").rank > parse_row("Z").rank
+    # alpha_width distinguishes single- vs double-letter rows (so the
+    # venue-dependent AA-vs-Z direction isn't silently assumed).
+    assert parse_row("A").alpha_width == 1
+    assert parse_row("AA").alpha_width == 2
+    # Within a width, ordering is monotonic and unambiguous.
+    assert parse_row("BB").rank > parse_row("AA").rank
 
 
 def test_parse_row_ga_variants():
@@ -62,6 +65,15 @@ def test_compare_alpha_earlier_is_upgrade():
     assert compare_rows("C", "A") == UPGRADE
     assert compare_rows("C", "C") == SAME
     assert compare_rows("C", "D") == DOWNGRADE
+    # Same-width double letters compare cleanly too.
+    assert compare_rows("CC", "AA") == UPGRADE
+    assert compare_rows("AA", "BB") == DOWNGRADE
+
+
+def test_compare_alpha_cross_width_is_incomparable():
+    # AA-vs-Z direction is venue-specific -> never guessed.
+    assert compare_rows("Z", "AA") == INCOMPARABLE
+    assert compare_rows("AA", "A") == INCOMPARABLE
 
 
 def test_compare_cross_kind_is_incomparable():
@@ -135,6 +147,15 @@ def test_find_routes_cross_kind_to_ambiguous():
     assert [s["ticket_group_id"] for s in out["subs"]] == ["num"]
     assert [s["ticket_group_id"] for s in out["ambiguous"]] == ["alpha"]
     assert out["counts"]["ambiguous"] == 1
+
+
+def test_find_cross_width_alpha_goes_to_ambiguous():
+    # Target row "C" (width 1); "AA" (width 2) is venue-dependent -> ambiguous,
+    # while "A" (width 1) is a clean upgrade.
+    cands = [_c("FLOOR", "A", gid="up"), _c("FLOOR", "AA", gid="wide")]
+    out = find_row_substitutions("FLOOR", "C", 1, cands)
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["up"]
+    assert [s["ticket_group_id"] for s in out["ambiguous"]] == ["wide"]
 
 
 def test_find_section_normalization_matches_whitespace():

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -237,3 +237,31 @@ def test_section_subs_unknown_candidate_section_excluded():
     out = find_section_substitutions("310", 1, [_c("777", "1", gid="unk")], quality)
     assert out["section_subs"] == []
     assert out["counts"]["scanned"] == 0
+
+
+# ---------- buy-in fees (market P&L) ----------
+
+def test_find_fee_pct_lands_cost_and_pnl():
+    # Market buy-in: $100 ask + 30% buyer fee = $130 landed. P&L vs $90/tix
+    # revenue is computed on the LANDED cost, not the bare ask.
+    cands = [_c("104", "12", quantity=2, gid="m", price=100)]
+    out = find_row_substitutions("104", "12", 2, cands,
+                                 revenue_per_ticket=90, fee_pct=30)
+    b = out["best"]
+    assert b["unit_cost"] == 100.0          # raw ask preserved
+    assert b["landed_cost"] == 130.0        # ask + 30%
+    assert b["pnl_per_ticket"] == round(90 - 130.0, 2)
+    assert b["pnl_total"] == round((90 - 130.0) * 2, 2)
+
+
+def test_find_fee_changes_cheapest_ranking():
+    # Without fees A ($100) beats B ($110). A flat-ish % fee that hits the
+    # pricier ask harder can't flip order here, but a per-listing fee model
+    # would; assert fees at least re-rank on landed cost monotonically.
+    cands = [
+        _c("104", "12", quantity=2, gid="A", price=100),
+        _c("104", "10", quantity=2, gid="B", price=110),
+    ]
+    out = find_row_substitutions("104", "12", 1, cands, fee_pct=50)
+    assert out["best"]["ticket_group_id"] == "A"
+    assert out["best"]["landed_cost"] == 150.0   # 100 * 1.5

--- a/tests/test_substitutions.py
+++ b/tests/test_substitutions.py
@@ -111,21 +111,49 @@ def test_find_filters_to_same_section():
     assert out["counts"]["scanned"] == 1  # other section never scanned
 
 
-def test_find_orders_upgrades_first_then_closer_in():
+def test_find_orders_cheapest_first():
+    # The Petco lesson: a big upgrade that costs a fortune must NOT outrank a
+    # break-even same-row seat. Cost is the primary sort.
     cands = [
-        _c("104", "12", gid="same"),   # SAME row
-        _c("104", "5", gid="best"),    # big upgrade
-        _c("104", "10", gid="mid"),    # smaller upgrade
-        _c("104", "20", gid="worse"),  # downgrade -> dropped
+        _c("104", "12", gid="same", price=100),   # SAME row, cheap
+        _c("104", "5", gid="best", price=500),     # big upgrade, expensive
+        _c("104", "10", gid="mid", price=50),      # small upgrade, cheapest
+        _c("104", "20", gid="worse", price=10),    # downgrade -> dropped despite cheapest
     ]
     out = find_row_substitutions("104", "12", 1, cands)
-    assert [s["ticket_group_id"] for s in out["subs"]] == ["best", "mid", "same"]
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["mid", "same", "best"]
     assert all(s["ticket_group_id"] != "worse" for s in out["subs"])
-    # row_delta = how many rows closer (positive = better).
-    best = next(s for s in out["subs"] if s["ticket_group_id"] == "best")
-    assert best["row_delta"] == 7
+    assert out["best"]["ticket_group_id"] == "mid"
     same = next(s for s in out["subs"] if s["ticket_group_id"] == "same")
     assert same["match_type"] == SAME and same["row_delta"] == 0
+
+
+def test_find_without_cost_falls_back_to_smallest_upgrade():
+    # No prices => prefer the smallest acceptable upgrade (closest to sold row,
+    # i.e. least over-delivery), since a smaller upgrade is generally cheaper.
+    cands = [
+        _c("104", "5", gid="big"),    # 7 rows better
+        _c("104", "12", gid="same"),  # same row
+        _c("104", "10", gid="near"),  # 2 rows better
+    ]
+    out = find_row_substitutions("104", "12", 1, cands)
+    assert [s["ticket_group_id"] for s in out["subs"]] == ["same", "near", "big"]
+
+
+def test_find_pnl_against_revenue_petco_shape():
+    # Mirrors the real Petco case: sold 4 @ $16.78/tix; cover from market.
+    cands = [
+        _c("310", "14", quantity=4, gid="cheap", price=17.95),  # same row, break-even
+        _c("310", "9", quantity=5, gid="pricey", price=281.05),  # upgrade, ruinous
+    ]
+    out = find_row_substitutions("310", "14", 4, cands, revenue_per_ticket=16.78)
+    # cheapest acceptable wins -> the same-row $17.95 lot, not the $281 upgrade.
+    assert out["best"]["ticket_group_id"] == "cheap"
+    assert out["best"]["unit_cost"] == 17.95
+    assert out["best"]["pnl_per_ticket"] == round(16.78 - 17.95, 2)
+    assert out["best"]["pnl_total"] == round((16.78 - 17.95) * 4, 2)
+    pricey = next(s for s in out["subs"] if s["ticket_group_id"] == "pricey")
+    assert pricey["pnl_total"] < out["best"]["pnl_total"]  # far worse loss
 
 
 def test_find_respects_quantity_needed():


### PR DESCRIPTION
## What

A **substitution checker** for covering double-sold / problem listings: enter a sold ticket (event / section / row / qty) and get the **cheapest acceptable replacement** — same section with same-or-better row, with a better-section fallback. Engine + API + a D0 terminal page. Built and validated against a real StubHub sale (Braves @ Padres, Petco, OrderID 646538298).

## How it ranks (the core idea)

A valid sub must be **same-or-better seat + enough quantity**, and among those the **cheapest wins** — over-delivering a better seat than was sold is wasted money. The Petco case proved it: sold 4 in `310/row14` @ ~$16.78/tix; in-section options were `row14` @ $17.95 (break-even) vs a `row9` upgrade @ $281 (≈ −$1,050). Quality-first ordering would have picked the $281 lot; cost-first picks the $17.95 cover.

## Phases (pure logic — `core/substitutions.py`)

- **Row** (`find_row_substitutions`) — same section, same-or-better row. Numeric / alpha / GA aware; alpha rows only compare within the same letter-width (the `AA`-vs-`Z` direction is venue-specific → cross-width pairs go to an `ambiguous` bucket, never guessed). Cheapest-first, then smallest acceptable upgrade, then smallest lot.
- **Section** (`find_section_substitutions`) — fallback: a better section (market `retail_median` per section as a venue-agnostic quality proxy; quality ≥ sold section's). Same cost-aware ordering.

## Cost / inventory

- Real `cost` basis for owned inventory; `retail_price` ask for a market buy-in (`source=owned|market`).
- Owned pool spans **TEvo `is_owned` + our SeatGeek SellerDirect book** (deduped to latest per `seller_listing_id`); each sub tagged with `inv_source`.
- Optional `revenue` → per-sub `pnl_per_ticket`/`pnl_total` + a `best` pick.

## API + UI

- `GET /api/broker/event/{id}/substitutions?section=&row=&quantity=&revenue=&source=` → `{ target, subs, ambiguous, section_subs, best, counts, ... }` (auth-gated).
- **D0 page** `static/terminal/subs.html` (nav: **SUBS**): a form (event / section / row / qty / revenue / pool) → best pick + row-subs table + section-subs table + ambiguous, each with cost, P&L, and source. Deep-linkable (`?event=&section=&row=&quantity=` auto-runs — order-strip ready). Vanilla JS on the existing `Terminal.api`/auth helpers; all dynamic values HTML-escaped before `innerHTML` (matches `app.js`/`nav.js`).

## Tests & validation

- `tests/test_substitutions.py` (engine) + `tests/test_broker_routes.py` (route over `FakeSupabase`) — **49 passing**, incl. a P&L test from the exact Petco numbers, the seller-book merge, and the section fallback.
- Prod-verified: `is_owned` populates broadly (not for this speculative sale); ~75% of recent seller rows carry `tevo_event_id`; Petco section 310 median $31.16, 32/47 sections better-or-equal.
- RULE-2 readonly static audit clean (313 files); frontend JS syntax-checked; all DOM ids verified.

## Known limits / next

- Seller rows join on `tevo_event_id`, so the ~25% not-yet-AQ-mapped are invisible until `sg_seller_sync_and_map` fills them (§0 hub rule — self-heals).
- Section quality uses market median; a per-venue quality/zone map could refine it.
- Buy-in **fees** not yet folded into market P&L (ask ≠ landed cost) — easy follow-up.
- Page takes a `tevo_event_id`; an event-name search box could come later.
- Lane: D0 (`/api/broker/*`, `static/terminal/*`) + a self-contained `core/` module; no DB/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)