### PR TITLE
chore(d0): move SUBS nav entry next to DISCOVERY/AXS

### DIFF
--- a/static/terminal/nav.js
+++ b/static/terminal/nav.js
@@ -22,10 +22,6 @@
     { id: 'venue',     label: 'VENUE',     href: 'venue.html' },
     { id: 'performer', label: 'PERFORMER', href: 'performer.html' },
     { id: 'movers',    label: 'MOVERS',    href: 'movers.html' },
-    // Subs — substitution checker. Given a sold ticket (event/section/row/qty)
-    // find the cheapest acceptable cover: same-section same-or-better row, then
-    // a better-section fallback. Backed by /api/broker/event/{id}/substitutions.
-    { id: 'subs',      label: 'SUBS',      href: 'subs.html' },
     // Retail chat — natural-language price/inventory lookups over the book
     // (full market on the terminal; owned-EVO-only on the storefront). Talks
     // to /api/retail-chat → the `chat` edge fn. Wired 2026-06-19.
@@ -38,6 +34,11 @@
     // its latest snapshot get-in / price band / listing depth. Backed by
     // /api/axs/events (service-role read; axs_* tables are RLS-locked). 2026-06-20.
     { id: 'axs',       label: 'AXS',       href: 'axs.html' },
+    // Subs — substitution checker. Given a sold ticket (event/section/row/qty)
+    // find the cheapest acceptable cover: same-section same-or-better row, then
+    // a better-section fallback. Backed by /api/broker/event/{id}/substitutions.
+    // Grouped with the discovery/axs tools cluster.
+    { id: 'subs',      label: 'SUBS',      href: 'subs.html' },
     { id: 'orders',    label: 'ORDERS',    href: 'orders.html' },
   ];
 


### PR DESCRIPTION
## What

Move the **SUBS** terminal nav entry to sit with the discovery/axs tools cluster instead of right after MOVERS.

Nav order is now: `… MOVERS · RETAIL CHAT · DISCOVERY · AXS · SUBS · ORDERS`.

Nav-only change (`static/terminal/nav.js`) — one entry repositioned, no behavior change. Follow-up to #648 (substitution checker), per request to group SUBS next to DISCOVERY/AXS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtjYqxU94A5Ed32wbFxGDL)_