### PR TITLE
feat(d0): real-time unmapped-section tracker + manual venue-map mapping

### DIFF
--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -490,6 +490,10 @@
         <div class="seatmap-mapwrap">
           <div id="seatmapHost" class="seatmap-host"></div>
         </div>
+        <!-- Real-time unmapped-section tracker: distinct sections the map can't color for
+             the selected source, with an inline control to map each to a venue-map polygon
+             (persisted via set_event_section_manual_map; survives the refresh cron). -->
+        <div id="seatmapUnmapped" class="seatmap-unmapped"></div>
         <div class="seatmap-side-hd row">
           <span id="seatmapSelLabel">Click a section to filter listings</span>
           <button type="button" id="seatmapResetBtn" class="seatmap-reset" hidden>Reset</button>

--- a/static/terminal/event.js
+++ b/static/terminal/event.js
@@ -3601,6 +3601,14 @@
   let _seatmapUserPicked = false; // user clicked a source → stop auto-picking
   let _seatmapConfigName = '';
   let _seatmapVenueLabel = '';
+  // Operator manual overrides (persisted in venue_section_map, match_method='manual').
+  // Shape: { evo: Map(section_raw_lower → real-case manifest key), sg: …, … }. Loaded once
+  // per event from get_event_section_map; authoritative — they win over the heuristic matcher
+  // and the */10 refresh cron cannot clobber them (mig 20260620130000).
+  let _seatmapManual = {};
+  // Frontend source key → venue_section_map.platform. GT is absent (the crosswalk's CHECK
+  // allows only evo/sg/tp/vd/sh), so GameTime sections can be TRACKED but not manually mapped.
+  const _SM_PLATFORM = { EVO: 'evo', SG: 'sg', SH: 'sh', VD: 'vd', TP: 'tp' };
   const SEATMAP_MAPS_DOMAIN = 'https://maps.ticketevolution.com';  // lib default; we read the same manifest
   // Source registry — TM excluded (primary/box-office, no section-level resale
   // listings for these events). TP is INCLUDED but is ZONE-ONLY: it lists whole
@@ -3770,8 +3778,30 @@
   // Match one listing section → manifest key (cached per venue). Tier chain:
   // numberless (GA/Pit/Lawn) → name exact, else name token-overlap;
   // numbered → T1/T2 exact (num+suffix) → T2b suffixed-but-only-numeric → T3 family → T4 bowl.
+  // Lowercased manifest key → real-case key (the map library needs exact case).
+  // venue_section_map stores keys lowercased; we translate back through the manifest index.
+  function _seatmapKeyByLower(idx) {
+    if (!idx) return new Map();
+    if (idx._keyByLower) return idx._keyByLower;
+    const m = new Map();
+    _seatmapAllKeys(idx).forEach(k => m.set(String(k).toLowerCase(), k));
+    idx._keyByLower = m;
+    return m;
+  }
+
+  // Does the CURRENT source have a manual override for this raw section? → real manifest key.
+  function _seatmapManualKey(section) {
+    const plat = _SM_PLATFORM[_seatmapSource];
+    if (!plat) return null;
+    const m = _seatmapManual[plat];
+    if (!m) return null;
+    return m.get(String(section == null ? '' : section).trim().toLowerCase()) || null;
+  }
+
   function _seatmapMatchSection(section, idx) {
     if (!idx) return null;
+    const manual = _seatmapManualKey(section);   // operator override wins over the heuristic
+    if (manual) return manual;
     if (idx.cache.has(section)) return idx.cache.get(section);
     const p = _smParse(section);
     let key = null;
@@ -3828,6 +3858,8 @@
   }
   function _seatmapZoneKeys(label, idx) {
     if (!idx) return [];
+    const manual = _seatmapManualKey(label);   // operator override wins over zone expansion
+    if (manual) return [manual];
     const cache = idx._zoneCache || (idx._zoneCache = new Map());
     if (cache.has(label)) return cache.get(label);
     const norm = _smNorm(label);
@@ -3902,6 +3934,170 @@
     }
   }
 
+  // ----- Manual-map persistence (real-time tracking surface + operator mapping) -----
+  // Load this event's persisted crosswalk and keep the match_method='manual' rows as
+  // authoritative overrides. Fetched once per event; non-manual rows are ignored here
+  // (the live heuristic + manifest still drive auto-coloring for every source incl. GT).
+  async function _seatmapLoadManual(eventId) {
+    _seatmapManual = {};
+    const r = await rpcOrNull('get_event_section_map', { p_event_id: eventId });
+    const rows = (r && r.data) || [];
+    if (!Array.isArray(rows)) return;
+    const keyByLower = _seatmapKeyByLower(_seatmapRemap);
+    rows.forEach(row => {
+      if (!row || row.match_method !== 'manual' || !row.seatmap_key) return;
+      const plat = row.platform;
+      const real = keyByLower.get(String(row.seatmap_key).toLowerCase()) || row.seatmap_key;
+      (_seatmapManual[plat] || (_seatmapManual[plat] = new Map()))
+        .set(String(row.section_raw).toLowerCase(), real);
+    });
+  }
+
+  // <option> list of every manifest polygon key (built once per venue index).
+  function _seatmapKeyOptionsHtml(idx) {
+    if (!idx) return '';
+    if (idx._keyOptsHtml) return idx._keyOptsHtml;
+    const keys = _seatmapAllKeys(idx).slice().sort((a, b) => String(a).localeCompare(String(b)));
+    idx._keyOptsHtml = '<option value="">— pick a venue-map section —</option>' +
+      keys.map(k => `<option value="${escapeHtml(k)}">${escapeHtml(k)}</option>`).join('');
+    return idx._keyOptsHtml;
+  }
+
+  // Distinct CURRENT-source sections that DON'T resolve to a polygon (the live tracker rows).
+  function _seatmapUnmappedSections() {
+    const zoneSrc = _seatmapIsZoneSource(_seatmapSource);
+    const rows = _seatmapRowsBySource[_seatmapSource] || [];
+    const agg = new Map();   // sectionLower → { section, count, minPrice }
+    rows.forEach(r => {
+      const sec = (r.section || '').trim();
+      if (!sec || _seatmapIsParking(sec)) return;
+      if (_seatmapRowMapped(r, zoneSrc) !== false) return;   // skip mapped / no-manifest
+      const k = sec.toLowerCase();
+      const cur = agg.get(k) || { section: sec, count: 0, minPrice: Infinity };
+      cur.count += 1;
+      const p = Number(r.retail_price);
+      if (isFinite(p) && p > 0 && p < cur.minPrice) cur.minPrice = p;
+      agg.set(k, cur);
+    });
+    return Array.from(agg.values()).sort((a, b) => b.count - a.count);
+  }
+
+  // Sections this source has manually mapped (so the operator can review / clear them).
+  function _seatmapManualList() {
+    const plat = _SM_PLATFORM[_seatmapSource];
+    const m = plat && _seatmapManual[plat];
+    if (!m) return [];
+    return Array.from(m, ([section, key]) => ({ section, key })).sort((a, b) => a.section.localeCompare(b.section));
+  }
+
+  // Re-color the map for the current source (after a manual map/clear) without an SVG rebuild.
+  function _seatmapRecolor() {
+    if (!_seatmapApi || typeof _seatmapApi.updateTicketGroups !== 'function') return;
+    const rows = _seatmapRowsBySource[_seatmapSource] || [];
+    const tg = _seatmapTicketGroups(rows, _seatmapRemap, _seatmapIsZoneSource(_seatmapSource));
+    try { _seatmapApi.updateTicketGroups(tg); } catch (_) { /* ignore */ }
+    updateSeatmapMeta(tg.length);
+  }
+
+  // Renders the real-time "unmapped sections" tracker for the current source: each distinct
+  // section the map can't color, with its listing count + floor and an inline control to map
+  // it to a venue-map polygon. Manual maps are listed separately with a Clear control.
+  function renderSeatmapUnmapped() {
+    const host = document.getElementById('seatmapUnmapped');
+    if (!host) return;
+    if (!_seatmapRemap) { host.innerHTML = ''; return; }   // no manifest → nothing to judge
+    const plat = _SM_PLATFORM[_seatmapSource];
+    const src = _seatmapSrcLabel(_seatmapSource);
+    const unmapped = _seatmapUnmappedSections();
+    const manual = _seatmapManualList();
+    if (!unmapped.length && !manual.length) { host.innerHTML = ''; return; }
+
+    let html = '';
+    if (unmapped.length) {
+      const total = unmapped.reduce((s, u) => s + u.count, 0);
+      html += `<div class="sm-track-hd">${unmapped.length} unmapped ${escapeHtml(src)} section${unmapped.length === 1 ? '' : 's'} · ${T.fmtNum(total)} listing${total === 1 ? '' : 's'} not on the map</div>`;
+      if (!plat) {
+        html += `<div class="sm-track-note">Manual mapping isn't available for ${escapeHtml(src)} (not a tracked crosswalk source).</div>`;
+      }
+      html += '<table class="sm-track-tbl"><tbody>';
+      unmapped.slice(0, 200).forEach(u => {
+        const floor = isFinite(u.minPrice) ? '$' + T.fmtNum(Math.round(u.minPrice)) : '—';
+        const secAttr = escapeHtml(u.section.toLowerCase());
+        const ctrl = plat
+          ? `<button type="button" class="sm-map-btn" data-sec="${secAttr}">Map ▾</button>`
+          : '';
+        html += `<tr data-sec="${secAttr}">
+          <td class="sm-track-sec">${escapeHtml(u.section)}</td>
+          <td class="num">${T.fmtNum(u.count)}</td>
+          <td class="num">${floor}</td>
+          <td class="sm-track-ctrl">${ctrl}</td></tr>`;
+      });
+      html += '</tbody></table>';
+    }
+    if (manual.length) {
+      html += `<div class="sm-track-hd manual">${manual.length} manually mapped</div>`;
+      html += '<table class="sm-track-tbl"><tbody>';
+      manual.forEach(mp => {
+        const secAttr = escapeHtml(mp.section);
+        html += `<tr>
+          <td class="sm-track-sec">${escapeHtml(mp.section)}</td>
+          <td class="sm-track-arrow">→ ${escapeHtml(mp.key)}</td>
+          <td class="sm-track-ctrl"><button type="button" class="sm-unmap-btn" data-sec="${secAttr}">Clear</button></td></tr>`;
+      });
+      html += '</tbody></table>';
+    }
+    host.innerHTML = html;
+  }
+
+  // Open the inline polygon picker for one unmapped row.
+  function _seatmapOpenMapEditor(tr, secLower) {
+    if (!tr || tr.querySelector('.sm-map-pick')) return;
+    const cell = tr.querySelector('.sm-track-ctrl');
+    if (!cell) return;
+    cell.innerHTML =
+      `<select class="sm-map-pick">${_seatmapKeyOptionsHtml(_seatmapRemap)}</select>` +
+      `<button type="button" class="sm-map-save" data-sec="${escapeHtml(secLower)}">Save</button>` +
+      `<button type="button" class="sm-map-cancel">✕</button>`;
+  }
+
+  // Transient inline error banner (the terminal has no toast helper; avoids alert()).
+  function _seatmapFlash(msg) {
+    const host = document.getElementById('seatmapUnmapped');
+    if (!host) return;
+    const b = document.createElement('div');
+    b.className = 'sm-track-err';
+    b.textContent = msg;
+    host.prepend(b);
+    setTimeout(() => { try { b.remove(); } catch (_) { /* gone */ } }, 5000);
+  }
+
+  async function _seatmapSaveManual(secLower, key) {
+    const plat = _SM_PLATFORM[_seatmapSource];
+    if (!plat || !key) return;
+    const r = await rpcOrNull('set_event_section_manual_map', {
+      p_event_id: _seatmapEventId, p_platform: plat, p_section_raw: secLower, p_seatmap_key: key,
+    });
+    if (r.error) { _seatmapFlash('Map failed: ' + (r.error.message || 'error')); return; }
+    const real = _seatmapKeyByLower(_seatmapRemap).get(String(key).toLowerCase()) || key;
+    (_seatmapManual[plat] || (_seatmapManual[plat] = new Map())).set(secLower, real);
+    _seatmapRecolor();
+    renderSeatmapUnmapped();
+    renderSeatmapList();
+  }
+
+  async function _seatmapClearManual(secLower) {
+    const plat = _SM_PLATFORM[_seatmapSource];
+    if (!plat) return;
+    const r = await rpcOrNull('clear_event_section_manual_map', {
+      p_event_id: _seatmapEventId, p_platform: plat, p_section_raw: secLower,
+    });
+    if (r.error) { _seatmapFlash('Clear failed: ' + (r.error.message || 'error')); return; }
+    const m = _seatmapManual[plat]; if (m) m.delete(secLower);
+    _seatmapRecolor();
+    renderSeatmapUnmapped();
+    renderSeatmapList();
+  }
+
   async function loadSeatmap(eventId) {
     _tabState.loaded['seatmap'] = true;
     _seatmapEventId = eventId;
@@ -3951,6 +4147,8 @@
     _seatmapSource = 'EVO';
     _seatmapSelected = [];
     _seatmapUserPicked = false;
+    _seatmapManual = {};
+    await _seatmapLoadManual(eventId);   // persisted operator overrides (venue_section_map)
 
     // (3) Default source = TEvo. Build the map ONCE with its floors; later source
     //     switches re-color via updateTicketGroups() rather than rebuilding the SVG.
@@ -3979,6 +4177,7 @@
     wireSeatmapControls();
     renderSeatmapSelector();
     renderSeatmapList();
+    renderSeatmapUnmapped();
     updateSeatmapMeta(ticketGroups.length);
     _seatmapProbeSources(eventId);   // fire-and-forget: enable/disable + count the other sources
   }
@@ -4004,6 +4203,7 @@
     }
     renderSeatmapSelector();   // refresh active state
     renderSeatmapList();
+    renderSeatmapUnmapped();
     updateSeatmapMeta(ticketGroups.length);
   }
 
@@ -4142,12 +4342,13 @@
       if (cls.length) tr.className = cls.join(' ');
       const ownPill = r.is_owned ? '<span class="pill owned">ours</span>' : '<span class="pill market">market</span>';
       const unmappedPill = mapped === false ? ' <span class="pill unmapped" title="section not on the venue map — not colored">unmapped</span>' : '';
+      const manualPill = (mapped !== false && _seatmapManualKey(r.section)) ? ' <span class="pill manual" title="mapped to the venue map by hand">manual</span>' : '';
       tr.innerHTML = `
         <td>${escapeHtml(r.section || '—')}</td>
         <td>${escapeHtml(r.row || '—')}</td>
         <td class="num">${T.fmtNum(r.quantity)}</td>
         <td class="num">${r.retail_price != null ? '$' + T.fmtNum(Math.round(r.retail_price)) : '—'}</td>
-        <td>${ownPill}${unmappedPill}</td>`;
+        <td>${ownPill}${unmappedPill}${manualPill}</td>`;
       tb.appendChild(tr);
     });
     if (unmappedCount) {
@@ -4182,6 +4383,23 @@
           });
         }
         onSeatmapSelection([]);
+      });
+    }
+    // Unmapped-tracker controls (delegated; survives re-renders): open picker, save, cancel, clear.
+    const track = document.getElementById('seatmapUnmapped');
+    if (track) {
+      track.addEventListener('click', (e) => {
+        const mapBtn = e.target.closest('.sm-map-btn');
+        if (mapBtn) { _seatmapOpenMapEditor(mapBtn.closest('tr'), mapBtn.dataset.sec); return; }
+        const saveBtn = e.target.closest('.sm-map-save');
+        if (saveBtn) {
+          const sel = saveBtn.parentElement.querySelector('.sm-map-pick');
+          _seatmapSaveManual(saveBtn.dataset.sec, sel ? sel.value : '');
+          return;
+        }
+        if (e.target.closest('.sm-map-cancel')) { renderSeatmapUnmapped(); return; }
+        const clearBtn = e.target.closest('.sm-unmap-btn');
+        if (clearBtn) { _seatmapClearManual(clearBtn.dataset.sec); return; }
       });
     }
     _seatmapWired = true;

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -1690,9 +1690,27 @@ body[data-page="login"] {
 .full-list-tbl .pill.market { color: var(--muted); }
 .full-list-tbl .pill.broker { color: var(--accent); border-color: var(--accent); }
 .full-list-tbl .pill.unmapped { color: var(--warn); border-color: var(--warn); }
+.full-list-tbl .pill.manual { color: var(--accent); border-color: var(--accent); }
 .full-list-tbl tr.unmapped-row td { background: rgba(245, 158, 11, 0.07); }
 .sm-unmapped-note { font-size: 11px; color: var(--warn); padding: 4px 2px 6px; }
 .full-list-host { max-height: 70vh; overflow-y: auto; }
+
+/* Seat-map unmapped-section tracker (live) + inline manual-map control */
+.seatmap-unmapped { margin: 6px 0 10px; }
+.seatmap-unmapped:empty { display: none; }
+.sm-track-hd { font-size: 11px; font-weight: 600; color: var(--warn); padding: 6px 2px 3px; text-transform: uppercase; letter-spacing: .3px; }
+.sm-track-hd.manual { color: var(--accent); }
+.sm-track-note { font-size: 11px; color: var(--muted); padding: 0 2px 4px; }
+.sm-track-tbl { width: 100%; border-collapse: collapse; font-size: 12px; }
+.sm-track-tbl td { padding: 3px 6px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+.sm-track-tbl td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.sm-track-sec { font-weight: 600; }
+.sm-track-arrow { color: var(--accent); font-size: 11px; }
+.sm-track-ctrl { text-align: right; white-space: nowrap; }
+.sm-track-ctrl button { font-size: 11px; padding: 2px 8px; border: 1px solid var(--line); background: var(--panel); color: var(--text); border-radius: 4px; cursor: pointer; }
+.sm-track-ctrl button:hover { border-color: var(--accent); }
+.sm-map-pick { font-size: 11px; max-width: 240px; margin-right: 4px; background: var(--panel); color: var(--text); border: 1px solid var(--line); border-radius: 4px; padding: 2px; }
+.sm-track-err { font-size: 11px; color: var(--neg); border: 1px solid var(--neg); border-radius: 4px; padding: 4px 8px; margin-bottom: 6px; }
 
 .sales-window-ctrl {
   display: inline-flex; align-items: center; gap: 8px;

--- a/supabase/migrations/20260620130000_venue_section_manual_map.sql
+++ b/supabase/migrations/20260620130000_venue_section_manual_map.sql
@@ -1,0 +1,234 @@
+-- Migration 20260620130000 · level:2 · lane:D0
+-- writes: build_venue_section_map() [fn — adds manual-row protection],
+--         set_event_section_manual_map() [fn], clear_event_section_manual_map() [fn]
+-- reads:  events, seatmap_manifest, venue_section_map
+--
+-- Purpose: Manual seat-map crosswalk overrides + protecting them from the refresh cron.
+--   The venue_section_map crosswalk (mig 20260608120000 / 130000) auto-classifies each
+--   (venue, config, platform, raw-section) onto a seatmap polygon, leaving the misses as
+--   match_method='unmatched'. The terminal Seat Map tab surfaces those unmapped sections
+--   live (real-time tracker); this migration lets an operator MAP one by hand and have it
+--   STICK:
+--
+--     1. build_venue_section_map() — re-created VERBATIM from the config-aware version
+--        (mig 20260608130000) with ONE change: the ON CONFLICT DO UPDATE now carries
+--        `WHERE m.match_method <> 'manual'`, so the */10 venue_section_map_refresh cron
+--        can no longer clobber an operator's manual mapping. (Builder is lane:D0 — see the
+--        20260608120000 header.) No other behavior change; signature unchanged.
+--     2. set_event_section_manual_map(event, platform, section_raw, seatmap_key) — upserts a
+--        match_method='manual', confidence=1.0 row for the event's (venue, config bucket),
+--        resolving the bucket EXACTLY as get_event_section_map does (so the UI reads the row
+--        back). Validates seatmap_key against the venue's seatmap_manifest keys. Returns the
+--        resolved row as json. @s4kent.com-gated, like get_event_section_map.
+--     3. clear_event_section_manual_map(event, platform, section_raw) — deletes the manual
+--        row (the next cron tick re-derives it from the auto tiers). @s4kent.com-gated.
+--
+--   Grant pattern mirrors get_event_section_map (mig 20260608140000): EXECUTE to
+--   authenticated + an in-body @s4kent.com gate (NOT the service_role-only SECDEF
+--   convention — these are user-facing terminal RPCs, same shape as get_event_section_map /
+--   get_broker_event_page).
+--
+-- ## NOT yet applied to prod — author-only (D0). A1 applies after review.
+--   Test plan (preview branch): pick an 'unmatched' (venue,config,platform,section) row;
+--   call set_event_section_manual_map and confirm get_event_section_map returns it as
+--   'manual'; run build_venue_section_map(venue,'evo') and confirm the manual row SURVIVES
+--   (not reverted to its auto tier); call clear_event_section_manual_map and confirm the
+--   row is gone (so the next build re-derives it).
+
+-- ── PART 1: config-aware builder + manual-row protection ─────────────────────
+-- Identical to mig 20260608130000 EXCEPT the ON CONFLICT DO UPDATE ... WHERE clause.
+CREATE OR REPLACE FUNCTION public.build_venue_section_map(
+  p_venue_id bigint, p_platform text DEFAULT 'evo', p_window interval DEFAULT interval '7 days'
+) RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_now   timestamptz := now();
+  v_count integer := 0;
+  v_rc    integer;
+  v_cfg   integer;
+BEGIN
+  IF p_platform NOT IN ('evo','sg') THEN
+    RAISE EXCEPTION 'build_venue_section_map: platform % source not yet wired. evo + sg are live; tp/vd/sh need their per-platform listings source.', p_platform USING ERRCODE='0A000';
+  END IF;
+
+  -- one pass per real config, plus config 0 (union/fallback)
+  FOR v_cfg IN
+    SELECT DISTINCT configuration_id FROM public.seatmap_manifest
+      WHERE venue_id = p_venue_id AND has_map AND configuration_id IS NOT NULL
+    UNION SELECT 0
+  LOOP
+    WITH keys AS (  -- this config's keys (or ALL configs' keys when v_cfg = 0)
+      SELECT DISTINCT public.venue_section_token(k) AS tok, public.venue_section_token_base(k) AS tok_base, lower(btrim(k)) AS seatmap_key
+      FROM public.seatmap_manifest sm CROSS JOIN LATERAL unnest(sm.section_keys) AS k
+      WHERE sm.venue_id = p_venue_id AND sm.has_map
+        AND (v_cfg = 0 OR sm.configuration_id = v_cfg)
+    ),
+    keytok AS (SELECT tok, count(DISTINCT seatmap_key) nkeys, (array_agg(DISTINCT seatmap_key))[1] first_key, array_agg(DISTINCT seatmap_key) all_keys FROM keys WHERE tok IS NOT NULL GROUP BY tok),
+    keybase AS (SELECT tok_base, count(DISTINCT seatmap_key) nkeys, (array_agg(DISTINCT seatmap_key))[1] first_key, array_agg(DISTINCT seatmap_key) all_keys FROM keys WHERE tok_base IS NOT NULL GROUP BY tok_base),
+    evs AS (  -- the events feeding this config bucket
+      SELECT e.id, e.configuration_id FROM public.events e
+      WHERE e.venue_id = p_venue_id
+        AND (
+          (v_cfg <> 0 AND e.configuration_id = v_cfg)
+          OR (v_cfg = 0 AND (e.configuration_id IS NULL
+              OR NOT EXISTS (SELECT 1 FROM public.seatmap_manifest s2 WHERE s2.venue_id = p_venue_id AND s2.has_map AND s2.configuration_id = e.configuration_id)))
+        )
+    ),
+    raw AS (
+      SELECT lower(btrim(s)) AS section_raw, count(*) AS seen FROM (
+        SELECT ls.section AS s FROM public.listings_snapshots ls
+          WHERE p_platform = 'evo' AND ls.event_id IN (SELECT id FROM evs)
+            AND ls.captured_at > v_now - p_window AND ls.type = 'event' AND ls.is_ancillary = false
+        UNION ALL
+        SELECT sl.section AS s FROM public.seatgeek_listings_snapshots sl
+          WHERE p_platform = 'sg' AND sl.sg_event_id IN (
+            SELECT m.sg_event_id FROM public.aq_event_map m JOIN evs ON evs.id = m.tevo_event_id
+            WHERE m.sg_event_id IS NOT NULL)
+            AND sl.captured_at > v_now - p_window
+      ) u WHERE s IS NOT NULL AND btrim(s) <> '' GROUP BY 1
+    ),
+    scored AS (
+      SELECT r.section_raw, r.seen, public.vsm_listing_token(r.section_raw, p_platform) AS tok, public.vsm_listing_token_base(r.section_raw, p_platform) AS tok_base,
+        kx.seatmap_key AS exact_key, kt.nkeys AS kt_n, kt.first_key AS kt_key, kt.all_keys AS kt_keys, kb.nkeys AS kb_n, kb.first_key AS kb_key, kb.all_keys AS kb_keys
+      FROM raw r LEFT JOIN keys kx ON kx.seatmap_key = r.section_raw
+      LEFT JOIN keytok kt ON kt.tok = public.vsm_listing_token(r.section_raw, p_platform)
+      LEFT JOIN keybase kb ON kb.tok_base = public.vsm_listing_token_base(r.section_raw, p_platform)
+    ),
+    classed AS (
+      SELECT section_raw, seen, tok, tok_base,
+        CASE WHEN exact_key IS NOT NULL THEN 'exact' WHEN kt_n=1 THEN 'token' WHEN kt_n>1 THEN 'token_ambiguous'
+             WHEN tok_base IS NOT NULL AND kb_n=1 THEN 'token_base' WHEN tok_base IS NOT NULL AND kb_n>1 THEN 'token_base_ambiguous' ELSE 'unmatched' END AS method,
+        CASE WHEN exact_key IS NOT NULL THEN exact_key WHEN kt_n=1 THEN kt_key WHEN kt_n>1 THEN kt_key WHEN tok_base IS NOT NULL AND kb_n>=1 THEN kb_key ELSE NULL END AS seatmap_key,
+        CASE WHEN kt_n>1 THEN kt_keys WHEN coalesce(kt_n,0)=0 AND tok_base IS NOT NULL AND kb_n>1 THEN kb_keys ELSE NULL END AS candidate_keys
+      FROM scored
+    )
+    INSERT INTO public.venue_section_map AS m
+      (tevo_venue_id, configuration_id, platform, section_raw, section_token, section_token_base, seatmap_key, match_method, confidence, candidate_keys, seen_listings, first_seen_at, updated_at)
+    SELECT p_venue_id, v_cfg, p_platform, section_raw, tok, tok_base, seatmap_key, method,
+           CASE method WHEN 'exact' THEN 1.0 WHEN 'token' THEN 0.9 WHEN 'token_base' THEN 0.75 WHEN 'token_ambiguous' THEN 0.5 WHEN 'token_base_ambiguous' THEN 0.45 ELSE 0 END,
+           candidate_keys, seen, v_now, v_now
+    FROM classed
+    ON CONFLICT (tevo_venue_id, configuration_id, platform, section_raw) DO UPDATE
+      SET section_token=excluded.section_token, section_token_base=excluded.section_token_base, seatmap_key=excluded.seatmap_key,
+          match_method=excluded.match_method, confidence=excluded.confidence, candidate_keys=excluded.candidate_keys, seen_listings=excluded.seen_listings, updated_at=excluded.updated_at
+      WHERE m.match_method <> 'manual';   -- never clobber an operator's manual mapping
+    GET DIAGNOSTICS v_rc = ROW_COUNT;
+    v_count := v_count + v_rc;
+  END LOOP;
+
+  RETURN v_count;
+END; $function$;
+COMMENT ON FUNCTION public.build_venue_section_map(bigint, text, interval) IS
+  'Config-aware builder. Loops the venue''s seatmap configurations (+ config 0 union/fallback for NULL/unmapped-config events); each event''s sections match ITS config''s keys. Manual rows (match_method=manual) are NEVER overwritten (ON CONFLICT WHERE m.match_method<>manual). Returns total rows upserted across configs.';
+REVOKE EXECUTE ON FUNCTION public.build_venue_section_map(bigint, text, interval) FROM anon, authenticated, public;
+
+-- ── PART 2: manual-map writer (terminal UI) ──────────────────────────────────
+CREATE OR REPLACE FUNCTION public.set_event_section_manual_map(
+  p_event_id bigint, p_platform text, p_section_raw text, p_seatmap_key text
+) RETURNS json
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path TO 'public','pg_temp'
+AS $function$
+DECLARE
+  v_email   text;
+  v_venue   bigint;
+  v_cfg     integer;
+  v_use     integer;
+  v_section text;
+  v_key     text;   -- canonical lower(btrim) manifest key
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email','');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not @s4kent.com', v_email USING ERRCODE='42501';
+  END IF;
+
+  IF p_platform NOT IN ('evo','sg','tp','vd','sh') THEN
+    RAISE EXCEPTION 'set_event_section_manual_map: bad platform %', p_platform USING ERRCODE='22023';
+  END IF;
+  v_section := lower(btrim(coalesce(p_section_raw,'')));
+  IF v_section = '' THEN
+    RAISE EXCEPTION 'set_event_section_manual_map: empty section_raw' USING ERRCODE='22023';
+  END IF;
+
+  SELECT e.venue_id, e.configuration_id INTO v_venue, v_cfg FROM public.events e WHERE e.id = p_event_id;
+  IF v_venue IS NULL THEN
+    RAISE EXCEPTION 'set_event_section_manual_map: event % has no venue', p_event_id USING ERRCODE='22023';
+  END IF;
+
+  -- Validate the target polygon exists in this venue's seatmap manifest; capture the
+  -- canonical lower(btrim) form so it joins the same namespace as the auto-built keys.
+  SELECT lower(btrim(k)) INTO v_key
+  FROM public.seatmap_manifest sm CROSS JOIN LATERAL unnest(sm.section_keys) AS k
+  WHERE sm.venue_id = v_venue AND sm.has_map
+    AND lower(btrim(k)) = lower(btrim(coalesce(p_seatmap_key,'')))
+  LIMIT 1;
+  IF v_key IS NULL THEN
+    RAISE EXCEPTION 'set_event_section_manual_map: % is not a seatmap key for venue %', p_seatmap_key, v_venue USING ERRCODE='22023';
+  END IF;
+
+  -- Resolve the config bucket EXACTLY as get_event_section_map does so the UI reads it back.
+  v_use := v_cfg;
+  IF v_use IS NULL OR NOT EXISTS (SELECT 1 FROM public.venue_section_map m WHERE m.tevo_venue_id=v_venue AND m.configuration_id=v_use) THEN
+    v_use := 0;
+  END IF;
+
+  INSERT INTO public.venue_section_map AS m
+    (tevo_venue_id, configuration_id, platform, section_raw, section_token, section_token_base,
+     seatmap_key, match_method, confidence, candidate_keys, seen_listings, first_seen_at, updated_at)
+  VALUES
+    (v_venue, v_use, p_platform, v_section,
+     public.venue_section_token(v_section), public.venue_section_token_base(v_section),
+     v_key, 'manual', 1.0, NULL, NULL, now(), now())
+  ON CONFLICT (tevo_venue_id, configuration_id, platform, section_raw) DO UPDATE
+    SET seatmap_key  = excluded.seatmap_key,
+        match_method = 'manual',
+        confidence   = 1.0,
+        candidate_keys = NULL,
+        updated_at   = now();   -- preserve section_token(_base)/seen_listings already on the row
+
+  RETURN json_build_object(
+    'tevo_venue_id', v_venue, 'configuration_id', v_use, 'platform', p_platform,
+    'section_raw', v_section, 'seatmap_key', v_key, 'match_method', 'manual');
+END $function$;
+COMMENT ON FUNCTION public.set_event_section_manual_map(bigint, text, text, text) IS
+  'Terminal Seat Map tab: assign a listing section to a venue-map polygon by hand (match_method=manual, confidence=1.0). Resolves the event''s (venue, config bucket) like get_event_section_map, validates seatmap_key against seatmap_manifest, and upserts. Sticky: the refresh cron will not overwrite it. @s4kent.com-gated.';
+REVOKE EXECUTE ON FUNCTION public.set_event_section_manual_map(bigint, text, text, text) FROM anon, public;
+GRANT EXECUTE ON FUNCTION public.set_event_section_manual_map(bigint, text, text, text) TO authenticated;
+
+-- ── PART 3: clear a manual map ───────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.clear_event_section_manual_map(
+  p_event_id bigint, p_platform text, p_section_raw text
+) RETURNS boolean
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path TO 'public','pg_temp'
+AS $function$
+DECLARE
+  v_email   text;
+  v_venue   bigint;
+  v_cfg     integer;
+  v_use     integer;
+  v_section text;
+  v_n       integer;
+BEGIN
+  v_email := coalesce(auth.jwt()->>'email','');
+  IF v_email NOT LIKE '%@s4kent.com' THEN
+    RAISE EXCEPTION 'forbidden: % is not @s4kent.com', v_email USING ERRCODE='42501';
+  END IF;
+  v_section := lower(btrim(coalesce(p_section_raw,'')));
+  SELECT e.venue_id, e.configuration_id INTO v_venue, v_cfg FROM public.events e WHERE e.id = p_event_id;
+  IF v_venue IS NULL THEN RETURN false; END IF;
+  v_use := v_cfg;
+  IF v_use IS NULL OR NOT EXISTS (SELECT 1 FROM public.venue_section_map m WHERE m.tevo_venue_id=v_venue AND m.configuration_id=v_use) THEN
+    v_use := 0;
+  END IF;
+  -- Only deletes manual rows — never touches an auto-classified row. The next
+  -- build_venue_section_map tick re-derives this section from the auto tiers.
+  DELETE FROM public.venue_section_map m
+   WHERE m.tevo_venue_id = v_venue AND m.configuration_id = v_use
+     AND m.platform = p_platform AND m.section_raw = v_section
+     AND m.match_method = 'manual';
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n > 0;
+END $function$;
+COMMENT ON FUNCTION public.clear_event_section_manual_map(bigint, text, text) IS
+  'Terminal Seat Map tab: remove a manual section->polygon mapping (only deletes match_method=manual rows). The next venue_section_map_refresh re-derives the section from the auto tiers. @s4kent.com-gated.';
+REVOKE EXECUTE ON FUNCTION public.clear_event_section_manual_map(bigint, text, text) FROM anon, public;
+GRANT EXECUTE ON FUNCTION public.clear_event_section_manual_map(bigint, text, text) TO authenticated;


### PR DESCRIPTION
## Problem

On the terminal's **Seat Map** tab, listing sections were matched to venue-map polygons **purely client-side**, and listings that *didn't* resolve to a polygon were surfaced only as an ephemeral grey **"unmapped"** pill. There was no way to (a) see what's unmapped at a glance / by volume, or (b) fix a miss so it sticks.

The server-side crosswalk to do this already existed (`venue_section_map` + the `venue_section_map_refresh` cron + `get_event_section_map`), and the table's `match_method` CHECK even reserved a `'manual'` value — but **nothing wrote it**, and the UI ignored the persisted crosswalk entirely.

## What this does

Enhances the existing Seat Map tab (per the chosen scope: *track + manual-map, in the Seat Map tab*).

### Frontend — `static/terminal/{event.js, event.html, style.css}`
- **Live "unmapped sections" tracker** for the selected source: each distinct section the map can't color, sorted by listing volume, with listing count + floor price.
- **Inline manual-map control** — pick the correct venue-map polygon from the manifest and save. The override:
  - wins over the heuristic matcher and **recolors the map immediately** (no SVG rebuild),
  - persists across sessions/devices,
  - is marked with a `manual` pill in the listing table, and can be **Cleared** to revert to auto-matching.
- Loads persisted overrides via `get_event_section_map` on tab open. GameTime can be *tracked* but not mapped (the crosswalk only allows `evo/sg/tp/vd/sh`).

### Migration — `supabase/migrations/20260620130000_venue_section_manual_map.sql` (lane:D0, **author-only**)
- `set_event_section_manual_map(event, platform, section_raw, seatmap_key)` / `clear_event_section_manual_map(...)` — `@s4kent.com`-gated SECDEF RPCs that write/delete `match_method='manual'` rows, resolving the event's config bucket **exactly** as `get_event_section_map` reads it (so the write is visible to the reader), and validating the polygon against `seatmap_manifest`.
- `build_venue_section_map` gains `ON CONFLICT … DO UPDATE … WHERE m.match_method <> 'manual'` so the `*/10` refresh cron **can no longer clobber** a manual mapping. Otherwise verbatim from the config-aware builder (mig `20260608130000`); signature unchanged.

Grant pattern mirrors `get_event_section_map` (EXECUTE to `authenticated` + in-body email gate), consistent with the other user-facing terminal RPCs.

## Apply / review notes (for A1)
- **Not applied to prod.** D-tier has no DB mutation authority — A1 applies after review.
- Suggested preview-branch smoke test (also in the migration header): pick an `unmatched` row → `set_…` → confirm `get_event_section_map` returns it as `manual` → run `build_venue_section_map(venue,'evo')` → confirm the manual row **survives** → `clear_…` → confirm it's gone.

## Test done here
- `node --check static/terminal/event.js` ✓
- Dollar-quote / grant balance verified on the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZcZucru7ru4DJCDyEpCUs)_