### PR TITLE
feat(d0): look up subs from an order number

### DIFF
--- a/routers/broker.py
+++ b/routers/broker.py
@@ -213,4 +213,83 @@ def build_broker_router(
                        "source": source, "fee_pct": eff_fee_pct})
         return result
 
+    @router.get("/api/broker/order-lookup")
+    def broker_order_lookup(order_id: str, source: str | None = None,
+                            _=Depends(require_auth)):
+        """Resolve one of OUR order numbers to the fields the substitution
+        checker needs (event/section/row/quantity/revenue), so a broker can
+        paste an order # instead of typing the sold ticket by hand.
+
+        Searches the 4 ingested order sources (seatgeek / tickpick / vivid /
+        evo). `source` narrows the search; omit it to try all. StubHub is NOT
+        ingested as an order source — those orders won't resolve here, use the
+        manual fields. `revenue` is the order's own total/payment (editable in
+        the UI). EVO orders use the first line item for section/row and report
+        `line_items` so a multi-section order can be flagged.
+        """
+        db = get_require_sb()()
+        oid = (order_id or "").strip()
+        if not oid:
+            raise HTTPException(400, "order_id required")
+        src = ((source or "").strip().lower()) or None
+
+        def payload(source_name, tev, ev_name, section, row, qty, revenue, **extra):
+            return {
+                "found": True, "source": source_name, "order_id": oid,
+                "tevo_event_id": tev, "event_name": ev_name,
+                "section": section, "row": row, "quantity": qty,
+                "revenue": revenue, **extra,
+            }
+
+        if src in (None, "seatgeek"):
+            r = (db.table("seatgeek_orders")
+                 .select("sg_order_id,tevo_event_id,sg_event_name,sale_section,sale_row,sale_quantity,payment_total,payment_price")
+                 .eq("sg_order_id", oid).limit(1).execute().data or [])
+            if r:
+                o = r[0]
+                return payload("seatgeek", o.get("tevo_event_id"), o.get("sg_event_name"),
+                               o.get("sale_section"), o.get("sale_row"), o.get("sale_quantity"),
+                               o.get("payment_total") if o.get("payment_total") is not None else o.get("payment_price"))
+
+        if src in (None, "tickpick"):
+            r = (db.table("tickpick_orders")
+                 .select("tp_order_id,tevo_event_id,event_name,section,row,quantity,total")
+                 .eq("tp_order_id", oid).limit(1).execute().data or [])
+            if r:
+                o = r[0]
+                return payload("tickpick", o.get("tevo_event_id"), o.get("event_name"),
+                               o.get("section"), o.get("row"), o.get("quantity"), o.get("total"))
+
+        if src in (None, "vivid"):
+            r = (db.table("vivid_orders")
+                 .select("vivid_order_id,tevo_event_id,event_name,section,row,quantity,total")
+                 .eq("vivid_order_id", oid).limit(1).execute().data or [])
+            if r:
+                o = r[0]
+                return payload("vivid", o.get("tevo_event_id"), o.get("event_name"),
+                               o.get("section"), o.get("row"), o.get("quantity"), o.get("total"))
+
+        if src in (None, "evo"):
+            try:
+                eoid = int(oid)
+            except (TypeError, ValueError):
+                eoid = None
+            if eoid is not None:
+                hdr = (db.table("evo_orders")
+                       .select("evo_order_id,tevo_event_id,total,subtotal")
+                       .eq("evo_order_id", eoid).limit(1).execute().data or [])
+                if hdr:
+                    items = (db.table("evo_order_items")
+                             .select("ticket_group_section,ticket_group_row,quantity,event_name,event_id")
+                             .eq("evo_order_id", eoid).execute().data or [])
+                    it = items[0] if items else {}
+                    tev = hdr[0].get("tevo_event_id") or it.get("event_id")
+                    rev = hdr[0].get("subtotal") if hdr[0].get("subtotal") is not None else hdr[0].get("total")
+                    return payload("evo", tev, it.get("event_name"),
+                                   it.get("ticket_group_section"), it.get("ticket_group_row"),
+                                   it.get("quantity"), rev, line_items=len(items))
+
+        return {"found": False, "order_id": oid, "source": src,
+                "note": "no matching order in seatgeek/tickpick/vivid/evo (StubHub orders aren't ingested — enter details manually)"}
+
     return router

--- a/static/terminal/axs.html
+++ b/static/terminal/axs.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — AXS Events</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="axs">
 

--- a/static/terminal/discovery.html
+++ b/static/terminal/discovery.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Discovery</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="discovery">
 

--- a/static/terminal/event.html
+++ b/static/terminal/event.html
@@ -16,7 +16,7 @@
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Event</title>
   <link rel="stylesheet" href="lib/uplot.min.css" />
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="event">
 

--- a/static/terminal/index.html
+++ b/static/terminal/index.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Home</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="home">
 

--- a/static/terminal/login.html
+++ b/static/terminal/login.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Sign in</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="login">
 

--- a/static/terminal/movers.html
+++ b/static/terminal/movers.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Movers</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="movers">
 

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="orders">
 

--- a/static/terminal/performer.html
+++ b/static/terminal/performer.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Performer</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
   <style>
     .trip-controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-bottom: 14px; }
     .trip-controls label { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--muted, #9aa); text-transform: uppercase; letter-spacing: .04em; }

--- a/static/terminal/retail-chat.html
+++ b/static/terminal/retail-chat.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Retail Chat</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
   <style>
     /* Page layout: let the chat panel fill the viewport under the topbar. */
     body[data-page="retail-chat"] { height:100vh; display:flex; flex-direction:column; overflow:hidden; }

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -2181,3 +2181,6 @@ body[data-page="login"] {
 .subs-typeahead .ta-empty.err { color: var(--neg); }
 .sub-link { color: var(--accent); text-decoration: none; font-size: 10px; margin-left: 6px; font-family: var(--mono); }
 .sub-link:hover { text-decoration: underline; }
+.subs-orderbar { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin-top: 12px; }
+.subs-order-msg { flex-basis: 100%; min-height: 14px; }
+.subs-or { text-align: center; color: var(--dim); font-family: var(--mono); font-size: 11px; letter-spacing: .06em; margin: 14px 0 2px; }

--- a/static/terminal/subs.html
+++ b/static/terminal/subs.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Subs</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="subs">
 
@@ -30,8 +30,29 @@
       <p class="muted small">
         Cover a sold / double-sold ticket from our own inventory. Finds the
         <strong>cheapest acceptable</strong> sub — same section &amp; same-or-better row
-        first, then a better-section fallback. Enter the sold ticket below.
+        first, then a better-section fallback. Paste an order # to auto-fill, or enter the sold ticket below.
       </p>
+      <div class="subs-orderbar">
+        <div class="subs-field">
+          <label for="subOrderId">Order # <span class="muted small">(auto-fill from a sale)</span></label>
+          <input id="subOrderId" type="text" placeholder="paste an order number" autocomplete="off" />
+        </div>
+        <div class="subs-field narrow">
+          <label for="subOrderSource">Order source</label>
+          <select id="subOrderSource">
+            <option value="">Auto</option>
+            <option value="seatgeek">SeatGeek</option>
+            <option value="tickpick">TickPick</option>
+            <option value="vivid">Vivid</option>
+            <option value="evo">EVO</option>
+          </select>
+        </div>
+        <div class="subs-field submit">
+          <button type="button" class="btn-primary" id="subOrderLoad">Load order →</button>
+        </div>
+        <div id="subOrderMsg" class="subs-order-msg muted small"></div>
+      </div>
+      <div class="subs-or">— or enter the sold ticket manually —</div>
       <form id="subsForm" class="subs-form" autocomplete="off">
         <div class="subs-field event-search">
           <label for="subEventSearch">Event <span class="muted small">(search by name)</span></label>
@@ -98,6 +119,6 @@
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620b"></script>
-  <script src="subs.js?v=20260620"></script>
+  <script src="subs.js?v=20260620c"></script>
 </body>
 </html>

--- a/static/terminal/subs.js
+++ b/static/terminal/subs.js
@@ -18,9 +18,53 @@
   function init() {
     const form = document.getElementById('subsForm');
     if (form) form.addEventListener('submit', onSubmit);
+    wireOrderLoad();
     wireEventSearch();
     wireFeeToggle();
     prefillFromQuery();
+  }
+
+  // ---------- order # → auto-fill the sold ticket ----------
+
+  function wireOrderLoad() {
+    const btn = document.getElementById('subOrderLoad');
+    if (btn) btn.addEventListener('click', loadOrder);
+    const inp = document.getElementById('subOrderId');
+    if (inp) inp.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); loadOrder(); }
+    });
+  }
+
+  function setVal(id, v) {
+    const el = document.getElementById(id);
+    if (el && v !== null && v !== undefined && v !== '') el.value = v;
+  }
+
+  async function loadOrder() {
+    const id = (document.getElementById('subOrderId').value || '').trim();
+    const src = document.getElementById('subOrderSource').value;
+    const msg = document.getElementById('subOrderMsg');
+    if (!id) { msg.innerHTML = '<span class="neg">enter an order number</span>'; return; }
+    msg.textContent = 'looking up…';
+    try {
+      const qs = new URLSearchParams({ order_id: id });
+      if (src) qs.set('source', src);
+      const o = await T.api(`/api/broker/order-lookup?${qs.toString()}`);
+      if (!o.found) { msg.innerHTML = `<span class="neg">${esc(o.note || 'order not found')}</span>`; return; }
+      setVal('subEvent', o.tevo_event_id);
+      setVal('subSection', o.section);
+      setVal('subRow', o.row);
+      setVal('subQty', o.quantity || 1);
+      setVal('subRevenue', o.revenue);
+      if (o.event_name) document.getElementById('subEventSearch').value = o.event_name;
+      const multi = (o.line_items && o.line_items > 1)
+        ? ` · ⚠ ${esc(o.line_items)} line items — showing the first` : '';
+      msg.innerHTML = `<span class="pos">loaded ${esc(o.source)} order</span> · ` +
+        `${esc(o.event_name || ('event ' + o.tevo_event_id))}${multi}`;
+      run();  // auto-search subs from the loaded details
+    } catch (err) {
+      msg.innerHTML = `<span class="neg">${esc(String(err.message || err))}</span>`;
+    }
   }
 
   // ---------- event-name search (typeahead → tevo_event_id) ----------

--- a/static/terminal/venue.html
+++ b/static/terminal/venue.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Venue</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="venue">
 

--- a/tests/test_broker_routes.py
+++ b/tests/test_broker_routes.py
@@ -535,3 +535,50 @@ def test_substitutions_quantity_filter_and_ambiguous_bucket(client, monkeypatch)
     # numeric "3" would upgrade but lacks quantity; alpha "A" is incomparable.
     assert body["subs"] == []
     assert [s["ticket_group_id"] for s in body["ambiguous"]] == ["alpha"]
+
+
+# ---------- /api/broker/order-lookup (order # -> sub fields) ----------
+
+def test_order_lookup_seatgeek(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(table_data={"seatgeek_orders": [{
+        "sg_order_id": "SG123", "tevo_event_id": 3100123, "sg_event_name": "Braves at Padres",
+        "sale_section": "310", "sale_row": "14", "sale_quantity": 4,
+        "payment_total": 67.12, "payment_price": 60.0,
+    }]}))
+    body = client.get("/api/broker/order-lookup?order_id=SG123").json()
+    assert body["found"] is True and body["source"] == "seatgeek"
+    assert body["tevo_event_id"] == 3100123
+    assert body["section"] == "310" and body["row"] == "14" and body["quantity"] == 4
+    assert body["revenue"] == 67.12
+
+
+def test_order_lookup_tickpick_when_source_pinned(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(table_data={"tickpick_orders": [{
+        "tp_order_id": "TP9", "tevo_event_id": 5, "event_name": "X", "section": "A",
+        "row": "2", "quantity": 2, "total": 100,
+    }]}))
+    body = client.get("/api/broker/order-lookup?order_id=TP9&source=tickpick").json()
+    assert body["source"] == "tickpick" and body["section"] == "A" and body["revenue"] == 100
+
+
+def test_order_lookup_evo_uses_first_item_and_counts(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase(table_data={
+        "evo_orders": [{"evo_order_id": 42, "tevo_event_id": 7, "total": 500, "subtotal": 450}],
+        "evo_order_items": [
+            {"ticket_group_section": "100", "ticket_group_row": "5", "quantity": 2,
+             "event_name": "Y", "event_id": 7},
+            {"ticket_group_section": "200", "ticket_group_row": "9", "quantity": 2,
+             "event_name": "Y", "event_id": 7},
+        ],
+    }))
+    body = client.get("/api/broker/order-lookup?order_id=42").json()
+    assert body["source"] == "evo" and body["section"] == "100" and body["row"] == "5"
+    assert body["revenue"] == 450  # subtotal preferred
+    assert body["line_items"] == 2
+
+
+def test_order_lookup_not_found(client, monkeypatch):
+    _use_db(monkeypatch, FakeSupabase())
+    body = client.get("/api/broker/order-lookup?order_id=NOPE").json()
+    assert body["found"] is False
+    assert "note" in body


### PR DESCRIPTION
## What

Add an **order-# auto-fill** to the substitution checker so a broker can paste a sale's order number and have the sold-ticket details extracted automatically — in addition to the existing manual entry.

## How

- **`GET /api/broker/order-lookup?order_id=&source=`** — resolves one of our **ingested** order sources (seatgeek / tickpick / vivid / evo) to `{tevo_event_id, section, row, quantity, revenue, event_name}`. `source` narrows the search; omit to try all. EVO orders read the first line item and report `line_items` so a multi-section order is flagged. **StubHub isn't an ingested order source** → returns `found:false` with a note to use the manual fields.
- **SUBS page** — an "Order #" bar (id + source select + Load). Loading an order prefills event/section/row/qty/revenue and **auto-runs** the search. Manual entry still works unchanged.

## Data model note

`unified_orders` carries event/qty/amount but **not section/row** (those are per-line-item) and is too heavy to query live, so the lookup hits the per-source tables directly: `seatgeek_orders` (`sale_section/row/quantity/payment_total`), `tickpick_orders` / `vivid_orders` (`section/row/quantity/total`), and `evo_orders` + `evo_order_items` (`ticket_group_section/row`, `quantity`, `subtotal`).

## Tests

- `tests/test_broker_routes.py`: order-lookup for seatgeek, source-pinned tickpick, evo (first item + `line_items`), and not-found. **56 passing** total; readonly audit clean.

## Notes

- StubHub orders aren't ingested, so they won't resolve by number — the example StubHub sale still goes through manual entry. If we want StubHub order resolution, that's a separate ingestion piece.
- Revenue is the order's own total/payment and is editable in the form before searching.
- Cache tokens bumped (`subs.js`, `style.css`) per the bump-on-change rule.

Follow-up to #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtjYqxU94A5Ed32wbFxGDL)_