### PR TITLE
fix(a1): repair movers cron, definer-view check, and NOT VALID fk backlog

### DIFF
--- a/supabase/migrations/20260623190000_fix_movers_agg_cron_statement_timeout.sql
+++ b/supabase/migrations/20260623190000_fix_movers_agg_cron_statement_timeout.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- Migration 20260623190000 — fix refresh_movers_agg: statement_timeout never armed
+--
+-- Lane:     A1 (crons / data plane)
+-- Touches:  cron.job 'refresh_movers_agg' (W, re-schedule). No table/function DDL.
+-- Pre-reqs: 20260601140000 (two-tier agg cache + refresh_event_movers_agg),
+--           20260608031000 (prior — INEFFECTIVE — per-window timeout attempt).
+-- Apply:    NOT APPLIED. A1/operator to apply. See post-apply bootstrap below.
+--
+-- ── SYMPTOM ─────────────────────────────────────────────────────────────────
+--   release_health_check() → cron.failed_jobs_90min = warn, every run of
+--   'refresh_movers_agg' FAILS at exactly 120s with:
+--     ERROR: canceling statement due to statement timeout
+--     CONTEXT: SQL statement "INSERT INTO public.event_movers_agg ..."
+--   Downstream: event_movers_agg cache frozen since 2026-06-08, and
+--   event_movers_index frozen since 2026-06-03 (the 18h-staleness guard in
+--   compute_event_movers_index makes Tier-2 a no-op once the cache is stale).
+--   Net effect: the terminal MOVERS rail has served ~20-day-old data.
+--
+-- ── ROOT CAUSE ──────────────────────────────────────────────────────────────
+--   pg_cron runs the whole job command as a sequence of top-level statements.
+--   The 06-08 version put ALL five windows inside ONE `DO` block and tried to
+--   widen the budget with `PERFORM set_config('statement_timeout','480000',true)`
+--   INSIDE that block. statement_timeout is armed by the backend when a
+--   top-level statement BEGINS; changing the GUC *inside* an already-running
+--   statement does NOT re-arm the timer for that statement. So the entire DO ran
+--   under the role default (120s) and was cancelled — exactly the trap the
+--   06-01 header documented ("a function-local statement_timeout does NOT re-arm
+--   the cron's already-running outer statement"), reintroduced by 06-08.
+--   The `EXCEPTION WHEN OTHERS` could not rescue it either: once the deadline
+--   has passed, every subsequent operation re-cancels at the next interrupt.
+--
+-- ── FIX ─────────────────────────────────────────────────────────────────────
+--   Issue `SET statement_timeout` as its OWN top-level statement BEFORE the work.
+--   In a multi-statement command each statement's timer is armed fresh from the
+--   *current* GUC value when that statement starts, so the following DO block now
+--   runs under 900s (15 min — ample for the ~68s historical batch + growth, and
+--   harmless at a twice-daily cadence). The inner, ineffective set_config is
+--   removed. The per-window EXCEPTION savepoints are KEPT so a single bad window
+--   (e.g. a genuine error, not a timeout) can't roll back the others.
+-- ============================================================================
+
+SELECT cron.schedule('refresh_movers_agg', '20 7,19 * * *', $cron$
+  SET statement_timeout = '900000';   -- 15 min, armed for the DO statement below
+  DO $g$
+  DECLARE w int;
+  BEGIN
+    IF NOT public.cron_should_fire('refresh_movers_agg') THEN RETURN; END IF;
+    FOREACH w IN ARRAY ARRAY[7,15,30,180,365] LOOP
+      BEGIN
+        PERFORM public.refresh_event_movers_agg(w);
+      EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'refresh_event_movers_agg(%) skipped: %', w, SQLERRM;
+      END;
+    END LOOP;
+  END $g$;
+$cron$);
+
+-- ── POST-APPLY BOOTSTRAP (A1 runs manually; don't wait for the next 07:20/19:20)
+--   Refresh each window in its own statement under a widened timeout, then drive
+--   Tier-2 so the MOVERS index recovers immediately:
+--     SET statement_timeout = '900000';
+--     SELECT public.refresh_event_movers_agg(w) FROM unnest(ARRAY[7,15,30,180,365]) w;
+--     SELECT public.compute_event_movers_index_all();
+--
+-- ── VERIFICATION (next scheduled run) ───────────────────────────────────────
+--   SELECT status, start_time, return_message FROM cron.job_run_details d
+--     JOIN cron.job j ON j.jobid=d.jobid WHERE j.jobname='refresh_movers_agg'
+--     ORDER BY start_time DESC LIMIT 2;            -- expect status='succeeded'
+--   SELECT max(computed_at) FROM public.event_movers_agg;        -- ~now()
+--   SELECT max(last_computed_at) FROM public.event_movers_index; -- ~now()
+--
+-- ── FOLLOW-UP (separate task, not this migration) ───────────────────────────
+--   The 180/365d windows re-percentile the raw ticketsdata firehose (1.7M-3.25M
+--   rows). Source them from event_listing_snapshot_daily (pre-aggregated daily
+--   medians, ~100x fewer rows) so even a 15-min budget is never approached.
+-- ============================================================================

--- a/supabase/migrations/20260623190000_fix_movers_agg_cron_statement_timeout.sql
+++ b/supabase/migrations/20260623190000_fix_movers_agg_cron_statement_timeout.sql
@@ -5,7 +5,10 @@
 -- Touches:  cron.job 'refresh_movers_agg' (W, re-schedule). No table/function DDL.
 -- Pre-reqs: 20260601140000 (two-tier agg cache + refresh_event_movers_agg),
 --           20260608031000 (prior — INEFFECTIVE — per-window timeout attempt).
--- Apply:    NOT APPLIED. A1/operator to apply. See post-apply bootstrap below.
+-- Apply:    APPLIED to prod 2026-06-23 (operator-authorized). Cron re-scheduled.
+--           Post-apply bootstrap: windows 7+15 refreshed + index recomputed via
+--           execute_sql (226/291 entries @ 20:27Z); windows 30/180/365 exceed the
+--           60s MCP gateway, so they self-heal at the next fixed cron run (07:20Z).
 --
 -- ── SYMPTOM ─────────────────────────────────────────────────────────────────
 --   release_health_check() → cron.failed_jobs_90min = warn, every run of

--- a/supabase/migrations/20260623190100_health_check_invoker_predicate_and_flip_safe_definer_views.sql
+++ b/supabase/migrations/20260623190100_health_check_invoker_predicate_and_flip_safe_definer_views.sql
@@ -1,0 +1,211 @@
+-- ============================================================================
+-- Migration 20260623190100 — security_definer_views: fix the check + flip/lock
+--                            the views that are safe to act on
+--
+-- Lane:     A1 (DB security) — health-check fn is shared with B1; PR-reviewed.
+-- Touches:  public.release_health_check() (W, CREATE OR REPLACE — views check only),
+--           ALTER VIEW security_invoker on 6 views (W),
+--           REVOKE anon/authenticated on 2 ops views (W).
+-- Pre-reqs: 20260515170000 (release_health_check), 20260621180156 (last view flip).
+-- Apply:    NOT APPLIED. A1/operator to apply (PR-reviewed). Behavioral-but-verified
+--           — see per-view evidence below. Shared seams flagged for C1.
+--
+-- ── PROBLEM ─────────────────────────────────────────────────────────────────
+--   release_health_check() → views.security_definer_views = FAIL, metric 23.
+--   Investigation (live prod, 2026-06-23) splits the 23 into THREE groups:
+--
+--   GROUP A — 12 FALSE POSITIVES (check bug). These views ARE invoker-secured
+--     but store the option as `security_invoker=on` (PG's boolean spelling),
+--     while the check matches the literal string 'security_invoker=true'. PG
+--     accepts on/true/1/yes; the check only recognizes `true`. (The 5 views the
+--     06-21 migration flipped with `= true` store as `=true` and pass; older
+--     views set with `= on` store as `=on` and wrongly trip.) → fixed in PART 1.
+--
+--   GROUP B — 6 GENUINE definers that are SAFE to act on → PART 2/PART 3.
+--     · 4 service_role-only (no anon/authenticated grant): flipping is a no-op
+--       behaviorally (service_role bypasses RLS + has full grants):
+--         listings_snapshots_recent, seatgeek_listings_snapshots_recent,
+--         v_bot_chat_unresolved, v_event_listing_trends
+--     · 2 ops-internal views wrongly granted to anon, with NO app/FE consumer
+--       (grep of *.py/*.js/*.ts/*.html = docs only) and base tables that RLS-deny
+--       anon: v_sg_token_budget (base sg_broker_pending USING false),
+--       v_ticketsdata_credit_usage_daily (base ticketsdata_credit_usage =
+--       service_role only). → REVOKE the unnecessary anon/authenticated grant,
+--       THEN flip (only service_role remains → safe). Hardening + clears check.
+--
+--   GROUP C — 5 GENUINE definers that are INTENTIONAL public-read boundaries
+--     (SECDEF by necessity — base tables RLS-deny anon, so they CANNOT be flipped
+--     without breaking anon):
+--       · exos_public_events / exos_public_orgs / exos_public_tiers — the D4
+--         Bridge public storefront reads these with the ANON key
+--         (d4_bridge/src/lib/{events,orgs}.ts, server.ts). Curated anon
+--         projections of RLS-protected exos_* tables. → whitelisted in PART 1
+--         (pattern exos_public_%) — same spirit as the existing pg_% exclusion.
+--       · unified_listings, v_event_full_sports — anon-exposed curated cross-
+--         source views; base tables (listings_snapshots, espn_news, ticketsdata_*)
+--         RLS-deny / don't-grant anon, so flipping empties/errors them for anon.
+--         NOT touched here: each needs an explicit A1/C1 decision —
+--           (a) confirmed-intentional anon boundary → add to the PART-1 allowlist; OR
+--           (b) unintended exposure (esp. unified_listings may surface ticketsdata
+--               to anon — cf. PROJECT_BIBLE §2.6 broker/wholesale read boundary)
+--               → REVOKE anon instead.
+--         Left flagged on purpose so the decision is explicit, not silent.
+--
+--   NET after this migration: metric 23 (fail) → 2 (warn) = exactly
+--   {unified_listings, v_event_full_sports}, the two views that need a human call.
+-- ============================================================================
+
+-- ── PART 1: fix the views check (recognize on/true/1/yes; whitelist exos_public_)
+CREATE OR REPLACE FUNCTION public.release_health_check()
+ RETURNS TABLE(check_class text, check_name text, status text, metric numeric, detail text)
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH agg AS (
+    SELECT count(*)::int AS n,
+           string_agg(j.jobname || ':' || coalesce(left(r.return_message,80),''), ' | ') AS msg
+    FROM cron.job j JOIN cron.job_run_details r ON r.jobid = j.jobid
+    WHERE r.start_time > now() - interval '90 minutes' AND r.status = 'failed'
+  )
+  SELECT 'cron'::text, 'failed_jobs_90min'::text,
+         CASE WHEN n = 0 THEN 'ok' WHEN n <= 2 THEN 'warn' ELSE 'fail' END,
+         n::numeric, msg FROM agg;
+
+  RETURN QUERY
+  WITH stuck AS (
+    SELECT count(*)::int AS n, string_agg(jobname, ', ') AS msg
+    FROM cron.job j
+    WHERE j.active
+      AND (
+        j.schedule ~ '^\s*\d+\s+(seconds?|minutes?)\s*$'
+        OR (
+          split_part(j.schedule, ' ', 2) = '*'
+          AND split_part(j.schedule, ' ', 3) = '*'
+          AND split_part(j.schedule, ' ', 4) = '*'
+          AND split_part(j.schedule, ' ', 5) = '*'
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM cron.job_run_details r
+        WHERE r.jobid = j.jobid AND r.status = 'succeeded'
+          AND r.start_time > now() - interval '90 minutes'
+      )
+  )
+  SELECT 'cron'::text, 'subhourly_jobs_silent_90min'::text,
+         CASE WHEN n = 0 THEN 'ok' WHEN n <= 3 THEN 'warn' ELSE 'fail' END,
+         n::numeric, msg FROM stuck;
+
+  RETURN QUERY
+  WITH bad AS (
+    SELECT count(*)::int AS n, string_agg(p.proname, ', ') AS msg
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.prokind = 'f'
+      AND pg_get_functiondef(p.oid) ~* '\m(hmac|digest|gen_random_bytes|encrypt|decrypt)\s*\('
+      AND NOT EXISTS (
+        SELECT 1 FROM unnest(coalesce(p.proconfig, ARRAY[]::text[])) cfg
+        WHERE cfg ILIKE 'search_path=%extensions%'
+      )
+  )
+  SELECT 'functions'::text, 'pgcrypto_missing_extensions_searchpath'::text,
+         CASE WHEN n = 0 THEN 'ok' ELSE 'fail' END,
+         n::numeric, msg FROM bad;
+
+  RETURN QUERY
+  WITH bad AS (
+    SELECT count(*)::int AS n, string_agg(c.relname, ', ' ORDER BY c.relname) AS msg
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind = 'v'
+      -- FIX: recognize all PG boolean-true spellings, not just the literal 'true'.
+      -- security_invoker may be stored as on/true/1/yes depending on how it was set.
+      AND NOT EXISTS (
+        SELECT 1 FROM unnest(coalesce(c.reloptions, ARRAY[]::text[])) opt
+        WHERE split_part(opt, '=', 1) = 'security_invoker'
+          AND lower(split_part(opt, '=', 2)) IN ('true','on','1','yes')
+      )
+      AND c.relname NOT LIKE 'pg_%'
+      -- WHITELIST: deliberate anon public-read projections. SECDEF by necessity —
+      -- the base exos_* tables RLS-deny anon, so these CANNOT be security_invoker
+      -- without breaking the D4 Bridge public storefront (anon-key reads).
+      AND c.relname NOT LIKE 'exos_public_%'
+  )
+  SELECT 'views'::text, 'security_definer_views'::text,
+         CASE WHEN n = 0 THEN 'ok' WHEN n <= 3 THEN 'warn' ELSE 'fail' END,
+         n::numeric, msg FROM bad;
+
+  RETURN QUERY
+  WITH nv AS (
+    SELECT count(*)::int AS n, string_agg(conname, ', ' ORDER BY conname) AS msg
+    FROM pg_constraint WHERE contype = 'f' AND NOT convalidated
+  )
+  SELECT 'fks'::text, 'not_valid_fks'::text,
+         CASE WHEN n = 0 THEN 'ok' WHEN n <= 60 THEN 'warn' ELSE 'fail' END,
+         n::numeric, msg FROM nv;
+
+  RETURN QUERY
+  SELECT x.check_class, x.check_name,
+    CASE
+      WHEN x.metric IS NULL          THEN 'warn'
+      WHEN x.metric <  60            THEN 'ok'
+      WHEN x.metric <  240           THEN 'warn'
+      ELSE                                'fail'
+    END,
+    x.metric,
+    CASE
+      WHEN x.metric IS NULL THEN 'no rows yet'
+      WHEN x.metric < 60    THEN 'fresh'
+      WHEN x.metric < 240   THEN round(x.metric)::text || ' min stale'
+      ELSE                       round(x.metric)::text || ' min stale - investigate'
+    END
+  FROM (VALUES
+    ('data_freshness'::text, 'evo_orders_age_min'::text,
+      (SELECT EXTRACT(epoch FROM (now() - max(pulled_at)))/60 FROM public.evo_orders)::numeric),
+    ('data_freshness',       'listings_snapshots_age_min',
+      (SELECT EXTRACT(epoch FROM (now() - max(captured_at)))/60 FROM public.listings_snapshots)),
+    ('data_freshness',       'espn_event_snapshots_age_min',
+      (SELECT EXTRACT(epoch FROM (now() - max(captured_at)))/60 FROM public.espn_event_snapshots)),
+    ('data_freshness',       'vivid_orders_age_min',
+      (SELECT EXTRACT(epoch FROM (now() - max(pulled_at)))/60 FROM public.vivid_orders))
+  ) AS x(check_class, check_name, metric);
+
+  RETURN QUERY
+  WITH q AS (
+    SELECT
+      (SELECT count(*) FROM public.vivid_orders_pending     WHERE resolved_at IS NULL) AS vivid_pending,
+      (SELECT count(*) FROM public.tickpick_orders_pending  WHERE resolved_at IS NULL) AS tickpick_pending
+  )
+  SELECT 'queues'::text, 'unresolved_pending_total'::text,
+         CASE WHEN vivid_pending + tickpick_pending = 0 THEN 'ok'
+              WHEN vivid_pending + tickpick_pending < 20 THEN 'warn' ELSE 'fail' END,
+         (vivid_pending + tickpick_pending)::numeric,
+         format('vivid=%s, tickpick=%s', vivid_pending, tickpick_pending)
+  FROM q;
+
+  RETURN;
+END $function$;
+
+-- ── PART 2: flip the 4 service_role-only genuine-definer views (safe — no
+--    anon/authenticated consumer; service_role bypasses RLS).
+ALTER VIEW public.listings_snapshots_recent          SET (security_invoker = true);
+ALTER VIEW public.seatgeek_listings_snapshots_recent SET (security_invoker = true);
+ALTER VIEW public.v_bot_chat_unresolved              SET (security_invoker = true);
+ALTER VIEW public.v_event_listing_trends             SET (security_invoker = true);
+
+-- ── PART 3: ops-internal views wrongly exposed to anon — revoke the unnecessary
+--    grant (no app/FE consumer; verified via repo grep), then flip. Hardening.
+REVOKE ALL ON public.v_sg_token_budget                FROM anon, authenticated;
+REVOKE ALL ON public.v_ticketsdata_credit_usage_daily FROM anon, authenticated;
+ALTER VIEW public.v_sg_token_budget                SET (security_invoker = true);
+ALTER VIEW public.v_ticketsdata_credit_usage_daily SET (security_invoker = true);
+
+-- ── VERIFICATION (run after apply) ──────────────────────────────────────────
+--   SELECT status, metric, detail FROM public.release_health_check()
+--    WHERE check_name = 'security_definer_views';
+--   -- expect: status='warn', metric=2, detail='unified_listings, v_event_full_sports'
+--
+-- ── FOLLOW-UP (separate decision, A1/C1) ────────────────────────────────────
+--   Decide unified_listings + v_event_full_sports: whitelist (confirmed anon
+--   boundary) or REVOKE anon (unintended exposure). Resolving both → check = ok.
+-- ============================================================================

--- a/supabase/migrations/20260623190100_health_check_invoker_predicate_and_flip_safe_definer_views.sql
+++ b/supabase/migrations/20260623190100_health_check_invoker_predicate_and_flip_safe_definer_views.sql
@@ -7,8 +7,11 @@
 --           ALTER VIEW security_invoker on 6 views (W),
 --           REVOKE anon/authenticated on 2 ops views (W).
 -- Pre-reqs: 20260515170000 (release_health_check), 20260621180156 (last view flip).
--- Apply:    NOT APPLIED. A1/operator to apply (PR-reviewed). Behavioral-but-verified
---           — see per-view evidence below. Shared seams flagged for C1.
+-- Apply:    APPLIED to prod 2026-06-23 (operator-authorized). Verified:
+--           security_definer_views 23(fail) -> 2(warn) = {unified_listings,
+--           v_event_full_sports}; the 4 flips + 2 revoke/flip succeeded.
+--           Behavioral-but-verified — see per-view evidence below; shared seams
+--           still flagged for the C1 decision on the remaining 2.
 --
 -- ── PROBLEM ─────────────────────────────────────────────────────────────────
 --   release_health_check() → views.security_definer_views = FAIL, metric 23.

--- a/supabase/migrations/20260623190200_validate_not_valid_fk_backlog.sql
+++ b/supabase/migrations/20260623190200_validate_not_valid_fk_backlog.sql
@@ -5,9 +5,24 @@
 -- Touches:  VALIDATE CONSTRAINT on all public NOT VALID foreign keys (54 at
 --           authoring time). No schema shape change; no data mutation.
 -- Pre-reqs: none. Idempotent — re-running only touches still-NOT-VALID FKs.
--- Apply:    NOT APPLIED. A1/operator to apply. Run under a controlled window
---           (some target tables are large — see note). VALIDATE takes only
---           SHARE UPDATE EXCLUSIVE → does NOT block reads or writes.
+-- Apply:    APPLIED to prod 2026-06-23 (operator-authorized), but NOT via this
+--           single DO — the all-in-one transaction exceeds the 60s MCP gateway
+--           (the client reset rolls the whole txn back). Instead run in size-
+--           bounded batches that each commit independently:
+--             1) one DO over all FKs on tables < ~700k rows  -> 54 -> 13
+--             2) espn_athlete_team_history (2.5M) x2          -> -> 11
+--             3) seatgeek_sales/listings_snapshots (13M/17M) one VALIDATE per
+--                call (each ~60-120s; commits just past the client cutoff) -> 5
+--           Result: 54 -> 5. The 5 left are orphan-bearing and were skipped:
+--             performer_wikipedia (152/746) + seatgeek_performer_xref (31/132)
+--               -> performer_metadata(performer_id)
+--             seatgeek_orders_resolved (2/271) + seatgeek_venue_xref (4/38)
+--               + venue_pulls (1/3) -> venue_assets(tevo_venue_id)
+--           These FKs reference COVERAGE tables (performer_metadata/venue_assets),
+--           not the entity tables — likely a mis-targeted parent. A1 data call:
+--           repoint to the entity table, backfill coverage, or prune orphans.
+--           VALIDATE takes only SHARE UPDATE EXCLUSIVE → never blocks reads/writes.
+--           (This DO remains correct for a future direct-psql run with no gateway.)
 --
 -- ── BACKGROUND ──────────────────────────────────────────────────────────────
 --   release_health_check() → fks.not_valid_fks = warn (metric 54). These FKs

--- a/supabase/migrations/20260623190200_validate_not_valid_fk_backlog.sql
+++ b/supabase/migrations/20260623190200_validate_not_valid_fk_backlog.sql
@@ -1,0 +1,71 @@
+-- ============================================================================
+-- Migration 20260623190200 — validate the NOT VALID foreign-key backlog
+--
+-- Lane:     A1 (constraints / data plane)
+-- Touches:  VALIDATE CONSTRAINT on all public NOT VALID foreign keys (54 at
+--           authoring time). No schema shape change; no data mutation.
+-- Pre-reqs: none. Idempotent — re-running only touches still-NOT-VALID FKs.
+-- Apply:    NOT APPLIED. A1/operator to apply. Run under a controlled window
+--           (some target tables are large — see note). VALIDATE takes only
+--           SHARE UPDATE EXCLUSIVE → does NOT block reads or writes.
+--
+-- ── BACKGROUND ──────────────────────────────────────────────────────────────
+--   release_health_check() → fks.not_valid_fks = warn (metric 54). These FKs
+--   were added `NOT VALID` (the standard way to attach an FK to a large table
+--   without a long ACCESS EXCLUSIVE lock): they enforce on NEW rows but the
+--   pre-existing rows were never validated, so the catalog flag never cleared.
+--   Spot-check (event_alerts, vivid_orders, seatgeek_orders) found NO orphans,
+--   so most should validate cleanly.
+--
+-- ── APPROACH ────────────────────────────────────────────────────────────────
+--   Iterate every NOT VALID FK in `public` and VALIDATE each in its OWN
+--   subtransaction (EXCEPTION = savepoint). A constraint that DOES have orphans
+--   raises on VALIDATE; we catch it, RAISE NOTICE the constraint + table, and
+--   leave it NOT VALID for targeted data cleanup — one bad FK can't abort the
+--   batch. statement_timeout is disabled (own statement, see below) so a large-
+--   table scan can't trip the role default mid-batch; VALIDATE's lock is
+--   non-blocking, so this is safe to run live.
+--
+--   ⚠ Large target tables (full scan on VALIDATE): listings_snapshots (~8M),
+--   seatgeek_listings_snapshots, ticketsdata_*-keyed, seatdata_*-keyed. Expect
+--   minutes, not seconds, for those. Run when load permits.
+-- ============================================================================
+
+-- Disable statement_timeout for THIS migration session as its own statement so
+-- the DO block below inherits it (a SET inside the DO would not re-arm the timer).
+SET statement_timeout = '0';
+
+DO $$
+DECLARE
+  r           record;
+  v_validated int := 0;
+  v_skipped   int := 0;
+BEGIN
+  FOR r IN
+    SELECT con.conname, rel.relname
+    FROM pg_constraint con
+    JOIN pg_class     rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE con.contype = 'f'
+      AND NOT con.convalidated
+      AND nsp.nspname = 'public'
+    ORDER BY rel.relname, con.conname
+  LOOP
+    BEGIN
+      EXECUTE format('ALTER TABLE public.%I VALIDATE CONSTRAINT %I', r.relname, r.conname);
+      v_validated := v_validated + 1;
+      RAISE NOTICE 'validated %.%', r.relname, r.conname;
+    EXCEPTION WHEN OTHERS THEN
+      v_skipped := v_skipped + 1;
+      RAISE NOTICE 'SKIP %.% — has orphans or errored: %', r.relname, r.conname, SQLERRM;
+    END;
+  END LOOP;
+  RAISE NOTICE 'done: % validated, % skipped (still NOT VALID)', v_validated, v_skipped;
+END $$;
+
+-- ── VERIFICATION (run after apply) ──────────────────────────────────────────
+--   SELECT status, metric, detail FROM public.release_health_check()
+--    WHERE check_name = 'not_valid_fks';
+--   -- metric should drop to 0 (status 'ok') if all validated; any remaining are
+--   -- the skipped, orphan-bearing FKs that need data cleanup first.
+-- ============================================================================


### PR DESCRIPTION
## ✅ APPLIED to prod 2026-06-23 (operator-authorized)

All three migrations were applied directly to prod (`hzrizjeaxlqcxfrtczpq`) at the operator's instruction, and `release_health_check()` was used to verify. **Failing checks: 1 → 0.**

| Check | Before | After |
|---|---|---|
| `views / security_definer_views` | **fail / 23** | **warn / 2** — `unified_listings`, `v_event_full_sports` (left for an A1/C1 decision) |
| `fks / not_valid_fks` | warn / 54 | **warn / 5** — orphan-bearing FKs that target *coverage* tables (`performer_metadata`, `venue_assets`); A1 data call |
| `cron / refresh_movers_agg` | warn (active timeout) | cron re-scheduled & fixed; the lingering `warn/1` is the historical failure aging out of the 90-min window |
| MOVERS index | frozen ~20 days | windows 7 & 15 recomputed today; 30/180/365 self-heal at the next cron run (07:20 UTC) |

Migration headers updated to record the applied method + results. Two follow-ups remain (intentionally not forced):
1. **Views:** decide `unified_listings` + `v_event_full_sports` — whitelist (confirmed anon boundary) or REVOKE anon (unintended exposure; note the `unified_listings`→ticketsdata/broker-data question, PROJECT_BIBLE §2.6).
2. **FKs:** the 5 orphan-bearing FKs reference coverage tables, not entity tables — repoint to the entity table, backfill coverage rows, or prune orphans.

---

## Original triage & rationale

Triages all failing/warning `release_health_check()` checks on the D0 **HEALTH** dashboard. All findings verified read-only against live prod on 2026-06-23.

### 1. `cron / failed_jobs_90min` → `refresh_movers_agg`
`20260623190000_fix_movers_agg_cron_statement_timeout.sql`
- **Symptom:** every run failed at exactly 120s inside `INSERT INTO event_movers_agg`; cache frozen since 2026-06-08, index since 2026-06-03 → MOVERS rail ~20 days stale behind a yellow badge.
- **Root cause:** the 06-08 version set `statement_timeout` *inside* a single `DO` statement, which can't re-arm a timer armed when the statement began (the 06-01 trap, reintroduced).
- **Fix:** `SET statement_timeout` as its own statement before the `DO`; keep per-window savepoints; drop the dead `set_config`.

### 2. `views / security_definer_views`
`20260623190100_health_check_invoker_predicate_and_flip_safe_definer_views.sql`
- 12 false positives (check matched literal `'security_invoker=true'`, missing `=on`), 6 safe genuine definers, 5 intentional public-read boundaries.
- Fix the predicate (`on/true/1/yes`) + whitelist `exos_public_%`; flip 4 service_role-only views; REVOKE anon + flip 2 unused ops views.

### 3. `fks / not_valid_fks`
`20260623190200_validate_not_valid_fk_backlog.sql`
- FKs added `NOT VALID` (enforce on new rows; pre-existing never validated).
- Validate each in its own subtransaction; orphan-bearing ones skipped, not fatal. `VALIDATE` takes only `SHARE UPDATE EXCLUSIVE` (non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)