### PR TITLE
feat(d0): render the orders dashboard inline in the terminal

### DIFF
--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -11,104 +11,67 @@
   <meta name="apple-mobile-web-app-title" content="S4K Terminal" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
   <link rel="manifest" href="/manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com https://d2-orders-dashboard.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vibepass-storefront-test.onrender.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
-  <link rel="stylesheet" href="style.css?v=20260608" />
+  <link rel="stylesheet" href="style.css?v=20260620" />
 </head>
 <body data-page="orders">
 
   <header class="topbar">
     <span class="brand">TERMINAL · D0</span>
-    <span id="status" class="status">—</span>
+    <span id="status" class="status">Loading…</span>
   </header>
 
   <main class="wrap orders">
-    <section id="orders-doorway">
-      <div class="doorway">
-        <div class="doorway-tag">D0 · D2 MERGE POINT</div>
-        <h1>Orders Dashboard</h1>
-        <p>
-          The orders surface is owned by <strong>D2</strong> (Order Clients lane).
-          A unified Evo + SeatGeek + TickPick + Vivid view, plus a SeatData analytics tab,
-          lives at <strong>d2-orders-dashboard.onrender.com</strong>.
-          D0's terminal nav routes you there — both lanes converge at this page.
-        </p>
-        <div class="doorway-cta">
-          <a id="d2Open" class="btn-primary" href="https://d2-orders-dashboard.onrender.com" target="_blank" rel="noopener">
-            Open Orders Dashboard ↗
-          </a>
-          <span id="d2HealthBadge" class="health-badge dim">checking…</span>
-        </div>
-        <p class="muted small">
-          The dashboard has its own Supabase login (Google OAuth → @s4kent.com).
-          Sign in once; the session persists in <code>localStorage</code> on the d2 origin.
-        </p>
-      </div>
-    </section>
 
-    <section id="orders-merge-contract">
-      <div class="panel-title">MERGE CONTRACT (D0 ↔ D2)</div>
-      <div class="merge-grid">
-        <div class="mg-cell">
-          <span class="mg-lbl">D0 owns</span>
-          <ul>
-            <li>Terminal top-nav including the <code>Orders</code> entry</li>
-            <li>This doorway page (route, branding, link target)</li>
-            <li><code>vibepass-terminal-test.onrender.com</code> service</li>
-          </ul>
-        </div>
-        <div class="mg-cell">
-          <span class="mg-lbl">D2 owns</span>
-          <ul>
-            <li>The full orders dashboard implementation</li>
-            <li>All 4 order sources (Evo, SeatGeek, TickPick, Vivid) + SeatData tab</li>
-            <li><code>d2-orders-dashboard.onrender.com</code> service</li>
-            <li>Auth: Supabase JWT + <code>@s4kent.com</code> allowlist (mirrors <code>app.py</code>)</li>
-          </ul>
-        </div>
-        <div class="mg-cell">
-          <span class="mg-lbl">Shared</span>
-          <ul>
-            <li>Supabase project <code>hzrizjeaxlqcxfrtczpq</code> + auth users</li>
-            <li>Data tables: <code>evo_orders</code>, <code>evo_order_items</code>, <code>seatgeek_orders</code>, <code>tickpick_orders</code>, <code>vivid_orders</code> (D2 writes; D0 read-only)</li>
-            <li>Render branch: <code>main</code> auto-deploys both services</li>
-          </ul>
-        </div>
-        <div class="mg-cell">
-          <span class="mg-lbl">Future</span>
-          <ul>
-            <li>If D0 wants inline summary stats in the terminal: D2 adds CORS allowlist for <code>vibepass-terminal-test.onrender.com</code> on <code>/api/d2/*</code></li>
-            <li>Per-event order strip on the Event Detail page stays on <code>/api/broker/event/{id}/orders</code> (D1's API, already shipped)</li>
-            <li>Path C: an <code>get_broker_orders_*</code> SECDEF RPC suite would let either lane render orders directly from Supabase</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section id="orders-feature-list">
+    <!-- Inline orders dashboard. The D2 order surface (Evo + SeatGeek +
+         SeatData + TickPick + Vivid, mirrored to public.unified_orders) is
+         served by the d2_dashboard router, mounted same-origin into this
+         FastAPI shell (app.py — `app.include_router(d2_router)`). The terminal
+         reads /api/d2/orders directly with the operator's Supabase JWT — no
+         hop to a separate d2-orders-dashboard service. -->
+    <section id="orders-controls">
       <div class="panel-title row">
-        <span>WHAT'S OVER THERE</span>
-        <a class="more-link" href="https://github.com/JulianS4K/Terminal-2/blob/main/d2_dashboard/main.py" target="_blank" rel="noopener">source ↗</a>
+        <span>ORDERS · UNIFIED BOOK</span>
+        <span class="muted small" id="ordersCount"></span>
       </div>
-      <div class="feature-grid">
-        <div class="ft-cell">
-          <span class="ft-lbl">Orders tab</span>
-          <p>Single window: Evo <code>list_orders</code> + SG <code>seller_orders(open)</code> + TickPick <code>list_orders(unfulfilled)</code> + Vivid <code>list_active_orders</code>. Active/All filter pill.</p>
+
+      <div class="ctrl-row">
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">SOURCE</span>
+          <button class="ctrl-btn is-active" data-source="all">All</button>
+          <button class="ctrl-btn" data-source="evo">EVO</button>
+          <button class="ctrl-btn" data-source="seatgeek_sales">SG</button>
+          <button class="ctrl-btn" data-source="seatdata">SeatData</button>
+          <button class="ctrl-btn" data-source="tickpick">TickPick</button>
+          <button class="ctrl-btn" data-source="vivid">Vivid</button>
         </div>
-        <div class="ft-cell">
-          <span class="ft-lbl">Metrics tab</span>
-          <p>KPI grid + sparkline + hot/top events + biggest sales + gaps + live feed. Backed by <code>d2_metrics_*</code> RPCs (PR #116).</p>
+        <div class="ctrl-group">
+          <span class="ctrl-lbl">STATE</span>
+          <button class="ctrl-btn is-active" data-term="0">Active</button>
+          <button class="ctrl-btn" data-term="1">All</button>
         </div>
-        <div class="ft-cell">
-          <span class="ft-lbl">SeatData tab</span>
-          <p>Account + usage analytics (read-only — paid-pull budget protected).</p>
+        <div class="ctrl-group">
+          <button class="ctrl-btn" id="refreshBtn">↻ Refresh</button>
         </div>
-        <div class="ft-cell">
-          <span class="ft-lbl">Diagnostics</span>
-          <p><code>/api/d2/cron-freshness</code> · <code>/api/d2/health</code> · per-source latency · auth posture.</p>
-        </div>
+      </div>
+
+      <!-- Per-source freshness chips (count + last-seen age) from the
+           /api/d2/orders `sources` summary, enriched with cron cadence. -->
+      <div class="ctrl-row" id="freshStrip"></div>
+    </section>
+
+    <section id="orders-table">
+      <div id="ordersBody"><div class="empty">loading…</div></div>
+    </section>
+
+    <section id="orders-note">
+      <div class="muted small">
+        Data is SQL-only from <code>public.unified_orders</code> (no live broker-API
+        calls in the read path) — cron freshness above is the staleness signal.
+        Rows are read-only per the 2026-05-13 listing-source lockdown.
       </div>
     </section>
   </main>
@@ -118,6 +81,6 @@
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620"></script>
-  <script src="orders.js?v=20260608"></script>
+  <script src="orders.js?v=20260620"></script>
 </body>
 </html>

--- a/static/terminal/orders.js
+++ b/static/terminal/orders.js
@@ -1,44 +1,227 @@
-// D0 Terminal — Orders page (doorway to D2's dashboard).
-// Pings D2's /healthz (unauthenticated) cross-origin to surface live/down
-// state for the CTA badge. Fails silently if CORS blocks — D2 may not
-// allowlist us until a real inline-data integration is requested.
+// D0 Terminal — Orders page (inline unified order book).
+//
+// Renders the D2 order surface directly inside the terminal instead of
+// linking out to a separate d2-orders-dashboard service. The d2_dashboard
+// router is mounted same-origin into this FastAPI shell (app.py —
+// `app.include_router(d2_router)`), so /api/d2/orders is reachable with the
+// terminal's own Supabase JWT (TerminalAuth) via Terminal.api(). All five
+// sources (evo / seatgeek_sales / seatdata / tickpick / vivid) come from
+// public.unified_orders — SQL-only, read-only (2026-05-13 lockdown).
 
 (function () {
   'use strict';
   const T = window.Terminal;
-  const D2_BASE = 'https://d2-orders-dashboard.onrender.com';
 
-  async function init() {
-    if (window.TerminalAuth) await window.TerminalAuth.requireAuth();
-    if (T && T.setStatus) T.setStatus('D2 doorway', 'ok');
-    pingD2Health();
+  // Source pills. ids match unified_orders.source values; `all` is the FE
+  // catch-all (no server-side source filter — we filter the page client-side).
+  const SOURCE_LABELS = {
+    evo: 'EVO',
+    seatgeek_sales: 'SG',
+    seatdata: 'SeatData',
+    tickpick: 'TickPick',
+    vivid: 'Vivid',
+  };
+
+  const state = {
+    source: 'all',        // 'all' | one of SOURCE_LABELS keys
+    includeTerminal: 0,   // 0 = active-only, 1 = all states
+    perPage: 100,
+  };
+
+  let lastPayload = null; // cache the last /api/d2/orders response for re-filter
+
+  function init() {
+    if (window.TerminalAuth) {
+      window.TerminalAuth.requireAuth().then(wire).catch(() => wire());
+    } else {
+      wire();
+    }
   }
 
-  function pingD2Health() {
-    const badge = document.getElementById('d2HealthBadge');
-    if (!badge) return;
-    const t0 = performance.now();
-    // /healthz is unauthenticated on the D2 service. CORS-allowed in default
-    // FastAPI deploys via the CORSMiddleware (D2 doesn't currently configure
-    // one explicitly — if this fails with CORS, we silently show "unknown"
-    // and the CTA still works).
-    fetch(`${D2_BASE}/healthz`, { credentials: 'omit', mode: 'cors' })
-      .then(res => {
-        const ms = Math.round(performance.now() - t0);
-        if (res.ok) setHealth('live', `live · ${ms}ms`);
-        else        setHealth('down', `HTTP ${res.status}`);
-      })
-      .catch(() => {
-        // CORS or network error — D2 may not allowlist us. Silent.
-        setHealth('dim', 'status unknown');
+  function wire() {
+    // Source pills — client-side filter, no refetch needed.
+    document.querySelectorAll('[data-source]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        setActive('[data-source]', btn);
+        state.source = btn.dataset.source;
+        if (lastPayload) renderRows(lastPayload);
       });
+    });
+    // State toggle — Active vs All changes the server query (include_terminal).
+    document.querySelectorAll('[data-term]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        setActive('[data-term]', btn);
+        state.includeTerminal = +btn.dataset.term;
+        load();
+      });
+    });
+    const refresh = document.getElementById('refreshBtn');
+    if (refresh) refresh.addEventListener('click', load);
+    load();
   }
 
-  function setHealth(cls, text) {
-    const badge = document.getElementById('d2HealthBadge');
-    if (!badge) return;
-    badge.className = 'health-badge ' + cls;
-    badge.textContent = text;
+  function setActive(selector, btn) {
+    document.querySelectorAll(selector).forEach(b => b.classList.remove('is-active'));
+    btn.classList.add('is-active');
+  }
+
+  async function load() {
+    const body = document.getElementById('ordersBody');
+    if (body) body.innerHTML = '<div class="empty">loading…</div>';
+    if (T && T.setStatus) T.setStatus('loading orders…', '');
+    const qs = `per_page=${state.perPage}&page=1&include_terminal=${state.includeTerminal}`;
+    try {
+      const data = await T.api(`/api/d2/orders?${qs}`);
+      lastPayload = data;
+      renderRows(data);
+      renderFreshness(data.sources || []);
+      // Cron cadence is a separate, slower poll — enrich the chips when it lands.
+      loadCronFreshness();
+      const n = (data.rows || []).length;
+      if (T && T.setStatus) T.setStatus(`${n} order${n === 1 ? '' : 's'}`, 'ok');
+    } catch (e) {
+      lastPayload = null;
+      if (body) body.innerHTML = `<div class="empty">${esc(e.message)}</div>`;
+      if (T && T.setStatus) T.setStatus(e.message, 'err');
+    }
+  }
+
+  function renderRows(data) {
+    const body = document.getElementById('ordersBody');
+    const countEl = document.getElementById('ordersCount');
+    if (!body) return;
+    let rows = data.rows || [];
+    if (state.source !== 'all') rows = rows.filter(r => r.source === state.source);
+
+    if (countEl) {
+      const total = (data.rows || []).length;
+      countEl.textContent = state.source === 'all'
+        ? `${total} row${total === 1 ? '' : 's'} · ${state.includeTerminal ? 'all states' : 'active only'}`
+        : `${rows.length} of ${total} · ${SOURCE_LABELS[state.source] || state.source}`;
+    }
+
+    if (!rows.length) {
+      body.innerHTML = '<div class="empty">no orders for this source + state filter</div>';
+      return;
+    }
+
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead><tr>
+        <th>Source</th>
+        <th>Event</th>
+        <th>Date</th>
+        <th class="num">Qty</th>
+        <th>Status</th>
+        <th class="num">Amount</th>
+        <th>Ordered</th>
+      </tr></thead>`;
+    const tbody = document.createElement('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td><span class="badge muted">${esc(SOURCE_LABELS[r.source] || r.source || '—')}</span></td>
+        <td>${esc(r.event_name || '—')}</td>
+        <td class="muted small">${r.event_date ? esc(T.fmtDate(r.event_date)) : '—'}</td>
+        <td class="num">${r.qty != null ? r.qty : '—'}</td>
+        <td>${statusBadge(r)}</td>
+        <td class="num">${fmtAmount(r.amount, r.currency)}</td>
+        <td class="muted small" title="${esc(r.ordered_at || '')}">${ago(r.ordered_at)}</td>`;
+      tbody.appendChild(tr);
+    });
+    tbl.appendChild(tbody);
+    body.innerHTML = '';
+    body.appendChild(tbl);
+  }
+
+  // Active = pending / accepted / substitution; terminal = fulfilled / rejected
+  // / cancelled (mirror d2_dashboard _ACTIVE_STATUSES / _TERMINAL_STATUSES).
+  const POS_STATUS = new Set(['accepted', 'fulfilled']);
+  const NEG_STATUS = new Set(['rejected', 'cancelled']);
+
+  function statusBadge(r) {
+    const canon = r.canonical_status;
+    const raw = r.status;
+    const label = canon || raw || '—';
+    let cls = '';
+    if (POS_STATUS.has(canon)) cls = 'pos';
+    else if (NEG_STATUS.has(canon)) cls = 'neg';
+    const title = (raw && raw !== canon) ? ` title="raw: ${esc(raw)}"` : '';
+    return `<span class="badge ${cls}"${title}>${esc(label)}</span>`;
+  }
+
+  function renderFreshness(sources) {
+    const strip = document.getElementById('freshStrip');
+    if (!strip) return;
+    if (!sources.length) { strip.innerHTML = ''; return; }
+    strip.innerHTML = sources.map(s => {
+      const lbl = SOURCE_LABELS[s.source] || s.source;
+      const okCls = s.ok ? '' : 'neg';
+      const age = s.as_of ? ago(s.as_of) : 'no data';
+      return `<span class="badge ${okCls}" data-fresh="${esc(s.source)}" `
+        + `title="${esc(s.source)} · ${s.count} row(s) · last seen ${esc(s.as_of || 'never')}">`
+        + `${esc(lbl)} · ${s.count} · ${esc(age)}</span>`;
+    }).join('');
+  }
+
+  // Best-effort cadence overlay — adds "· every 30m" to each freshness chip
+  // when the cron-freshness RPC reports a schedule. Silent on failure (the
+  // chips still show count + last-seen age without it).
+  async function loadCronFreshness() {
+    try {
+      const data = await T.api('/api/d2/cron-freshness');
+      const bySource = data.sources || {};
+      Object.keys(bySource).forEach(src => {
+        const chip = document.querySelector(`[data-fresh="${cssEsc(src)}"]`);
+        if (!chip) return;
+        const sched = bySource[src] && bySource[src].schedule;
+        if (sched) chip.textContent += ` · ${cronCadence(sched)}`;
+      });
+    } catch (_) { /* cadence is decorative — ignore */ }
+  }
+
+  // Compress a cron expression to a human cadence for the chip suffix.
+  function cronCadence(expr) {
+    if (!expr) return '';
+    const m = /^\*\/(\d+)\s/.exec(expr);
+    if (m) return `every ${m[1]}m`;
+    if (/^0\s\*\//.test(expr)) {
+      const h = /^0\s\*\/(\d+)\s/.exec(expr);
+      if (h) return `every ${h[1]}h`;
+    }
+    return expr;
+  }
+
+  function fmtAmount(amount, currency) {
+    if (amount === null || amount === undefined || Number.isNaN(amount)) return '—';
+    const sym = currency === 'USD' || !currency ? '$' : '';
+    return sym + T.fmtNum(amount, { min: 0, max: 0 });
+  }
+
+  function ago(iso) {
+    if (!iso) return '—';
+    const ms = Date.now() - new Date(iso).getTime();
+    if (!Number.isFinite(ms)) return '—';
+    if (ms < 0) return 'just now';
+    const m = Math.round(ms / 60000);
+    if (m < 1) return 'just now';
+    if (m < 60) return m + 'm ago';
+    const h = Math.round(m / 60);
+    if (h < 24) return h + 'h ago';
+    const d = Math.round(h / 24);
+    return d + 'd ago';
+  }
+
+  function esc(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    }[c]));
+  }
+
+  // Escape a value for use inside an attribute-equals CSS selector.
+  function cssEsc(s) {
+    return String(s).replace(/["\\]/g, '\\$&');
   }
 
   if (document.readyState === 'loading') {

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -864,87 +864,9 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 }
 .topbar .status.warn { color: var(--warn); }
 
-/* ---------- ORDERS doorway (D0 ↔ D2 merge) ---------- */
-
-.doorway {
-  padding: 24px 8px;
-}
-.doorway h1 {
-  margin: 8px 0 12px;
-  font-size: 28px;
-  color: var(--text);
-}
-.doorway p {
-  color: var(--muted);
-  max-width: 720px;
-  line-height: 1.6;
-  margin: 8px 0;
-}
-.doorway p strong { color: var(--text); }
-.doorway-tag {
-  display: inline-block;
-  font-family: var(--mono); font-size: 10px;
-  text-transform: uppercase; letter-spacing: 0.8px;
-  padding: 3px 10px;
-  background: var(--panel-2);
-  border: 1px solid var(--accent);
-  color: var(--accent);
-}
-.doorway-cta {
-  display: flex; align-items: center; gap: 12px;
-  margin: 16px 0;
-}
-.btn-primary {
-  display: inline-block;
-  background: var(--accent);
-  color: #000;
-  text-decoration: none;
-  font-family: var(--mono); font-size: 13px; font-weight: 600;
-  padding: 10px 20px;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  border: 1px solid var(--accent);
-}
-.btn-primary:hover { background: #fde047; border-color: #fde047; text-decoration: none; }
-.health-badge {
-  font-family: var(--mono); font-size: 11px;
-  padding: 4px 10px;
-  border: 1px solid var(--line);
-  background: var(--panel-2);
-  letter-spacing: 0.5px;
-}
-.health-badge.live { color: var(--pos); border-color: var(--pos); }
-.health-badge.down { color: var(--neg); border-color: var(--neg); }
-.health-badge.dim  { color: var(--muted); }
-
-.merge-grid, .feature-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-}
-.mg-cell, .ft-cell {
-  background: var(--panel-2);
-  border: 1px solid var(--line);
-  padding: 12px;
-}
-.mg-lbl, .ft-lbl {
-  display: block;
-  font-family: var(--mono); font-size: 10px;
-  color: var(--accent);
-  text-transform: uppercase; letter-spacing: 0.8px;
-  margin-bottom: 8px;
-}
-.mg-cell ul {
-  margin: 0; padding-left: 18px;
-  color: var(--muted); font-size: 12px;
-}
-.mg-cell li { padding: 3px 0; }
-.ft-cell p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.5;
-}
+/* Per-source freshness chips on the orders controls strip. */
+#freshStrip { flex-wrap: wrap; gap: 6px; }
+#freshStrip:empty { display: none; }
 
 /* ---------- v3 enrichment panels (PR pending) ---------- */
 


### PR DESCRIPTION
## What

Wires the **Orders Dashboard into the D0 terminal directly**, replacing the doorway page that linked out to the separate `d2-orders-dashboard.onrender.com` service.

The D2 dashboard router is already mounted same-origin into the FastAPI shell (`app.py` — `app.include_router(d2_router)`), so `/api/d2/orders` is reachable with the terminal's own Supabase JWT. The terminal Orders page now renders the unified order book itself instead of bouncing the operator to another service.

## Changes (all D0 lane — `static/terminal/*`)

- **`orders.html`** — replaced the doorway / merge-contract markup with an inline controls strip (source pills · Active/All state toggle · refresh), an orders table, and a per-source freshness chip row. CSP narrowed to the standard terminal authed-fetch set (dropped the now-unused `d2-orders-dashboard` origin).
- **`orders.js`** — fetches `/api/d2/orders` via `Terminal.api()` (authed; same-origin on the shell, CDN-proxied on the static host). Renders rows with canonical status badges, client-side source filtering, and a decorative cron-cadence overlay from `/api/d2/cron-freshness`. Read-only — no broker-API calls.
- **`style.css`** — removed the orphaned doorway/merge-grid/health-badge CSS (confirmed unused across all terminal pages); added `#freshStrip`.

## Notes

- All 5 sources (`evo` / `seatgeek_sales` / `seatdata` / `tickpick` / `vivid`) come from `public.unified_orders` — SQL-only, read-only (2026-05-13 lockdown). RULE-2 static audit passes; `node --check` clean on the JS.
- Graceful degradation: if the shell lacks `SUPABASE_SERVICE_ROLE_KEY`, `/api/d2/orders` 503s and the error surfaces in the status pill rather than a blank page.
- The standalone `d2-orders-dashboard` service is untouched and still deployable; this only changes what the terminal nav's **Orders** entry renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fQB2LKEW7w5LvksY87uTt)_