### PR TITLE
fix(d0): bump nav/style cache tokens so SUBS tab appears

### DIFF
--- a/static/terminal/axs.html
+++ b/static/terminal/axs.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — AXS Events</title>
-  <link rel="stylesheet" href="style.css?v=20260620" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="axs">
 
@@ -72,7 +72,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="axs.js?v=20260620b"></script>
 </body>
 </html>

--- a/static/terminal/discovery.html
+++ b/static/terminal/discovery.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Discovery</title>
-  <link rel="stylesheet" href="style.css?v=20260608" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="discovery">
 
@@ -166,7 +166,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="discovery.js?v=20260620"></script>
 </body>
 </html>

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -16,7 +16,7 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Event</title>
   <link rel="stylesheet" href="lib/uplot.min.css" />
-  <link rel="stylesheet" href="style.css?v=20260616" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="event">
 
@@ -509,7 +509,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="alerts.js?v=20260608"></script>
   <script src="event.js?v=20260620"></script>
 </body>

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Home</title>
-  <link rel="stylesheet" href="style.css?v=20260615" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="home">
 
@@ -102,7 +102,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="home.js?v=20260620"></script>
 </body>
 </html>

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Sign in</title>
-  <link rel="stylesheet" href="style.css?v=20260608" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="login">
 

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Movers</title>
-  <link rel="stylesheet" href="style.css?v=20260608" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="movers">
 
@@ -120,7 +120,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="movers.js?v=20260608"></script>
 </body>
 </html>

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
-  <link rel="stylesheet" href="style.css?v=20260620" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="orders">
 
@@ -80,7 +80,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="orders.js?v=20260620a"></script>
 </body>
 </html>

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Performer</title>
-  <link rel="stylesheet" href="style.css?v=20260608" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
   <style>
     .trip-controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-bottom: 14px; }
     .trip-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--muted, #9aa); text-transform: uppercase; letter-spacing: .04em; }
@@ -234,7 +234,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="alerts.js?v=20260608"></script>
   <script src="performer.js?v=20260608"></script>
 </body>

--- a/static/terminal/retail-chat.html
+++ b/static/terminal/retail-chat.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Retail Chat</title>
-  <link rel="stylesheet" href="style.css?v=20260615" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
   <style>
     /* Page layout: let the chat panel fill the viewport under the topbar. */
     body[data-page="retail-chat"] { height:100vh; display:flex; flex-direction:column; overflow:hidden; }
@@ -48,7 +48,7 @@
   <!-- Cache-busting: bump ?v= on any first-party asset change. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260619"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="/static/shared/retail-chat-widget.js?v=20260619"></script>
   <script src="retail-chat.js?v=20260619"></script>
 </body>

--- a/static/terminal/subs.html
+++ b/static/terminal/subs.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Subs</title>
-  <link rel="stylesheet" href="style.css?v=20260620" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="subs">
 
@@ -97,7 +97,7 @@
   <!-- Cache-busting: bump ?v=<date> on any first-party asset change. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="subs.js?v=20260620"></script>
 </body>
 </html>

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Venue</title>
-  <link rel="stylesheet" href="style.css?v=20260608" />
+  <link rel="stylesheet" href="style.css?v=20260620b" />
 </head>
 <body data-page="venue">
 
@@ -188,7 +188,7 @@
   <!-- Cache-busting: first-party JS/CSS carry ?v=<token>. Bump the token (date) on ANY first-party asset change so the static CDN/browser fetch fresh bundles instead of serving a stale cached copy. -->
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
-  <script src="nav.js?v=20260620"></script>
+  <script src="nav.js?v=20260620b"></script>
   <script src="alerts.js?v=20260608"></script>
   <script src="venue.js?v=20260620"></script>
 </body>


### PR DESCRIPTION
## What

The **SUBS** nav tab wasn't appearing on the live site. Root cause: the SUBS entry + subs styles shipped in #648/#653, but the terminal HTML pages still loaded `nav.js?v=20260620` and stale `style.css?v=…` — the **same cache tokens used before the change**. Browsers and the Render static CDN key on those tokens, so they kept serving the cached `nav.js` (no SUBS link).

The service worker is network-first (doesn't mask deploys), so this is purely the HTTP/CDN cache. Per the repo's stated rule ("bump the token on ANY first-party asset change"), this bumps both tokens.

## Change

`nav.js?v=` and `style.css?v=` → `20260620b` across all terminal pages (11 files). **Tokens only — no JS/CSS content change.** Forces a fresh fetch so the SUBS tab (and subs/sub-link styles) load.

Follow-up to #648/#653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtjYqxU94A5Ed32wbFxGDL)_