### PR TITLE
fix(a1/d0): coerce seating_chart 'null' string poison at TEvo ingestion source (re-apply #505)

### DIFF
--- a/core/helpers.py
+++ b/core/helpers.py
@@ -168,7 +168,7 @@ def clean_opt_url(v) -> str | None:
     if v is None:
         return None
     s = str(v).strip()
-    if s.lower() in ("null", "none", ""):
+    if s.lower() in ("null", "none", "undefined", ""):
         return None
     return v
 

--- a/supabase/functions/backfill-event-configurations/index.ts
+++ b/supabase/functions/backfill-event-configurations/index.ts
@@ -10,6 +10,17 @@ async function hmac(secret: string, msg: string): Promise<string> {
   const s = await crypto.subtle.sign("HMAC", k, enc.encode(msg));
   let bin = ""; for (const b of new Uint8Array(s)) bin += String.fromCharCode(b); return btoa(bin);
 }
+// TEvo serializes an absent seat-map as the literal string "null" (and
+// occasionally "none"/"undefined"/""). `typeof x === "string"` is true for
+// those, so storing x verbatim poisons events.seating_chart_* — a downstream
+// consumer then renders <img src="null">. Keep only genuine http(s) URLs;
+// coerce every sentinel / non-URL to real null. Mirrors store.js cleanMapUrl
+// and the SQL read-side guards (`<> 'null' AND ILIKE 'http%'`).
+function cleanMapUrl(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const s = v.trim();
+  return s.toLowerCase().startsWith("http") ? s : null;
+}
 async function tevoEvent(token: string, secret: string, id: number, attempt = 0): Promise<any> {
   const path = `/v9/events/${id}`; const sig = await hmac(secret, `GET ${HOST}${path}?`);
   const r = await fetch(`${BASE}${path}?`, { headers: { "X-Token": token, "X-Signature": sig, "Accept": "application/vnd.ticketevolution.api+json; version=9" } });
@@ -50,9 +61,9 @@ Deno.serve(async (req) => {
       const ev = await tevoEvent(m.tevo_token, m.tevo_secret, id);
       const cfg = ev.configuration ?? {};
       const sc = cfg.seating_chart ?? {};
-      const med = typeof sc.medium === "string" ? sc.medium : null;
-      const lg = typeof sc.large === "string" ? sc.large : null;
-      const hasMap = !!(med && med !== "null" && med.startsWith("http"));
+      const med = cleanMapUrl(sc.medium);
+      const lg = cleanMapUrl(sc.large);
+      const hasMap = !!med;
       if (hasMap) withMap++;
       const patch: any = {
         configuration_id: cfg.id ?? null,

--- a/supabase/migrations/20260609120000_coerce_seating_chart_null_strings.sql
+++ b/supabase/migrations/20260609120000_coerce_seating_chart_null_strings.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- Migration 20260609120000 — Coerce literal 'null' seat-map strings to SQL NULL
+--
+-- Data-quality fix (D0/D1 lane). The `backfill-event-configurations` edge fn
+-- stored TEvo's absent seat-map URLs as the literal 4-char string 'null'
+-- (it serialized a JSON null via `typeof x === "string"`, which is true for
+-- the string "null"). As of 2026-06-09, ~5,225 of ~9,208 events held
+-- seating_chart_large / seating_chart_medium = 'null' and 0 held true NULL.
+--
+-- No live broken-image bug exists today — every read path already defends:
+--   * SQL: get_broker_event_detail / v_event_seating_chart and the search RPCs
+--          gate on `<> 'null' AND ILIKE 'http%'`.
+--   * Python: app.py _clean_opt_url() coerces null/none/undefined/'' -> None.
+--   * JS: static/store/store.js cleanMapUrl() strips the same sentinels.
+-- But the stored poison is latent: any new consumer rendering the raw column
+-- without that guard emits <img src="null">. This migration removes the
+-- poison at the source-of-truth so the guards are belt-and-suspenders.
+--
+-- The edge-fn write path is fixed in the same change set
+-- (supabase/functions/backfill-event-configurations/index.ts: cleanMapUrl now
+-- persists only genuine http(s) URLs, everything else -> null) so rows will
+-- not re-poison after this runs.
+--
+-- RULE 1 compliance: data-only UPDATE on prod, authored as a file for A1 to
+-- apply. No DDL, no cron/vault/auth/edge changes. Idempotent + bounded by a
+-- WHERE so re-running is a no-op once clean.
+-- ============================================================================
+
+UPDATE public.events
+SET
+  seating_chart_large = NULLIF(NULLIF(NULLIF(NULLIF(seating_chart_large, 'null'), 'none'), 'undefined'), ''),
+  seating_chart_medium = NULLIF(NULLIF(NULLIF(NULLIF(seating_chart_medium, 'null'), 'none'), 'undefined'), '')
+WHERE seating_chart_large IN ('null', 'none', 'undefined', '')
+   OR seating_chart_medium IN ('null', 'none', 'undefined', '');
+
+-- Verify (run manually after apply):
+--   SELECT
+--     count(*) FILTER (WHERE seating_chart_large  = 'null') AS large_null_str,
+--     count(*) FILTER (WHERE seating_chart_medium = 'null') AS medium_null_str,
+--     count(*) FILTER (WHERE seating_chart_large IS NULL)   AS large_true_null,
+--     count(*) FILTER (WHERE seating_chart_large LIKE 'http%') AS large_http
+--   FROM public.events;
+-- Expect: large_null_str = 0, medium_null_str = 0, http count unchanged.


### PR DESCRIPTION
Re-applies #505 (`bc669e1`) onto current `main`. The original branch had unrelated histories after intervening squash-merges. app.py conflict resolved by applying the `'undefined'` sentinel parity fix to `core/helpers.py` (where `_clean_opt_url` was refactored to since #505 was authored) instead of the now-removed inline definition.

## ⚠️ This fix is NOT yet live in prod — verified 2026-06-22

Unlike the recent re-applications, #505 was **never applied** (its migration was correctly left A1-gated, and the edge fn was never redeployed). Confirmed against prod (`hzrizjeaxlqcxfrtczpq`) today:

| metric | count |
|---|---|
| `seating_chart_large = 'null'` | **5,336** (was 5,225 in the 06-09 report — still growing) |
| `seating_chart_medium = 'null'` | **5,336** |
| real `http%` URLs | 3,955 |

The deployed edge fn is still **v4**, which persists `med`/`lg` verbatim (`typeof "null" === "string"` is `true`), so every backfill run re-poisons. This PR lands the git-side fix; the prod-apply is **operator-gated** (see below).

## Changes
1. **Edge fn** `backfill-event-configurations/index.ts` — new `cleanMapUrl()`: only genuine `http(s)` URLs persist; every sentinel → real `null`.
2. **Migration** `20260609120000_coerce_seating_chart_null_strings.sql` — data-only `NULLIF`-coerce of existing `null`/`none`/`undefined`/`''` rows → SQL `NULL`. Idempotent, `WHERE`-bounded.
3. **core/helpers.py `clean_opt_url`** — add `'undefined'` sentinel for parity with the JS guard.

## 🔒 Operator action required to actually fix prod (RULE 1)
After this merges, the following are **operator-gated** and have NOT been done:
- [ ] Apply `20260609120000_coerce_seating_chart_null_strings.sql` to prod (`UPDATE` on `events`)
- [ ] Redeploy `backfill-event-configurations` edge fn (write-path change)
- [ ] Verify `large_null_str = 0`, `medium_null_str = 0`, `http%` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N48AwfnXjvatZJtmyZS8no)_