### PR TITLE
fix(d0): exclude seatdata from the inline terminal orders view

### DIFF
--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -27,11 +27,12 @@
   <main class="wrap orders">
 
     <!-- Inline orders dashboard. The D2 order surface (Evo + SeatGeek +
-         SeatData + TickPick + Vivid, mirrored to public.unified_orders) is
-         served by the d2_dashboard router, mounted same-origin into this
-         FastAPI shell (app.py — `app.include_router(d2_router)`). The terminal
-         reads /api/d2/orders directly with the operator's Supabase JWT — no
-         hop to a separate d2-orders-dashboard service. -->
+         TickPick + Vivid, mirrored to public.unified_orders) is served by the
+         d2_dashboard router, mounted same-origin into this FastAPI shell
+         (app.py — `app.include_router(d2_router)`). The terminal reads
+         /api/d2/orders directly with the operator's Supabase JWT — no hop to a
+         separate d2-orders-dashboard service. seatdata is excluded here —
+         it's third-party completed-sales analytics, not our order book. -->
     <section id="orders-controls">
       <div class="panel-title row">
         <span>ORDERS · UNIFIED BOOK</span>
@@ -44,7 +45,6 @@
           <button class="ctrl-btn is-active" data-source="all">All</button>
           <button class="ctrl-btn" data-source="evo">EVO</button>
           <button class="ctrl-btn" data-source="seatgeek_sales">SG</button>
-          <button class="ctrl-btn" data-source="seatdata">SeatData</button>
           <button class="ctrl-btn" data-source="tickpick">TickPick</button>
           <button class="ctrl-btn" data-source="vivid">Vivid</button>
         </div>
@@ -81,6 +81,6 @@
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620"></script>
-  <script src="orders.js?v=20260620"></script>
+  <script src="orders.js?v=20260620a"></script>
 </body>
 </html>

--- a/static/terminal/orders.js
+++ b/static/terminal/orders.js
@@ -4,9 +4,11 @@
 // linking out to a separate d2-orders-dashboard service. The d2_dashboard
 // router is mounted same-origin into this FastAPI shell (app.py —
 // `app.include_router(d2_router)`), so /api/d2/orders is reachable with the
-// terminal's own Supabase JWT (TerminalAuth) via Terminal.api(). All five
-// sources (evo / seatgeek_sales / seatdata / tickpick / vivid) come from
-// public.unified_orders — SQL-only, read-only (2026-05-13 lockdown).
+// terminal's own Supabase JWT (TerminalAuth) via Terminal.api(). The order
+// sources (evo / seatgeek_sales / tickpick / vivid) come from
+// public.unified_orders — SQL-only, read-only (2026-05-13 lockdown). The
+// view excludes seatdata: it's a third-party completed-sales market feed,
+// not our broker order book (see HIDDEN_SOURCES).
 
 (function () {
   'use strict';
@@ -17,10 +19,14 @@
   const SOURCE_LABELS = {
     evo: 'EVO',
     seatgeek_sales: 'SG',
-    seatdata: 'SeatData',
     tickpick: 'TickPick',
     vivid: 'Vivid',
   };
+
+  // Sources hidden from this view. seatdata is third-party completed-sales
+  // analytics (a market feed), not our broker order book — exclude its rows
+  // and freshness chip entirely.
+  const HIDDEN_SOURCES = new Set(['seatdata']);
 
   const state = {
     source: 'all',        // 'all' | one of SOURCE_LABELS keys
@@ -90,11 +96,14 @@
     const body = document.getElementById('ordersBody');
     const countEl = document.getElementById('ordersCount');
     if (!body) return;
-    let rows = data.rows || [];
+    // Drop hidden sources (seatdata — third-party market feed) before any
+    // count or per-source filtering so they never surface in this view.
+    const visible = (data.rows || []).filter(r => !HIDDEN_SOURCES.has(r.source));
+    let rows = visible;
     if (state.source !== 'all') rows = rows.filter(r => r.source === state.source);
 
     if (countEl) {
-      const total = (data.rows || []).length;
+      const total = visible.length;
       countEl.textContent = state.source === 'all'
         ? `${total} row${total === 1 ? '' : 's'} · ${state.includeTerminal ? 'all states' : 'active only'}`
         : `${rows.length} of ${total} · ${SOURCE_LABELS[state.source] || state.source}`;
@@ -153,6 +162,7 @@
   function renderFreshness(sources) {
     const strip = document.getElementById('freshStrip');
     if (!strip) return;
+    sources = sources.filter(s => !HIDDEN_SOURCES.has(s.source));
     if (!sources.length) { strip.innerHTML = ''; return; }
     strip.innerHTML = sources.map(s => {
       const lbl = SOURCE_LABELS[s.source] || s.source;


### PR DESCRIPTION
## What

Removes **SeatData** from the inline terminal Orders view. seatdata is a third-party completed-sales market feed (analytics), not part of our broker order book — it shouldn't sit alongside our Evo / SeatGeek / TickPick / Vivid orders.

## Changes (D0 lane — `static/terminal/*`)

- **`orders.html`** — dropped the `SeatData` source pill; updated the surface comment.
- **`orders.js`** — removed `seatdata` from `SOURCE_LABELS`; added a `HIDDEN_SOURCES` set that filters seatdata rows out of the table, the per-source freshness strip, and the All-tab total count. Bumped the `orders.js` cache token.

## Notes

- The `/api/d2/orders` API still returns seatdata (unchanged — it's used elsewhere); the terminal just hides it client-side.
- `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fQB2LKEW7w5LvksY87uTt)_