### PR TITLE
feat(d0): paginate + filter the terminal orders book

### DIFF
--- a/d2_dashboard/main.py
+++ b/d2_dashboard/main.py
@@ -907,6 +907,149 @@ def _fetch_unified_orders_page(per_page: int, page: int = 1, include_terminal: b
         return {"rows": [], "per_source_count": {}, "per_source_as_of": {}, "error": _scrub_err("unified_orders.sql", e)}
 
 
+# Column projection shared by the unified_orders page fetchers.
+_UO_PAGE_SELECT = (
+    "source,source_order_id,tevo_event_id,source_status,canonical_status,"
+    "is_terminal,quantity,gross_value,created_at,last_seen_at,event_name,event_date"
+)
+
+
+def _build_order_rows(sb, all_uo_rows: list[dict]) -> list[dict]:
+    """Map raw unified_orders rows → API row dicts, back-filling event_name +
+    event_date from v_event_base for any row whose source left them null
+    (same fallback the balanced fan-out uses)."""
+    missing_event_ids = list({
+        r["tevo_event_id"] for r in all_uo_rows
+        if r.get("tevo_event_id") and not r.get("event_name")
+    })
+    events_by_id: dict = {}
+    if missing_event_ids:
+        ev_res = (
+            sb.table("v_event_base")
+            .select("tevo_event_id,event_name,event_at_local,event_at_utc")
+            .in_("tevo_event_id", missing_event_ids)
+            .execute()
+        )
+        events_by_id = {e["tevo_event_id"]: e for e in (ev_res.data or [])}
+    rows = []
+    for r in all_uo_rows:
+        event_name = r.get("event_name")
+        event_date = r.get("event_date")
+        if not event_name:
+            ev = events_by_id.get(r.get("tevo_event_id")) or {}
+            event_name = ev.get("event_name")
+            event_date = ev.get("event_at_local") or ev.get("event_at_utc")
+        rows.append({
+            "source": r.get("source") or "",
+            "order_id": str(r.get("source_order_id") or ""),
+            "event_name": event_name,
+            "event_date": event_date,
+            "qty": _to_int(r.get("quantity")),
+            "status": r.get("source_status"),
+            "canonical_status": r.get("canonical_status"),
+            "amount": _to_float(r.get("gross_value")),
+            "currency": None,
+            "ordered_at": r.get("created_at"),
+        })
+    return rows
+
+
+def _fetch_filtered_orders(
+    source: str,
+    per_page: int,
+    page: int = 1,
+    include_terminal: bool = False,
+    q: str | None = None,
+    when: str = "all",
+) -> dict | None:
+    """Server-side filtered + paginated order fetch backing the terminal's
+    Source / Search / Date controls. Returns None when Supabase isn't wired.
+
+    Crucially this honours an explicit single-source selection: when `source`
+    names one SQL-backed source it gets the FULL per_page window (so the
+    operator can page through ALL of e.g. EVO's book), instead of the
+    balanced fan-out's per_page//n_sources cap that only ever surfaces the
+    first ~20 rows of each source on page 1. `source='all'` keeps the
+    balanced split so every source gets surface area.
+
+    Filters are all pushed down to SQL:
+      - include_terminal=False → active-only (hide terminal canonical_status)
+      - q                      → event_name ILIKE %q%
+      - when='upcoming'        → event_date >= now()-12h
+      - when='past'            → event_date <  now()-12h
+
+    Shape matches `_fetch_unified_orders_page` plus a `has_more` flag derived
+    from whether any pulled source filled its page window (drives the
+    Next-page control without an extra count(*) round-trip)."""
+    sb = _sb()
+    if sb is None:
+        return None
+    try:
+        single = source != "all" and source in _SQL_BACKED_SOURCES
+        sources_to_pull = [source] if single else sorted(_SQL_BACKED_SOURCES)
+        per_source = per_page if single else max(1, per_page // max(1, len(sources_to_pull)))
+        start = max(0, (page - 1) * per_source)
+        end = start + per_source - 1
+
+        cutoff = None
+        if when in ("upcoming", "past"):
+            from datetime import datetime, timedelta, timezone
+            cutoff = (datetime.now(timezone.utc) - timedelta(hours=12)).isoformat()
+
+        def _pull_one(src: str) -> tuple[str, list[dict], str | None]:
+            try:
+                query = (
+                    sb.table("unified_orders")
+                    .select(_UO_PAGE_SELECT)
+                    .eq("source", src)
+                )
+                if not include_terminal:
+                    query = query.or_(f"canonical_status.is.null,canonical_status.in.({','.join(_ACTIVE_STATUSES)})")
+                if q:
+                    query = query.ilike("event_name", f"%{q}%")
+                if cutoff is not None and when == "upcoming":
+                    query = query.gte("event_date", cutoff)
+                elif cutoff is not None and when == "past":
+                    query = query.lt("event_date", cutoff)
+                res = query.order("created_at", desc=True).range(start, end).execute()
+                return src, (res.data or []), None
+            except Exception as e:
+                return src, [], _scrub_err(f"unified_orders.filtered.{src}", e)
+
+        all_uo_rows: list[dict] = []
+        per_source_as_of: dict[str, str] = {}
+        per_source_count: dict[str, int] = {}
+        per_source_filled: dict[str, bool] = {}
+        any_error = None
+        with ThreadPoolExecutor(max_workers=len(sources_to_pull)) as ex:
+            for src, rows_for_src, err in ex.map(_pull_one, sources_to_pull):
+                if err:
+                    any_error = err
+                per_source_filled[src] = len(rows_for_src) >= per_source
+                for r in rows_for_src:
+                    all_uo_rows.append(r)
+                    ls = r.get("last_seen_at")
+                    if ls and (per_source_as_of.get(src, "") < ls):
+                        per_source_as_of[src] = ls
+                    per_source_count[src] = per_source_count.get(src, 0) + 1
+
+        rows = _build_order_rows(sb, all_uo_rows)
+        result = {
+            "rows": rows,
+            "per_source_count": per_source_count,
+            "per_source_as_of": per_source_as_of,
+            "has_more": any(per_source_filled.values()),
+        }
+        if any_error:
+            result["error"] = any_error
+        return result
+    except Exception as e:
+        return {
+            "rows": [], "per_source_count": {}, "per_source_as_of": {},
+            "has_more": False, "error": _scrub_err("unified_orders.filtered", e),
+        }
+
+
 def _fetch_orders_from_sql(source: str, per_page: int, page: int = 1) -> dict | None:
     """Pull a source's orders out of unified_orders, joined to v_event_base
     for event_name + event_date. Returns None when Supabase isn't configured
@@ -1222,6 +1365,9 @@ def orders(
     page: int = 1,
     fast: int = 0,
     include_terminal: int = 0,
+    source: str = "all",
+    q: str | None = None,
+    when: str = "all",
     _=Depends(require_auth),
 ):
     """SQL-only orders feed. All 5 sources (evo / seatgeek_sales / seatdata /
@@ -1240,6 +1386,14 @@ def orders(
 
     `?include_terminal=1`: show all — no canonical_status filter. The
     primary tab's "All" pill flips this.
+
+    `?source=<evo|seatgeek_sales|tickpick|vivid>`, `?q=<event name>`,
+    `?when=<all|upcoming|past>`: terminal Orders filters. Any non-default
+    value routes to the server-side filtered fetch — a single `source` gets
+    the full `per_page` window (page through ALL of that source's book)
+    instead of the balanced per_page//n_sources cap. `q` is an event-name
+    ILIKE; `when` filters on event_date around now()-12h. Responses carry
+    `has_more` so the client can drive Prev/Next without a count(*).
 
     ?fast=1 mode (two-phase load): single global SQL query, upcoming-only
     (event_date >= now()-12h), event_date ASC, NO event_window join.
@@ -1260,8 +1414,64 @@ def orders(
     page = max(1, page)
     include_terminal_flag = bool(include_terminal)
 
+    # Source / Search / Date filters (terminal Orders controls). When any is
+    # set we route to the server-side filtered fetch: a single source gets the
+    # FULL per_page window (page through all of e.g. EVO), not the balanced
+    # per_page//n_sources cap. `source=all` + no q + when=all keeps the
+    # original balanced fan-out untouched.
+    source_norm = (source or "all").strip().lower()
+    q_norm = (q or "").strip() or None
+    when_norm = (when or "all").strip().lower()
+    if when_norm not in ("all", "upcoming", "past"):
+        when_norm = "all"
+    use_filtered = (source_norm != "all") or (q_norm is not None) or (when_norm != "all")
+
     timings: dict = {}
     t0 = _time.perf_counter()
+
+    if use_filtered and not fast:
+        bundle = _timed(
+            "sql.filtered", _fetch_filtered_orders,
+            source_norm, per_page, page, include_terminal_flag, q_norm, when_norm,
+            _timings=timings,
+        )
+        if bundle is None:
+            raise HTTPException(503, "Supabase not configured (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required)")
+        rows = bundle["rows"]
+        per_source_count = dict(bundle.get("per_source_count") or {})
+        per_source_as_of = dict(bundle.get("per_source_as_of") or {})
+        sql_err = bundle.get("error")
+        sources_summary = [
+            {
+                "source": src,
+                "ok": not bool(sql_err),
+                "count": per_source_count.get(src, 0),
+                "total_reported": None,
+                "error": sql_err,
+                "origin": "sql",
+                "as_of": per_source_as_of.get(src),
+            }
+            for src in _ALL_SOURCES
+        ]
+        rows.sort(key=lambda x: (x.get("ordered_at") or ""), reverse=True)
+        total_ms = (_time.perf_counter() - t0) * 1000
+        response = JSONResponse({
+            "sources": sources_summary,
+            "rows": rows,
+            "page": page,
+            "per_page": per_page,
+            "phase": "filtered",
+            "include_terminal": include_terminal_flag,
+            "source": source_norm,
+            "q": q_norm,
+            "when": when_norm,
+            "has_more": bool(bundle.get("has_more")),
+            "timings_ms": {k: round(v, 1) for k, v in timings.items()} | {"total": round(total_ms, 1)},
+        })
+        response.headers["Server-Timing"] = ", ".join(
+            f"{k.replace('.','_')};dur={v:.1f}" for k, v in timings.items()
+        ) + f", total;dur={total_ms:.1f}"
+        return response
 
     if fast:
         # Single query, single thread, upcoming-only. Phase 1 of two-phase load.
@@ -1321,6 +1531,11 @@ def orders(
     per_source_as_of = dict(bundle.get("per_source_as_of") or {})
     sql_err = bundle.get("error")
 
+    # has_more for the balanced fan-out: any source that filled its per_page//n
+    # slice may have more rows on the next page.
+    _balanced_per_source = max(1, per_page // max(1, len(_SQL_BACKED_SOURCES)))
+    has_more = any(c >= _balanced_per_source for c in per_source_count.values())
+
     sources_summary = [
         {
             "source": src,
@@ -1355,6 +1570,8 @@ def orders(
         "per_page": per_page,
         "phase": "full",
         "include_terminal": include_terminal_flag,
+        "source": "all",
+        "has_more": has_more,
         "timings_ms": {k: round(v, 1) for k, v in timings.items()} | {"total": round(total_ms, 1)},
     })
     response.headers["Server-Timing"] = ", ".join(

--- a/static/terminal/orders.html
+++ b/static/terminal/orders.html
@@ -15,7 +15,7 @@
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Terminal — Orders</title>
-  <link rel="stylesheet" href="style.css?v=20260620b" />
+  <link rel="stylesheet" href="style.css?v=20260620c" />
 </head>
 <body data-page="orders">
 
@@ -54,6 +54,16 @@
           <button class="ctrl-btn" data-term="1">All</button>
         </div>
         <div class="ctrl-group">
+          <span class="ctrl-lbl">DATE</span>
+          <button class="ctrl-btn is-active" data-when="all">All</button>
+          <button class="ctrl-btn" data-when="upcoming">Upcoming</button>
+          <button class="ctrl-btn" data-when="past">Past</button>
+        </div>
+        <div class="ctrl-group">
+          <input type="search" id="ordersSearch" class="ctrl-input"
+                 placeholder="search event…" autocomplete="off" />
+        </div>
+        <div class="ctrl-group">
           <button class="ctrl-btn" id="refreshBtn">↻ Refresh</button>
         </div>
       </div>
@@ -65,6 +75,11 @@
 
     <section id="orders-table">
       <div id="ordersBody"><div class="empty">loading…</div></div>
+      <div class="ctrl-row orders-pager" id="ordersPager" hidden>
+        <button class="ctrl-btn" id="pagePrev">← Prev</button>
+        <span class="ctrl-lbl" id="pageLabel">Page 1</span>
+        <button class="ctrl-btn" id="pageNext">Next →</button>
+      </div>
     </section>
 
     <section id="orders-note">
@@ -81,6 +96,6 @@
   <script src="auth.js?v=20260608"></script>
   <script src="app.js?v=20260608"></script>
   <script src="nav.js?v=20260620b"></script>
-  <script src="orders.js?v=20260620a"></script>
+  <script src="orders.js?v=20260620b"></script>
 </body>
 </html>

--- a/static/terminal/orders.js
+++ b/static/terminal/orders.js
@@ -31,10 +31,14 @@
   const state = {
     source: 'all',        // 'all' | one of SOURCE_LABELS keys
     includeTerminal: 0,   // 0 = active-only, 1 = all states
+    when: 'all',          // 'all' | 'upcoming' | 'past' (event_date filter)
+    q: '',                // event-name search
+    page: 1,              // 1-based; server paginates
     perPage: 100,
   };
 
   let lastPayload = null; // cache the last /api/d2/orders response for re-filter
+  let searchTimer = null; // debounce handle for the search box
 
   function init() {
     if (window.TerminalAuth) {
@@ -45,12 +49,14 @@
   }
 
   function wire() {
-    // Source pills — client-side filter, no refetch needed.
+    // Source pills — server-side filter now, so a single source returns its
+    // FULL page (not the balanced ~20/source cap). Reset to page 1 + refetch.
     document.querySelectorAll('[data-source]').forEach(btn => {
       btn.addEventListener('click', () => {
         setActive('[data-source]', btn);
         state.source = btn.dataset.source;
-        if (lastPayload) renderRows(lastPayload);
+        state.page = 1;
+        load();
       });
     });
     // State toggle — Active vs All changes the server query (include_terminal).
@@ -58,8 +64,47 @@
       btn.addEventListener('click', () => {
         setActive('[data-term]', btn);
         state.includeTerminal = +btn.dataset.term;
+        state.page = 1;
         load();
       });
+    });
+    // Date filter — all / upcoming / past (event_date around now-12h).
+    document.querySelectorAll('[data-when]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        setActive('[data-when]', btn);
+        state.when = btn.dataset.when;
+        state.page = 1;
+        load();
+      });
+    });
+    // Search box — debounced event-name filter pushed to the server.
+    const search = document.getElementById('ordersSearch');
+    if (search) {
+      search.addEventListener('input', () => {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(() => {
+          state.q = search.value.trim();
+          state.page = 1;
+          load();
+        }, 350);
+      });
+      search.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+          clearTimeout(searchTimer);
+          state.q = search.value.trim();
+          state.page = 1;
+          load();
+        }
+      });
+    }
+    // Pager.
+    const prev = document.getElementById('pagePrev');
+    const next = document.getElementById('pageNext');
+    if (prev) prev.addEventListener('click', () => {
+      if (state.page > 1) { state.page--; load(); }
+    });
+    if (next) next.addEventListener('click', () => {
+      if (lastPayload && lastPayload.has_more) { state.page++; load(); }
     });
     const refresh = document.getElementById('refreshBtn');
     if (refresh) refresh.addEventListener('click', load);
@@ -75,11 +120,19 @@
     const body = document.getElementById('ordersBody');
     if (body) body.innerHTML = '<div class="empty">loading…</div>';
     if (T && T.setStatus) T.setStatus('loading orders…', '');
-    const qs = `per_page=${state.perPage}&page=1&include_terminal=${state.includeTerminal}`;
+    const params = new URLSearchParams({
+      per_page: state.perPage,
+      page: state.page,
+      include_terminal: state.includeTerminal,
+      source: state.source,
+      when: state.when,
+    });
+    if (state.q) params.set('q', state.q);
     try {
-      const data = await T.api(`/api/d2/orders?${qs}`);
+      const data = await T.api(`/api/d2/orders?${params.toString()}`);
       lastPayload = data;
       renderRows(data);
+      renderPager(data);
       renderFreshness(data.sources || []);
       // Cron cadence is a separate, slower poll — enrich the chips when it lands.
       loadCronFreshness();
@@ -88,8 +141,26 @@
     } catch (e) {
       lastPayload = null;
       if (body) body.innerHTML = `<div class="empty">${esc(e.message)}</div>`;
+      renderPager(null);
       if (T && T.setStatus) T.setStatus(e.message, 'err');
     }
+  }
+
+  // Pager: show Prev when past page 1, Next when the server reports has_more.
+  // Hidden entirely on page 1 with nothing more to load (keeps the chrome
+  // clean for small result sets).
+  function renderPager(data) {
+    const pager = document.getElementById('ordersPager');
+    const prev = document.getElementById('pagePrev');
+    const next = document.getElementById('pageNext');
+    const label = document.getElementById('pageLabel');
+    if (!pager) return;
+    const hasMore = !!(data && data.has_more);
+    const show = state.page > 1 || hasMore;
+    pager.hidden = !show;
+    if (prev) prev.disabled = state.page <= 1;
+    if (next) next.disabled = !hasMore;
+    if (label) label.textContent = `Page ${state.page}`;
   }
 
   function renderRows(data) {

--- a/static/terminal/style.css
+++ b/static/terminal/style.css
@@ -659,6 +659,17 @@ table .empty { color: var(--muted); padding: 12px; text-align: center; }
 }
 .ctrl-input::placeholder { color: var(--muted); }
 .ctrl-input:focus { outline: none; border-color: var(--accent); }
+.ctrl-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.ctrl-btn:disabled:hover { color: var(--muted); border-color: var(--line); }
+.orders-pager {
+  justify-content: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+.orders-pager .ctrl-lbl { margin-right: 0; }
 .movers-tbl td a { color: var(--text); text-decoration: none; }
 .movers-tbl td a:hover { color: var(--accent); text-decoration: underline; }
 

--- a/tests/test_d2_dashboard.py
+++ b/tests/test_d2_dashboard.py
@@ -416,6 +416,86 @@ def test_orders_response_carries_per_leg_timings(monkeypatch, client):
     assert "total;dur="       in server_timing
 
 
+def test_orders_source_filter_routes_to_filtered_fetch(monkeypatch, client):
+    """?source=evo routes to the single-source filtered fetch (full per_page
+    window, not the balanced ~20/source cap) and echoes source + has_more so
+    the client can page through ALL of that source's book."""
+    captured = {}
+
+    def fake_filtered(source, per_page, page=1, include_terminal=False, q=None, when="all"):
+        captured.update(source=source, per_page=per_page, page=page,
+                        include_terminal=include_terminal, q=q, when=when)
+        return {
+            "rows": [{"source": "evo", "order_id": "111", "event_name": "Knicks vs Lakers",
+                      "event_date": "2026-06-01T19:30:00Z", "qty": 2, "status": "accepted",
+                      "canonical_status": "accepted", "amount": 450.0, "currency": None,
+                      "ordered_at": "2026-05-10T12:00:00Z"}],
+            "per_source_count": {"evo": 1},
+            "per_source_as_of": {"evo": "2026-05-13T20:35:00Z"},
+            "has_more": True,
+        }
+
+    # The balanced path must NOT be used when a source filter is set.
+    def fail_balanced(*a, **kw):
+        raise AssertionError("balanced fan-out should not run for a source filter")
+
+    monkeypatch.setattr(d2_main, "_fetch_filtered_orders", fake_filtered)
+    monkeypatch.setattr(d2_main, "_fetch_unified_orders_page", fail_balanced)
+    monkeypatch.setattr(d2_main, "_pull_event_window", lambda *a, **kw: [])
+
+    body = client.get("/api/d2/orders?source=evo&per_page=100&page=2").json()
+    assert body["phase"] == "filtered"
+    assert body["source"] == "evo"
+    assert body["has_more"] is True
+    assert body["page"] == 2
+    assert captured["source"] == "evo"
+    assert captured["per_page"] == 100
+    assert captured["page"] == 2
+    assert [r["source"] for r in body["rows"]] == ["evo"]
+
+
+def test_orders_search_and_when_route_to_filtered_fetch(monkeypatch, client):
+    """?q= and ?when= (even with source=all) route to the filtered fetch and
+    forward the normalized filter args."""
+    captured = {}
+
+    def fake_filtered(source, per_page, page=1, include_terminal=False, q=None, when="all"):
+        captured.update(source=source, q=q, when=when)
+        return {"rows": [], "per_source_count": {}, "per_source_as_of": {}, "has_more": False}
+
+    monkeypatch.setattr(d2_main, "_fetch_filtered_orders", fake_filtered)
+    monkeypatch.setattr(d2_main, "_pull_event_window", lambda *a, **kw: [])
+
+    body = client.get("/api/d2/orders?q=Knicks&when=upcoming").json()
+    assert body["phase"] == "filtered"
+    assert captured["source"] == "all"
+    assert captured["q"] == "Knicks"
+    assert captured["when"] == "upcoming"
+    assert body["when"] == "upcoming"
+
+
+def test_orders_default_all_stays_on_balanced_path(monkeypatch, client):
+    """No source/q/when → the original balanced fan-out (phase=full) runs,
+    and the filtered fetch is NOT called. Guards the back-compat default."""
+    def fail_filtered(*a, **kw):
+        raise AssertionError("filtered fetch should not run for the default view")
+
+    monkeypatch.setattr(
+        d2_main, "_fetch_unified_orders_page",
+        lambda n, p=1, include_terminal=False: {
+            "rows": [], "per_source_count": {"evo": 20}, "per_source_as_of": {},
+        },
+    )
+    monkeypatch.setattr(d2_main, "_fetch_filtered_orders", fail_filtered)
+    monkeypatch.setattr(d2_main, "_pull_event_window", lambda *a, **kw: [])
+
+    body = client.get("/api/d2/orders?per_page=100").json()
+    assert body["phase"] == "full"
+    assert body["source"] == "all"
+    # per_source slice = 100//5 = 20; evo filled it → more pages exist.
+    assert body["has_more"] is True
+
+
 def test_cron_freshness_endpoint_returns_per_source(monkeypatch, client):
     """/api/d2/cron-freshness returns the same per-source blob the orders
     endpoint used to carry inline. Front-end polls this on a 60s timer."""


### PR DESCRIPTION
## Why

The terminal **Orders** tab only ever surfaced ~20 EVO rows. Root cause: the `/api/d2/orders` "balanced" fan-out caps each source at `per_page // n_sources` (= 20 on page 1) so every source gets surface area, and the page had **no pagination** — so most of EVO's ~423 active (and 1,040 total) orders were unreachable. The source pills were also client-side only, filtering the already-capped 20 rows.

## What

**Backend (`d2_dashboard/main.py`)**
- New server-side filters on `/api/d2/orders`: `source`, `q` (event-name `ILIKE`), `when` (`all`/`upcoming`/`past` on `event_date` around `now()-12h`).
- A specific `source` now gets the **full `per_page` window** (page through *all* of that source's book) instead of the balanced 20-row cap. `source=all` keeps the original balanced fan-out.
- Responses carry `has_more` so the client drives Prev/Next without a `count(*)`.
- Default view (`source=all`, no `q`, `when=all`) routes to the **unchanged** balanced path — fully back-compatible.
- Shared `_build_order_rows` / `_UO_PAGE_SELECT` helpers; all filters pushed down to SQL. Read-only (RULE 2 audit clean).

**Frontend (`static/terminal/orders.{html,js}` + `style.css`)**
- Source pills refetch server-side (reset to page 1).
- New **search box** (debounced event-name search), **date filter** (All/Upcoming/Past), and **Prev/Next pagination** with a page indicator.
- Cache-bust tokens bumped.

## Tests
- `?source=evo` routes to the filtered fetch, echoes `source` + `has_more`, paginates.
- `?q=`/`?when=` (even with `source=all`) route to the filtered fetch with normalized args.
- Default `source=all` stays on the balanced path (`phase=full`).
- Full suite: **66 passed**. `scripts/check_readonly.py` clean.

## Note
This PR makes the orders *findable*. Separately I noticed two EVO statuses (`canceled`, `canceled_post_acceptance`) are missing from `order_status_xref`, so they fall through as `NULL` canonical_status and show as "active" with no badge — a small data fix (operator-gated migration) I can do as a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016d9W8nFsFdFxg29XNCJsQc)_