### PR TITLE
feat(d0): add true venue price-band metrics + per-event popularity heat

### DIFF
--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -77,6 +77,19 @@
           <div class="ru-cell"><span class="ru-num" id="vrOwnedNotional">—</span><span class="ru-lbl">owned notional</span></div>
         </div>
       </section>
+      <!-- Venue-level price band: TRUE percentiles over the latest listings
+           snapshot of every upcoming event (server-side percentile_cont). -->
+      <section id="venue-priceband">
+        <div class="panel-title">PRICE BAND — all listings across upcoming events</div>
+        <div class="rollup-grid">
+          <div class="ru-cell"><span class="ru-num" id="vrGetin">—</span><span class="ru-lbl">get-in</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrP25">—</span><span class="ru-lbl">p25</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrMedian">—</span><span class="ru-lbl">median</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrP90">—</span><span class="ru-lbl">p90</span></div>
+          <div class="ru-cell"><span class="ru-num" id="vrSg7d">—</span><span class="ru-lbl">SG sales 7d</span></div>
+        </div>
+        <div class="muted small" id="vrBandMeta" style="margin-top:6px"></div>
+      </section>
     </div>
 
     <!-- Upcoming Events pane -->
@@ -177,6 +190,6 @@
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620"></script>
   <script src="alerts.js?v=20260608"></script>
-  <script src="venue.js?v=20260608"></script>
+  <script src="venue.js?v=20260620"></script>
 </body>
 </html>

--- a/static/terminal/venue.js
+++ b/static/terminal/venue.js
@@ -221,6 +221,66 @@
     setText('vrMarketTix',      T.fmtNum(ag.market_tickets_total));
     setText('vrOwnedTix',       T.fmtNum(ag.owned_tickets_total));
     setText('vrOwnedNotional',  ag.owned_notional ? '$' + T.fmtNum(Math.round(+ag.owned_notional)) : '—');
+
+    // Price band — TRUE venue-level percentiles from the RPC (mig 20260620130000).
+    const pb = ag.price_band || {};
+    const $r = v => (v != null ? '$' + T.fmtNum(Math.round(+v)) : '—');
+    setText('vrGetin',  $r(pb.getin));
+    setText('vrP25',    $r(pb.p25));
+    setText('vrMedian', $r(pb.median));
+    setText('vrP90',    $r(pb.p90));
+    setText('vrSg7d',   ag.sg_sales_7d_total != null ? T.fmtNum(ag.sg_sales_7d_total) : '—');
+    const meta = document.getElementById('vrBandMeta');
+    if (meta) {
+      meta.textContent = pb.listing_rows
+        ? `${T.fmtNum(pb.listing_rows)} listings · ${T.fmtNum(pb.market_tickets || 0)} tickets · max ${$r(pb.max)}`
+        : 'no live listings across upcoming events';
+    }
+  }
+
+  // ---------- Event popularity / "heat" score ----------
+  // Relative demand signal computed across THIS venue's upcoming events (0–100).
+  // Blends signals the RPC returns per event:
+  //   • price level   (retail_median, normalized) — marquee / willingness-to-pay
+  //   • market tightness (inverse price_dispersion) — firm pricing reads hot
+  //   • SG velocity   (sg_sales_7d, normalized) — actual sales pressure
+  // SG sales are sparse (e.g. preseason NFL = 0); when the whole venue has zero
+  // velocity the weight collapses onto price + tightness. Thin pseudo-events
+  // (season packages / parking, < 50 tickets) are flagged and excluded from the
+  // hot ranking so they don't masquerade as demand. Relative within the venue —
+  // a 100 here is "hottest at this venue," not an absolute cross-venue score.
+  const HEAT_MIN_TICKETS = 50;
+  function computeHeat(events) {
+    const arr = events || [];
+    const liquid = arr.filter(e => (+e.tickets_count || 0) >= HEAT_MIN_TICKETS);
+    const norm = (vals) => {
+      const lo = Math.min(...vals), hi = Math.max(...vals), sp = hi - lo;
+      return (v) => (sp > 0 ? (v - lo) / sp : 0);
+    };
+    const heat = {};
+    if (!liquid.length) { arr.forEach(e => { heat[e.id] = null; }); return heat; }
+    const meds = liquid.map(e => +e.retail_median || 0);
+    const disps = liquid.map(e => +e.price_dispersion || 0);
+    const vels = liquid.map(e => +e.sg_sales_7d || 0);
+    const nMed = norm(meds), nDisp = norm(disps), nVel = norm(vels);
+    const velActive = vels.some(v => v > 0);
+    arr.forEach(e => {
+      if ((+e.tickets_count || 0) < HEAT_MIN_TICKETS) { heat[e.id] = null; return; }
+      const pl    = nMed(+e.retail_median || 0);
+      const tight = 1 - nDisp(+e.price_dispersion || 0);
+      const vl    = nVel(+e.sg_sales_7d || 0);
+      const score = velActive
+        ? 0.40 * pl + 0.20 * tight + 0.40 * vl
+        : 0.70 * pl + 0.30 * tight;
+      heat[e.id] = Math.round(score * 100);
+    });
+    return heat;
+  }
+  function heatBadge(score) {
+    if (score == null) return '<span class="muted small" title="thin liquidity — package/parking, excluded from ranking">pkg</span>';
+    const cls = score >= 67 ? 'pos' : score >= 34 ? '' : 'muted small';
+    const flame = score >= 67 ? '🔥 ' : '';
+    return `<span class="badge ${cls}" title="relative demand vs other events at this venue">${flame}${score}</span>`;
   }
 
   // ---------- Upcoming Events tab ----------
@@ -241,14 +301,18 @@
     // T.moversChipHtml(e.id) can produce inline chips in the event-name cell.
     // Idempotent + cached.
     await T.moversPreloadIndex();
+    const heat = computeHeat(events);
     const tbl = document.createElement('table');
     tbl.innerHTML = `
       <thead><tr>
         <th>Event</th><th>Performer</th><th class="num">T-days</th>
-        <th class="num">Mkt qty</th><th class="num">Mkt median</th>
+        <th class="num" title="relative demand vs other events at this venue (0–100)">Heat</th>
+        <th class="num">Mkt qty</th><th class="num">Get-in</th>
+        <th class="num">Mkt median</th><th class="num" title="90th-percentile listing price">p90</th>
         <th class="num">Owned qty</th><th class="num">Owned med</th>
       </tr></thead><tbody></tbody>`;
     const tb = tbl.querySelector('tbody');
+    const $r = v => (v ? '$' + T.fmtNum(Math.round(+v)) : '—');
     events.forEach(e => {
       const d = T.daysUntil(e.occurs_at_local);
       const tr = document.createElement('tr');
@@ -256,10 +320,13 @@
         <td><a href="event.html?event=${e.id}">${escapeHtml(e.name || ('Event ' + e.id))}</a> ${T.moversChipHtml(e.id)} ${T.temporalChipHtml(e.occurs_at_local)}</td>
         <td>${escapeHtml(e.primary_performer_name || '—')}</td>
         <td class="num">${d === null ? '—' : d}</td>
+        <td class="num">${heatBadge(heat[e.id])}</td>
         <td class="num">${T.fmtNum(e.tickets_count || 0)}</td>
-        <td class="num">${e.retail_median ? '$' + T.fmtNum(Math.round(+e.retail_median)) : '—'}</td>
+        <td class="num">${$r(e.getin_price)}</td>
+        <td class="num">${$r(e.retail_median)}</td>
+        <td class="num">${$r(e.retail_p90)}</td>
         <td class="num ${(e.owned_tickets_count || 0) > 0 ? 'ours' : ''}">${T.fmtNum(e.owned_tickets_count || 0)}</td>
-        <td class="num">${e.owned_median_retail ? '$' + T.fmtNum(Math.round(+e.owned_median_retail)) : '—'}</td>`;
+        <td class="num">${$r(e.owned_median_retail)}</td>`;
       tb.appendChild(tr);
     });
     body.appendChild(tbl);
@@ -417,16 +484,27 @@
     const allGaps   = Object.values(gapsByEvent).flat();
     const gapCount  = allGaps.length;
 
-    const sgSpreadPct = (avgEvo && avgSg) ? ((avgSg - avgEvo) / avgEvo * 100) : null;
+    // TRUE venue median from the RPC price band (percentile_cont over the latest
+    // listings snapshot of every event) — replaces the old mean-of-per-event-
+    // medians that was mislabeled "EVO MEDIAN".
+    const pb = ag.price_band || {};
+    const venueMedian = pb.median != null ? Math.round(+pb.median) : null;
+    const venueGetin  = pb.getin  != null ? Math.round(+pb.getin)  : null;
+    const sgSpreadPct = (venueMedian && avgSg) ? ((avgSg - venueMedian) / venueMedian * 100) : null;
     const $p = v => (v != null ? '$' + T.fmtNum(v) : '—');
+
+    // Hottest event at the venue (relative demand) for the ticker headline.
+    const heat = computeHeat(events);
+    let hottest = null, hottestScore = -1;
+    events.forEach(e => { const s = heat[e.id]; if (s != null && s > hottestScore) { hottestScore = s; hottest = e; } });
 
     if (tickerBody) {
       tickerBody.innerHTML = `
         <div class="market-ticker-strip">
           <div class="ticker-cell ticker-price">
-            <span class="ticker-lbl">EVO MEDIAN</span>
-            <span class="ticker-val">${$p(avgEvo)}</span>
-            ${avgSg ? `<span class="ticker-sub ${sgSpreadPct && sgSpreadPct > 0 ? 'pos' : sgSpreadPct && sgSpreadPct < 0 ? 'neg' : ''}">${sgSpreadPct != null ? (sgSpreadPct >= 0 ? '+' : '') + sgSpreadPct.toFixed(1) + '% vs SG' : ''}</span>` : ''}
+            <span class="ticker-lbl">VENUE MEDIAN</span>
+            <span class="ticker-val">${$p(venueMedian)}</span>
+            <span class="ticker-sub">${venueGetin != null ? 'get-in ' + $p(venueGetin) : ''}${avgSg && sgSpreadPct != null ? ` · <span class="${sgSpreadPct > 0 ? 'pos' : sgSpreadPct < 0 ? 'neg' : ''}">${(sgSpreadPct >= 0 ? '+' : '') + sgSpreadPct.toFixed(1)}% vs SG</span>` : ''}</span>
           </div>
           <div class="ticker-cell">
             <span class="ticker-lbl">PLATFORM MED</span>
@@ -447,6 +525,11 @@
             <span class="ticker-lbl">SIGNALS</span>
             <span class="ticker-val ${priceUp > priceDown ? 'pos' : priceDown > priceUp ? 'neg' : ''}">${priceUp > 0 ? '↑' + priceUp : ''}${priceDown > 0 ? ' ↓' + priceDown : ''}${!priceUp && !priceDown ? '—' : ''}</span>
             <span class="ticker-sub">${gapCount ? gapCount + ' gap' + (gapCount > 1 ? 's' : '') : 'no gaps'}</span>
+          </div>
+          <div class="ticker-cell">
+            <span class="ticker-lbl">HOTTEST EVENT</span>
+            <span class="ticker-val ${hottestScore >= 67 ? 'pos' : ''}">${hottest ? (hottestScore >= 67 ? '🔥 ' : '') + escapeHtml((hottest.primary_performer_name || hottest.name || 'Event').slice(0, 22)) : '—'}</span>
+            <span class="ticker-sub">${hottest ? 'heat ' + hottestScore + ' · ' + $p(Math.round(+hottest.retail_median || 0)) + ' med' : ''}</span>
           </div>
         </div>`;
     }

--- a/supabase/migrations/20260620130000_d0_venue_price_band_demand.sql
+++ b/supabase/migrations/20260620130000_d0_venue_price_band_demand.sql
@@ -1,0 +1,218 @@
+-- ============================================================================
+-- Migration 20260620130000 — D0 venue page: true price band + per-event demand
+--
+-- Lane:     D0 (author) → A1 (apply)   [D0 has no prod-DB apply authority]
+-- Touches:  get_broker_venue_page (W, CREATE OR REPLACE)
+--           events (R), event_metrics (R), aq_venue_map (R), venue_assets (R),
+--           listings_snapshots (R), seatgeek_event_xref (R),
+--           seatgeek_sales_snapshots (R)
+-- Pre-reqs: 20260525120000_venue_mlb_resilience.sql (current fn definition)
+--
+-- WHY: the venue rollup carried NO price metric, and the "EVO MEDIAN" shown in
+--   the Market Carpet ticker was computed client-side as a *mean of per-event
+--   medians* (mislabeled, and equal-weighted so a 24-ticket season-ticket
+--   listing counted the same as a 2,635-ticket game). This adds:
+--
+--   1. aggregate.price_band — a TRUE venue-level percentile band (getin / p25 /
+--      median / p90 / max + listing_rows + market_tickets) computed server-side
+--      with percentile_cont over the LATEST listings_snapshots snapshot of every
+--      upcoming event at the venue. One real cross-event median, not a mean.
+--
+--   2. Richer per-event fields already precomputed in event_metrics but never
+--      surfaced (retail_min/p25/p90/max, getin_price, retail_mean,
+--      price_dispersion, groups_count, sections_count, owned_share) so the
+--      frontend can render a price band + demand signals per event.
+--
+--   3. Per-event SeatGeek sales velocity (sg_sales_7d / sg_tix_7d), DISTINCT ON
+--      sg_sale_id per PROJECT_BIBLE §3 (firehose 11-23x overcount), feeding the
+--      frontend popularity/heat score. Sparse for some events (e.g. preseason
+--      NFL = 0) — the FE score degrades gracefully to price/inventory/momentum.
+--
+-- §3 LANDMINES honored:
+--   • listings_snapshots: query by event_id only (aq_short_event_id 0% pop);
+--     non-ancillary, retail_price>0, latest snapshot per event (max captured_at).
+--   • seatgeek_sales_snapshots: DISTINCT ON (sg_sale_id) ORDER BY pulled_at DESC
+--     before any aggregate; join on sg_event_id (tevo_event_id 0% pop).
+--   • events.occurs_at_local is TEXT — regex guard + cast, unchanged from prior.
+--
+-- Canonical v3 SECDEF: @s4kent.com gate, REVOKE PUBLIC + GRANT anon/auth.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_broker_venue_page(p_venue_id integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_email      text;
+  v_venue      jsonb;
+  v_aggregate  jsonb;
+  v_events     jsonb;
+  v_sg         jsonb;
+  v_price_band jsonb;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email', '');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not an @s4kent.com email', v_email USING ERRCODE = '42501';
+  END IF;
+
+  -- ── Hero: venue identity (aq_venue_map + venue_assets, events fallback) ──────
+  SELECT jsonb_build_object(
+    'tevo_venue_id', av.tevo_venue_id, 'venue_name', av.venue_name,
+    'city', av.city, 'state', av.state, 'country', av.country,
+    'sg_venue_id', av.sg_venue_id, 'tickpick_venue_id', av.tickpick_venue_id,
+    'latitude', coalesce(va.latitude, av.latitude),
+    'longitude', coalesce(va.longitude, av.longitude),
+    'capacity', va.capacity, 'is_indoor', va.is_indoor,
+    'hero_image_url', va.hero_image_url
+  ) INTO v_venue
+  FROM public.aq_venue_map av
+  LEFT JOIN public.venue_assets va ON va.tevo_venue_id = av.tevo_venue_id
+  WHERE av.tevo_venue_id = p_venue_id LIMIT 1;
+
+  -- Fallback: venue not in aq_venue_map (e.g. MLB stadiums pending the matcher
+  -- backfill) — build a minimal header from the events table.
+  IF v_venue IS NULL THEN
+    SELECT jsonb_build_object(
+      'tevo_venue_id', p_venue_id, 'venue_name', e.vn,
+      'city', NULLIF(split_part(e.vl, ',', 1), ''),
+      'state', NULLIF(trim(split_part(e.vl, ',', 2)), ''), 'country', NULL,
+      'sg_venue_id', NULL, 'tickpick_venue_id', NULL,
+      'latitude', NULL, 'longitude', NULL, 'capacity', NULL, 'is_indoor', NULL,
+      'hero_image_url', NULL
+    ) INTO v_venue
+    FROM (
+      SELECT max(venue_name) AS vn, max(venue_location) AS vl
+      FROM public.events WHERE venue_id = p_venue_id
+    ) e
+    WHERE e.vn IS NOT NULL;
+  END IF;
+
+  IF v_venue IS NULL THEN
+    RETURN jsonb_build_object('hidden', true, 'reason', 'venue_not_found');
+  END IF;
+
+  -- ── Events tab + aggregate: per-event metrics + SG sales velocity ───────────
+  WITH ev AS (
+    SELECT id, name, primary_performer_name, occurs_at_local
+    FROM public.events
+    WHERE venue_id = p_venue_id
+      AND occurs_at_local ~ '^\d{4}'
+      AND occurs_at_local::timestamptz >= now()
+      AND occurs_at_local::timestamptz < now() + interval '90 days'
+  ),
+  -- Per-event SG sales velocity (last 7d) — DISTINCT ON sg_sale_id (§3 dedupe).
+  sg_dedup AS (
+    SELECT DISTINCT ON (s.sg_sale_id)
+      s.sg_sale_id, x.tevo_event_id, s.quantity
+    FROM public.seatgeek_sales_snapshots s
+    JOIN public.seatgeek_event_xref x ON x.sg_event_id = s.sg_event_id
+    JOIN ev ON ev.id = x.tevo_event_id
+    WHERE s.sale_at_utc > now() - interval '7 days'
+    ORDER BY s.sg_sale_id, s.pulled_at DESC
+  ),
+  sg_vel AS (
+    SELECT tevo_event_id,
+           count(*)                  AS sg_sales_7d,
+           coalesce(sum(quantity),0) AS sg_tix_7d
+    FROM sg_dedup GROUP BY tevo_event_id
+  ),
+  ev_rows AS (
+    SELECT
+      ev.id, ev.name, ev.primary_performer_name, ev.occurs_at_local,
+      em.tickets_count, em.groups_count, em.sections_count,
+      em.retail_min, em.retail_p25, em.retail_median, em.retail_mean,
+      em.retail_p75, em.retail_p90, em.retail_max, em.getin_price,
+      em.price_dispersion,
+      em.owned_tickets_count, em.owned_median_retail, em.owned_share,
+      coalesce(sv.sg_sales_7d, 0) AS sg_sales_7d,
+      coalesce(sv.sg_tix_7d,   0) AS sg_tix_7d
+    FROM ev
+    LEFT JOIN LATERAL (
+      SELECT tickets_count, groups_count, sections_count,
+             retail_min, retail_p25, retail_median, retail_mean,
+             retail_p75, retail_p90, retail_max, getin_price, price_dispersion,
+             owned_tickets_count, owned_median_retail, owned_share
+      FROM public.event_metrics m
+      WHERE m.event_id = ev.id ORDER BY captured_at DESC LIMIT 1
+    ) em ON true
+    LEFT JOIN sg_vel sv ON sv.tevo_event_id = ev.id
+  )
+  SELECT
+    coalesce(jsonb_agg(to_jsonb(r) ORDER BY r.occurs_at_local), '[]'::jsonb),
+    jsonb_build_object(
+      'events_count',         count(*),
+      'distinct_performers',  count(DISTINCT r.primary_performer_name),
+      'market_tickets_total', coalesce(sum(r.tickets_count), 0),
+      'owned_tickets_total',  coalesce(sum(r.owned_tickets_count), 0),
+      'owned_notional',       coalesce(sum(r.owned_tickets_count * r.owned_median_retail), 0)::numeric(20,2),
+      'sg_sales_7d_total',    coalesce(sum(r.sg_sales_7d), 0),
+      'sg_tix_7d_total',      coalesce(sum(r.sg_tix_7d), 0)
+    )
+  INTO v_events, v_aggregate FROM ev_rows r;
+
+  -- ── TRUE venue-level price band ─────────────────────────────────────────────
+  -- percentile_cont over the LATEST listings snapshot of every upcoming event at
+  -- the venue. One real cross-event median (vs the old client-side mean-of-medians).
+  WITH ev AS (
+    SELECT id FROM public.events
+    WHERE venue_id = p_venue_id
+      AND occurs_at_local ~ '^\d{4}'
+      AND occurs_at_local::timestamptz >= now()
+      AND occurs_at_local::timestamptz < now() + interval '90 days'
+  ),
+  latest AS (
+    SELECT ls.retail_price, ls.quantity,
+           ls.captured_at,
+           max(ls.captured_at) OVER (PARTITION BY ls.event_id) AS max_cap
+    FROM public.listings_snapshots ls
+    JOIN ev ON ev.id = ls.event_id
+    WHERE coalesce(ls.is_ancillary, false) = false
+      AND ls.retail_price > 0
+  ),
+  cur AS (SELECT retail_price, quantity FROM latest WHERE captured_at = max_cap)
+  SELECT jsonb_build_object(
+    'listing_rows',   count(*),
+    'market_tickets', coalesce(sum(quantity), 0),
+    'getin',          round(min(retail_price), 2),
+    'p25',            round(percentile_cont(0.25) WITHIN GROUP (ORDER BY retail_price)::numeric, 2),
+    'median',         round(percentile_cont(0.50) WITHIN GROUP (ORDER BY retail_price)::numeric, 2),
+    'p90',            round(percentile_cont(0.90) WITHIN GROUP (ORDER BY retail_price)::numeric, 2),
+    'max',            round(max(retail_price), 2)
+  ) INTO v_price_band
+  FROM cur;
+
+  -- Merge the price band into the aggregate payload.
+  v_aggregate := v_aggregate || jsonb_build_object('price_band', coalesce(v_price_band, '{}'::jsonb));
+
+  -- ── SG Activity tab: venue-wide 24h sales (unchanged) ───────────────────────
+  WITH event_xrefs AS (
+    SELECT x.sg_event_id FROM public.events ev
+    JOIN public.seatgeek_event_xref x ON x.tevo_event_id = ev.id
+    WHERE ev.venue_id = p_venue_id
+  ),
+  deduped AS (
+    SELECT DISTINCT ON (s.sg_sale_id) s.sg_sale_id, s.sg_event_id, s.broadcast_price, s.quantity
+    FROM public.seatgeek_sales_snapshots s
+    JOIN event_xrefs ex ON ex.sg_event_id = s.sg_event_id
+    WHERE s.sale_at_utc > now() - interval '24 hours'
+    ORDER BY s.sg_sale_id, s.pulled_at DESC
+  )
+  SELECT jsonb_build_object(
+    'sales_24h', count(*), 'tickets_24h', coalesce(sum(quantity), 0),
+    'gmv_24h', coalesce(sum(broadcast_price * quantity), 0)::numeric(20,2),
+    'distinct_events_with_sales', count(DISTINCT sg_event_id)
+  ) INTO v_sg FROM deduped;
+
+  RETURN jsonb_build_object(
+    'venue', v_venue, 'aggregate', v_aggregate,
+    'events', v_events, 'sg_activity', v_sg, 'hidden', false
+  );
+END $function$;
+
+REVOKE ALL ON FUNCTION public.get_broker_venue_page(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_broker_venue_page(integer) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_broker_venue_page(integer) IS
+  'D0 venue page DETAIL — hero + aggregate (now incl. TRUE price_band percentiles over latest listings_snapshots + SG 7d velocity totals) + per-event metrics (full retail percentile band, getin, dispersion, SG 7d velocity) + SG 24h activity. Email-gated. See mig 20260620130000.';


### PR DESCRIPTION
## Why

Looking at venue-level data we generate (e.g. `venue.html?venue=36` — EverBank Stadium), two gaps stood out:

1. **No price metric anywhere in the venue rollup** — just event/ticket counts and owned position.
2. The Market Carpet ticker's **"EVO MEDIAN" was a client-side *mean of per-event medians*** (mislabeled, and equal-weighted — a 24-ticket season-ticket listing counted the same as a 2,635-ticket game).
3. **No event popularity signal** — nothing surfaced that the Browns regular-season game (median $274) is the marquee event vs the $84–96 preseason games at the same venue.

This adds real median price metrics and event popularity, per the requested scope (frontend + new RPC).

## Changes

### RPC — `supabase/migrations/20260620130000_d0_venue_price_band_demand.sql`
> Authored by D0; **applied by A1** (D0 has no prod-DB apply authority). `CREATE OR REPLACE` of `get_broker_venue_page` — additive, backward-compatible.

- `aggregate.price_band` — a **TRUE venue-level percentile band** (get-in / p25 / median / p90 / max + listing/ticket counts) computed server-side with `percentile_cont` over the **latest `listings_snapshots` snapshot of every upcoming event**. One real cross-event median, not a mean.
- Surfaces richer per-event fields already in `event_metrics` but never returned: `retail_min/p25/p90/max`, `getin_price`, `retail_mean`, `price_dispersion`, `groups/sections_count`, `owned_share`.
- Per-event **SeatGeek sales velocity** (`sg_sales_7d` / `sg_tix_7d`), `DISTINCT ON (sg_sale_id)` per PROJECT_BIBLE §3 firehose dedupe.
- §3 landmines honored: `listings_snapshots` queried by `event_id` only; SG sales joined on `sg_event_id` and deduped; `occurs_at_local` TEXT regex-guarded.

### Frontend — `static/terminal/venue.js`, `venue.html`
- New **PRICE BAND** rollup row (get-in / p25 / median / p90 / SG sales 7d) with a listings/tickets/max meta line.
- Ticker headline now shows the **TRUE venue median + get-in** (replacing the mislabeled mean) plus a **HOTTEST EVENT** cell.
- Upcoming Events table gains **Heat**, **Get-in** and **p90** columns.
- `computeHeat()` — relative **0–100 demand score** per event blending price level, market tightness (inverse `price_dispersion`) and SG velocity. Degrades gracefully when SG velocity is sparse (e.g. preseason NFL = 0); thin pseudo-events (<50 tix — season packages / parking) are flagged `pkg` and excluded from the ranking so they don't masquerade as demand. Relative *within the venue*.

## Validation
- All new query paths validated read-only against prod for venue 36: true band = get-in **$25**, median **$185**, p90 **$562** over 1,765 live listings; Browns game heat tops the venue vs preseason.
- `bin/check-docs.sh` ✅ · `scripts/check_readonly.py` ✅ · `node --check venue.js` ✅

## Note for A1
The migration must be applied for the new fields to appear. The frontend reads the new keys defensively (`price_band || {}`, `getin_price` etc.), so it renders safely against the old RPC until then — band cells just show `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019imxyD28utPyCa5XhBurNP)_