### PR TITLE
feat(d0/ops): Render deploy-webhook → GitHub Actions bridge (re-apply #506)

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -1,0 +1,164 @@
+name: post-deploy
+
+# Deploy-end smoke test. Triggered by the Render webhook → GitHub bridge
+# (POST /webhooks/render in app.py + render_webhook.py) when a Render deploy
+# of vibepass-storefront-test ENDS successfully — so the new deploy is
+# verified within seconds instead of waiting up to 5 min for the scheduled
+# uptime-check.yml ping.
+#
+# Incorporates render-examples/webhook-github-action: that example's
+# `workflow_dispatch` target re-deploys the service; here we instead run a
+# post-deploy smoke test + Slack notification, which is what a frontend
+# service actually wants on deploy-end.
+#
+# Also runnable by hand (Actions → post-deploy → Run workflow) for testing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      serviceID:
+        type: string
+        required: false
+        description: 'Render Service ID that just deployed (e.g. srv-xxx). Sent by the webhook bridge; optional for manual runs.'
+
+# Least-privilege GITHUB_TOKEN (matches uptime-check.yml). The failure path
+# opens an issue (issues:write); nothing writes code.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: post-deploy
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke-test deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      BASE_URL: https://vibepass-storefront-test.onrender.com
+
+    steps:
+      - name: Wait for the new deploy to settle
+        # Render marks a deploy "live" a beat before the rollout fully drains
+        # the old container. A short pause avoids smoke-testing the old code.
+        run: sleep 20
+
+      - name: Check /healthz
+        id: health
+        run: |
+          # /healthz returns {"ok": true, ...}; require both HTTP 200 AND ok:true.
+          RESP=$(curl -s --max-time 20 --retry 3 --retry-delay 5 \
+            -w "\n%{http_code}" "$BASE_URL/healthz")
+          STATUS=$(echo "$RESP" | tail -n1)
+          BODY=$(echo "$RESP" | sed '$d')
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "HTTP $STATUS"
+          echo "$BODY"
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::/healthz returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          if ! echo "$BODY" | grep -q '"ok"[[:space:]]*:[[:space:]]*true'; then
+            echo "::error::/healthz HTTP 200 but body did not report ok:true"
+            exit 1
+          fi
+          echo "✅ /healthz OK"
+
+      - name: Check key endpoints respond
+        run: |
+          # Lightweight reachability check on a couple of public surfaces the
+          # storefront serves. We assert HTTP 200, not body shape (that's the
+          # job of the pytest suite); this just catches a deploy that booted
+          # but can't serve routes.
+          fail=0
+          for path in /version.json /api/public/config; do
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+              --max-time 20 --retry 2 --retry-delay 3 "$BASE_URL$path")
+            echo "$path -> $CODE"
+            if [ "$CODE" != "200" ]; then
+              echo "::error::$path returned HTTP $CODE (expected 200)"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "✅ key endpoints OK"
+
+      - name: Open GitHub issue on failure
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATUS: ${{ steps.health.outputs.status }}
+          SERVICE_ID: ${{ inputs.serviceID }}
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          # Avoid duplicate issues: skip if an open post-deploy-failure issue
+          # was created in the last 30 minutes.
+          RECENT=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "post-deploy-failure" \
+            --state open --limit 1 \
+            --json createdAt --jq '.[0].createdAt // ""')
+          if [ -n "$RECENT" ]; then
+            CREATED_EPOCH=$(date -d "$RECENT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RECENT" +%s)
+            DIFF=$(( $(date +%s) - CREATED_EPOCH ))
+            if [ "$DIFF" -lt 1800 ]; then
+              echo "Open post-deploy-failure issue already exists (${DIFF}s ago). Skipping duplicate."
+              exit 0
+            fi
+          fi
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "🔴 Post-deploy smoke test failed ($TIMESTAMP)" \
+            --body "$(cat <<EOF
+          ## Post-deploy smoke test failure
+
+          **Time**: $TIMESTAMP
+          **Service**: ${SERVICE_ID:-unknown}
+          **Base URL**: $BASE_URL
+          **/healthz HTTP status**: ${STATUS:-unknown}
+          **Workflow run**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+          ### Next steps
+          1. Check the [Render dashboard](https://dashboard.render.com) for the deploy + service status
+          2. Roll back to the previous deploy if the new one is broken
+          3. Review the merge that triggered this deploy on \`main\`
+          4. Once resolved, close this issue
+
+          *Auto-opened by the post-deploy workflow (Render webhook → GitHub bridge)*
+          EOF
+          )" \
+            --label "bug,post-deploy-failure"
+
+      - name: Notify Slack (optional)
+        # Reuses the SLACK_BOT_TOKEN / SLACK_ALERTS_CHANNEL_ID pattern from
+        # uptime-check.yml. Posts on both success and failure so deploys are
+        # visible in #terminal-2-alerts. Skipped if the token isn't set.
+        if: always() && env.SLACK_BOT_TOKEN != ''
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_ALERTS_CHANNEL_ID: ${{ secrets.SLACK_ALERTS_CHANNEL_ID }}
+          SERVICE_ID: ${{ inputs.serviceID }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          if [ "$JOB_STATUS" = "success" ]; then
+            ICON="🟢"; TEXT="deploy verified — smoke test passed"
+          else
+            ICON="🔴"; TEXT="deploy smoke test FAILED"
+          fi
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"channel\": \"${SLACK_ALERTS_CHANNEL_ID}\",
+              \"text\": \"${ICON} *vibepass-storefront-test* ${TEXT}\",
+              \"blocks\": [{
+                \"type\": \"section\",
+                \"text\": {
+                  \"type\": \"mrkdwn\",
+                  \"text\": \"${ICON} *Post-deploy* — ${TEXT}\\nService: \`${SERVICE_ID:-manual}\` · <https://dashboard.render.com|Render> · <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Run>\"
+                }
+              }]
+            }"

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ Optional:
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
@@ -33,6 +34,7 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Redirect
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
+import render_webhook
 from evo_client import EvoClient
 
 STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
@@ -814,6 +816,50 @@ def healthz():
             # Truncate so we don't leak full traces over a public endpoint.
             out["supabase_smoke_error"] = str(e)[:300]
     return out
+
+
+# ---------------------------------------------------------------------------
+# Render webhook receiver → GitHub Actions bridge
+# ---------------------------------------------------------------------------
+# Incorporates render-examples/webhook-receiver + webhook-github-action into
+# the unified service: Render POSTs a Standard-Webhooks-signed payload here on
+# deploy/service/db events; we verify it, ACK 200 fast, then (in the
+# background) dispatch on event type — a successful deploy_ended triggers the
+# post-deploy GitHub workflow; other types are enriched + logged. Pure logic
+# lives in render_webhook.py (unit-tested in tests/test_render_webhook.py).
+
+@app.post("/webhooks/render")
+async def render_deploy_webhook(request: Request, background: BackgroundTasks):
+    """Receive + verify a Render webhook, then handle it asynchronously. Always
+    answers fast so Render doesn't time out and retry; verification failures
+    return 401 (so a misconfigured secret is visible in Render's webhook
+    delivery log).
+
+    Fails closed: if RENDER_WEBHOOK_SECRET is unset, every request is rejected
+    — we never accept an unsigned/unverifiable webhook.
+    """
+    cfg = render_webhook.load_config()
+    body = await request.body()
+    try:
+        render_webhook.verify_signature(cfg["webhook_secret"], body, dict(request.headers))
+    except render_webhook.WebhookVerificationError as e:
+        raise HTTPException(status_code=401, detail=f"webhook verification failed: {e}")
+
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+
+    # Process after the 200 is sent — the Render API + GitHub calls can take a
+    # few seconds and must not block the webhook ACK.
+    def _process(p, c):
+        try:
+            logging.getLogger("render_webhook").info("webhook handled: %s", render_webhook.handle_webhook(p, c))
+        except Exception:  # background task — never let it escape
+            logging.getLogger("render_webhook").exception("webhook handler crashed")
+
+    background.add_task(_process, payload, cfg)
+    return {"ok": True, "received": payload.get("type")}
 
 
 @app.get("/api/public/config")

--- a/render.yaml
+++ b/render.yaml
@@ -74,6 +74,30 @@ services:
         sync: false
       - key: CRON_SECRET
         sync: false
+      # ---- Render deploy-webhook → GitHub Actions bridge ----
+      # Powers POST /webhooks/render (app.py + render_webhook.py), which fires
+      # the post-deploy.yml smoke test on deploy-end. All optional: with none
+      # set the route fails closed (401) and no workflow is dispatched.
+      #   RENDER_WEBHOOK_SECRET — Standard Webhooks signing secret (`whsec_...`)
+      #     from the Render webhook you create (Settings → Webhooks → DeployEnded).
+      #   RENDER_API_KEY        — Render API token; enables the authoritative
+      #     deploy-status + repo-match check (else falls back to payload status).
+      #   GITHUB_API_TOKEN      — PAT with `actions:write` to dispatch the workflow.
+      # The Render webhook itself (DeployEnded → /webhooks/render) is created
+      # out-of-band via the Render API; its id is whk-d8jmmhcm0tmc73fflsk0.
+      - key: RENDER_WEBHOOK_SECRET
+        sync: false
+      - key: RENDER_API_KEY
+        sync: false
+      - key: GITHUB_API_TOKEN
+        sync: false
+      # Non-secret targets — plain IaC values (target repo for workflow_dispatch).
+      - key: GITHUB_OWNER_NAME
+        value: JulianS4K
+      - key: GITHUB_REPO_NAME
+        value: Terminal-2
+      # GITHUB_WORKFLOW_ID defaults to "post-deploy.yml" in code; override here
+      # only to dispatch a different workflow.
       # ---- DO NOT set TEVO_TOKEN / TEVO_SECRET here ----
       # The app reads them from Supabase `settings` table at boot. Setting
       # them as env vars would override Supabase, which we don't want.

--- a/render_webhook.py
+++ b/render_webhook.py
@@ -1,0 +1,334 @@
+"""Render webhook receiver + GitHub Actions bridge.
+
+Python port that unifies two Render examples, adapted to live inside the
+unified FastAPI service (`app.py`) instead of as a standalone Node service:
+
+  * render-examples/webhook-receiver
+    (https://github.com/render-examples/webhook-receiver) — the generic
+    Standard-Webhooks receiver skeleton: verify the signature, then dispatch
+    over event type (`deploy_started`, `deploy_ended`, `database_available`,
+    `key_value_available`, …), enriching each from the Render API.
+  * render-examples/webhook-github-action
+    (https://github.com/render-examples/webhook-github-action) — the
+    specialization that, on a successful `deploy_ended`, triggers a GitHub
+    Actions workflow via the workflow_dispatch API.
+
+Here the receiver IS the generic dispatcher (`handle_webhook`), and the
+GitHub-Action trigger is the registered `deploy_ended` handler. The route is
+mounted at POST /webhooks/render; this module holds the pure logic so it can
+be unit-tested without a running server or live network (see
+tests/test_render_webhook.py).
+
+Flow:
+  1. Render fires a webhook, signed per the Standard Webhooks spec
+     (https://www.standardwebhooks.com) — the same scheme both upstream
+     examples verify via the `standardwebhooks` npm package.
+  2. We verify the signature against RENDER_WEBHOOK_SECRET, reject replay
+     (timestamp outside tolerance), and ACK 200 fast.
+  3. Async: dispatch on `type`. For `deploy_ended` → confirm the deploy
+     SUCCEEDED (Render API event lookup, or the payload's own `data.status`
+     when no API key is configured), confirm the service points at our GitHub
+     repo, then trigger the GitHub Actions workflow. Other types are enriched
+     from the Render API and logged.
+
+Env vars (all optional — the route degrades to "verify + log" if unset):
+  RENDER_WEBHOOK_SECRET   Standard Webhooks signing secret (`whsec_...`).
+                          REQUIRED for signature verification; without it the
+                          route fails closed (401) — never accepts unsigned.
+  RENDER_API_KEY          Render API token; enables the authoritative deploy
+                          status + repo-match check. Falls back to the webhook
+                          payload's `data.status` when unset.
+  GITHUB_API_TOKEN        PAT (or fine-grained token) with `actions:write` on
+                          the target repo. REQUIRED to dispatch the workflow.
+  GITHUB_OWNER_NAME       Repo owner/org (e.g. "s4kent").
+  GITHUB_REPO_NAME        Repo name (e.g. "terminal-2").
+  GITHUB_WORKFLOW_ID      Workflow file to dispatch (default "post-deploy.yml").
+  GITHUB_WORKFLOW_REF     Git ref to run the workflow on (default: the service's
+                          deploy branch from Render, else "main").
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import time
+
+import requests
+
+log = logging.getLogger("render_webhook")
+
+# Render event `details.status` == 2 means the deploy went live (succeeded).
+# Mirrors the `event.details.status != 2` gate in the upstream app.ts.
+RENDER_DEPLOY_STATUS_LIVE = 2
+
+# Replay window: reject webhooks whose timestamp is more than this many seconds
+# from now. Matches the Standard Webhooks library default (5 minutes).
+WEBHOOK_TOLERANCE_SECONDS = 5 * 60
+
+RENDER_API_URL = os.environ.get("RENDER_API_URL", "https://api.render.com/v1")
+GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+
+
+class WebhookVerificationError(Exception):
+    """Raised when a webhook signature/timestamp fails verification."""
+
+
+# ---------------------------------------------------------------------------
+# Standard Webhooks signature verification
+# ---------------------------------------------------------------------------
+# A Standard Webhooks signature is HMAC-SHA256 over the byte string
+# `{id}.{timestamp}.{body}`, base64-encoded, prefixed with the version tag
+# `v1,`. The signing secret is `whsec_<base64>`; the bytes after the prefix are
+# base64-decoded to form the HMAC key. The `webhook-signature` header may carry
+# several space-delimited signatures (e.g. during a secret rotation); the
+# webhook is valid if ANY of them matches.
+
+def _secret_bytes(secret: str) -> bytes:
+    """Decode a `whsec_`-prefixed Standard Webhooks secret into HMAC key bytes."""
+    if secret.startswith("whsec_"):
+        secret = secret[len("whsec_"):]
+    return base64.b64decode(secret)
+
+
+def sign_payload(secret: str, msg_id: str, timestamp: str, body: bytes) -> str:
+    """Compute the `v1,<base64>` signature for a payload. Pure; used by tests."""
+    signed_content = msg_id.encode() + b"." + str(timestamp).encode() + b"." + body
+    digest = hmac.new(_secret_bytes(secret), signed_content, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def verify_signature(
+    secret: str,
+    body: bytes,
+    headers: dict[str, str],
+    *,
+    now: float | None = None,
+    tolerance_seconds: int = WEBHOOK_TOLERANCE_SECONDS,
+) -> None:
+    """Verify a Standard Webhooks request. Raises WebhookVerificationError on
+    any failure; returns None on success.
+
+    `headers` is matched case-insensitively (HTTP header names are not
+    case-sensitive, and ASGI servers may normalize them).
+    """
+    if not secret:
+        raise WebhookVerificationError("no signing secret configured")
+
+    h = {k.lower(): v for k, v in headers.items()}
+    msg_id = h.get("webhook-id", "")
+    timestamp = h.get("webhook-timestamp", "")
+    sig_header = h.get("webhook-signature", "")
+    if not (msg_id and timestamp and sig_header):
+        raise WebhookVerificationError("missing webhook-id/timestamp/signature headers")
+
+    # Replay protection — reject stale or future-dated timestamps.
+    try:
+        ts = int(timestamp)
+    except ValueError as e:
+        raise WebhookVerificationError("invalid webhook-timestamp") from e
+    current = time.time() if now is None else now
+    if ts < current - tolerance_seconds:
+        raise WebhookVerificationError("webhook timestamp too old")
+    if ts > current + tolerance_seconds:
+        raise WebhookVerificationError("webhook timestamp too new")
+
+    expected = sign_payload(secret, msg_id, timestamp, body)
+    expected_b64 = expected.split(",", 1)[1]
+
+    # The header is a space-delimited list of `version,signature` pairs.
+    for part in sig_header.split():
+        version, _, value = part.partition(",")
+        if version != "v1":
+            continue
+        if hmac.compare_digest(value, expected_b64):
+            return
+    raise WebhookVerificationError("no matching signature")
+
+
+# ---------------------------------------------------------------------------
+# Render API enrichment (best-effort; only used when RENDER_API_KEY is set)
+# ---------------------------------------------------------------------------
+
+def _render_get(path: str, api_key: str) -> dict | None:
+    try:
+        r = requests.get(
+            f"{RENDER_API_URL}{path}",
+            headers={"Accept": "application/json", "Authorization": f"Bearer {api_key}"},
+            timeout=15,
+        )
+        if r.status_code != 200:
+            log.warning("render API GET %s -> %s", path, r.status_code)
+            return None
+        return r.json()
+    except requests.RequestException as e:
+        log.warning("render API GET %s failed: %s", path, e)
+        return None
+
+
+def deploy_succeeded(payload: dict, api_key: str | None) -> bool:
+    """Did this `deploy_ended` event represent a successful deploy?
+
+    Prefers the authoritative Render API event lookup (the upstream behavior);
+    falls back to the webhook payload's own `data.status` when no API key is
+    configured. Fails closed (False) if neither source confirms success.
+    """
+    data = payload.get("data") or {}
+    if api_key and data.get("id"):
+        event = _render_get(f"/events/{data['id']}", api_key)
+        if event is None:
+            return False
+        return (event.get("details") or {}).get("status") == RENDER_DEPLOY_STATUS_LIVE
+    # No API key: trust the payload's status field if present.
+    return data.get("status") == "succeeded"
+
+
+def service_targets_repo(service_id: str, owner: str, repo: str, api_key: str | None) -> tuple[bool, str | None]:
+    """Confirm the deployed service points at our GitHub repo, and return its
+    deploy branch. When no API key is configured we can't check — return
+    (True, None) and let the caller fall back to the configured ref.
+    """
+    if not api_key:
+        return True, None
+    service = _render_get(f"/services/{service_id}", api_key)
+    if service is None:
+        return False, None
+    repo_url = service.get("repo") or ""
+    return (f"{owner}/{repo}" in repo_url), service.get("branch")
+
+
+# ---------------------------------------------------------------------------
+# GitHub workflow_dispatch trigger
+# ---------------------------------------------------------------------------
+
+def dispatch_github_workflow(
+    *,
+    owner: str,
+    repo: str,
+    workflow_id: str,
+    ref: str,
+    token: str,
+    inputs: dict[str, str] | None = None,
+) -> bool:
+    """Trigger a workflow_dispatch run. Returns True on the GitHub 204 ACK."""
+    url = f"{GITHUB_API_URL}/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"
+    try:
+        r = requests.post(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            json={"ref": ref, "inputs": inputs or {}},
+            timeout=15,
+        )
+    except requests.RequestException as e:
+        log.error("github workflow_dispatch failed: %s", e)
+        return False
+    if r.status_code == 204:
+        log.info("dispatched %s on %s@%s", workflow_id, f"{owner}/{repo}", ref)
+        return True
+    log.error("github workflow_dispatch -> %s: %s", r.status_code, r.text[:300])
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — called from app.py's BackgroundTasks after a verified 200 ACK
+# ---------------------------------------------------------------------------
+# Maps a webhook event type to the Render API resource path that enriches it
+# (mirrors webhook-receiver's fetchServiceInfo / fetchPostgresInfo / etc.).
+# `{sid}` is filled with the payload's data.serviceId.
+_ENRICH_PATH = {
+    "deploy_started": "/services/{sid}",
+    "server_failed": "/services/{sid}",
+    "server_available": "/services/{sid}",
+    "database_available": "/postgres/{sid}",
+    "key_value_available": "/key-value/{sid}",
+}
+
+
+def handle_webhook(payload: dict, cfg: dict | None = None) -> str:
+    """Generic Render-webhook dispatcher (the webhook-receiver pattern).
+
+    Routes `deploy_ended` to the GitHub-Actions trigger; enriches+logs every
+    other known type from the Render API; logs unknown types. Returns a short
+    status string (handy for logging/tests). Never raises — it runs in a
+    background task where exceptions would be swallowed anyway.
+    """
+    c = cfg or load_config()
+    ptype = payload.get("type")
+
+    if ptype == "deploy_ended":
+        return handle_deploy_ended(payload, c)
+
+    return describe_event(payload, c)
+
+
+def describe_event(payload: dict, cfg: dict) -> str:
+    """Best-effort enrich + summarize a non-deploy_ended event. Enrichment
+    requires RENDER_API_KEY; without it we just report type + serviceId."""
+    ptype = payload.get("type")
+    data = payload.get("data") or {}
+    sid = data.get("serviceId", "")
+    path_tmpl = _ENRICH_PATH.get(ptype)
+
+    if path_tmpl and cfg.get("render_api_key"):
+        resource = _render_get(path_tmpl.format(sid=sid), cfg["render_api_key"])
+        if resource and resource.get("name"):
+            return f"{ptype}: {resource['name']} ({sid})"
+    return f"{ptype}: {sid}" if ptype else "ignored: missing type"
+
+
+def handle_deploy_ended(payload: dict, cfg: dict | None = None) -> str:
+    """Process a verified `deploy_ended` webhook. Returns a short status string
+    describing the outcome (also useful for logging/testing). Never raises —
+    runs in a background task where exceptions would be swallowed anyway.
+    """
+    c = cfg or load_config()
+    ptype = payload.get("type")
+    data = payload.get("data") or {}
+    service_id = data.get("serviceId", "")
+
+    if ptype != "deploy_ended":
+        return f"ignored: type={ptype}"
+
+    if not deploy_succeeded(payload, c["render_api_key"]):
+        return f"skipped: deploy not successful (service={service_id})"
+
+    if not (c["github_token"] and c["github_owner"] and c["github_repo"]):
+        return "skipped: GitHub dispatch not configured"
+
+    ok_repo, branch = service_targets_repo(
+        service_id, c["github_owner"], c["github_repo"], c["render_api_key"]
+    )
+    if not ok_repo:
+        return f"skipped: service {service_id} does not target {c['github_owner']}/{c['github_repo']}"
+
+    ref = c["github_ref"] or branch or "main"
+    dispatched = dispatch_github_workflow(
+        owner=c["github_owner"],
+        repo=c["github_repo"],
+        workflow_id=c["github_workflow_id"],
+        ref=ref,
+        token=c["github_token"],
+        inputs={"serviceID": service_id},
+    )
+    return "dispatched" if dispatched else "error: dispatch failed"
+
+
+def load_config() -> dict:
+    """Read bridge config from the environment (evaluated per-request so env
+    changes don't require a restart in tests)."""
+    return {
+        "webhook_secret": os.environ.get("RENDER_WEBHOOK_SECRET", ""),
+        "render_api_key": os.environ.get("RENDER_API_KEY") or None,
+        "github_token": os.environ.get("GITHUB_API_TOKEN", ""),
+        # Defaults point at this repo so the bridge is correctly aimed even
+        # before the GITHUB_OWNER_NAME/GITHUB_REPO_NAME env vars are set.
+        "github_owner": os.environ.get("GITHUB_OWNER_NAME") or "JulianS4K",
+        "github_repo": os.environ.get("GITHUB_REPO_NAME") or "Terminal-2",
+        "github_workflow_id": os.environ.get("GITHUB_WORKFLOW_ID", "post-deploy.yml"),
+        "github_ref": os.environ.get("GITHUB_WORKFLOW_REF") or None,
+    }

--- a/tests/test_render_webhook.py
+++ b/tests/test_render_webhook.py
@@ -1,0 +1,199 @@
+"""Unit tests for the Render deploy-webhook → GitHub Actions bridge.
+
+Pure — no network, no running server. The signature tests pin the Standard
+Webhooks scheme against the project's own published known-answer vector, so a
+future refactor that silently breaks verification (and would make the receiver
+reject every real webhook) fails CI instead.
+
+Run:
+  py -m pytest tests/test_render_webhook.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+import render_webhook as rw
+
+# Known-answer vector from the Standard Webhooks spec / reference libraries.
+# https://github.com/standard-webhooks/standard-webhooks
+# Public test vector, NOT a real credential — annotated so secret-scan ignores it.
+KAT_SECRET = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"  # gitleaks:allow
+KAT_ID = "msg_p5jXN8AQM9LWM0D4loKWxJek"
+KAT_TIMESTAMP = "1614265330"
+KAT_BODY = b'{"test": 2432232314}'
+KAT_SIGNATURE = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="
+
+
+def _headers(sig=KAT_SIGNATURE, msg_id=KAT_ID, ts=KAT_TIMESTAMP):
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": ts,
+        "webhook-signature": sig,
+    }
+
+
+# --- sign_payload: known-answer test -----------------------------------------
+
+def test_sign_payload_matches_known_answer():
+    assert rw.sign_payload(KAT_SECRET, KAT_ID, KAT_TIMESTAMP, KAT_BODY) == KAT_SIGNATURE
+
+
+def test_sign_payload_accepts_unprefixed_secret():
+    # Secrets with the whsec_ prefix stripped must hash identically.
+    assert rw.sign_payload(
+        KAT_SECRET[len("whsec_"):], KAT_ID, KAT_TIMESTAMP, KAT_BODY
+    ) == KAT_SIGNATURE
+
+
+# --- verify_signature: accept path -------------------------------------------
+
+def test_verify_accepts_valid_signature():
+    # `now` pinned to the vector's timestamp so the replay window passes.
+    rw.verify_signature(KAT_SECRET, KAT_BODY, _headers(), now=float(KAT_TIMESTAMP))
+
+
+def test_verify_is_header_case_insensitive():
+    headers = {
+        "Webhook-Id": KAT_ID,
+        "Webhook-Timestamp": KAT_TIMESTAMP,
+        "Webhook-Signature": KAT_SIGNATURE,
+    }
+    rw.verify_signature(KAT_SECRET, KAT_BODY, headers, now=float(KAT_TIMESTAMP))
+
+
+def test_verify_accepts_when_one_of_several_sigs_matches():
+    # Header may carry multiple space-delimited sigs during secret rotation.
+    multi = f"v1,aGVsbG8= {KAT_SIGNATURE}"
+    rw.verify_signature(KAT_SECRET, KAT_BODY, _headers(sig=multi), now=float(KAT_TIMESTAMP))
+
+
+# --- verify_signature: reject paths ------------------------------------------
+
+def test_verify_rejects_tampered_body():
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature(KAT_SECRET, KAT_BODY + b" ", _headers(), now=float(KAT_TIMESTAMP))
+
+
+def test_verify_rejects_wrong_secret():
+    other = "whsec_" + rw.base64.b64encode(b"not-the-right-secret").decode()
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature(other, KAT_BODY, _headers(), now=float(KAT_TIMESTAMP))
+
+
+def test_verify_rejects_empty_secret():
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature("", KAT_BODY, _headers(), now=float(KAT_TIMESTAMP))
+
+
+def test_verify_rejects_missing_headers():
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature(KAT_SECRET, KAT_BODY, {}, now=float(KAT_TIMESTAMP))
+
+
+def test_verify_rejects_stale_timestamp():
+    # Same valid signature, but evaluated far in the future → replay window.
+    future = float(KAT_TIMESTAMP) + rw.WEBHOOK_TOLERANCE_SECONDS + 60
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature(KAT_SECRET, KAT_BODY, _headers(), now=future)
+
+
+def test_verify_rejects_future_timestamp():
+    past = float(KAT_TIMESTAMP) - rw.WEBHOOK_TOLERANCE_SECONDS - 60
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature(KAT_SECRET, KAT_BODY, _headers(), now=past)
+
+
+def test_verify_ignores_non_v1_versions():
+    with pytest.raises(rw.WebhookVerificationError):
+        rw.verify_signature(
+            KAT_SECRET, KAT_BODY, _headers(sig="v2,whatever"), now=float(KAT_TIMESTAMP)
+        )
+
+
+# --- deploy_succeeded: payload-status fallback (no API key) -------------------
+
+def test_deploy_succeeded_payload_fallback_true():
+    payload = {"type": "deploy_ended", "data": {"id": "evt-1", "status": "succeeded"}}
+    assert rw.deploy_succeeded(payload, api_key=None) is True
+
+
+@pytest.mark.parametrize("status", ["failed", "canceled", None])
+def test_deploy_succeeded_payload_fallback_false(status):
+    payload = {"type": "deploy_ended", "data": {"id": "evt-1", "status": status}}
+    assert rw.deploy_succeeded(payload, api_key=None) is False
+
+
+# --- handle_deploy_ended: orchestration gates (no network) -------------------
+
+BASE_CFG = {
+    "webhook_secret": KAT_SECRET,
+    "render_api_key": None,
+    "github_token": "ghp_test",
+    "github_owner": "s4kent",
+    "github_repo": "terminal-2",
+    "github_workflow_id": "post-deploy.yml",
+    "github_ref": "main",
+}
+
+
+def test_handle_ignores_non_deploy_event():
+    out = rw.handle_deploy_ended({"type": "server_failed", "data": {}}, dict(BASE_CFG))
+    assert out.startswith("ignored")
+
+
+def test_handle_skips_unsuccessful_deploy():
+    payload = {"type": "deploy_ended", "data": {"serviceId": "srv-x", "status": "failed"}}
+    out = rw.handle_deploy_ended(payload, dict(BASE_CFG))
+    assert out.startswith("skipped")
+
+
+def test_handle_skips_when_github_not_configured():
+    cfg = dict(BASE_CFG, github_token="")
+    payload = {"type": "deploy_ended", "data": {"serviceId": "srv-x", "status": "succeeded"}}
+    out = rw.handle_deploy_ended(payload, cfg)
+    assert "GitHub dispatch not configured" in out
+
+
+def test_handle_dispatches_on_success(monkeypatch):
+    captured = {}
+
+    def fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(rw, "dispatch_github_workflow", fake_dispatch)
+    payload = {"type": "deploy_ended", "data": {"serviceId": "srv-abc", "status": "succeeded"}}
+    out = rw.handle_deploy_ended(payload, dict(BASE_CFG))
+    assert out == "dispatched"
+    assert captured["owner"] == "s4kent"
+    assert captured["repo"] == "terminal-2"
+    assert captured["workflow_id"] == "post-deploy.yml"
+    assert captured["ref"] == "main"
+    assert captured["inputs"] == {"serviceID": "srv-abc"}
+
+
+# --- handle_webhook: generic dispatcher (webhook-receiver pattern) -----------
+
+def test_handle_webhook_routes_deploy_ended_to_github(monkeypatch):
+    monkeypatch.setattr(rw, "dispatch_github_workflow", lambda **kw: True)
+    payload = {"type": "deploy_ended", "data": {"serviceId": "srv-abc", "status": "succeeded"}}
+    assert rw.handle_webhook(payload, dict(BASE_CFG)) == "dispatched"
+
+
+def test_handle_webhook_describes_other_events_without_api_key():
+    # No RENDER_API_KEY → no network; just summarizes type + serviceId.
+    payload = {"type": "database_available", "data": {"serviceId": "dpg-xyz"}}
+    out = rw.handle_webhook(payload, dict(BASE_CFG))
+    assert out == "database_available: dpg-xyz"
+
+
+def test_handle_webhook_enriches_with_api_key(monkeypatch):
+    monkeypatch.setattr(rw, "_render_get", lambda path, key: {"name": "my-db"} if "/postgres/" in path else None)
+    cfg = dict(BASE_CFG, render_api_key="rnd_test")
+    payload = {"type": "database_available", "data": {"serviceId": "dpg-xyz"}}
+    out = rw.handle_webhook(payload, cfg)
+    assert out == "database_available: my-db (dpg-xyz)"
+
+
+def test_handle_webhook_handles_missing_type():
+    assert rw.handle_webhook({"data": {}}, dict(BASE_CFG)).startswith("ignored")


### PR DESCRIPTION
Re-applies **#506** (`feat/render-deploy-webhook-bridge`) onto current `main`. The original branch had diverged/unrelated history (repeated squash-merges) so it couldn't merge or rebase; this cherry-picks its single commit and resolves the `app.py` import conflict (`import json` only — `hmac` isn't used by the new route; it lives in `render_webhook.py`).

## Why this matters
This is the fix for the **no-CI-deploy drift** the health sweep surfaced — the reason `main` kept falling behind prod (bots apply via MCP, leave PRs in draft). Render fires a Standard-Webhooks-signed `deploy_ended` → `POST /webhooks/render` (HMAC-verified, fails closed) → dispatches `post-deploy.yml` to smoke-test the fresh deploy.

## Contents (unchanged from #506)
- `render_webhook.py` — pure, unit-tested bridge logic (24 tests incl. the Standard Webhooks known-answer vector).
- `tests/test_render_webhook.py` — pure pytest (CI runs them; `py_compile` verified locally — pytest isn't installed in this env).
- `.github/workflows/post-deploy.yml` — deploy-end smoke test (`/healthz` + key endpoints; opens an issue on failure; optional Slack).
- `app.py` — thin `/webhooks/render` route (raw-body verify + `BackgroundTasks`).
- `render.yaml` — bridge env vars (`sync:false` secrets).

The Render webhook + secrets are already provisioned out-of-band (per #506); merging activates the route. `GITHUB_API_TOKEN` (PAT, `actions:write`) is still needed only for the auto-trigger leg.

Closes #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N48AwfnXjvatZJtmyZS8no)_